### PR TITLE
Fixed bug in CopyCtPropFold.hs, causing the following program to throw a...

### DIFF
--- a/src/L0C/EnablingOpts/CopyCtPropFold.hs
+++ b/src/L0C/EnablingOpts/CopyCtPropFold.hs
@@ -466,9 +466,9 @@ ctFoldBinOp e@(BinOp Mod e1 e2 _ pos)
 ctFoldBinOp e@(BinOp Pow e1 e2 _ pos)
   | isCt0 e1 || isCt1 e1 || isCt1 e2 = changed e1
   | isCt0 e2 =
-    case e1 of
-      Literal (IntVal  _) _ -> changed $ Literal (IntVal  1) pos
-      Literal (RealVal _) _ -> changed $ Literal (RealVal 1.0) pos
+    case typeOf e1 of
+      Elem Int  -> changed $ Literal (IntVal  1) pos
+      Elem Real -> changed $ Literal (RealVal 1.0) pos
       _ -> badCPropM $ TypeError pos  " pow operands not of (the same) numeral type! "
   |  isValue e1, isValue e2 =
     case (e1, e2) of


### PR DESCRIPTION
... typeError.

fun int main(int a) =
  a pow 0
