### PR TITLE
Support hexadecimal float literals in lexer and parser

### DIFF
--- a/docs/language-reference.rst
+++ b/docs/language-reference.rst
@@ -56,6 +56,10 @@ and decimal literals are of type ``f64``.  Hexadecimal literals are
 supported by prefixing with ``0x``, and binary literals by prefixing
 with ``0b``.
 
+Floats can also be written in hexadecimal format such as ``0x1.fp3``,
+instead of the usual decimal notation. Here, ``0x1.f`` evaluates to
+``1 15/16`` and the ``p3`` multiplies it by ``2^3 = 8``.
+
 .. productionlist::
    intnumber: (`decimal` | `hexadecimal` | `binary`) [`int_type`]
    decimal: `decdigit` (`decdigit` |"_")*
@@ -66,8 +70,11 @@ with ``0b``.
    floatnumber: (`pointfloat` | `exponentfloat`) [`float_type`]
    pointfloat: [`intpart`] `fraction`
    exponentfloat: (`intpart` | `pointfloat`) `exponent`
+   hexadecimalfloat: 0 ("x" | "X") `hexintpart` `hexfraction` ("p"|"P") ["+" | "-"] `decdigit`+
    intpart: `decdigit` (`decdigit` |"_")*
    fraction: "." `decdigit` (`decdigit` |"_")*
+   hexintpart: `hexdigit` (`hexdigit` | "_")*
+   hexfraction: "." `hexdigit` (`hexdigit` |"_")*
    exponent: ("e" | "E") ["+" | "-"] `decdigit`+
 
 .. productionlist::

--- a/src/Language/Futhark/Parser/Parser.y
+++ b/src/Language/Futhark/Parser/Parser.y
@@ -90,6 +90,7 @@ import Language.Futhark.Parser.Lexer
       u32lit          { L _ (U32LIT _) }
       u64lit          { L _ (U64LIT _) }
       reallit         { L _ (REALLIT _) }
+      hexreallit      { L _ (REALLIT _) }
       f32lit          { L _ (F32LIT _) }
       f64lit          { L _ (F64LIT _) }
       stringlit       { L _ (STRINGLIT _) }
@@ -803,6 +804,7 @@ FloatLit :: { (FloatValue, SrcLoc) }
          : f32lit { let L pos (F32LIT num) = $1 in (Float32Value num, pos) }
          | f64lit { let L pos (F64LIT num) = $1 in (Float64Value num, pos) }
          | reallit {% let L pos (REALLIT num) = $1 in do num' <- getRealValue num; return (num', pos) }
+         | hexreallit {% let L pos (REALLIT num) = $1 in do num' <- getRealValue num; return (num', pos)}
 
 PrimLit :: { (PrimValue, SrcLoc) }
         : SignedLit { let (x,loc) = $1 in (SignedValue x, loc) }

--- a/tests/hexfloats.fut
+++ b/tests/hexfloats.fut
@@ -1,0 +1,11 @@
+-- Futhark supports hexadecimal float literals
+-- ==
+-- input {}
+-- output {
+-- [31.875f64, 31.875f64, 17.996094f64, 3.984375f64, -17.996094f64]
+-- [31.875f32, 17.996094f32, 3.984375f32, -17.996094f32, 0.9375f32]
+-- }
+
+let main (): ([]f64, []f32) =
+    ([0xf.fp1, 0xf.fp1f64, 0x11.ffp0f64, 0xf.fp-2f64, -0x11.ffp0f64],
+    [0xf.fp1f32, 0x11.ffp0f32, 0xf.fp-2f32, -0x11.ffp0f32, 0x0.f0p0f32])


### PR DESCRIPTION
See: https://github.com/diku-dk/futhark/issues/382

This does not include changes for Python and C readers.