### PR TITLE
Use higher-order functions instead of modules for segmented_scan.

### DIFF
--- a/futlib/segmented.fut
+++ b/futlib/segmented.fut
@@ -1,15 +1,13 @@
--- Segmented operations using parametric modules.
+-- | Segmented operations.
 
-import "/futlib/monoid"
-
-module segmented_scan(M: monoid): {
-  val segmented_scan: []bool -> []M.t -> []M.t
-} = {
-  let segmented_scan [n] (flags: [n]bool) (as: [n]M.t): []M.t =
-    (unzip (scan (\(x_flag,x) (y_flag,y) ->
-                  if y_flag
-                  then (x_flag || y_flag, y)
-                  else (x_flag || y_flag, M.op x y))
-            (false, M.ne)
-            (zip flags as))).2
-}
+-- | Segmented scan. Given a binary associative operator ``op`` with
+-- neutral element ``ne``, compute the inclusive prefix scan of the
+-- segments of ``as`` specified by the ``flags`` array, where `true`
+-- starts a segment and `false` continues a segment.
+let segmented_scan [n] 't (op: t -> t -> t) (ne: t)
+                          (flags: [n]bool) (as: [n]t): [n]t =
+  (unzip (scan (\(x_flag,x) (y_flag,y) ->
+                (x_flag || y_flag,
+                 if y_flag then y else x `op` y))
+          (false, ne)
+          (zip flags as))).2

--- a/tests/futlib_tests/segmented.fut
+++ b/tests/futlib_tests/segmented.fut
@@ -1,4 +1,3 @@
-import "/futlib/monoid"
 import "/futlib/segmented"
 
 -- ==
@@ -6,13 +5,5 @@ import "/futlib/segmented"
 -- input { [true,false,false,true,false,false,true,false,false,false] [1,2,3,4,5,6,7,8,9,10] }
 -- output { [1,3,6,4,9,15,7,15,24,34] }
 
-module i32plus = {
-  type t = i32
-  let ne = 0
-  let op (x: i32) (y: i32) = x + y
-}
-
-module segprefixsum = segmented_scan(i32plus)
-
 entry test_segmented_scan (flags: []bool) (as: []i32) =
-  segprefixsum.segmented_scan flags as
+  segmented_scan (+) 0 flags as


### PR DESCRIPTION
The `accelerate/pagerank` benchmark needs to be modified as well.