### PR TITLE
Support for gzipped files for futhark-bench/futhark-test  

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -49,6 +49,7 @@ dependencies:
   - extra
   - process
   - markdown
+  - zlib
 
 when:
 - condition: "!impl(ghc >= 8.0)"


### PR DESCRIPTION
A first attempt at implementing #416 . I wasn't sure if I should add any tests for the issue (esp. since futhark-benchmarks is a separate repo) so I've left it as-is. 

The change simply decompresses any input files that end in ".gz". 