### PR TITLE
Genreduce fusion

### DIFF
--- a/futlib/soacs.fut
+++ b/futlib/soacs.fut
@@ -232,6 +232,6 @@ let scatter 't [m] [n] (dest: *[m]t) (is: [n]i32) (vs: [n]t): *[m]t =
 
 -- | The `gen_reduce dest f ne g as` expression computes the same as `scatter`,
 -- but in the case where we have duplicate values in the index array it produces
--- a deterministc result by applying the combining operator `f`.
-let gen_reduce 'a 'b [m] [n] (dest : *[m]a) (f : a -> a -> a) (ne : a) (g : b -> (i32, a)) (as : [n]b) : *[m]a =
-  intrinsics.gen_reduce (dest, f, ne, g, as)
+-- a deterministic result by applying the combining operator `f`.
+let gen_reduce 'a 'b [m] [n] (dest : *[m]a) (f : a -> a -> a) (ne : a) (is : [n]i32) (as : [n]b) : *[m]a =
+  intrinsics.gen_reduce (dest, f, ne, is, as)

--- a/src/Futhark/Internalise/Monomorphise.hs
+++ b/src/Futhark/Internalise/Monomorphise.hs
@@ -242,9 +242,9 @@ transformExp (Apply e1 e2 d tp loc) =
           transformExp $ Stream (MapLike InOrder) f arr loc
       | intrinsic "stream_map_per" v ->
           transformExp $ Stream (MapLike Disorder) f arr loc
-    (Var v _ _, TupLit [dest, op, ne, bfun, img] _)
+    (Var v _ _, TupLit [dest, op, ne, buckets, img] _)
       | intrinsic "gen_reduce" v ->
-          transformExp $ GenReduce dest op ne bfun img loc
+          transformExp $ GenReduce dest op ne buckets img loc
 
     _ -> do
       e1' <- transformExp e1
@@ -346,12 +346,12 @@ transformExp (Stream form e1 e2 loc) = do
              RedLike so comm e -> RedLike so comm <$> transformExp e
   Stream form' <$> transformExp e1 <*> transformExp e2 <*> pure loc
 
-transformExp (GenReduce e1 e2 e3 e4 e5 loc) = do
+transformExp (GenReduce e1 e2 e3 e4 e5 loc) =
   GenReduce
     <$> transformExp e1 -- hist
     <*> transformExp e2 -- operator
     <*> transformExp e3 -- neutral element
-    <*> transformExp e4 -- bucket function
+    <*> transformExp e4 -- buckets
     <*> transformExp e5 -- input image
     <*> pure loc
 

--- a/src/Language/Futhark/Attributes.hs
+++ b/src/Language/Futhark/Attributes.hs
@@ -745,9 +745,10 @@ intrinsics = M.fromList $ zipWith namify [10..] $
                              [uarr_a,
                               t_a `arr` (t_a `arr` t_a),
                               t_a,
-                              t_b `arr` (tupleRecord [Prim $ Signed Int32, t_a]),
+                              Array (ArrayPrimElem (Signed Int32) ()) (rank 1) Nonunique,
                               arr_b]
                              uarr_a),
+
               ("zip", IntrinsicPolyFun [tp_a, tp_b] [arr_a, arr_b] arr_a_b),
               ("unzip", IntrinsicPolyFun [tp_a, tp_b] [arr_a_b] t_arr_a_arr_b),
 

--- a/src/Language/Futhark/Syntax.hs
+++ b/src/Language/Futhark/Syntax.hs
@@ -649,7 +649,7 @@ data ExpBase f vn =
 
             | GenReduce (ExpBase f vn) (ExpBase f vn) (ExpBase f vn)
                         (ExpBase f vn) (ExpBase f vn) SrcLoc
-             -- ^ @gen_reduce [1,1,1] (+) 0 (\x -> (x, x)) [1,1,1] = [4,1,1]@
+             -- ^ @gen_reduce [1,1,1] (+) 0 [1,1,1] [1,1,1] = [4,1,1]@
 
             | Scan (ExpBase f vn) (ExpBase f vn) (ExpBase f vn) SrcLoc
              -- ^ @scan (+) 0 ([ 1, 2, 3 ]) = [ 1, 3, 6 ]@.

--- a/tests/genred/array.fut
+++ b/tests/genred/array.fut
@@ -5,4 +5,4 @@
 -- output {}
 
 let main [m][n] (xs : *[n][m]i32) (image : *[]i32) : *[n][m]i32 =
-  gen_reduce xs (\x y -> map2 (+) x y) [1,1,1] (\x -> (x, [1,2,3])) image
+  gen_reduce xs (\x y -> map2 (+) x y) [1,1,1] image (replicate (length image) [1,2,3])

--- a/tests/genred/equiv.fut
+++ b/tests/genred/equiv.fut
@@ -10,7 +10,7 @@ let hist_equiv [m][n] (xs : [n][m]i32) (image : []i32) : [n][m]i32 =
   let (inds, vals) = unzip (map (\x -> (x, [1,2,3])) image)
   let vals' = transpose vals
   let xs' = transpose xs
-  let res = map2 (\row x -> gen_reduce (copy x) (+) 1 (\i -> (inds[i], row[i])) (iota m)) vals' xs'
+  let res = map2 (\row x -> gen_reduce (copy x) (+) 1 inds row) vals' xs'
   in transpose res
 
 let oned_equal [m] (xs : [m]i32) (ys : [m]i32) : bool =
@@ -18,5 +18,5 @@ let oned_equal [m] (xs : [m]i32) (ys : [m]i32) : bool =
 
 let main [m][n] (xs : [n][m]i32) (image : []i32) : bool = -- : *[n][m]i32 =
   let res2 = hist_equiv (copy xs) image
-  let res1 = gen_reduce (copy xs) (\x y -> map2 (+) x y) [1,1,1] (\x -> (x, [1,2,3])) image
+  let res1 = gen_reduce (copy xs) (\x y -> map2 (+) x y) [1,1,1] image (replicate (length image) [1,2,3])
   in reduce (&&) true (map2 oned_equal res1 res2)

--- a/tests/genred/simple.fut
+++ b/tests/genred/simple.fut
@@ -26,4 +26,4 @@
 -- }
 
 let main [m][n] (hist : *[n]i32, image : [m]i32) : [n]i32 =
-  gen_reduce hist (+) 0 (\x -> (x, x)) image
+  gen_reduce hist (+) 0 image image

--- a/tests/genred/tuple.fut
+++ b/tests/genred/tuple.fut
@@ -11,4 +11,5 @@ let operator ((x0, y0) : (i32, i32)) ((x1, y1) : (i32, i32)) : (i32, i32) =
   (x0 + x1, y0 + y1)
 
 let main [m][n] (xs : *[m](i32, i32)) (image : [n]i32) : [m](i32, i32) =
-  gen_reduce xs operator (1,1) bucket_function image
+  let (is, vs) = unzip (map bucket_function image)
+  in gen_reduce xs operator (1,1) is vs


### PR DESCRIPTION
This implements simple producer-consumer map-genreduce fusion.

It also slightly changes the source language `gen_reduce` to no longer accept a bucket function, but a bucket array.