### PR TITLE
Add recognition of binary operators

### DIFF
--- a/src/Futhark/CodeGen/ImpGen/Kernels/ToOpenCL.hs
+++ b/src/Futhark/CodeGen/ImpGen/Kernels/ToOpenCL.hs
@@ -322,19 +322,19 @@ inKernelOperations = GenericC.Operations
           GenericC.stm [C.cstm|mem_fence(CLK_GLOBAL_MEM_FENCE);|]
         kernelOps (Atomic aop) = atomicOps aop
 
-        atomicOps (AtomicAdd old val ind x) = do
+        atomicOps (AtomicAdd old arr ind val) = do
           ind' <- GenericC.compileExp $ innerExp ind
-          x' <- GenericC.compileExp x
-          GenericC.stm [C.cstm|$id:old = atomic_add(&$id:val[$exp:ind' * 4], $exp:x');|]
-        atomicOps (AtomicCmpXchg old val ind x y) = do
+          val' <- GenericC.compileExp val
+          GenericC.stm [C.cstm|$id:old = atomic_add((volatile __global int *)&$id:arr[$exp:ind' * 4], $exp:val');|]
+        atomicOps (AtomicCmpXchg old arr ind cmp val) = do
           ind' <- GenericC.compileExp $ innerExp ind
-          x' <- GenericC.compileExp x
-          y' <- GenericC.compileExp y
-          GenericC.stm [C.cstm|$id:old = atomic_cmpxchg(&$id:val[$exp:ind' * 4], $exp:x', $exp:y');|]
-        atomicOps (AtomicXchg old val ind x) = do
+          cmp' <- GenericC.compileExp cmp
+          val' <- GenericC.compileExp val
+          GenericC.stm [C.cstm|$id:old = atomic_cmpxchg((volatile __global int *)&$id:arr[$exp:ind' * 4], $exp:cmp', $exp:val');|]
+        atomicOps (AtomicXchg old arr ind val) = do
           ind' <- GenericC.compileExp $ innerExp ind
-          x' <- GenericC.compileExp x
-          GenericC.stm [C.cstm|$id:old = atomic_xchg((volatile __global int *)&$id:val[$exp:ind' * 4], $exp:x');|]
+          val' <- GenericC.compileExp val
+          GenericC.stm [C.cstm|$id:old = atomic_xchg((volatile __global int *)&$id:arr[$exp:ind' * 4], $exp:val');|]
 
         cannotAllocate :: GenericC.Allocate KernelOp UsedFunctions
         cannotAllocate _ =


### PR DESCRIPTION
This allows utilizing a handful of atomic implementations when
generating code for GenReduce.