### PR TITLE
Implement cooperation level for GenReduce

### DIFF
--- a/src/Futhark/Pass/ExplicitAllocations.hs
+++ b/src/Futhark/Pass/ExplicitAllocations.hs
@@ -570,7 +570,7 @@ handleKernel (Kernel desc space kernel_ts kbody) = subAllocM handleKernelExp Tru
           let (x_params, y_params) = splitAt (length vs) $ lambdaParams op
               sliceDest dest = do
                 dest_t <- lookupType dest
-                sliceInfo dest $ fullSlice dest_t [DimFix bucket]
+                sliceInfo dest $ fullSlice dest_t $ map DimFix bucket
           x_params' <- zipWith Param (map paramName x_params) <$>
                        mapM sliceDest dests
           y_params' <- zipWith Param (map paramName y_params) <$>


### PR DESCRIPTION
The previous implementation would let all threads write to the same histogram in global memory. This solution lets threads cooperate on subhistograms (still in global memory) before summing them all up into the final histogram.