### PR TITLE
Adds error accumulation to futhark-test, addresses issues #630/#421, improves futhark-test output.

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -59,6 +59,7 @@ dependencies:
   - free >= 4.12.4
   - zip-archive >= 0.3.1.1
   - time >= 1.6.0.1
+  - ansi-terminal >= 0.6.3.1
 
 when:
 - condition: "!impl(ghc >= 8.0)"

--- a/src/Futhark/Test.hs
+++ b/src/Futhark/Test.hs
@@ -110,6 +110,7 @@ data TestRun = TestRun
                { runTags :: [String]
                , runInput :: Values
                , runExpectedResult :: ExpectedResult Values
+               , runIndex :: Int
                , runDescription :: String
                }
              deriving (Show)
@@ -184,7 +185,7 @@ parseRunCases = parseRunCases' (0::Int)
           tags <- parseRunTags
           input <- parseInput
           expr <- parseExpectedResult
-          return $ TestRun tags input expr $ desc i input
+          return $ TestRun tags input expr i $ desc i input
 
         -- If the file is gzipped, we strip the 'gz' extension from
         -- the dataset name.  This makes it more convenient to rename

--- a/src/Futhark/Test/Values.hs
+++ b/src/Futhark/Test/Values.hs
@@ -467,14 +467,15 @@ explainMismatch i what got expected =
 
 -- | Compare two sets of Futhark values for equality.  Shapes and
 -- types must also match.
-compareValues :: [Value] -> [Value] -> Maybe Mismatch
+compareValues :: [Value] -> [Value] -> Maybe [Mismatch]
 compareValues got expected
-  | n /= m = Just $ ValueCountMismatch n m
+  | n /= m = Just [ValueCountMismatch n m]
   | otherwise = case catMaybes $ zipWith3 compareValue [0..] got expected of
-    e : _ -> Just e
-    []    -> Nothing
+    [] -> Nothing
+    es -> Just es
   where n = length got
         m = length expected
+
 
 compareValue :: Int -> Value -> Value -> Maybe Mismatch
 compareValue i got_v expected_v

--- a/src/Futhark/Util/Table.hs
+++ b/src/Futhark/Util/Table.hs
@@ -1,0 +1,53 @@
+-- | Basic table building for prettier futhark-test output.
+module Futhark.Util.Table
+     ( buildTable
+     , mkEntry
+     , Entry
+     ) where
+
+import Data.List
+import System.Console.ANSI
+
+data RowTemplate = RowTemplate [Int] Int deriving (Show)
+
+-- | A table entry. Consists of the content as well a list of
+-- SGR commands to color/stylelize the entry.
+type Entry = (String, [SGR])
+
+-- | Makes a table entry with the default SGR mode.
+mkEntry :: String -> (String, [SGR])
+mkEntry s = (s, [])
+
+color :: [SGR] -> String -> String
+color sgr s = setSGRCode sgr ++ s ++ setSGRCode [Reset]
+
+buildRowTemplate :: [[Entry]] -> Int -> RowTemplate
+
+buildRowTemplate rows = RowTemplate widths
+  where widths = map (maximum . map (length . fst)) . transpose $ rows
+
+buildRow :: RowTemplate -> [Entry] -> String
+buildRow (RowTemplate widths pad) entries = cells ++ "\n"
+  where bar   = "\x2502"
+        cells = concatMap buildCell (zip entries widths) ++ bar
+        buildCell ((entry, sgr), width) =
+          let padding = width - length entry + pad
+          in  bar ++ " " ++ color sgr entry ++ replicate padding ' '
+
+buildSep :: Char -> Char -> Char -> RowTemplate -> String
+buildSep lCorner rCorner sep (RowTemplate widths pad) =
+  corners . concatMap cellFloor $ widths
+  where cellFloor width = replicate (width + pad + 1) '\x2500' ++ [sep]
+        corners [] = ""
+        corners s  = [lCorner] ++ init s ++ [rCorner]
+
+-- | Builds a table from a list of entries and a padding amount that
+-- determines padding from the right side of the widest entry in each column.
+buildTable :: [[Entry]] -> Int -> String
+buildTable rows pad = buildTop template ++ sepRows ++ buildBottom template
+  where sepRows       = intercalate (buildFloor template) builtRows
+        builtRows     = map (buildRow template) rows
+        template      = buildRowTemplate rows pad
+        buildTop rt   = buildSep '\x250C' '\x2510' '\x252C' rt ++ "\n"
+        buildFloor rt = buildSep '\x251C' '\x2524' '\x253C' rt ++ "\n"
+        buildBottom   = buildSep '\x2514' '\x2518' '\x2534'

--- a/src/futhark-bench.hs
+++ b/src/futhark-bench.hs
@@ -174,12 +174,12 @@ io = liftIO
 
 runBenchmarkCase :: BenchOptions -> FilePath -> T.Text -> Int -> TestRun
                  -> IO (Maybe DataResult)
-runBenchmarkCase _ _ _ _ (TestRun _ _ RunTimeFailure{} _) =
+runBenchmarkCase _ _ _ _ (TestRun _ _ RunTimeFailure{} _ _) =
   return Nothing -- Not our concern, we are not a testing tool.
-runBenchmarkCase opts _ _ _ (TestRun tags _ _ _)
+runBenchmarkCase opts _ _ _ (TestRun tags _ _ _ _)
   | any (`elem` tags) $ optExcludeCase opts =
       return Nothing
-runBenchmarkCase opts program entry pad_to (TestRun _ input_spec (Succeeds expected_spec) dataset_desc) =
+runBenchmarkCase opts program entry pad_to (TestRun _ input_spec (Succeeds expected_spec) _ dataset_desc) =
   -- We store the runtime in a temporary file.
   withSystemTempFile "futhark-bench" $ \tmpfile h -> do
   hClose h -- We will be writing and reading this ourselves.


### PR DESCRIPTION
Changes:

- Adds error accumulation. `futhark-test` will now report all errors for a program, with some limitations (which can be easily changed as desired): Structure tests, warning tests, compile tests, compiled tests, and interpreted tests do not mutually accumulate. For example, if there is an error when running a compiled test, futhark-test will not run any interpreted tests for that program. This can be modified by placing an `accErrors_` call in the relevant place but I thought this was the most reasonable implementation.

- Adds (basic) table building and uses it to format the output of `futhark-test` more clearly.

- Adds a (tiny) bit of color to the output of `futhark-test` :) 

- Because `futhark-test` now allows for multiple failures when testing a program, `<test>.fut.actual` and `<test>.fut.expected` test output files were changed to `<test>.fut.<entry>.<index>.actual` and `<test>.fut.<entry>.<index>.expected`, respectively.

- Changes "files" to "programs" and calls the individual tested components of programs a "run" (e.g., a single input-output case or warning test). 

- Now reports the total number of runs run, the failed number of runs, and the passed number of runs.