### PR TITLE
[WIP] Improve the pretty printer formatting for higher dimensional arrays

### DIFF
--- a/src/Language/Futhark/Interpreter.hs
+++ b/src/Language/Futhark/Interpreter.hs
@@ -104,8 +104,15 @@ prettyRecord m
       where field (k, v) = ppr k <+> equals <+> ppr v
 
 instance Pretty Value where
-  ppr (ValuePrim v) = ppr v
-  ppr (ValueArray a) = brackets $ commasep $ map ppr $ elems a
+  ppr (ValuePrim v)  = ppr v
+  ppr (ValueArray a) =
+    let elements  = elems a -- [Value]
+        (x:_)     = elements
+        separator = case x of
+                      (ValueArray _) -> comma <> line
+                      _              -> comma <> space
+     in brackets $ cat $ punctuate separator (map ppr elements)
+
   ppr (ValueRecord m) = prettyRecord m
   ppr ValueFun{} = text "#<fun>"
 


### PR DESCRIPTION
Attempt to fix https://github.com/diku-dk/futhark/issues/637

The pretty printer after this commit:

```
replicate 10 (replicate 10 0)
[[0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32]
 , [0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32]
 , [0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32]
 , [0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32]
 , [0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32]
 , [0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32]
 , [0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32]
 , [0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32]
 , [0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32]
 , [0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32]
 ]
```
And for cases when the total columns exceeds 80 characters

```
[[0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32]
 , [0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32,
    0i32]
 , [0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32,
    0i32]
 , [0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32,
    0i32]
 , [0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32,
    0i32]
 , [0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32,
    0i32]
 , [0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32,
    0i32]
 , [0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32,
    0i32]
 , [0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32,
    0i32]
 , [0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32,
    0i32]
 , [0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32,
    0i32]
 , [0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32,
    0i32]
 , [0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32,
    0i32]
 ]
```

I played around with some of the other combinators of `mainland-pretty` but in most other cases the indentation gets spoiled. This could serve as a stopgap solution to the existing formatting. Another option could be to `flatten` the entire representation. This looks better to me. It works fairly well for higher dimensional arrays:

```
[9]> replicate 5 (replicate 5 (replicate 5 0))
[[[0i32, 0i32, 0i32, 0i32, 0i32]
  , [0i32, 0i32, 0i32, 0i32, 0i32]
  , [0i32, 0i32, 0i32, 0i32, 0i32]
  , [0i32, 0i32, 0i32, 0i32, 0i32]
  , [0i32, 0i32, 0i32, 0i32, 0i32]
  ]
 , [[0i32, 0i32, 0i32, 0i32, 0i32]
    , [0i32, 0i32, 0i32, 0i32, 0i32]
    , [0i32, 0i32, 0i32, 0i32, 0i32]
    , [0i32, 0i32, 0i32, 0i32, 0i32]
    , [0i32, 0i32, 0i32, 0i32, 0i32]
    ]
 , [[0i32, 0i32, 0i32, 0i32, 0i32]
    , [0i32, 0i32, 0i32, 0i32, 0i32]
    , [0i32, 0i32, 0i32, 0i32, 0i32]
    , [0i32, 0i32, 0i32, 0i32, 0i32]
    , [0i32, 0i32, 0i32, 0i32, 0i32]
    ]
 , [[0i32, 0i32, 0i32, 0i32, 0i32]
    , [0i32, 0i32, 0i32, 0i32, 0i32]
    , [0i32, 0i32, 0i32, 0i32, 0i32]
    , [0i32, 0i32, 0i32, 0i32, 0i32]
    , [0i32, 0i32, 0i32, 0i32, 0i32]
    ]
 , [[0i32, 0i32, 0i32, 0i32, 0i32]
    , [0i32, 0i32, 0i32, 0i32, 0i32]
    , [0i32, 0i32, 0i32, 0i32, 0i32]
    , [0i32, 0i32, 0i32, 0i32, 0i32]
    , [0i32, 0i32, 0i32, 0i32, 0i32]
    ]
 ]
```

In other array libraries from other languages like NumPy, the pretty printers are highly configurable: https://docs.scipy.org/doc/numpy/reference/generated/numpy.set_printoptions.html which could serve as an inspiration.