### PR TITLE
Add itob/btoi intrinsics for bool/integer conversions.

### DIFF
--- a/examples/rosettacode/life.fut
+++ b/examples/rosettacode/life.fut
@@ -35,8 +35,8 @@
 --    [1, 0, 0, 0, 0]]
 --   }
 
-let bint(b: bool): i32 = if b then 1 else 0
-let intb(x: i32): bool = if x == 0 then false else true
+let bint: bool -> i32 = i32.bool
+let intb : i32 -> bool = bool.i32
 
 let to_bool_board(board: [][]i32): [][]bool =
   map (\(r: []i32): []bool  -> map intb r) board
@@ -45,7 +45,6 @@ let to_int_board(board: [][]bool): [][]i32 =
   map (\(r: []bool): []i32  -> map bint r) board
 
 let all_neighbours [n][m] (world: [n][m]bool): [n][m]i32 =
-    let world = map (map bint) world
     let ns  = map (rotate (-1)) world
     let ss  = map (rotate   1)  world
     let ws  = rotate      (-1)  world
@@ -55,7 +54,10 @@ let all_neighbours [n][m] (world: [n][m]bool): [n][m]i32 =
     let sws = map (rotate   1)  ws
     let ses = map (rotate   1)  es
     in map3 (\(nws_r, ns_r, nes_r) (ws_r, world_r, es_r) (sws_r, ss_r, ses_r) ->
-             map3 (\(nw,n,ne) (w,_,e) (sw,s,se) -> nw + n + ne + w + e + sw + s + se)
+             map3 (\(nw,n,ne) (w,_,e) (sw,s,se) ->
+                   bint nw + bint n + bint ne +
+                   bint w + bint e +
+                   bint sw + bint s + bint se)
              (zip3 nws_r ns_r nes_r) (zip3 ws_r world_r es_r) (zip3 sws_r ss_r ses_r))
             (zip3 nws ns nes) (zip3 ws world es) (zip3 sws ss ses)
 

--- a/futlib/math.fut
+++ b/futlib/math.fut
@@ -172,15 +172,15 @@ module type float = {
 module bool: from_prim with t = bool = {
   type t = bool
 
-  let i8  (x: i8)  = x != 0i8
-  let i16 (x: i16) = x != 0i16
-  let i32 (x: i32) = x != 0i32
-  let i64 (x: i64) = x != 0i64
+  let i8  = intrinsics.itob_i8_bool
+  let i16 = intrinsics.itob_i16_bool
+  let i32 = intrinsics.itob_i32_bool
+  let i64 = intrinsics.itob_i64_bool
 
-  let u8  (x: u8)  = x != 0u8
-  let u16 (x: u16) = x != 0u16
-  let u32 (x: u32) = x != 0u32
-  let u64 (x: u64) = x != 0u64
+  let u8  (x: u8)  = intrinsics.itob_i8_bool (intrinsics.sign_i8 x)
+  let u16 (x: u16) = intrinsics.itob_i16_bool (intrinsics.sign_i16 x)
+  let u32 (x: u32) = intrinsics.itob_i32_bool (intrinsics.sign_i32 x)
+  let u64 (x: u64) = intrinsics.itob_i64_bool (intrinsics.sign_i64 x)
 
   let f32 (x: f32) = x != 0f32
   let f64 (x: f64) = x != 0f64
@@ -222,7 +222,7 @@ module i8: (size with t = i8) = {
   let f32 (x: f32) = intrinsics.fptosi_f32_i8 x
   let f64 (x: f64) = intrinsics.fptosi_f64_i8 x
 
-  let bool (x: bool) = if x then 1i8 else 0i8
+  let bool = intrinsics.btoi_bool_i8
 
   let to_i32(x: i8) = intrinsics.sext_i8_i32 x
   let to_i64(x: i8) = intrinsics.sext_i8_i64 x
@@ -292,7 +292,7 @@ module i16: (size with t = i16) = {
   let f32 (x: f32) = intrinsics.fptosi_f32_i16 x
   let f64 (x: f64) = intrinsics.fptosi_f64_i16 x
 
-  let bool (x: bool) = if x then 1i16 else 0i16
+  let bool = intrinsics.btoi_bool_i16
 
   let to_i32(x: i16) = intrinsics.sext_i16_i32 x
   let to_i64(x: i16) = intrinsics.sext_i16_i64 x
@@ -365,7 +365,7 @@ module i32: (size with t = i32) = {
   let f32 (x: f32) = intrinsics.fptosi_f32_i32 x
   let f64 (x: f64) = intrinsics.fptosi_f64_i32 x
 
-  let bool (x: bool) = if x then 1i32 else 0i32
+  let bool = intrinsics.btoi_bool_i32
 
   let to_i32(x: i32) = intrinsics.sext_i32_i32 x
   let to_i64(x: i32) = intrinsics.sext_i32_i64 x
@@ -438,7 +438,7 @@ module i64: (size with t = i64) = {
   let f32 (x: f32) = intrinsics.fptosi_f32_i64 x
   let f64 (x: f64) = intrinsics.fptosi_f64_i64 x
 
-  let bool (x: bool) = if x then 1i64 else 0i64
+  let bool = intrinsics.btoi_bool_i64
 
   let to_i32(x: i64) = intrinsics.sext_i64_i32 x
   let to_i64(x: i64) = intrinsics.sext_i64_i64 x
@@ -511,7 +511,7 @@ module u8: (size with t = u8) = {
   let f32 (x: f32) = unsign (intrinsics.fptoui_f32_i8 x)
   let f64 (x: f64) = unsign (intrinsics.fptoui_f64_i8 x)
 
-  let bool (x: bool) = if x then 1u8 else 0u8
+  let bool x = unsign (intrinsics.btoi_bool_i8 x)
 
   let to_i32(x: u8) = intrinsics.zext_i8_i32 (sign x)
   let to_i64(x: u8) = intrinsics.zext_i8_i64 (sign x)
@@ -584,7 +584,7 @@ module u16: (size with t = u16) = {
   let f32 (x: f32) = unsign (intrinsics.fptoui_f32_i16 x)
   let f64 (x: f64) = unsign (intrinsics.fptoui_f64_i16 x)
 
-  let bool (x: bool) = if x then 1u16 else 0u16
+  let bool x = unsign (intrinsics.btoi_bool_i16 x)
 
   let to_i32(x: u16) = intrinsics.zext_i16_i32 (sign x)
   let to_i64(x: u16) = intrinsics.zext_i16_i64 (sign x)
@@ -657,7 +657,7 @@ module u32: (size with t = u32) = {
   let f32 (x: f32) = unsign (intrinsics.fptoui_f32_i32 x)
   let f64 (x: f64) = unsign (intrinsics.fptoui_f64_i32 x)
 
-  let bool (x: bool) = if x then 1u32 else 0u32
+  let bool x = unsign (intrinsics.btoi_bool_i32 x)
 
   let to_i32(x: u32) = intrinsics.zext_i32_i32 (sign x)
   let to_i64(x: u32) = intrinsics.zext_i32_i64 (sign x)
@@ -730,7 +730,7 @@ module u64: (size with t = u64) = {
   let f32 (x: f32) = unsign (intrinsics.fptoui_f32_i64 x)
   let f64 (x: f64) = unsign (intrinsics.fptoui_f64_i64 x)
 
-  let bool (x: bool) = if x then 1u64 else 0u64
+  let bool x = unsign (intrinsics.btoi_bool_i64 x)
 
   let to_i32(x: u64) = intrinsics.zext_i64_i32 (sign x)
   let to_i64(x: u64) = intrinsics.zext_i64_i64 (sign x)

--- a/rts/csharp/scalar.cs
+++ b/rts/csharp/scalar.cs
@@ -186,6 +186,16 @@ private static short sext_i64_i16(long x){return (short) (x);}
 private static int sext_i64_i32(long x){return (int) (x);}
 private static long sext_i64_i64(long x){return (long) (x);}
 
+private static sbyte btoi_bool_i8 (bool x){return (sbyte) (Convert.ToInt32(x));}
+private static short btoi_bool_i16(bool x){return (short) (Convert.ToInt32(x));}
+private static int   btoi_bool_i32(bool x){return (int)   (Convert.ToInt32(x));}
+private static long  btoi_bool_i64(bool x){return (long)  (Convert.ToInt32(x));}
+
+private static bool itob_i8_bool (sbyte x){return x != 0;}
+private static bool itob_i16_bool(short x){return x != 0;}
+private static bool itob_i32_bool(int x)  {return x != 0;}
+private static bool itob_i64_bool(long x) {return x != 0;}
+
 private static sbyte zext_i8_i8(sbyte x)   {return (sbyte) ((byte)(x));}
 private static short zext_i8_i16(sbyte x)  {return (short)((byte)(x));}
 private static int   zext_i8_i32(sbyte x)  {return (int)((byte)(x));}

--- a/rts/python/scalar.py
+++ b/rts/python/scalar.py
@@ -107,6 +107,21 @@ def sext_T_i32(x):
 def sext_T_i64(x):
   return np.int64(x)
 
+def itob_T_bool(x):
+  return np.bool(x)
+
+def btoi_bool_i8(x):
+  return np.int8(x)
+
+def btoi_bool_i16(x):
+  return np.int8(x)
+
+def btoi_bool_i32(x):
+  return np.int8(x)
+
+def btoi_bool_i64(x):
+  return np.int8(x)
+
 def zext_i8_i8(x):
   return np.int8(np.uint8(x))
 
@@ -179,6 +194,7 @@ sext_i8_i8 = sext_i16_i8 = sext_i32_i8 = sext_i64_i8 = sext_T_i8
 sext_i8_i16 = sext_i16_i16 = sext_i32_i16 = sext_i64_i16 = sext_T_i16
 sext_i8_i32 = sext_i16_i32 = sext_i32_i32 = sext_i64_i32 = sext_T_i32
 sext_i8_i64 = sext_i16_i64 = sext_i32_i64 = sext_i64_i64 = sext_T_i64
+itob_i8_bool = itob_i16_bool = itob_i32_bool = itob_i64_bool = itob_T_bool
 
 def ssignum(x):
   return np.sign(x)

--- a/src/Futhark/CodeGen/Backends/SimpleRepresentation.hs
+++ b/src/Futhark/CodeGen/Backends/SimpleRepresentation.hs
@@ -108,7 +108,8 @@ cIntOps = concatMap (`map` [minBound..maxBound]) ops
                mkShl, mkLShr, mkAShr,
                mkAnd, mkOr, mkXor,
                mkUlt, mkUle,  mkSlt, mkSle,
-               mkPow
+               mkPow,
+               mkIToB, mkBToI
               ] ++
               map mkSExt [minBound..maxBound] ++
               map mkZExt [minBound..maxBound]
@@ -184,6 +185,20 @@ cIntOps = concatMap (`map` [minBound..maxBound]) ops
           where name = "zext_"++pretty from_t++"_"++pretty to_t
                 from_ct = uintTypeToCType from_t
                 to_ct = uintTypeToCType to_t
+
+        mkBToI to_t =
+          [C.cedecl|static inline $ty:to_ct
+                    $id:name($ty:from_ct x) { return x; } |]
+          where name = "btoi_bool_"++pretty to_t
+                from_ct = primTypeToCType Bool
+                to_ct = intTypeToCType to_t
+
+        mkIToB from_t =
+          [C.cedecl|static inline $ty:to_ct
+                    $id:name($ty:from_ct x) { return x; } |]
+          where name = "itob_"++pretty from_t++"_bool"
+                to_ct = primTypeToCType Bool
+                from_ct = intTypeToCType from_t
 
         simpleUintOp s e t =
           [C.cedecl|static inline $ty:ct $id:(taggedI s t)($ty:ct x, $ty:ct y) { return $exp:e; }|]

--- a/src/Futhark/Representation/Primitive.hs
+++ b/src/Futhark/Representation/Primitive.hs
@@ -371,6 +371,12 @@ data ConvOp = ZExt IntType IntType
               -- ^ Convert an unsigned integer to a floating-point value.
             | SIToFP IntType FloatType
               -- ^ Convert a signed integer to a floating-point value.
+            | IToB IntType
+              -- ^ Convert an integer to a boolean value.  Zero
+              -- becomes false; anything else is true.
+            | BToI IntType
+              -- ^ Convert a boolean to an integer.  True is converted
+              -- to 1 and False to 0.
              deriving (Eq, Ord, Show)
 
 -- | A list of all unary operators for all types.
@@ -434,6 +440,8 @@ allConvOps = concat [ ZExt <$> allIntTypes <*> allIntTypes
                     , FPToSI <$> allFloatTypes <*> allIntTypes
                     , UIToFP <$> allIntTypes <*> allFloatTypes
                     , SIToFP <$> allIntTypes <*> allFloatTypes
+                    , IToB <$> allIntTypes
+                    , BToI <$> allIntTypes
                     ]
 
 doUnOp :: UnOp -> PrimValue -> Maybe PrimValue
@@ -632,6 +640,8 @@ doConvOp (FPToUI _ to) (FloatValue v) = Just $ IntValue $ doFPToUI v to
 doConvOp (FPToSI _ to) (FloatValue v) = Just $ IntValue $ doFPToSI v to
 doConvOp (UIToFP _ to) (IntValue v)   = Just $ FloatValue $ doUIToFP v to
 doConvOp (SIToFP _ to) (IntValue v)   = Just $ FloatValue $ doSIToFP v to
+doConvOp (IToB from) (IntValue v)     = Just $ BoolValue $ intToInt64 v /= 0
+doConvOp (BToI to) (BoolValue v)      = Just $ IntValue $ intValue to $ if v then 1 else 0
 doConvOp _ _                          = Nothing
 
 -- | Zero-extend the given integer value to the size of the given
@@ -801,6 +811,8 @@ convOpType (FPToUI from to) = (FloatType from, IntType to)
 convOpType (FPToSI from to) = (FloatType from, IntType to)
 convOpType (UIToFP from to) = (IntType from, FloatType to)
 convOpType (SIToFP from to) = (IntType from, FloatType to)
+convOpType (IToB from) = (IntType from, Bool)
+convOpType (BToI to) = (Bool, IntType to)
 
 -- | A mapping from names of primitive functions to their parameter
 -- types, their result type, and a function for evaluating them.
@@ -1040,6 +1052,8 @@ convOpFun FPToUI{} = "fptoui"
 convOpFun FPToSI{} = "fptosi"
 convOpFun UIToFP{} = "uitofp"
 convOpFun SIToFP{} = "sitofp"
+convOpFun IToB{} = "itob"
+convOpFun BToI{} = "btoi"
 
 taggedI :: String -> IntType -> Doc
 taggedI s Int8  = text $ s ++ "8"


### PR DESCRIPTION
This saves a lot of (tiny) branches in some programs.