### PR TITLE
Fixed tabulate_3d.

### DIFF
--- a/futlib/array.fut
+++ b/futlib/array.fut
@@ -141,4 +141,4 @@ let tabulate_2d 'a (n: i32) (m: i32) (f: i32 -> i32 -> a): *[n][m]a =
 
 -- | Create a value for each point in a three-dimensional index space.
 let tabulate_3d 'a (n: i32) (m: i32) (o: i32) (f: i32 -> i32 -> i32 -> a): *[n][m][o]a =
-  map1 (f >-> tabulate_2d m n) (iota n)
+  map1 (f >-> tabulate_2d m o) (iota n)


### PR DESCRIPTION
Fix to the typo in tabulate_3d, which caused the function to fail. Array now has correct dimensions.