### PR TITLE
Transpose 4 elements per thread in TransposeNormal

### DIFF
--- a/src/Futhark/CodeGen/ImpGen/Kernels/ToOpenCL.hs
+++ b/src/Futhark/CodeGen/ImpGen/Kernels/ToOpenCL.hs
@@ -128,7 +128,9 @@ onKernel called@(Map kernel) = do
   return $ LaunchKernel
     (calledKernelName called) (kernelArgs called) kernel_size workgroup_size
 
-  where (kernel_size, workgroup_size) = kernelAndWorkgroupSize called
+  where kernel_size = [sizeToExp (mapKernelNumGroups kernel) *
+                       sizeToExp (mapKernelGroupSize kernel)]
+        workgroup_size = [sizeToExp $ mapKernelGroupSize kernel]
 
 onKernel called@(AnyKernel kernel) = do
   let (kernel_body, _) =
@@ -167,7 +169,9 @@ onKernel called@(AnyKernel kernel) = do
           return (Nothing,
                   [C.citem|ALIGNED_LOCAL_MEMORY($id:mem, $exp:size');|])
         name = calledKernelName called
-        (kernel_size, workgroup_size) = kernelAndWorkgroupSize called
+        kernel_size = [sizeToExp (kernelNumGroups kernel) *
+                       sizeToExp (kernelGroupSize kernel)]
+        workgroup_size = [sizeToExp $ kernelGroupSize kernel]
 
 onKernel (MapTranspose bt
           destmem destoffset
@@ -274,20 +278,8 @@ kernelArgs (MapTranspose bt destmem destoffset srcmem srcoffset _ x_elems y_elem
   , SharedMemoryKArg shared_memory
   ]
   where shared_memory =
-          bytes $ (transposeBlockDim + 1) * transposeBlockDim *
+          bytes $ (transposeBlockDim * 2 + 1) * transposeBlockDim * 2 *
           LeafExp (SizeOf bt) (IntType Int32)
-
-kernelAndWorkgroupSize :: CallKernel -> ([Exp], [Exp])
-kernelAndWorkgroupSize (Map kernel) =
-  ([sizeToExp (mapKernelNumGroups kernel) *
-    sizeToExp (mapKernelGroupSize kernel)],
-   [sizeToExp $ mapKernelGroupSize kernel])
-kernelAndWorkgroupSize (AnyKernel kernel) =
-  ([sizeToExp (kernelNumGroups kernel) *
-    sizeToExp (kernelGroupSize kernel)],
-   [sizeToExp $ kernelGroupSize kernel])
-kernelAndWorkgroupSize (MapTranspose _ _ _ _ _ num_arrays x_elems y_elems _ _) =
-  transposeKernelAndGroupSize num_arrays x_elems y_elems
 
 --- Generating C
 
@@ -463,25 +455,6 @@ generateTransposeFunction bt =
         asArg (ScalarParam name t) =
           ValueKArg (ImpOpenCL.LeafExp (ImpOpenCL.ScalarVar name) t) t
 
-        normal_kernel_args =
-          map asArg [destmem_p, destoffset_p, srcmem_p, srcoffset_p,
-                     x_p, y_p, in_p, out_p] ++
-          [SharedMemoryKArg shared_memory]
-
-        lowwidth_kernel_args =
-          map asArg [destmem_p, destoffset_p, srcmem_p, srcoffset_p,
-                     x_p, y_p, in_p, out_p, muly] ++
-          [SharedMemoryKArg shared_memory]
-
-        lowheight_kernel_args =
-          map asArg [destmem_p, destoffset_p, srcmem_p, srcoffset_p,
-                     x_p, y_p, in_p, out_p, mulx] ++
-          [SharedMemoryKArg shared_memory]
-
-        shared_memory =
-          bytes $ (transposeBlockDim + 1) * transposeBlockDim *
-          LeafExp (SizeOf bt) (IntType Int32)
-
         transposeBlockDimDivTwo = BinOpExp (SQuot Int32) transposeBlockDim 2
 
         should_use_lowwidth = BinOpExp LogAnd
@@ -539,9 +512,35 @@ generateTransposeFunction bt =
                (paramName srcmem_p) (Count $ asExp srcoffset_p) space
                (Count num_bytes)
 
+        shared_memory tile_dim =
+          [SharedMemoryKArg $ bytes $ tile_dim * (tile_dim + 1) *
+           LeafExp (SizeOf bt) (IntType Int32)]
+
+        normal_kernel_args =
+          map asArg [destmem_p, destoffset_p, srcmem_p, srcoffset_p,
+                     x_p, y_p, in_p, out_p] ++
+          shared_memory (transposeBlockDim * 2)
+
+        lowwidth_kernel_args =
+          map asArg [destmem_p, destoffset_p, srcmem_p, srcoffset_p,
+                     x_p, y_p, in_p, out_p, muly] ++
+          shared_memory transposeBlockDim
+
+        lowheight_kernel_args =
+          map asArg [destmem_p, destoffset_p, srcmem_p, srcoffset_p,
+                     x_p, y_p, in_p, out_p, mulx] ++
+          shared_memory transposeBlockDim
+
         normal_transpose_code =
-          let (kernel_size, workgroup_size) =
-                transposeKernelAndGroupSize (asExp num_arrays_p) (asExp x_p) (asExp y_p)
+          let actual_dim = transposeBlockDim * 2
+              elems_per_thread = 4
+              group_rows = BinOpExp (SQuot Int32) actual_dim elems_per_thread
+              workgroup_size = [actual_dim, group_rows, 1]
+              num_groups = [ (asExp x_p) `quotRoundingUp` actual_dim
+                           , (asExp y_p) `quotRoundingUp` actual_dim
+                           , asExp num_arrays_p
+                           ]
+              kernel_size = zipWith (*) num_groups workgroup_size
           in ImpOpenCL.Op $ LaunchKernel
              (transposeKernelName bt Kernels.TransposeNormal) normal_kernel_args kernel_size workgroup_size
 
@@ -555,13 +554,19 @@ generateTransposeFunction bt =
                          num_arrays_p, x_p, y_p, in_p, out_p])
              [kernel_size] [group_size]
 
+        lowDimKernelAndGroupSize num_arrays x_elems y_elems =
+          ([x_elems `roundUpTo` transposeBlockDim ,
+            y_elems `roundUpTo` transposeBlockDim,
+            num_arrays],
+           [transposeBlockDim, transposeBlockDim, 1])
+
         lowwidth_transpose_code =
           let set_muly = DeclareScalar (paramName muly) (IntType Int32)
                         :>>: SetScalar (paramName muly) (BinOpExp (SQuot Int32) transposeBlockDim (asExp x_p))
               set_new_height = DeclareScalar (paramName new_height) (IntType Int32)
                 :>>: SetScalar (paramName new_height) (asExp y_p `quotRoundingUp` asExp muly)
               (kernel_size, workgroup_size) =
-                transposeKernelAndGroupSize (asExp num_arrays_p) (asExp x_p) (asExp new_height)
+                lowDimKernelAndGroupSize (asExp num_arrays_p) (asExp x_p) (asExp new_height)
               launch = ImpOpenCL.Op $ LaunchKernel
                 (transposeKernelName bt Kernels.TransposeLowWidth) lowwidth_kernel_args kernel_size workgroup_size
           in set_muly :>>: set_new_height :>>: launch
@@ -572,18 +577,10 @@ generateTransposeFunction bt =
               set_new_width = DeclareScalar (paramName new_width) (IntType Int32)
                 :>>: SetScalar (paramName new_width) (asExp x_p `quotRoundingUp` asExp mulx)
               (kernel_size, workgroup_size) =
-                transposeKernelAndGroupSize (asExp num_arrays_p) (asExp new_width) (asExp y_p)
+                lowDimKernelAndGroupSize (asExp num_arrays_p) (asExp new_width) (asExp y_p)
               launch = ImpOpenCL.Op $ LaunchKernel
                 (transposeKernelName bt Kernels.TransposeLowHeight) lowheight_kernel_args kernel_size workgroup_size
           in set_mulx :>>: set_new_width :>>: launch
-
-transposeKernelAndGroupSize :: ImpOpenCL.Exp -> ImpOpenCL.Exp -> ImpOpenCL.Exp
-                            -> ([ImpOpenCL.Exp], [ImpOpenCL.Exp])
-transposeKernelAndGroupSize num_arrays x_elems y_elems =
-  ([x_elems `roundUpTo` transposeBlockDim ,
-    y_elems `roundUpTo` transposeBlockDim,
-    num_arrays],
-   [transposeBlockDim, transposeBlockDim, 1])
 
 roundUpTo :: ImpOpenCL.Exp -> ImpOpenCL.Exp -> ImpOpenCL.Exp
 roundUpTo x y = x + ((y - (x `impRem` y)) `impRem` y)

--- a/src/Futhark/CodeGen/OpenCL/Kernels.hs
+++ b/src/Futhark/CodeGen/OpenCL/Kernels.hs
@@ -88,13 +88,52 @@ mapTranspose :: C.ToIdent a => a -> C.Type -> TransposeType -> C.Func
 mapTranspose kernel_name elem_type transpose_type =
   case transpose_type of
     TransposeNormal ->
-      bigKernel []
-      [C.cexp|get_global_id(0)|]
-      [C.cexp|get_global_id(1)|]
-      [C.cexp|get_group_id(1) * FUT_BLOCK_DIM + get_local_id(0)|]
-      [C.cexp|get_group_id(0) * FUT_BLOCK_DIM + get_local_id(1)|]
+      mkTranspose [] [C.citems|
+        // This kernel is optimized to ensure all global reads and writes are
+        // coalesced, and to avoid bank conflicts in shared memory.  Each
+        // thread group transposes a 2D tile of FUT_BLOCK_DIM*2 by
+        // FUT_BLOCK_DIM*2 elements. The size of a thread group is
+        // FUT_BLOCK_DIM/2 by FUT_BLOCK_DIM*2, meaning that each thread will
+        // process 4 elements in a 2D tile.  The shared memory array containing
+        // the 2D tile consists of FUT_BLOCK_DIM*2 by FUT_BLOCK_DIM*2+1
+        // elements. Padding each row with an additional element prevents bank
+        // conflicts from occuring when the tile is accessed column-wise.
+        //
+        // Note that input_size and output_size may not equal width*height if
+        // we are dealing with a truncated array - this happens sometimes for
+        // coalescing optimisations.
+        const uint tile_dim = 2 * FUT_BLOCK_DIM;
+        const uint elems_per_thread = 4;
+        uint x_index = get_global_id(0);
+        uint y_index = get_group_id(1) * tile_dim + get_local_id(1);
+        if (x_index < width) {
+          for (int i = 0; i < tile_dim; i += tile_dim/elems_per_thread)
+          {
+            uint index_in = (y_index + i) * width + x_index;
+            if (y_index + i < height && index_in < input_size)
+            {
+              block[(get_local_id(1) + i)*(tile_dim+1)+get_local_id(0)] = idata[index_in];
+            }
+          }
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        x_index = get_group_id(1) * tile_dim + get_local_id(0);
+        y_index = get_group_id(0) * tile_dim + get_local_id(1);
+        if (x_index < height)
+        {
+          for (int i = 0; i < tile_dim; i += tile_dim/elems_per_thread)
+          {
+            uint index_out = (y_index + i) * height + x_index;
+            if (y_index + i < width && index_out < output_size)
+            {
+              odata[index_out] = block[get_local_id(0)*(tile_dim+1)+get_local_id(1)+i];
+            }
+          }
+        }
+      |]
     TransposeLowWidth ->
-      bigKernel [C.cparams|uint muly|]
+      mkTranspose [C.cparams|uint muly|] $ lowDimBody
       [C.cexp|get_group_id(0) * FUT_BLOCK_DIM + (get_local_id(0) / muly)|]
       [C.cexp|get_group_id(1) * FUT_BLOCK_DIM * muly
            + get_local_id(1)
@@ -105,7 +144,7 @@ mapTranspose kernel_name elem_type transpose_type =
            + (get_local_id(1) % muly) * FUT_BLOCK_DIM|]
       [C.cexp|get_group_id(0) * FUT_BLOCK_DIM + (get_local_id(1) / muly)|]
     TransposeLowHeight ->
-      bigKernel [C.cparams|uint mulx|]
+      mkTranspose [C.cparams|uint mulx|] $ lowDimBody
       [C.cexp|get_group_id(0) * FUT_BLOCK_DIM * mulx
            + get_local_id(0)
            + (get_local_id(1) % mulx) * FUT_BLOCK_DIM
@@ -119,63 +158,45 @@ mapTranspose kernel_name elem_type transpose_type =
     TransposeSmall ->
       smallKernel
   where
-    bigKernel extraparams x_in_index y_in_index x_out_index y_out_index =
+    mkTranspose extra_params body =
       [C.cfun|
-       // This kernel is optimized to ensure all global reads and writes are coalesced,
-       // and to avoid bank conflicts in shared memory.  The shared memory array is sized
-       // to (BLOCK_DIM+1)*BLOCK_DIM.  This pads each row of the 2D block in shared memory
-       // so that bank conflicts do not occur when threads address the array column-wise.
-       //
-       // Note that input_size/output_size may not equal width*height if we are dealing with
-       // a truncated array - this happens sometimes for coalescing optimisations.
        __kernel void $id:kernel_name($params:params) {
-         uint x_index;
-         uint y_index;
-         uint our_array_offset;
-
-         // Adjust the input and output arrays with the basic offset.
          odata += odata_offset/sizeof($ty:elem_type);
          idata += idata_offset/sizeof($ty:elem_type);
-
-         // Adjust the input and output arrays for the third dimension.
-         our_array_offset = get_global_id(2) * width * height;
+         uint our_array_offset = get_group_id(2) * width * height;
          odata += our_array_offset;
          idata += our_array_offset;
-
-         // read the matrix tile into shared memory
-         x_index = $exp:x_in_index;
-         y_index = $exp:y_in_index;
-
+         $items:body
+       }|]
+        where params = [C.cparams|__global $ty:elem_type *odata,
+                             uint odata_offset,
+                             __global $ty:elem_type *idata,
+                             uint idata_offset,
+                             uint width,
+                             uint height,
+                             uint input_size,
+                             uint output_size
+                             |] ++ extra_params ++ shared_param
+              shared_param = [C.cparams|__local $ty:elem_type* block|]
+    lowDimBody x_in_index y_in_index x_out_index y_out_index =
+      [C.citems|
+         uint x_index = $exp:x_in_index;
+         uint y_index = $exp:y_in_index;
          uint index_in = y_index * width + x_index;
-
          if(x_index < width && y_index < height && index_in < input_size)
          {
-             block[get_local_id(1)*(FUT_BLOCK_DIM+1)+get_local_id(0)] = idata[index_in];
+           block[get_local_id(1)*(FUT_BLOCK_DIM+1)+get_local_id(0)] = idata[index_in];
          }
-
          barrier(CLK_LOCAL_MEM_FENCE);
 
-         // Scatter the transposed matrix tile to global memory.
          x_index = $exp:x_out_index;
          y_index = $exp:y_out_index;
-
          uint index_out = y_index * height + x_index;
-
          if(x_index < height && y_index < width && index_out < output_size)
          {
-             odata[index_out] = block[get_local_id(0)*(FUT_BLOCK_DIM+1)+get_local_id(1)];
+           odata[index_out] = block[get_local_id(0)*(FUT_BLOCK_DIM+1)+get_local_id(1)];
          }
-       }|]
-           where params = [C.cparams|__global $ty:elem_type *odata,
-                                uint odata_offset,
-                                __global $ty:elem_type *idata,
-                                uint idata_offset,
-                                uint width,
-                                uint height,
-                                uint input_size,
-                                uint output_size|] ++ extraparams ++
-                          [C.cparams|__local $ty:elem_type* block|]
-
+      |]
     smallKernel =
       [C.cfun|
          __kernel void $id:kernel_name(__global $ty:elem_type *odata,


### PR DESCRIPTION
For the TransposeNormal transposition type:
Change group size to 32x8 and make threads transpose 4 elements each.
This means that each group now transposes a tile of size 32x32.