### PR TITLE
Header guards

### DIFF
--- a/src/Futhark/CodeGen/Backends/GenericC.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC.hs
@@ -1464,7 +1464,8 @@ $edecls:entry_point_decls
   |]
 
   return $ CParts (pretty headerdefs) (pretty utildefs) (pretty clidefs) (pretty libdefs)
-  where compileProg' = do
+    where
+      compileProg' = do
           (memstructs, memfuns, memreport) <- unzip3 <$> mapM defineMemorySpace spaces
 
           (prototypes, definitions) <- unzip <$> mapM compileFun funs
@@ -1478,28 +1479,29 @@ $edecls:entry_point_decls
           ctx_ty <- contextType
           headerDecl MiscDecl [C.cedecl|void futhark_debugging_report($ty:ctx_ty *ctx);|]
           libDecl [C.cedecl|void futhark_debugging_report($ty:ctx_ty *ctx) {
-  if (ctx->detail_memory) {
-    $items:memreport
-  }
-  if (ctx->debugging) {
-    $items:debugreport
-  }
-}|]
+                      if (ctx->detail_memory) {
+                        $items:memreport
+                      }
+                      if (ctx->debugging) {
+                        $items:debugreport
+                      }
+                    }|]
 
           return (prototypes, definitions, entry_points)
-        funcToDef func = C.FuncDef func loc
-          where loc = case func of
-                        C.OldFunc _ _ _ _ _ _ l -> l
-                        C.Func _ _ _ _ _ l      -> l
 
-        builtin = cIntOps ++ cFloat32Ops ++ cFloat64Ops ++ cFloatConvOps ++
-                  cFloat32Funs ++ cFloat64Funs
+      funcToDef func = C.FuncDef func loc
+        where loc = case func of
+                       C.OldFunc _ _ _ _ _ _ l -> l
+                       C.Func _ _ _ _ _ l      -> l
 
-        panic_h = $(embedStringFile "rts/c/panic.h")
-        values_h = $(embedStringFile "rts/c/values.h")
-        timing_h = $(embedStringFile "rts/c/timing.h")
-        lock_h = $(embedStringFile "rts/c/lock.h")
-        tuning_h = $(embedStringFile "rts/c/tuning.h")
+      builtin = cIntOps ++ cFloat32Ops ++ cFloat64Ops ++ cFloatConvOps ++
+                cFloat32Funs ++ cFloat64Funs
+
+      panic_h  = $(embedStringFile "rts/c/panic.h")
+      values_h = $(embedStringFile "rts/c/values.h")
+      timing_h = $(embedStringFile "rts/c/timing.h")
+      lock_h   = $(embedStringFile "rts/c/lock.h")
+      tuning_h = $(embedStringFile "rts/c/tuning.h")
 
 compileFun :: (Name, Function op) -> CompilerM op s (C.Definition, C.Func)
 compileFun (fname, Function _ outputs inputs body _ _) = do

--- a/src/Futhark/CodeGen/Backends/GenericC.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC.hs
@@ -1307,6 +1307,7 @@ compileProg ops extra header_extra spaces options prog@(Functions funs) = do
       option_parser = generateOptionParser "parse_options" $ benchmarkOptions++options
 
   let headerdefs = [C.cunit|
+$esc:("#pragma once\n")
 $esc:("/*\n * Headers\n*/\n")
 $esc:("#include <stdint.h>")
 $esc:("#include <stddef.h>")

--- a/src/Futhark/CodeGen/Backends/GenericC.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC.hs
@@ -426,7 +426,7 @@ decl x = item [C.citem|$decl:x;|]
 addrOf :: C.Exp -> C.Exp
 addrOf e = [C.cexp|&$exp:e|]
 
--- | Public names must have a consistent prefix.
+-- | Public names must have a consitent prefix.
 publicName :: String -> CompilerM op s String
 publicName s = return $ "futhark_" ++ s
 
@@ -1304,11 +1304,9 @@ compileProg ops extra header_extra spaces options prog@(Functions funs) = do
         runCompilerM prog ops src () compileProg'
       (entry_point_decls, cli_entry_point_decls, entry_point_inits) =
         unzip3 entry_points
-      option_parser = generateOptionParser "parse_options" $ benchmarkOptions <> options
-
+      option_parser = generateOptionParser "parse_options" $ benchmarkOptions++options
 
   let headerdefs = [C.cunit|
-$esc:("#ifndef " <> headerGuard <> "\n#define " <> headerGuard <> "\n")
 $esc:("/*\n * Headers\n*/\n")
 $esc:("#include <stdint.h>")
 $esc:("#include <stddef.h>")
@@ -1330,7 +1328,6 @@ $edecls:(entryDecls endstate)
 $esc:("\n/*\n * Miscellaneous\n*/\n")
 $edecls:(miscDecls endstate)
                            |]
-
 
   let utildefs = [C.cunit|
 $esc:("#include <stdio.h>")
@@ -1433,6 +1430,7 @@ int main(int argc, char** argv) {
   return 0;
 }
                         |]
+
   let early_decls = DL.toList $ compEarlyDecls endstate
   let lib_decls = DL.toList $ compLibDecls endstate
   let libdefs = [C.cunit|
@@ -1462,7 +1460,6 @@ $edecls:(arrayDefinitions endstate)
 $edecls:(opaqueDefinitions endstate)
 
 $edecls:entry_point_decls
-
   |]
 
   return $ CParts (pretty headerdefs) (pretty utildefs) (pretty clidefs) (pretty libdefs)
@@ -1478,10 +1475,7 @@ $edecls:entry_point_decls
           debugreport <- gets $ DL.toList . compDebugItems
 
           ctx_ty <- contextType
-
           headerDecl MiscDecl [C.cedecl|void futhark_debugging_report($ty:ctx_ty *ctx);|]
-          headerDecl MiscDecl [C.cedecl|$esc:("\n#endif // " <> headerGuard <> "\n")|]
-
           libDecl [C.cedecl|void futhark_debugging_report($ty:ctx_ty *ctx) {
   if (ctx->detail_memory) {
     $items:memreport
@@ -1499,8 +1493,6 @@ $edecls:entry_point_decls
 
         builtin = cIntOps ++ cFloat32Ops ++ cFloat64Ops ++ cFloatConvOps ++
                   cFloat32Funs ++ cFloat64Funs
-
-        headerGuard = "FUTHARK_H"
 
         panic_h = $(embedStringFile "rts/c/panic.h")
         values_h = $(embedStringFile "rts/c/values.h")


### PR DESCRIPTION
An attempt to add header guards to generated C headers, resolving #718. @athas, may I ask your advice on where to draw the filename from? I thought I could use one of the generated function filepaths but this ended up evaluating to GenericC.hs instead of the C file like I intended. 

Thank you very much for your time. 
Max 