### PR TITLE
Fix #pragma once compiler warnings 

### DIFF
--- a/src/Futhark/CodeGen/Backends/GenericC.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC.hs
@@ -1280,7 +1280,7 @@ data CParts = CParts { cHeader :: String
 
 -- | Produce header and implementation files.
 asLibrary :: CParts -> (String, String)
-asLibrary parts = (cHeader parts, cUtils parts <> cLib parts)
+asLibrary parts = ("#pragma once\n\n" <> cHeader parts, cUtils parts <> cLib parts)
 
 -- | As executable with command-line interface.
 asExecutable :: CParts -> String
@@ -1305,7 +1305,6 @@ compileProg ops extra header_extra spaces options prog@(Functions funs) = do
       option_parser = generateOptionParser "parse_options" $ benchmarkOptions++options
 
   let headerdefs = [C.cunit|
-$esc:("#pragma once\n")
 $esc:("/*\n * Headers\n*/\n")
 $esc:("#include <stdint.h>")
 $esc:("#include <stddef.h>")


### PR DESCRIPTION
Work towards proper header guards (#747). 

The header guard name is hardcoded right now, coming full circle from my `pragma once` patch :sweat_smile:. 

I started plumbing the `.fut` name from the backends outwards and felt like I was vandalizing all the function signatures for a small benefit (at one point having to tweak C# backend code for a C-related change). This is probably mostly an inexperience thing.

The change seems more justifiable to support more relevant public names, but perhaps it's better to defer that decision. 