### PR TITLE
Add section about what `futhark bench` measures

### DIFF
--- a/docs/man/futhark-bench.rst
+++ b/docs/man/futhark-bench.rst
@@ -108,10 +108,8 @@ WHAT FUTHARK BENCH MEASURES
 ===========================
 
 ``futhark bench`` measures the time it takes to run the given Futhark
-program. It starts measuring after all kernels have been compiled and
-data has been copied to the device buffers but before setting any kernel
-arguments. It stops measuring after the kernels are done running and
-data has been read off the buffer but before releasing the buffers.
+program by passing the ``-t FILE`` option to the generated program. See
+the man page for the specific compiler to see exactly what is measured.
 
 EXAMPLES
 ========

--- a/docs/man/futhark-bench.rst
+++ b/docs/man/futhark-bench.rst
@@ -104,6 +104,15 @@ OPTIONS
   ``foo.fut`` will be passed the tuning file ``foo.fut.tuning`` if it
   exists.
 
+WHAT FUTHARK BENCH MEASURES
+===========================
+
+``futhark bench`` measures the time it takes to run the given Futhark
+program. It starts measuring after all kernels have been compiled and
+data has been copied to the device buffers but before setting any kernel
+arguments. It stops measuring after the kernels are done running and
+data has been read off the buffer but before releasing the buffers.
+
 EXAMPLES
 ========
 

--- a/docs/man/futhark-opencl.rst
+++ b/docs/man/futhark-opencl.rst
@@ -52,6 +52,20 @@ OPTIONS
 --Werror
   Treat warnings as errors.
 
+OPTIONS ON THE GENERATED EXECUTABLE
+===================================
+
+-t timingfile
+  Print the time taken to execute the program to the indicated file, an
+  integral number of microseconds. The time taken to perform setup or
+  teardown, including reading the input or writing the result, is not
+  included in the measurement. In particular, this means that timing
+  starts after all kernels have been compiled and data has been copied
+  to the device buffers but before setting any kernel arguments. Timing
+  stops after the kernels are done running, but before data has been
+  read from the buffers or the buffers have been released.
+
+
 SEE ALSO
 ========
 


### PR DESCRIPTION
This is an attempt at addressing my questions in #827. 

The answers have been inferred by inspecting this patch to the rodinia benchmarks created by @athas: https://github.com/diku-dk/futhark-pldi17/blob/master/rodinia_3.1-some-instrumentation.patch. By inspecting the changes to nearestNeighbor.cpp, it looks like writing to buffers is not included, but reading from buffers is.

