### PR TITLE
Implement safety checks for parallel backends.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   * Futhark now type-checks size annotations using a size-dependent
     type system.
 
+  * The parallel code generators can now handle bounds checking and
+    other safety checks.
+
   * `reduce_by_index` may be somewhat faster for complex operators on
     histograms that barely fit in local memory.
 

--- a/src/Futhark/CodeGen/Backends/CSOpenCL/Boilerplate.hs
+++ b/src/Futhark/CodeGen/Backends/CSOpenCL/Boilerplate.hs
@@ -20,14 +20,41 @@ stringT = Primitive StringT
 intArrayT = Composite $ ArrayT intT
 stringArrayT = Composite $ ArrayT stringT
 
-generateBoilerplate :: String -> String -> [String] -> [PrimType]
+errorMsgNumArgs :: ErrorMsg a -> Int
+errorMsgNumArgs = length . errorMsgArgTypes
+
+formatEscape :: String -> String
+formatEscape = concatMap escapeChar
+  where escapeChar '{' = "{{"
+        escapeChar '}' = "}}"
+        escapeChar c = [c]
+
+failureCase :: Integer -> FailureMsg -> CSStmt
+failureCase i (FailureMsg (ErrorMsg parts) backtrace) =
+  If (BinOp "==" (Var "failure_idx") (Integer i))
+  [ let (formatstr, formatargs) = onParts 0 parts
+    in AST.Assert (AST.Bool False) $
+       String (formatstr ++ "\nBacktrace:\n" ++ formatEscape backtrace) :
+       formatargs
+  ]
+  []
+  where onParts _ [] = ("", [])
+        onParts j (ErrorString s : parts') =
+          let (formatstr, formatargs) = onParts j parts'
+          in (s ++ formatstr, formatargs)
+        onParts j (ErrorInt32 _ : parts') =
+          let (formatstr, formatargs) = onParts (j+1) parts'
+          in ("{" ++ show j ++ "}" ++ formatstr, Index (Var "args") (IdxExp $ Integer j) : formatargs)
+
+generateBoilerplate :: String -> String -> M.Map KernelName Safety -> [PrimType]
                     -> M.Map Name SizeClass
+                    -> [FailureMsg]
                     -> CS.CompilerM OpenCL () ()
-generateBoilerplate opencl_code opencl_prelude kernel_names types sizes = do
+generateBoilerplate opencl_code opencl_prelude kernels types sizes failures = do
   final_inits <- CS.contextFinalInits
 
   let (opencl_fields, opencl_inits, top_decls, later_top_decls) =
-        openClDecls kernel_names opencl_code opencl_prelude
+        openClDecls kernels opencl_code opencl_prelude
 
   CS.stm top_decls
 
@@ -133,6 +160,8 @@ generateBoilerplate opencl_code opencl_prelude kernel_names types sizes = do
     , (Primitive $ CSInt Int64T, "PeakMemUsageDevice")
     , (Primitive BoolT, "DetailMemory")
     , (Primitive BoolT, "Debugging")
+    , (CustomT "CLMemoryHandle", "GlobalFailure")
+    , (CustomT "CLMemoryHandle", "GlobalFailureArgs")
     , (CustomT "OpenCLContext", "OpenCL")
     , (CustomT "Sizes", "Sizes") ]
     ++ opencl_fields
@@ -155,7 +184,8 @@ generateBoilerplate opencl_code opencl_prelude kernel_names types sizes = do
       set_sizes = zipWith (\i k -> Reassign (Field (Var "Ctx.Sizes") (zEncodeString $ pretty k))
                                             (Index (Var "Cfg.Sizes") (IdxExp $ (Integer . toInteger) i)))
                           [(0::Int)..] $ M.keys sizes
-
+      max_failure_args =
+        foldl max 0 $ map (errorMsgNumArgs . failureError) failures
 
   CS.stm $ CS.privateFunDef new_ctx VoidT [(CustomT cfg, "Cfg")] $
     [ AssignTyped (CustomT "ComputeErrorCode") (Var "error") Nothing
@@ -168,35 +198,77 @@ generateBoilerplate opencl_code opencl_prelude kernel_names types sizes = do
     [ AssignTyped (CustomT "CLProgramHandle") (Var "prog")
         (Just $ CS.simpleCall "SetupOpenCL" [ Ref $ Var "Ctx"
                                             , Var "OpenCLProgram"
-                                            , Var "RequiredTypes"])]
-    ++ concatMap loadKernelByName kernel_names
+                                            , Var "RequiredTypes"])] ++
+    [Unsafe
+     [ Exp $ CS.simpleCall "OPENCL_SUCCEED"
+       [CS.simpleCall "OpenCLAllocActual" [ Ref $ Var "Ctx"
+                                          , Integer 4
+                                          , Ref $ Var "Ctx.GlobalFailure"]]
+     , AssignTyped intT (Var "no_failure") (Just (Integer (-1)))
+     , Exp $ CS.simpleCall "OPENCL_SUCCEED"
+       [CS.simpleCall "CL10.EnqueueWriteBuffer"
+        [ Var "Ctx.OpenCL.Queue", Var "Ctx.GlobalFailure", AST.Bool True
+        , CS.toIntPtr $ Integer 0
+        , CS.toIntPtr $ Integer 4
+        , CS.toIntPtr $ Addr (Var "no_failure")
+        , Integer 0, Null, Null]]
+
+     , Exp $ CS.simpleCall "OPENCL_SUCCEED"
+       [CS.simpleCall "OpenCLAllocActual" [ Ref $ Var "Ctx"
+                                          , Integer $ toInteger $ 4 * max_failure_args + 1
+                                          , Ref $ Var "Ctx.GlobalFailureArgs"]]]]
+    ++ concatMap loadKernel (M.toList kernels)
     ++ final_inits
     ++ set_sizes
 
-  CS.stm $ CS.privateFunDef sync_ctx intT []
-    [ Exp $ CS.simpleCall "OPENCL_SUCCEED" [CS.simpleCall "CL10.Finish" [Var "Ctx.OpenCL.Queue"]]
-    , Return $ Integer 0 ]
+  CS.stm $ CS.privateFunDef sync_ctx VoidT []
+    [ AssignTyped intT (Var "failure_idx") (Just $ CS.simpleInitClass (pretty intT) [])
+    , Unsafe [CS.assignScalarPointer (Var "failure_idx") (Var "ptr")
+             , Exp $ CS.simpleCall "OPENCL_SUCCEED" [
+                 CS.simpleCall "CL10.EnqueueReadBuffer"
+                 [ Var "Ctx.OpenCL.Queue", Var "Ctx.GlobalFailure", AST.Bool True
+                 , CS.toIntPtr $ Integer 0
+                 , CS.toIntPtr $ Integer 4
+                 , CS.toIntPtr $ Var "ptr"
+                , Integer 0, Null, Null]
+                ]
+            ]
 
-  CS.debugReport $ openClReport kernel_names
+    , If (BinOp "!=" (Var "failure_idx") (Integer (-1)))
+      ([ AssignTyped intArrayT (Var "args") $ Just $ CreateArray intT $ Left max_failure_args
+       , Unsafe [
+           Fixed (Var "ptr") (Addr (Index (Var "args") $ IdxExp $ Integer 0))
+           [Exp $ CS.simpleCall "CL10.EnqueueReadBuffer"
+            [ Var "Ctx.OpenCL.Queue", Var "Ctx.GlobalFailureArgs", AST.Bool True
+            , CS.toIntPtr $ Integer 0
+            , CS.toIntPtr $ Integer $ toInteger $ 4 * max_failure_args
+            , CS.toIntPtr $ Var "ptr"
+            , Integer 0, Null, Null]]]] ++
+        zipWith failureCase [0..] failures)
+      []
+    ]
+
+  CS.debugReport $ openClReport $ M.keys kernels
 
 
-openClDecls :: [String] -> String -> String
+openClDecls :: M.Map KernelName Safety -> String -> String
             -> ([(CSType, String)], [CSStmt], CSStmt, [CSStmt])
-openClDecls kernel_names opencl_program opencl_prelude =
+openClDecls kernels opencl_program opencl_prelude =
   (ctx_fields, ctx_inits, openCL_boilerplate, openCL_load)
   where ctx_fields =
           [ (intT, "TotalRuns")
           , (Primitive $ CSInt Int64T, "TotalRuntime")]
           ++ concatMap (\name -> [(CustomT "CLKernelHandle", name)
                                  ,(longT, kernelRuntime name)
-                                 ,(intT, kernelRuns name)]) kernel_names
+                                 ,(intT, kernelRuns name)])
+          (M.keys kernels)
 
         ctx_inits =
           [ Reassign (Var $ ctx "TotalRuns") (Integer 0)
           , Reassign (Var $ ctx "TotalRuntime") (Integer 0) ]
           ++ concatMap (\name -> [ Reassign (Var $ (ctx . kernelRuntime) name) (Integer 0)
-                                 , Reassign (Var $ (ctx . kernelRuns) name) (Integer 0)]
-                  ) kernel_names
+                                 , Reassign (Var $ (ctx . kernelRuns) name) (Integer 0)])
+          (M.keys kernels)
 
 
         futhark_context = CS.publicName "Context"
@@ -209,8 +281,8 @@ openClDecls kernel_names opencl_program opencl_prelude =
           AssignTyped stringArrayT (Var "OpenCLProgram")
               (Just $ Collection "string[]" [String $ opencl_prelude ++ opencl_program])
 
-loadKernelByName :: String -> [CSStmt]
-loadKernelByName name =
+loadKernel :: (String, Safety) -> [CSStmt]
+loadKernel (name, _) =
   [ Reassign (Var $ ctx name)
       (CS.simpleCall "CL10.CreateKernel" [Var "prog", String name, Out $ Var "error"])
   , AST.Assert (BinOp "==" (Var "error") (Integer 0)) []

--- a/src/Futhark/CodeGen/ImpCode.hs
+++ b/src/Futhark/CodeGen/ImpCode.hs
@@ -33,6 +33,7 @@ module Futhark.CodeGen.ImpCode
   , index
   , ErrorMsg(..)
   , ErrorMsgPart(..)
+  , errorMsgArgTypes
   , ArrayContents(..)
 
     -- * Typed enumerations
@@ -62,7 +63,7 @@ import Data.Traversable
 import Language.Futhark.Core
 import Futhark.Representation.Primitive
 import Futhark.Representation.AST.Syntax
-  (Space(..), SpaceId, ErrorMsg(..), ErrorMsgPart(..))
+  (Space(..), SpaceId, ErrorMsg(..), ErrorMsgPart(..), errorMsgArgTypes)
 import Futhark.Representation.AST.Attributes.Names
 import Futhark.Representation.AST.Pretty ()
 import Futhark.Analysis.PrimExp
@@ -488,8 +489,8 @@ instance FreeIn a => FreeIn (Code a) where
     freeIn' dests <> freeIn' args
   freeIn' (If cond t f) =
     freeIn' cond <> freeIn' t <> freeIn' f
-  freeIn' (Assert e _ _) =
-    freeIn' e
+  freeIn' (Assert e msg _) =
+    freeIn' e <> foldMap freeIn' msg
   freeIn' (Op op) =
     freeIn' op
   freeIn' (Comment _ code) =

--- a/src/Futhark/CodeGen/ImpGen/Kernels/SegHist.hs
+++ b/src/Futhark/CodeGen/ImpGen/Kernels/SegHist.hs
@@ -646,7 +646,7 @@ histKernelLocalPass num_subhistos_per_group_var groups_per_segment map_pes num_g
                   copyDWIM (paramName p) [] v is
                 do_op (bucket_is ++ is)
 
-    sOp Imp.LocalBarrier
+    sOp Imp.ErrorSync
     sOp Imp.GlobalBarrier
 
     sComment "Compact the multiple local memory subhistograms to result in global memory" $

--- a/src/Futhark/CodeGen/ImpGen/Kernels/SegRed.hs
+++ b/src/Futhark/CodeGen/ImpGen/Kernels/SegRed.hs
@@ -271,7 +271,7 @@ smallSegmentsReduction (Pattern _ segred_pes) num_groups group_size space reds b
              isActive (init $ zip gtids dims) .&&.
              ltid .<. segment_size * segments_per_group) in_bounds out_of_bounds
 
-      sOp Imp.LocalBarrier
+      sOp Imp.ErrorSync -- Also implicitly barrier.
 
       let crossesSegment from to = (to-from) .>. (to `rem` segment_size)
       sWhen (segment_size .>. 0) $
@@ -498,7 +498,7 @@ reductionStageZero constants ispace num_elements global_tid elems_per_thread thr
               when (primType $ paramType p) $
               copyDWIM arr [local_tid] (Var $ paramName p) []
 
-          sOp Imp.LocalBarrier
+          sOp Imp.ErrorSync -- Also implicitly barrier.
 
           groupReduce constants (kernelGroupSize constants) slug_op_renamed (slugArrs slug)
 

--- a/src/Futhark/CodeGen/ImpGen/Kernels/SegScan.hs
+++ b/src/Futhark/CodeGen/ImpGen/Kernels/SegScan.hs
@@ -115,6 +115,8 @@ scanStage1 (Pattern _ pes) num_groups group_size space scan_op nes kbody = do
                   to' = to + Imp.var chunk_offset int32
               in f from' to'
 
+      sOp Imp.ErrorSync -- Also implicitly barrier.
+
       groupScan constants crossesSegment'
         (kernelGroupSize constants) scan_op_renamed local_arrs
 

--- a/src/Futhark/CodeGen/ImpGen/Kernels/ToOpenCL.hs
+++ b/src/Futhark/CodeGen/ImpGen/Kernels/ToOpenCL.hs
@@ -10,7 +10,6 @@ module Futhark.CodeGen.ImpGen.Kernels.ToOpenCL
 
 import Control.Monad.State
 import Control.Monad.Identity
-import Control.Monad.Writer
 import Control.Monad.Reader
 import Data.Maybe
 import qualified Data.Set as S
@@ -41,17 +40,16 @@ translateKernels :: KernelTarget
                  -> ImpKernels.Program
                  -> Either InternalError ImpOpenCL.Program
 translateKernels target (ImpKernels.Functions funs) = do
-  (prog', ToOpenCL extra_funs kernels requirements sizes) <-
-    runWriterT $ fmap Functions $ forM funs $ \(fname, fun) ->
+  (prog', ToOpenCL kernels used_types sizes failures) <-
+    flip runStateT initialOpenCL $ fmap Functions $ forM funs $ \(fname, fun) ->
     (fname,) <$> runReaderT (traverse (onHostOp target) fun) fname
-  let kernel_names = M.keys kernels
-      opencl_code = openClCode $ M.elems kernels
-      opencl_prelude = pretty $ genPrelude target requirements
-  return $ ImpOpenCL.Program opencl_code opencl_prelude kernel_names
-    (S.toList $ openclUsedTypes requirements) (cleanSizes sizes) $
-    ImpOpenCL.Functions (M.toList extra_funs) <> prog'
+  let kernels' = M.map fst kernels
+      opencl_code = openClCode $ map snd $ M.elems kernels
+      opencl_prelude = pretty $ genPrelude target used_types
+  return $ ImpOpenCL.Program opencl_code opencl_prelude kernels'
+    (S.toList used_types) (cleanSizes sizes) failures prog'
   where genPrelude TargetOpenCL = genOpenClPrelude
-        genPrelude TargetCUDA = genCUDAPrelude
+        genPrelude TargetCUDA = const genCUDAPrelude
 
 -- | Due to simplifications after kernel extraction, some threshold
 -- parameters may contain KernelPaths that reference threshold
@@ -76,48 +74,44 @@ pointerQuals s            = error $ "'" ++ s ++ "' is not an OpenCL kernel addre
 -- In-kernel name and per-workgroup size in bytes.
 type LocalMemoryUse = (VName, Count Bytes Exp)
 
-newtype KernelRequirements =
-  KernelRequirements { kernelLocalMemory :: [LocalMemoryUse] }
+data KernelState =
+  KernelState { kernelLocalMemory :: [LocalMemoryUse]
+              , kernelFailures :: [FailureMsg]
+              , kernelNextSync :: Int
+              , kernelSyncPending :: Bool
+                -- ^ Has a potential failure occurred sine the last
+                -- ErrorSync?
+              , kernelHasBarriers :: Bool
+              }
 
-instance Semigroup KernelRequirements where
-  KernelRequirements lm1 <> KernelRequirements lm2 =
-    KernelRequirements (lm1<>lm2)
+newKernelState :: [FailureMsg] -> KernelState
+newKernelState failures = KernelState mempty failures 0 False False
 
-instance Monoid KernelRequirements where
-  mempty = KernelRequirements mempty
+errorLabel :: KernelState -> String
+errorLabel = ("error_"++) . show . kernelNextSync
 
-newtype OpenClRequirements =
-  OpenClRequirements { openclUsedTypes :: S.Set PrimType }
-
-instance Semigroup OpenClRequirements where
-  OpenClRequirements ts1 <> OpenClRequirements ts2 =
-    OpenClRequirements (ts1 <> ts2)
-
-instance Monoid OpenClRequirements where
-  mempty = OpenClRequirements mempty
-
-data ToOpenCL = ToOpenCL { clExtraFuns :: M.Map Name ImpOpenCL.Function
-                         , clKernels :: M.Map KernelName C.Func
-                         , clRequirements :: OpenClRequirements
+data ToOpenCL = ToOpenCL { clKernels :: M.Map KernelName (Safety, C.Func)
+                         , clUsedTypes :: S.Set PrimType
                          , clSizes :: M.Map Name SizeClass
+                         , clFailures :: [FailureMsg]
                          }
 
-instance Semigroup ToOpenCL where
-  ToOpenCL f1 k1 r1 sz1 <> ToOpenCL f2 k2 r2 sz2 =
-    ToOpenCL (f1<>f2) (k1<>k2) (r1<>r2) (sz1<>sz2)
+initialOpenCL :: ToOpenCL
+initialOpenCL = ToOpenCL mempty mempty mempty mempty
 
-instance Monoid ToOpenCL where
-  mempty = ToOpenCL mempty mempty mempty mempty
+type OnKernelM = ReaderT Name (StateT ToOpenCL (Either InternalError))
 
-type OnKernelM = ReaderT Name (WriterT ToOpenCL (Either InternalError))
+addSize :: Name -> SizeClass -> OnKernelM ()
+addSize key sclass =
+  modify $ \s -> s { clSizes = M.insert key sclass $ clSizes s }
 
 onHostOp :: KernelTarget -> HostOp -> OnKernelM OpenCL
 onHostOp target (CallKernel k) = onKernel target k
 onHostOp _ (ImpKernels.GetSize v key size_class) = do
-  tell mempty { clSizes = M.singleton key size_class }
+  addSize key size_class
   return $ ImpOpenCL.GetSize v key
 onHostOp _ (ImpKernels.CmpSizeLe v key size_class x) = do
-  tell mempty { clSizes = M.singleton key size_class }
+  addSize key size_class
   return $ ImpOpenCL.CmpSizeLe v key x
 onHostOp _ (ImpKernels.GetSizeMax v size_class) =
   return $ ImpOpenCL.GetSizeMax v size_class
@@ -125,17 +119,20 @@ onHostOp _ (ImpKernels.GetSizeMax v size_class) =
 onKernel :: KernelTarget -> Kernel -> OnKernelM OpenCL
 
 onKernel target kernel = do
-  let (kernel_body, requirements) =
-        GenericC.runCompilerM mempty inKernelOperations blankNameSource mempty $
+  failures <- gets clFailures
+  let (kernel_body, cstate) =
+        GenericC.runCompilerM mempty (inKernelOperations (kernelBody kernel))
+        blankNameSource
+        (newKernelState failures) $
         GenericC.blockScope $ GenericC.compileCode $ kernelBody kernel
+      kstate = GenericC.compUserState cstate
 
       use_params = mapMaybe useAsParam $ kernelUses kernel
 
       (local_memory_args, local_memory_params, local_memory_init) =
         unzip3 $
         flip evalState (blankNameSource :: VNameSource) $
-        mapM (prepareLocalMemory target) $ kernelLocalMemory $
-        GenericC.compUserState requirements
+        mapM (prepareLocalMemory target) $ kernelLocalMemory kstate
 
       -- CUDA has very strict restrictions on the number of blocks
       -- permitted along the 'y' and 'z' dimensions of the grid
@@ -158,22 +155,68 @@ onKernel target kernel = do
                  [C.citem|const int block_dim1 = 1;|],
                  [C.citem|const int block_dim2 = 2;|]])
 
-      params = perm_params ++ catMaybes local_memory_params ++ use_params
-
       const_defs = mapMaybe constDef $ kernelUses kernel
 
-  tell mempty { clExtraFuns = mempty
-              , clKernels = M.singleton name
-                            [C.cfun|__kernel void $id:name ($params:params) {
-                                $items:const_defs
-                                $items:block_dim_init
-                                $items:local_memory_init
-                                $items:kernel_body
-                                }|]
-              , clRequirements = OpenClRequirements (typesInKernel kernel)
-              }
+  let (safety, error_init)
+        | length (kernelFailures kstate) == length failures =
+            if kernelFailureTolerant kernel
+            then (SafetyNone, [])
+            else -- No possible failures in this kernel, so if we make
+                 -- it past an initial check, then we are good to go.
+                 (SafetyCheap,
+                  [C.citems|if (*global_failure >= 0) { return; }|])
 
-  return $ LaunchKernel name (catMaybes local_memory_args ++ kernelArgs kernel) num_groups group_size
+        | otherwise =
+            if not (kernelHasBarriers kstate)
+            then (SafetyFull,
+                  [C.citems|if (*global_failure >= 0) { return; }|])
+            else (SafetyFull,
+                  [C.citems|
+                     volatile __local bool local_failure;
+                     if (failure_is_an_option) {
+                       if (get_local_id(0) == 0) {
+                         local_failure = *global_failure >= 0;
+                       }
+                       barrier(CLK_LOCAL_MEM_FENCE);
+                       if (local_failure) { return; }
+                     } else {
+                       local_failure = false;
+                     }
+                     barrier(CLK_LOCAL_MEM_FENCE);
+                  |])
+
+      failure_params =
+        [[C.cparam|__global int *global_failure|],
+         [C.cparam|int failure_is_an_option|],
+         [C.cparam|__global int *global_failure_args|]]
+
+      params = perm_params ++
+               take (numFailureParams safety) failure_params ++
+               catMaybes local_memory_params ++
+               use_params
+
+      kernel_fun =
+        [C.cfun|__kernel void $id:name ($params:params) {
+                  $items:const_defs
+                  $items:block_dim_init
+                  $items:local_memory_init
+                  $items:error_init
+                  $items:kernel_body
+
+                  $id:(errorLabel kstate): return;
+                }|]
+  modify $ \s -> s
+    { clKernels = M.insert name (safety, kernel_fun) $ clKernels s
+    , clUsedTypes = typesInKernel kernel <> clUsedTypes s
+    , clFailures = kernelFailures kstate
+    }
+
+  -- The argument corresponding to the global_failure parameters is
+  -- added automatically later.
+  let args = catMaybes local_memory_args ++
+             kernelArgs kernel
+
+  return $ LaunchKernel safety name args num_groups group_size
   where name = nameToString $ kernelName kernel
         num_groups = kernelNumGroups kernel
         group_size = kernelGroupSize kernel
@@ -214,8 +257,8 @@ openClCode kernels =
           [[C.cedecl|$func:kernel_func|] |
            kernel_func <- kernels ]
 
-genOpenClPrelude :: OpenClRequirements -> [C.Definition]
-genOpenClPrelude (OpenClRequirements ts) =
+genOpenClPrelude :: S.Set PrimType -> [C.Definition]
+genOpenClPrelude ts =
   -- Clang-based OpenCL implementations need this for 'static' to work.
   [ [C.cedecl|$esc:("#ifdef cl_clang_storage_class_specifiers")|]
   , [C.cedecl|$esc:("#pragma OPENCL EXTENSION cl_clang_storage_class_specifiers : enable")|]
@@ -286,8 +329,8 @@ cudaAtomicOps = (mkOp <$> opNames <*> types) ++ extraOps
                   return atomicCAS(($ty:t *)p, cmp, val);
                 }|] | t <- types]
 
-genCUDAPrelude :: OpenClRequirements -> [C.Definition]
-genCUDAPrelude (OpenClRequirements _) =
+genCUDAPrelude :: [C.Definition]
+genCUDAPrelude =
   cudafy ++ cudaAtomicOps ++ ops
   where ops = cIntOps ++ cFloat32Ops ++ cFloat32Funs ++ cFloat64Ops
                 ++ cFloat64Funs ++ cFloatConvOps
@@ -403,21 +446,42 @@ kernelArgs = mapMaybe useToArg . kernelUses
         useToArg (ScalarUse v bt) = Just $ ValueKArg (LeafExp (ScalarVar v) bt) bt
         useToArg ConstUse{}       = Nothing
 
---- Generating C
+nextErrorLabel :: GenericC.CompilerM KernelOp KernelState String
+nextErrorLabel =
+  errorLabel <$> GenericC.getUserState
 
-inKernelOperations :: GenericC.Operations KernelOp KernelRequirements
-inKernelOperations = GenericC.Operations
-                     { GenericC.opsCompiler = kernelOps
-                     , GenericC.opsMemoryType = kernelMemoryType
-                     , GenericC.opsWriteScalar = kernelWriteScalar
-                     , GenericC.opsReadScalar = kernelReadScalar
-                     , GenericC.opsAllocate = cannotAllocate
-                     , GenericC.opsDeallocate = cannotDeallocate
-                     , GenericC.opsCopy = copyInKernel
-                     , GenericC.opsStaticArray = noStaticArrays
-                     , GenericC.opsFatMemory = False
-                     }
-  where kernelOps :: GenericC.OpCompiler KernelOp KernelRequirements
+incErrorLabel :: GenericC.CompilerM KernelOp KernelState ()
+incErrorLabel =
+  GenericC.modifyUserState $ \s -> s { kernelNextSync = kernelNextSync s + 1 }
+
+pendingError :: Bool -> GenericC.CompilerM KernelOp KernelState ()
+pendingError b =
+  GenericC.modifyUserState $ \s -> s { kernelSyncPending = b }
+
+hasCommunication :: ImpKernels.KernelCode -> Bool
+hasCommunication = any communicates
+  where communicates ErrorSync = True
+        communicates LocalBarrier = True
+        communicates GlobalBarrier = True
+        communicates _ = False
+
+inKernelOperations :: ImpKernels.KernelCode -> GenericC.Operations KernelOp KernelState
+inKernelOperations body =
+  GenericC.Operations
+  { GenericC.opsCompiler = kernelOps
+  , GenericC.opsMemoryType = kernelMemoryType
+  , GenericC.opsWriteScalar = kernelWriteScalar
+  , GenericC.opsReadScalar = kernelReadScalar
+  , GenericC.opsAllocate = cannotAllocate
+  , GenericC.opsDeallocate = cannotDeallocate
+  , GenericC.opsCopy = copyInKernel
+  , GenericC.opsStaticArray = noStaticArrays
+  , GenericC.opsFatMemory = False
+  , GenericC.opsError = errorInKernel
+  }
+  where has_communication = hasCommunication body
+
+        kernelOps :: GenericC.OpCompiler KernelOp KernelState
         kernelOps (GetGroupId v i) =
           GenericC.stm [C.cstm|$id:v = get_group_id($int:i);|]
         kernelOps (GetLocalId v i) =
@@ -430,10 +494,12 @@ inKernelOperations = GenericC.Operations
           GenericC.stm [C.cstm|$id:v = get_global_size($int:i);|]
         kernelOps (GetLockstepWidth v) =
           GenericC.stm [C.cstm|$id:v = LOCKSTEP_WIDTH;|]
-        kernelOps LocalBarrier =
+        kernelOps LocalBarrier = do
           GenericC.stm [C.cstm|barrier(CLK_LOCAL_MEM_FENCE);|]
-        kernelOps GlobalBarrier =
+          GenericC.modifyUserState $ \s -> s { kernelHasBarriers = True }
+        kernelOps GlobalBarrier = do
           GenericC.stm [C.cstm|barrier(CLK_GLOBAL_MEM_FENCE);|]
+          GenericC.modifyUserState $ \s -> s { kernelHasBarriers = True }
         kernelOps MemFenceLocal =
           GenericC.stm [C.cstm|mem_fence_local();|]
         kernelOps MemFenceGlobal =
@@ -445,8 +511,19 @@ inKernelOperations = GenericC.Operations
           GenericC.stm [C.cstm|$id:name = $id:name';|]
         kernelOps (LocalAlloc name size) = do
           name' <- newVName $ pretty name ++ "_backing"
-          GenericC.modifyUserState (<>KernelRequirements [(name', size)])
+          GenericC.modifyUserState $ \s ->
+            s { kernelLocalMemory = (name', size) : kernelLocalMemory s }
           GenericC.stm [C.cstm|$id:name = (__local char*) $id:name';|]
+        kernelOps ErrorSync = do
+          label <- nextErrorLabel
+          pending <- kernelSyncPending <$> GenericC.getUserState
+          when pending $ do
+            pendingError False
+            GenericC.stm [C.cstm|$id:label: barrier(CLK_LOCAL_MEM_FENCE);|]
+            GenericC.stm [C.cstm|if (local_failure) { return; }|]
+          GenericC.stm [C.cstm|barrier(CLK_LOCAL_MEM_FENCE);|]
+          GenericC.modifyUserState $ \s -> s { kernelHasBarriers = True }
+          incErrorLabel
         kernelOps (Atomic space aop) = atomicOps space aop
 
         atomicCast s t = do
@@ -498,19 +575,19 @@ inKernelOperations = GenericC.Operations
           cast <- atomicCast s [C.cty|int|]
           GenericC.stm [C.cstm|$id:old = atomic_xchg(&(($ty:cast *)$id:arr)[$exp:ind'], $exp:val');|]
 
-        cannotAllocate :: GenericC.Allocate KernelOp KernelRequirements
+        cannotAllocate :: GenericC.Allocate KernelOp KernelState
         cannotAllocate _ =
           error "Cannot allocate memory in kernel"
 
-        cannotDeallocate :: GenericC.Deallocate KernelOp KernelRequirements
+        cannotDeallocate :: GenericC.Deallocate KernelOp KernelState
         cannotDeallocate _ _ =
           error "Cannot deallocate memory in kernel"
 
-        copyInKernel :: GenericC.Copy KernelOp KernelRequirements
+        copyInKernel :: GenericC.Copy KernelOp KernelState
         copyInKernel _ _ _ _ _ _ _ =
           error "Cannot bulk copy in kernel."
 
-        noStaticArrays :: GenericC.StaticArray KernelOp KernelRequirements
+        noStaticArrays :: GenericC.StaticArray KernelOp KernelState
         noStaticArrays _ _ _ _ =
           error "Cannot create static array in kernel."
 
@@ -537,6 +614,28 @@ inKernelOperations = GenericC.Operations
         kernelReadScalar dest i elemtype space vol =
           GenericC.readScalarPointerWithQuals pointerQuals
           dest i elemtype space vol
+
+        errorInKernel msg@(ErrorMsg parts) backtrace = do
+          n <- length . kernelFailures <$> GenericC.getUserState
+          GenericC.modifyUserState $ \s ->
+            s { kernelFailures = kernelFailures s ++ [FailureMsg msg backtrace] }
+          let setArgs _ [] = return []
+              setArgs i (ErrorString{} : parts') = setArgs i parts'
+              setArgs i (ErrorInt32 x : parts') = do
+                x' <- GenericC.compileExp x
+                stms <- setArgs (i+1) parts'
+                return $ [C.cstm|global_failure_args[$int:i] = $exp:x';|] : stms
+          argstms <- setArgs (0::Int) parts
+          label <- nextErrorLabel
+          pendingError True
+          let what_next
+                | has_communication = [C.citems|local_failure = true;
+                                                goto $id:label;|]
+                | otherwise         = [C.citems|return;|]
+          GenericC.stm [C.cstm|{ if (atomic_cmpxchg(global_failure, -1, $int:n) == -1)
+                                 { $stms:argstms; }
+                                 $items:what_next
+                               }|]
 
 --- Checking requirements
 

--- a/src/Futhark/CodeGen/ImpGen/Kernels/Transpose.hs
+++ b/src/Futhark/CodeGen/ImpGen/Kernels/Transpose.hs
@@ -221,6 +221,7 @@ mapTransposeKernel desc block_dim_int args t kind =
   , kernelNumGroups = num_groups
   , kernelGroupSize = group_size
   , kernelName = nameFromString name
+  , kernelFailureTolerant = True
   }
   where pad2DBytes k = k * (k + 1) * primByteSize t
         block_size =

--- a/src/Futhark/Representation/AST/Syntax/Core.hs
+++ b/src/Futhark/Representation/AST/Syntax/Core.hs
@@ -30,6 +30,7 @@ module Futhark.Representation.AST.Syntax.Core
          , Diet(..)
          , ErrorMsg (..)
          , ErrorMsgPart (..)
+         , errorMsgArgTypes
 
          -- * Values
          , PrimValue(..)
@@ -342,3 +343,10 @@ instance Foldable ErrorMsgPart where
 instance Traversable ErrorMsgPart where
   traverse _ (ErrorString s) = pure $ ErrorString s
   traverse f (ErrorInt32 a) = ErrorInt32 <$> f a
+
+-- | How many non-constant parts does the error message have, and what
+-- is their type?
+errorMsgArgTypes :: ErrorMsg a -> [PrimType]
+errorMsgArgTypes (ErrorMsg parts) = mapMaybe onPart parts
+  where onPart ErrorString{} = Nothing
+        onPart ErrorInt32{} = Just $ IntType Int32

--- a/tests/distribution/inplace4.fut
+++ b/tests/distribution/inplace4.fut
@@ -1,6 +1,5 @@
 -- Distributing an in-place update of slice with a bounds check.
 -- ==
--- tags { no_opencl }
 -- input { [[1,2,3],[4,5,6]] [0,1] [42,1337] }
 -- output { [[42,1337,3],[4,42,1337]] }
 -- structure distributed { SegMap/Update 0 }

--- a/tests/issue667.fut
+++ b/tests/issue667.fut
@@ -1,6 +1,3 @@
--- ==
--- tags { no_opencl }
-
 type point = (f32, f32)
 
 let f (p1: point) (p2: point) =

--- a/tests/issue763.fut
+++ b/tests/issue763.fut
@@ -1,6 +1,3 @@
--- ==
--- tags { no_opencl }
-
 type vector = (f64,f64)
 
 let add(v1: vector)(v2: vector): vector =

--- a/tests/mapiota.fut
+++ b/tests/mapiota.fut
@@ -1,6 +1,5 @@
 -- iota cannot be mapped.
 -- ==
--- tags { no_opencl }
 -- error: type containing anonymous sizes
 
 let main(ns: []i32) = map iota ns

--- a/tests/safety/map0.fut
+++ b/tests/safety/map0.fut
@@ -1,0 +1,5 @@
+-- ==
+-- compiled random input { [20000]f32 } error: Index \[-1\]
+
+let main [n] (xs: [n]f32) =
+  map (\i -> xs[if i == 1000 then -1 else i]) (iota n)

--- a/tests/safety/reduce0.fut
+++ b/tests/safety/reduce0.fut
@@ -1,0 +1,5 @@
+-- ==
+-- compiled random input { [20000]f32 } error: Index \[-1\]
+
+let main [n] (xs: [n]f32) =
+  f32.sum (map (\i -> xs[if i == 1000 then -1 else i]) (iota n))

--- a/tests/safety/reduce1.fut
+++ b/tests/safety/reduce1.fut
@@ -1,0 +1,9 @@
+-- ==
+-- compiled random input { [20000]f32 } error: l != 1337
+
+let main [n] (xs: *[n]f32) =
+  let xs[1337] = f32.lowest
+  let op i j =
+    let l = if xs[i] < xs[j] then i else j
+    in assert (l != 1337) l
+  in reduce op 0 (iota n)

--- a/tests/safety/reduce_by_index0.fut
+++ b/tests/safety/reduce_by_index0.fut
@@ -1,0 +1,7 @@
+-- ==
+-- compiled random input { [20000]f32 } error: Index \[-1\]
+
+let main [n] (xs: [n]f32) =
+  reduce_by_index (replicate 3 0) (+) 0
+                  (map (%3) (iota n))
+                  (map (\i -> xs[if i == 1000 then -1 else i]) (iota n))

--- a/tests/safety/reduce_by_index1.fut
+++ b/tests/safety/reduce_by_index1.fut
@@ -1,0 +1,9 @@
+-- ==
+-- compiled random input { [20000]f32 } error: l != 1337
+
+let main [n] (xs: *[n]f32) =
+  let xs[1337] = f32.lowest
+  let op i j =
+    let l = if xs[i] < xs[j] then i else j
+    in assert (l != 1337) l
+  in reduce_by_index (replicate 3 0) op 0 (map (%3) (iota n)) (iota n)

--- a/tests/safety/scan0.fut
+++ b/tests/safety/scan0.fut
@@ -1,0 +1,5 @@
+-- ==
+-- compiled random input { [20000]f32 } error: Index \[-1\]
+
+let main [n] (xs: [n]f32) =
+  scan (+) 0 (map (\i -> xs[if i == 1000 then -1 else i]) (iota n))

--- a/tests/safety/scan1.fut
+++ b/tests/safety/scan1.fut
@@ -1,0 +1,9 @@
+-- ==
+-- compiled random input { [20000]f32 } error: l != 1337
+
+let main [n] (xs: *[n]f32) =
+  let xs[1337] = f32.lowest
+  let op i j =
+    let l = if xs[i] < xs[j] then i else j
+    in assert (l != 1337) l
+  in scan op 0 (iota n)

--- a/tests/safety/scatter0.fut
+++ b/tests/safety/scatter0.fut
@@ -1,0 +1,6 @@
+-- ==
+-- compiled random input { [20000]f32 } error: Index \[-1\]
+
+let main [n] (xs: [n]f32) =
+  scatter (replicate 3 0) (iota n)
+  (map (\i -> xs[if i == 1000 then -1 else i]) (iota n))


### PR DESCRIPTION
Bounds- and size checking can now be done in parallel kernels.

Performance is in most cases very close to running without bounds checks.