### PR TITLE
Loosen the restrictions on size parameters.

### DIFF
--- a/docs/language-reference.rst
+++ b/docs/language-reference.rst
@@ -190,7 +190,7 @@ presently not allowed.  See `Type Abbreviations`_ for further details.
    param_type: `type` | "(" `id` ":" `type` ")"
 
 Functions are classified via function types, but they are not fully
-first class.  See `Higher-order functions`_ for the details.
+first class.  See :ref:`hofs` for the details.
 
 .. productionlist::
    stringlit: '"' `stringchar` '"'
@@ -939,6 +939,8 @@ An *operator section* that is equivalent to ``\x -> x.a.b.c``.
 
 An *operator section* that is equivalent to ``\x -> x[i,j]``.
 
+.. _hofs:
+
 Higher-order functions
 ----------------------
 
@@ -1141,42 +1143,56 @@ Only expression-level type annotations give rise to run-time checks.
 Despite their similar syntax, parameter and return type annotations
 must be valid at compile-time, or type checking will fail.
 
-Constructivity restriction
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+Causality restriction
+~~~~~~~~~~~~~~~~~~~~~
 
 Conceptually, size parameters are assigned their value by reading the
 sizes of concrete values passed along as parameters.  This means that
-any size parameter must be used as the size of some non-functional
-parameter, as functions do not on their own have sizes.  This is an
-error::
+any size parameter must be used as the size of some parameter.  This
+is an error::
 
   let f [n] (x: i32) = n
 
-Similarly, this is also an error, because ``n`` is not used as the
-size of an array value::
+The following is not an error::
 
   let f [n] (g: [n]i32 -> [n]i32) = ...
 
-However, the following is permitted::
+However, using this function comes with a constraint: whenever an
+application ``f x`` occurs, the value of the size parameter must be
+inferable.  Specifically, this value must have been used as the size
+of an array *before* the ``f x`` application is encountered.  The
+notion of "before" is subtle, as there is no evaluation ordering of a
+Futhark expression, *except* that a ``let``-binding is always
+evaluated before its body, and the argument to a function is always
+evaluated before the function.
 
-  let f [n] (g: [n]i32 -> [n]i32) (arr: [n]i32) = ...
+The causality restriction only occurs when a function has size
+parameters whose first use is *not* as a concrete array size.  For
+example, it does not apply to uses of the following function::
 
-Array literals
-..............
+  let f [n] (arr: [n]i32) (g: [n]i32 -> [n]i32) = ...
 
-When constructing an *empty* array, the compiler must still be able to
-determine the element size of the array at run-time.  Concretely, if
-the element type is polymorphic, a function parameter of that
-polymorphic type (or an array, record, or sum containing it) must
-exist.  This is illegal::
+This is because the proper value of ``n`` can be read directly from
+the actual size of the array.
 
-  let empty 'a (x: i32) = (x, [] : [0]a)
+Empty array literals
+~~~~~~~~~~~~~~~~~~~~
 
-This restriction does not exist for *non-empty* array literals,
-because in those cases the actual provided elements have a size.
+Just as with size-polymorphic functions, when constructing an empty
+array, we must know the exact size of the (missing) elements.  For
+example, in the following proram we are forcing the elements of ``a``
+to be the same as the elements of ``b``, but the size of the elements
+of ``b`` are not known at the time ``a`` is constructed::
+
+  let main (b: bool) (xs: []i32) =
+    let a = [] : [][]i32
+    let b = [filter (>0) xs]
+    in a[0] == b[0]
+
+The result is a type error.
 
 Sum types
-.........
+~~~~~~~~~
 
 When constructing a value of a sum type, the compiler must still be
 able to determine the size of the constructors that are *not* used.
@@ -1188,8 +1204,8 @@ This is illegal::
     let v : sum = #foo xs
     in xs
 
-Abstract types
-..............
+Modules
+~~~~~~~
 
 When matching a module with a module type (see :ref:`module-system`),
 a non-lifted abstract type (i.e. one that is declared with ``type``
@@ -1202,8 +1218,8 @@ the following::
 Then we can construct an array of values of type ``m.t`` without
 worrying about constructing an irregular array.
 
-Interactions with higher-order functions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Higher-order functions
+~~~~~~~~~~~~~~~~~~~~~~
 
 When a higher-order function takes a functional argument whose return
 type is a non-lifted type parameter, any instantiation of that type

--- a/src/Futhark/CLI/REPL.hs
+++ b/src/Futhark/CLI/REPL.hs
@@ -276,11 +276,17 @@ onExp e = do
   case either (Left . T.prettyTypeError) Right $
        T.checkExp imports src tenv e of
     Left err -> liftIO $ putStrLn err
-    Right (_, e') -> do
-      r <- runInterpreter $ I.interpretExp ienv e'
-      case r of
-        Left err -> liftIO $ print err
-        Right v -> liftIO $ putStrLn $ pretty v
+    Right (tparams, e')
+      | null tparams -> do
+          r <- runInterpreter $ I.interpretExp ienv e'
+          case r of
+            Left err -> liftIO $ print err
+            Right v -> liftIO $ putStrLn $ pretty v
+
+      | otherwise -> liftIO $ do
+          putStrLn $ "Inferred type of expression: " ++ pretty (typeOf e')
+          putStrLn $ "The following types are ambiguous: " ++
+            intercalate ", " (map (prettyName . typeParamName) tparams)
 
 prettyBreaking :: Breaking -> String
 prettyBreaking b =

--- a/src/Futhark/Internalise/Defunctionalise.hs
+++ b/src/Futhark/Internalise/Defunctionalise.hs
@@ -113,7 +113,10 @@ lookupVar loc x = do
     Nothing -- If the variable is unknown, it may refer to the 'intrinsics'
             -- module, which we will have to treat specially.
       | baseTag x <= maxIntrinsicTag -> return IntrinsicSV
-      | otherwise -> error $ "Variable " ++ pretty x ++ " at "
+      | otherwise -> -- Anything not in scope is going to be an
+                     -- existential size.
+          return $ Dynamic $ Scalar $ Prim $ Signed Int32
+      | otherwise ->  error $ "Variable " ++ pretty x ++ " at "
                           ++ locStr loc ++ " is out of scope."
 
 -- Like patternDimNames, but ignores sizes that are only found in
@@ -133,7 +136,10 @@ arraySizes (Array _ _ t shape) =
 patternArraySizes :: Pattern -> S.Set VName
 patternArraySizes = arraySizes . patternStructType
 
-dimMapping :: PatternType -> PatternType -> M.Map VName VName
+dimMapping :: Monoid a =>
+              TypeBase (DimDecl VName) a
+           -> TypeBase (DimDecl VName) a
+           -> M.Map VName VName
 dimMapping t1 t2 = execState (matchDims f t1 t2) mempty
   where f (NamedDim d1) (NamedDim d2) = do
           modify $ M.insert (qualLeaf d1) (qualLeaf d2)
@@ -260,7 +266,7 @@ defuncExp e@(Var qn _ loc) = do
     -- Intrinsic functions used as variables are eta-expanded, so we
     -- can get rid of them.
     IntrinsicSV -> do
-      (pats, body, tp) <- etaExpand e
+      (pats, body, tp) <- etaExpand (typeOf e) e
       defuncExp $ Lambda pats body Nothing (Info (mempty, tp)) noLoc
     _ -> let tp = typeFromSV sv
          in return (Var qn (Info tp) loc, sv)
@@ -470,27 +476,28 @@ defuncSoacExp (Lambda params e0 decl tp loc) = do
 
 defuncSoacExp e
   | Scalar Arrow{} <- typeOf e = do
-      (pats, body, tp) <- etaExpand e
+      (pats, body, tp) <- etaExpand (typeOf e) e
       let env = foldMap envFromPattern pats
       body' <- localEnv env $ defuncExp' body
       return $ Lambda pats body' Nothing (Info (mempty, tp)) noLoc
   | otherwise = defuncExp' e
 
-etaExpand :: Exp -> DefM ([Pattern], Exp, StructType)
-etaExpand e = do
-  let (ps, ret) = getType $ typeOf e
-  (pats, vars) <- fmap unzip . forM ps $ \t -> do
-    x <- newNameFromString "x"
+etaExpand :: PatternType -> Exp -> DefM ([Pattern], Exp, StructType)
+etaExpand e_t e = do
+  let (ps, ret) = getType e_t
+  (pats, vars) <- fmap unzip . forM ps $ \(p, t) -> do
+    x <- case p of Named x -> pure x
+                   Unnamed -> newNameFromString "x"
     return (Id x (Info t) noLoc,
             Var (qualName x) (Info t) noLoc)
   let e' = foldl' (\e1 (e2, t2, argtypes) ->
                      Apply e1 e2 (Info (diet t2, Nothing))
                      (Info (foldFunType argtypes ret), Info []) noLoc)
-           e $ zip3 vars ps (drop 1 $ tails ps)
+           e $ zip3 vars (map snd ps) (drop 1 $ tails $ map snd ps)
   return (pats, e', toStruct ret)
 
-  where getType (Scalar (Arrow _ _ t1 t2)) =
-          let (ps, r) = getType t2 in (t1 : ps, r)
+  where getType (Scalar (Arrow _ p t1 t2)) =
+          let (ps, r) = getType t2 in ((p,t1) : ps, r)
         getType t = ([], t)
 
 -- | Defunctionalize an indexing of a single array dimension.
@@ -617,7 +624,7 @@ defuncApply depth e@(Apply e1 e2 d t@(Info ret, Info ext) loc) = do
           -- non-fully-applied intrinsic?
           if null argtypes
             then return (e', Dynamic $ typeOf e)
-            else do (pats, body, tp) <- etaExpand e'
+            else do (pats, body, tp) <- etaExpand (typeOf e') e'
                     defuncExp $ Lambda pats body Nothing (Info (mempty, tp)) noLoc
       | otherwise -> return (e', IntrinsicSV)
 
@@ -638,8 +645,11 @@ defuncApply depth e@(Var qn (Info t) loc) = do
         | otherwise -> do
             fname <- newName $ qualLeaf qn
             let (dims, pats, e0, sv') = liftDynFun sv depth
+                pats_names = S.map identName $ mconcat $ map patternIdents pats
+                notInPats = (`S.notMember` pats_names)
+                dims' = filter notInPats dims
                 (argtypes', rettype) = dynamicFunType sv' argtypes
-            liftValDec fname (fromStruct rettype) dims pats e0
+            liftValDec fname (fromStruct rettype) dims' pats e0
             return (Var (qualName fname)
                     (Info (foldFunType argtypes' $ fromStruct rettype)) loc, sv')
 
@@ -901,7 +911,8 @@ freeVars expr = case expr of
     where freeVarsField (RecordFieldExplicit _ e _)  = freeVars e
           freeVarsField (RecordFieldImplicit vn t _) = ident $ Ident vn t noLoc
 
-  ArrayLit es _ _      -> foldMap freeVars es
+  ArrayLit es t _      -> foldMap freeVars es <>
+                          names (typeDimNames $ unInfo t)
   Range e me incl _ _  -> freeVars e <> foldMap freeVars me <>
                           foldMap freeVars incl
   Var qn (Info t) _    -> NameSet $ M.singleton (qualLeaf qn) $ uniqueness t
@@ -971,17 +982,13 @@ defuncValBind :: ValBind -> DefM (ValBind, Env, Bool)
 
 -- Eta-expand entry points with a functional return type.
 defuncValBind (ValBind entry@Just{} name _ (Info (rettype, retext)) tparams params body _ loc)
-  | (rettype_ps, rettype') <- unfoldFunType rettype,
-    not $ null rettype_ps = do
-      (body_pats, body', _) <- etaExpand body
+  | Scalar Arrow{} <- rettype = do
+      (body_pats, body', rettype') <- etaExpand (fromStruct rettype) body
       -- FIXME: we should also handle non-constant size annotations
       -- here.
       defuncValBind $ ValBind entry name Nothing
-        (Info (onlyConstantDims rettype', retext))
+        (Info (rettype', retext))
         tparams (params <> body_pats) body' Nothing loc
-  where onlyConstantDims = first onDim
-        onDim (ConstDim x) = ConstDim x
-        onDim _            = AnyDim
 
 defuncValBind valbind@(ValBind _ name retdecl (Info (rettype, retext)) tparams params body _ _) = do
   (tparams', params', body', sv) <- defuncLet tparams params body rettype

--- a/src/Futhark/Internalise/Monomorphise.hs
+++ b/src/Futhark/Internalise/Monomorphise.hs
@@ -32,6 +32,7 @@ import           Control.Monad.State
 import           Control.Monad.Writer hiding (Sum)
 import           Data.Bitraversable
 import           Data.Bifunctor
+import           Data.List
 import           Data.Loc
 import qualified Data.Map.Strict as M
 import           Data.Maybe
@@ -44,6 +45,9 @@ import           Language.Futhark
 import           Language.Futhark.Traversals
 import           Language.Futhark.Semantic (TypeBinding(..))
 import           Language.Futhark.TypeChecker.Types
+
+i32 :: TypeBase dim als
+i32 = Scalar $ Prim $ Signed Int32
 
 -- | The monomorphization monad reads 'PolyBinding's and writes 'ValBinding's.
 -- The 'TypeParam's in a 'ValBinding' can only be shape parameters.
@@ -110,9 +114,22 @@ lookupFun vn = do
 lookupRecordReplacement :: VName -> MonoM (Maybe RecordReplacement)
 lookupRecordReplacement v = asks $ M.lookup v . envRecordReplacements
 
+-- | Given instantiated type of function, produce size arguments.
+type InferSizeArgs = StructType -> [Exp]
+
+-- | The kind of type relative to which we monomorphise.  What is
+-- important to us is not the specific dimensions, but merely whether
+-- they are known or anonymous (the latter False).
+type MonoType = TypeBase Bool ()
+
+monoType :: TypeBase (DimDecl VName) als -> MonoType
+monoType = bimap onDim (const ())
+  where onDim AnyDim = False
+        onDim _      = True
+
 -- | Mapping from function name and instance list to a new function name in case
 -- the function has already been instantiated with those concrete types.
-type Lifts = [((VName, TypeBase () ()), VName)]
+type Lifts = [((VName, MonoType), (VName, InferSizeArgs))]
 
 getLifts :: MonoM Lifts
 getLifts = MonoM $ lift get
@@ -120,30 +137,48 @@ getLifts = MonoM $ lift get
 modifyLifts :: (Lifts -> Lifts) -> MonoM ()
 modifyLifts = MonoM . lift . modify
 
-addLifted :: VName -> TypeBase () () -> VName -> MonoM ()
-addLifted fname il lifted_fname =
-  modifyLifts (((fname, il), lifted_fname) :)
+addLifted :: VName -> MonoType -> (VName, InferSizeArgs) -> MonoM ()
+addLifted fname il liftf =
+  modifyLifts (((fname, il), liftf) :)
 
-lookupLifted :: VName -> TypeBase () () -> MonoM (Maybe VName)
+lookupLifted :: VName -> MonoType -> MonoM (Maybe (VName, InferSizeArgs))
 lookupLifted fname t = lookup (fname, t) <$> getLifts
 
-transformFName :: VName -> TypeBase () () -> MonoM VName
-transformFName fname t
-  | baseTag fname <= maxIntrinsicTag = return fname
+transformFName :: SrcLoc -> QualName VName -> StructType -> MonoM Exp
+transformFName loc fname t
+  | baseTag (qualLeaf fname) <= maxIntrinsicTag = return $ var fname
   | otherwise = do
-      maybe_fname <- lookupLifted fname t
-      maybe_funbind <- lookupFun fname
+      maybe_fname <- lookupLifted (qualLeaf fname) (monoType t)
+      maybe_funbind <- lookupFun $ qualLeaf fname
+      t' <- removeTypeVariablesInType t
       case (maybe_fname, maybe_funbind) of
-        -- The function has already been monomorphized.
-        (Just fname', _) -> return fname'
+        -- The function has already been monomorphised.
+        (Just (fname', infer), _) ->
+          return $ applySizeArgs fname' t' $ infer t'
         -- An intrinsic function.
-        (Nothing, Nothing) -> return fname
+        (Nothing, Nothing) -> return $ var fname
         -- A polymorphic function.
         (Nothing, Just funbind) -> do
-          (fname', funbind') <- monomorphizeBinding False funbind t
-          tell $ Seq.singleton (fname, funbind')
-          addLifted fname t fname'
-          return fname'
+          (fname', infer, funbind') <- monomorphiseBinding False funbind (monoType t')
+          tell $ Seq.singleton (qualLeaf fname, funbind')
+          addLifted (qualLeaf fname) (monoType t) (fname', infer)
+          return $ applySizeArgs fname' t' $ infer t'
+
+  where var fname' = Var fname' (Info (fromStruct t)) loc
+
+        applySizeArg (i, f) size_arg =
+          (i-1,
+           Apply f size_arg (Info (Observe, Nothing))
+           (Info (foldFunType (replicate i i32) (fromStruct t)), Info [])
+           loc)
+
+        applySizeArgs fname' t' size_args =
+          snd $ foldl' applySizeArg (length size_args - 1,
+                                     Var (qualName fname')
+                                     (Info (foldFunType (map (const i32) size_args)
+                                            (fromStruct t')))
+                                     loc)
+          size_args
 
 -- | This carries out record replacements in the alias information of a type.
 transformType :: TypeBase dim Aliasing -> MonoM (TypeBase dim Aliasing)
@@ -183,8 +218,8 @@ transformExp (RecordLit fs loc) =
           transformField $ RecordFieldExplicit (baseName v)
             (Var (qualName v) t' loc) loc
 
-transformExp (ArrayLit es tp loc) =
-  ArrayLit <$> mapM transformExp es <*> pure tp <*> pure loc
+transformExp (ArrayLit es t loc) =
+  ArrayLit <$> mapM transformExp es <*> traverse transformType t <*> pure loc
 
 transformExp (Range e1 me incl tp loc) = do
   e1' <- transformExp e1
@@ -192,8 +227,8 @@ transformExp (Range e1 me incl tp loc) = do
   incl' <- mapM transformExp incl
   return $ Range e1' me' incl' tp loc
 
-transformExp (Var (QualName qs fname) (Info t) loc) = do
-  maybe_fs <- lookupRecordReplacement fname
+transformExp (Var fname (Info t) loc) = do
+  maybe_fs <- lookupRecordReplacement $ qualLeaf fname
   case maybe_fs of
     Just fs -> do
       let toField (f, (f_v, f_t)) = do
@@ -202,9 +237,8 @@ transformExp (Var (QualName qs fname) (Info t) loc) = do
             return $ RecordFieldExplicit f f_v' loc
       RecordLit <$> mapM toField (M.toList fs) <*> pure loc
     Nothing -> do
-      fname' <- transformFName fname (toStructural t)
       t' <- transformType t
-      return $ Var (QualName qs fname') (Info t') loc
+      transformFName loc fname (toStruct t')
 
 transformExp (Ascript e tp loc) =
   Ascript <$> transformExp e <*> pure tp <*> pure loc
@@ -261,18 +295,18 @@ transformExp (Lambda params e0 decl tp loc) = do
 transformExp (OpSection qn t loc) =
   transformExp $ Var qn t loc
 
-transformExp (OpSectionLeft (QualName qs fname) (Info t) e
+transformExp (OpSectionLeft fname (Info t) e
                (Info (xtype, xargext), Info ytype) (Info rettype, Info retext) loc) = do
-  fname' <- transformFName fname (toStructural t)
+  fname' <- transformFName loc fname $ toStruct t
   e' <- transformExp e
-  desugarBinOpSection (QualName qs fname') (Just e') Nothing
+  desugarBinOpSection fname' (Just e') Nothing
     t (xtype, xargext) (ytype, Nothing) (rettype, retext) loc
 
-transformExp (OpSectionRight (QualName qs fname) (Info t) e
+transformExp (OpSectionRight fname (Info t) e
               (Info xtype, Info (ytype, yargext)) (Info rettype) loc) = do
-  fname' <- transformFName fname (toStructural t)
+  fname' <- transformFName loc fname $ toStruct t
   e' <- transformExp e
-  desugarBinOpSection (QualName qs fname') Nothing (Just e')
+  desugarBinOpSection fname' Nothing (Just e')
     t (xtype, Nothing) (ytype, yargext) (rettype, []) loc
 
 transformExp (ProjectSection fields (Info t) loc) =
@@ -290,11 +324,19 @@ transformExp (DoLoop sparams pat e1 form e3 ret loc) = do
   e3' <- transformExp e3
   return $ DoLoop sparams pat e1' form' e3' ret loc
 
-transformExp (BinOp (QualName qs fname, oploc) (Info t) (e1, d1) (e2, d2) tp ext loc) = do
-  fname' <- transformFName fname (toStructural t)
+transformExp (BinOp (fname, oploc) (Info t) (e1, d1) (e2, d2) tp ext loc) = do
+  fname' <- transformFName loc fname $ toStruct t
   e1' <- transformExp e1
   e2' <- transformExp e2
-  return $ BinOp (QualName qs fname', oploc) (Info t) (e1', d1) (e2', d2) tp ext loc
+  return $
+    case fname' of
+      Var fname'' _ _ ->
+        BinOp (fname'', oploc) (Info t) (e1', d1) (e2', d2) tp ext loc
+      _ ->
+        Apply (Apply fname' e1' (Info (Observe, snd (unInfo d1)))
+               (Info (foldFunType [fromStruct $ fst (unInfo d2)] (unInfo tp)),
+                Info mempty) loc)
+        e2' (Info (Observe, snd (unInfo d2))) (tp, ext) loc
 
 transformExp (Project n e tp loc) = do
   maybe_fs <- case e of
@@ -350,16 +392,17 @@ transformDimIndex (DimSlice me1 me2 me3) =
   where trans = mapM transformExp
 
 -- | Transform an operator section into a lambda.
-desugarBinOpSection :: QualName VName -> Maybe Exp -> Maybe Exp
+desugarBinOpSection :: Exp -> Maybe Exp -> Maybe Exp
                     -> PatternType
                     -> (StructType, Maybe VName) -> (StructType, Maybe VName)
                     -> (PatternType, [VName]) -> SrcLoc -> MonoM Exp
-desugarBinOpSection qn e_left e_right t (xtype, xext) (ytype, yext) (rettype, retext) loc = do
+desugarBinOpSection op e_left e_right t (xtype, xext) (ytype, yext) (rettype, retext) loc = do
   (e1, p1) <- makeVarParam e_left $ fromStruct xtype
   (e2, p2) <- makeVarParam e_right $ fromStruct ytype
-  let body = BinOp (qn, loc) (Info t)
-             (e1, Info (xtype, xext)) (e2, Info (ytype, yext))
-             (Info rettype) (Info retext) loc
+  let apply_left = Apply op e1 (Info (Observe, xext))
+                   (Info $ foldFunType [fromStruct ytype] t, Info []) loc
+      body = Apply apply_left e2 (Info (Observe, yext))
+             (Info rettype, Info retext) loc
       rettype' = toStruct rettype
   return $ Lambda (p1 ++ p2) body Nothing (Info (mempty, rettype')) loc
 
@@ -392,7 +435,7 @@ desugarIndexSection  _ t _ = error $ "desugarIndexSection: not a function type: 
 
 noticeDims :: TypeBase (DimDecl VName) as -> MonoM ()
 noticeDims = mapM_ notice . nestedDims
-  where notice (NamedDim v) = void $ transformFName (qualLeaf v) $ Scalar $ Prim $ Signed Int32
+  where notice (NamedDim v) = void $ transformFName noLoc v i32
         notice _            = return ()
 
 -- | Convert a collection of 'ValBind's to a nested sequence of let-bound,
@@ -441,21 +484,57 @@ wildcard (Scalar (Record fs)) loc =
 wildcard t loc =
   Wildcard (Info t) loc
 
--- | Monomorphize a polymorphic function at the types given in the instance
--- list. Monomorphizes the body of the function as well. Returns the fresh name
+type DimInst = M.Map VName (DimDecl VName)
+
+dimMapping :: Monoid a =>
+              TypeBase (DimDecl VName) a
+           -> TypeBase (DimDecl VName) a
+           -> DimInst
+dimMapping t1 t2 = execState (matchDims f t1 t2) mempty
+  where f (NamedDim d1) d2 = do
+          modify $ M.insert (qualLeaf d1) d2
+          return $ NamedDim d1
+        f d _ = return d
+
+inferSizeArgs :: [TypeParam] -> StructType -> StructType -> [Exp]
+inferSizeArgs tparams bind_t t =
+  mapMaybe (tparamArg (dimMapping bind_t t)) tparams
+  where tparamArg dinst tp =
+          case M.lookup (typeParamName tp) dinst of
+            Just (NamedDim d) ->
+              Just $ Var d (Info i32) noLoc
+            Just (ConstDim x) ->
+              Just $ Literal (SignedValue $ Int32Value $ fromIntegral x) noLoc
+            _ ->
+              Nothing
+
+explicitSizes :: StructType -> MonoType -> S.Set VName
+explicitSizes t1 t2 =
+  execState (matchDims onDims t1 t2) mempty `S.intersection` mustBeExplicit t1
+  where onDims d1 d2 = do
+          case (d1, d2) of
+            (NamedDim v, True) -> modify $ S.insert $ qualLeaf v
+            _                  -> return ()
+          return d1
+
+-- | Monomorphise a polymorphic function at the types given in the instance
+-- list. Monomorphises the body of the function as well. Returns the fresh name
 -- of the generated monomorphic function and its 'ValBind' representation.
-monomorphizeBinding :: Bool -> PolyBinding -> TypeBase () () -> MonoM (VName, ValBind)
-monomorphizeBinding entry (PolyBinding rr (name, tparams, params, retdecl, rettype, retext, body, loc)) t =
+monomorphiseBinding :: Bool -> PolyBinding -> MonoType
+                    -> MonoM (VName, InferSizeArgs, ValBind)
+monomorphiseBinding entry (PolyBinding rr (name, tparams, params, retdecl, rettype, retext, body, loc)) t =
   replaceRecordReplacements rr $ do
-  t' <- removeTypeVariablesInType t
-  let bind_t = foldFunType (map (toStructural . patternType) params) $
-               toStructural rettype
-  (substs, t_shape_params) <- typeSubstsM loc bind_t t'
+  let bind_t = foldFunType (map patternStructType params) rettype
+  (substs, t_shape_params) <- typeSubstsM loc (noSizes bind_t) t
   let substs' = M.map Subst substs
       rettype' = substTypesAny (`M.lookup` substs') rettype
       substPatternType =
         substTypesAny (fmap (fmap fromStruct) . (`M.lookup` substs'))
       params' = map (substPattern entry substPatternType) params
+      bind_t' = substTypesAny (`M.lookup` substs') bind_t
+      (shape_params_explicit, shape_params_implicit) =
+        partition ((`S.member` explicitSizes bind_t' t) . typeParamName) $
+        shape_params ++ t_shape_params
 
   (params'', rrs) <- unzip <$> mapM transformPattern params'
 
@@ -463,8 +542,17 @@ monomorphizeBinding entry (PolyBinding rr (name, tparams, params, retdecl, retty
 
   body' <- updateExpTypes (`M.lookup` substs') body
   body'' <- withRecordReplacements (mconcat rrs) $ transformExp body'
-  name' <- if null tparams then return name else newName name
-  return (name', toValBinding t_shape_params name' params'' (rettype', retext) body'')
+  name' <- if null tparams && not entry then return name else newName name
+
+  return (name',
+          inferSizeArgs shape_params_explicit bind_t',
+          if entry
+          then toValBinding name'
+               (shape_params_explicit++shape_params_implicit) params''
+               (rettype', retext) body''
+          else toValBinding name' shape_params_implicit
+               (map shapeParam shape_params_explicit ++ params'')
+               (rettype', retext) body'')
 
   where shape_params = filter (not . isTypeParam) tparams
 
@@ -476,61 +564,57 @@ monomorphizeBinding entry (PolyBinding rr (name, tparams, params, retdecl, retty
                                   , mapOnPatternType = pure . applySubst substs
                                   }
 
-        toValBinding t_shape_params name' params'' rettype' body'' =
+        shapeParam tp = Id (typeParamName tp) (Info i32) $ srclocOf tp
+
+        toValBinding name' tparams' params'' rettype' body'' =
           ValBind { valBindEntryPoint = Nothing
                   , valBindName       = name'
                   , valBindRetDecl    = retdecl
                   , valBindRetType    = Info rettype'
-                  , valBindTypeParams = shape_params ++ t_shape_params
+                  , valBindTypeParams = tparams'
                   , valBindParams     = params''
                   , valBindBody       = body''
                   , valBindDoc        = Nothing
                   , valBindLocation   = loc
                   }
 
--- Careful not to introduce size parameters for non-positive positions
--- (i.e. function parameters).
 typeSubstsM :: MonadFreshNames m =>
-               SrcLoc -> TypeBase () () -> TypeBase () ()
+               SrcLoc -> TypeBase () () -> MonoType
             -> m (M.Map VName StructType, [TypeParam])
 typeSubstsM loc orig_t1 orig_t2 =
-  let (t1_pts, t1_rt) = unfoldFunType orig_t1
-      (t2_pts, t2_rt) = unfoldFunType orig_t2
-      m = do zipWithM_ (sub True) t1_pts t2_pts
-             sub False t1_rt t2_rt
+  let m = sub orig_t1 orig_t2
   in runWriterT $ execStateT m mempty
 
-  where sub pos t1@Array{} t2@Array{}
+  where sub t1@Array{} t2@Array{}
           | Just t1' <- peelArray (arrayRank t1) t1,
             Just t2' <- peelArray (arrayRank t1) t2 =
-              sub pos t1' t2'
-        sub pos (Scalar (TypeVar _ _ v _)) t = addSubst pos v t
-        sub pos (Scalar (Record fields1)) (Scalar (Record fields2)) =
-          zipWithM_ (sub pos)
+              sub t1' t2'
+        sub (Scalar (TypeVar _ _ v _)) t = addSubst v t
+        sub (Scalar (Record fields1)) (Scalar (Record fields2)) =
+          zipWithM_ sub
           (map snd $ sortFields fields1) (map snd $ sortFields fields2)
-        sub _ (Scalar Prim{}) (Scalar Prim{}) = return ()
-        sub _ (Scalar (Arrow _ _ t1a t1b)) (Scalar (Arrow _ _ t2a t2b)) = do
-          sub False t1a t2a
-          sub False t1b t2b
-        sub pos (Scalar (Sum cs1)) (Scalar (Sum cs2)) =
+        sub (Scalar Prim{}) (Scalar Prim{}) = return ()
+        sub (Scalar (Arrow _ _ t1a t1b)) (Scalar (Arrow _ _ t2a t2b)) = do
+          sub t1a t2a
+          sub t1b t2b
+        sub (Scalar (Sum cs1)) (Scalar (Sum cs2)) =
           zipWithM_ typeSubstClause (sortConstrs cs1) (sortConstrs cs2)
-          where typeSubstClause (_, ts1) (_, ts2) = zipWithM (sub pos) ts1 ts2
-        sub pos t1@(Scalar Sum{}) t2 = sub pos t1 t2
-        sub pos t1 t2@(Scalar Sum{}) = sub pos t1 t2
+          where typeSubstClause (_, ts1) (_, ts2) = zipWithM sub ts1 ts2
+        sub t1@(Scalar Sum{}) t2 = sub t1 t2
+        sub t1 t2@(Scalar Sum{}) = sub t1 t2
 
-        sub _ t1 t2 = error $ unlines ["typeSubstsM: mismatched types:", pretty t1, pretty t2]
+        sub t1 t2 = error $ unlines ["typeSubstsM: mismatched types:", pretty t1, pretty t2]
 
-        addSubst pos (TypeName _ v) t = do
+        addSubst (TypeName _ v) t = do
           exists <- gets $ M.member v
           unless exists $ do
-            t' <- if pos
-                  then bitraverse onDim pure t
-                  else pure $ addSizes t
+            t' <- bitraverse onDim pure t
             modify $ M.insert v t'
 
-        onDim () = do d <- lift $ lift $ newVName "d"
-                      tell [TypeParamDim d loc]
-                      return $ NamedDim $ qualName d
+        onDim True = do d <- lift $ lift $ newVName "d"
+                        tell [TypeParamDim d loc]
+                        return $ NamedDim $ qualName d
+        onDim False = return AnyDim
 
 -- | Perform a given substitution on the types in a pattern.
 substPattern :: Bool -> (PatternType -> PatternType) -> Pattern -> Pattern
@@ -569,21 +653,21 @@ removeTypeVariables entry valbind@(ValBind _ _ _ (Info (rettype, retext)) _ pats
                  , valBindBody    = body'
                  }
 
-removeTypeVariablesInType :: TypeBase () () -> MonoM (TypeBase () ())
+removeTypeVariablesInType :: StructType -> MonoM StructType
 removeTypeVariablesInType t = do
   subs <- asks $ M.map TypeSub . envTypeBindings
-  return $ noSizes $ substituteTypes subs $ addSizes t
+  return $ substituteTypes subs t
 
 transformValBind :: ValBind -> MonoM Env
 transformValBind valbind = do
-  valbind' <- toPolyBinding <$> removeTypeVariables (isJust (valBindEntryPoint valbind)) valbind
+  valbind' <- toPolyBinding <$>
+              removeTypeVariables (isJust (valBindEntryPoint valbind)) valbind
   when (isJust $ valBindEntryPoint valbind) $ do
-    t <- removeTypeVariablesInType $ noSizes $ foldFunType
+    t <- removeTypeVariablesInType $ foldFunType
          (map patternStructType (valBindParams valbind)) $
          fst $ unInfo $ valBindRetType valbind
-    (name, valbind'') <- monomorphizeBinding True valbind' t
+    (name, _, valbind'') <- monomorphiseBinding True valbind' $ monoType t
     tell $ Seq.singleton (name, valbind'' { valBindEntryPoint = valBindEntryPoint valbind})
-    addLifted (valBindName valbind) t name
   return mempty { envPolyBindings = M.singleton (valBindName valbind) valbind' }
 
 transformTypeBind :: TypeBind -> MonoM Env
@@ -594,7 +678,7 @@ transformTypeBind (TypeBind name l tparams tydecl _ _) = do
       tbinding = TypeAbbr l tparams tp
   return mempty { envTypeBindings = M.singleton name tbinding }
 
--- | Monomorphize a list of top-level declarations. A module-free input program
+-- | Monomorphise a list of top-level declarations. A module-free input program
 -- is expected, so only value declarations and type declaration are accepted.
 transformDecs :: [Dec] -> MonoM ()
 transformDecs [] = return ()

--- a/src/Language/Futhark/Pretty.hs
+++ b/src/Language/Futhark/Pretty.hs
@@ -234,8 +234,13 @@ instance (Eq vn, IsName vn, Annot f) => Pretty (ExpBase f vn) where
     | otherwise                     = braces $ commasep $ map ppr fs
     where fieldArray (RecordFieldExplicit _ e _) = hasArrayLit e
           fieldArray RecordFieldImplicit{} = False
-  pprPrec _ (ArrayLit es _ _) =
-    brackets $ commasep $ map ppr es
+  pprPrec _ (ArrayLit es info _) =
+    brackets (commasep $ map ppr es) <> info'
+    where info' = case unAnnot info of
+                    Just t
+                      | isEnvVarSet "FUTHARK_COMPILER_DEBUGGING" False ->
+                          text "@" <> parens (align $ ppr t)
+                    _ -> mempty
   pprPrec _ (StringLit s _) =
     text $ show $ decode s
   pprPrec p (Range start maybe_step end _ _) =
@@ -251,7 +256,7 @@ instance (Eq vn, IsName vn, Annot f) => Pretty (ExpBase f vn) where
                              text "then" <+> align (ppr t) </>
                              text "else" <+> align (ppr f)
   pprPrec p (Apply f arg _ _ _) =
-    parensIf (p >= 10) $ ppr f <+/> pprPrec 10 arg
+    parensIf (p >= 10) $ pprPrec 0 f <+/> pprPrec 10 arg
   pprPrec _ (Negate e _) = text "-" <> ppr e
   pprPrec p (LetPat pat e body _ _) =
     parensIf (p /= -1) $ align $

--- a/tests/operator/section3.fut
+++ b/tests/operator/section3.fut
@@ -1,0 +1,9 @@
+-- Operator section with interesting type to the left.
+-- ==
+-- input { [-1,1] } output { [1] }
+
+let (<*>) 'a 'b (f: a -> b) (xs: a) =
+  f xs
+
+let main (xs: []i32) =
+  (id<*>) (filter (>0) xs)

--- a/tests/operator/section4.fut
+++ b/tests/operator/section4.fut
@@ -1,0 +1,9 @@
+-- Operator section with interesting type to the left.
+-- ==
+-- input { [-1,1] } output { [1] }
+
+let (<*>) 'a 'b (f: a -> b) (xs: a) =
+  f xs
+
+let main (xs: []i32) =
+  (<*>(filter (>0) xs)) id

--- a/tests/shapes/concatmap.fut
+++ b/tests/shapes/concatmap.fut
@@ -1,0 +1,8 @@
+-- ==
+-- input { [1,2,3] } output { [0,0,1,0,1,2] }
+
+let concatmap [n] 'a 'b (f: a -> []b) (as: [n]a) : []b =
+  loop acc = [] for a in as do
+    acc ++ f a
+
+let main (xs: []i32) = concatmap iota xs

--- a/tests/shapes/emptydim3.fut
+++ b/tests/shapes/emptydim3.fut
@@ -1,0 +1,6 @@
+-- ==
+-- input { 2 } output { 2 empty([0][2]i32) }
+
+let empty 'a (x: i32) = (x, [] : [0]a)
+
+let main x : (i32, [][x]i32) = empty x

--- a/tests/shapes/error10.fut
+++ b/tests/shapes/error10.fut
@@ -1,0 +1,7 @@
+-- ==
+-- error: Causality check
+
+let main (b: bool) (xs: []i32) =
+  let a = [] : [][]i32
+  let b = [filter (>0) xs]
+  in a[0] == b[0]

--- a/tests/shapes/error11.fut
+++ b/tests/shapes/error11.fut
@@ -1,0 +1,5 @@
+-- Size parameters are only allowed for things that have parameters.
+-- ==
+-- error: Size parameter
+
+let iiota [n] : [n]i32 = iota n

--- a/tests/shapes/error8.fut
+++ b/tests/shapes/error8.fut
@@ -1,4 +1,6 @@
 -- ==
--- error: ambiguous
+-- error: Entry point
 
 let empty 'a (x: i32) = (x, [] : [0]a)
+
+let main x : (i32, [][]i32) = empty x

--- a/tests/shapes/flatmap.fut
+++ b/tests/shapes/flatmap.fut
@@ -1,0 +1,7 @@
+-- ==
+-- input { [1,2] } output { [1,2,2,3] }
+
+let flatmap [n] [m] 'a 'b (f: a -> [m]b) (as: [n]a) : []b =
+  flatten (map f as)
+
+let main (xs: []i32) = flatmap (\x -> [x,x+1]) xs

--- a/tests/shapes/funshape0.fut
+++ b/tests/shapes/funshape0.fut
@@ -1,0 +1,8 @@
+-- ==
+-- error: Causality check
+
+let f [n] (_: [n]i32 -> i32) : [n]i32 -> i32 =
+  let m = n + 1
+  in \_ -> m
+
+let main xs = filter (>0) xs |> f (\_ -> 0)

--- a/tests/shapes/funshape1.fut
+++ b/tests/shapes/funshape1.fut
@@ -1,0 +1,8 @@
+-- ==
+-- error: Causality check
+
+let f [n] (_: [n]i32 -> i32) : [n]i32 -> i32 =
+  let m = n + 1
+  in \_ -> m
+
+let main xs = f (\_ -> 0) <| filter (>0) xs

--- a/tests/shapes/funshape2.fut
+++ b/tests/shapes/funshape2.fut
@@ -1,0 +1,4 @@
+-- ==
+-- error: Causality check
+
+let main xs = (\f' -> f' (filter (>0) xs)) (\_ -> 0)

--- a/tests/shapes/funshape3.fut
+++ b/tests/shapes/funshape3.fut
@@ -1,0 +1,7 @@
+-- ==
+-- error: Causality check
+
+let f [n] (_: [n]i32) (_: [n]i32 -> i32, _: [n]i32) : i32 =
+  n
+
+let main x = f (iota (x+2)) (\_ -> 0, iota (x+2))

--- a/tests/shapes/modules1.fut
+++ b/tests/shapes/modules1.fut
@@ -1,0 +1,16 @@
+-- It is not allowed to create an opaque type whose size parameters
+-- are not used in array dimensions.
+-- ==
+-- error: "n"
+
+module m = {
+  type^ t [n] = [n]i32 -> i32
+  let f [n] (_: t [n]) = 0
+  let mk (n: i32) : t [n] = \(xs: [n]i32) -> n
+} : {
+  type^ t [n]
+  val f [n] : (x: t [n]) -> i32
+  val mk : (n: i32) -> t [n]
+}
+
+let main x = (x+2) |> m.mk |> m.f

--- a/tests/shapes/negative-position-shape0.fut
+++ b/tests/shapes/negative-position-shape0.fut
@@ -1,6 +1,8 @@
--- It should not be allowed to have a shape parameter that is only
--- used in negative position in the parameter types.
+-- It should be allowed to have a shape parameter that is only used in
+-- negative position in the parameter types.
 -- ==
--- error: Size parameter "n" must be used
+-- input {} output { 3 }
 
-let f [n] (g: i32 -> [n]i32) : i32 = n
+let f [n] (_g: i32 -> [n]i32) : i32 = n
+
+let main = f (replicate 3)

--- a/tests/shapes/negative-position-shape1.fut
+++ b/tests/shapes/negative-position-shape1.fut
@@ -1,6 +1,9 @@
 -- It should not be allowed to have a shape parameter that is only
--- used in negative position in the parameter types.
+-- used in negative position in the parameter types, but only if that
+-- size is unambiguous.
 -- ==
--- error: Size parameter "n" must be used
+-- error: ambiguous
 
 let f [n] (g: [n]i32 -> i32) : i32 = n
+
+let main = f (\xs -> xs[0])

--- a/tests/shapes/negative-position-shape3.fut
+++ b/tests/shapes/negative-position-shape3.fut
@@ -1,0 +1,5 @@
+-- Entry points may not be return-polymorphic.
+-- ==
+-- error: Entry point
+
+let main [n] (x: i32) : [n]i32 = replicate n x

--- a/tests/shapes/negative-position-shape4.fut
+++ b/tests/shapes/negative-position-shape4.fut
@@ -1,7 +1,6 @@
--- No hiding negative positions through type abbreviations!
 -- ==
--- error: Size parameter "n" must be used
+-- input { 2 } output { [2i32, 2i32] }
 
-type^ ft [n] = i32 -> [n]i32
+let f [n] (x: i32) : [n]i32 = replicate n x
 
-let f [n] (_: ft [n]) = 0
+let main (x: i32) : [x]i32 = f x

--- a/tests/shapes/size-inference6.fut
+++ b/tests/shapes/size-inference6.fut
@@ -1,8 +1,11 @@
--- Do not permit inference of a type with non-constructive size parameters.
+-- Permit inference of a type with non-constructive size parameters.
 -- ==
--- error: "r"
+-- input { 0 2 } output { empty([0]i32) [1i32,0i32] }
 
 let r =
   let f = reverse
   let g = reverse
   in {f, g}
+
+let main x y =
+  (\p -> (p.f (iota x), p.g (iota y))) r

--- a/tests/types/alias-error5.fut
+++ b/tests/types/alias-error5.fut
@@ -1,5 +1,5 @@
 -- A type abbreviation must use all of its size parameters.
 -- ==
--- error: Size parameter \[n\]
+-- error: Size parameter "\[n\]"
 
 type matrix [n] = i32


### PR DESCRIPTION
A size parameter need no longer be used in an actual array.  But if
you don't, then there are some other restrictions on how the overall
binding can be used.  Basically: the size parameter must be inferable
at the point of instantiation.

Now @kfl can get his concatmap and flatmap working.