### PR TITLE
Index function generalization/antiunification across if-then-else

### DIFF
--- a/src/Futhark/Analysis/PrimExp/Convert.hs
+++ b/src/Futhark/Analysis/PrimExp/Convert.hs
@@ -4,6 +4,7 @@ module Futhark.Analysis.PrimExp.Convert
   (
     primExpToExp
   , primExpFromExp
+  , primExpToSubExp
   , primExpFromSubExp
   , primExpFromSubExpM
   , replaceInPrimExp

--- a/src/Futhark/Analysis/PrimExp/Generalize.hs
+++ b/src/Futhark/Analysis/PrimExp/Generalize.hs
@@ -1,0 +1,70 @@
+module Futhark.Analysis.PrimExp.Generalize
+  (
+    leastGeneralGeneralization
+  ) where
+
+import           Control.Monad
+import           Data.List (elemIndex)
+
+
+import           Futhark.Analysis.PrimExp
+import           Futhark.Representation.AST.Syntax.Core (Ext(..))
+
+-- | Generalization (anti-unification)
+-- We assume that the two expressions have the same type.
+leastGeneralGeneralization :: (Eq v) => [(PrimExp v, PrimExp v)] -> PrimExp v -> PrimExp v ->
+                              Maybe (PrimExp (Ext v), [(PrimExp v, PrimExp v)])
+leastGeneralGeneralization m exp1@(LeafExp v1 t1) exp2@(LeafExp v2 _) =
+  if v1 == v2 then
+    Just (LeafExp (Free v1) t1, m)
+  else
+    Just $ generalize m exp1 exp2
+leastGeneralGeneralization m exp1@(ValueExp v1) exp2@(ValueExp v2) =
+  if v1 == v2 then
+    Just (ValueExp v1, m)
+  else
+    Just $ generalize m exp1 exp2
+leastGeneralGeneralization m exp1@(BinOpExp op1 e11 e12) exp2@(BinOpExp op2 e21 e22) =
+  if op1 == op2 then do
+    (e1, m1) <- leastGeneralGeneralization m e11 e21
+    (e2, m2) <- leastGeneralGeneralization m1 e12 e22
+    return (BinOpExp op1 e1 e2, m2)
+  else
+    Just $ generalize m exp1 exp2
+leastGeneralGeneralization m exp1@(CmpOpExp op1 e11 e12) exp2@(CmpOpExp op2 e21 e22) =
+  if op1 == op2 then do
+    (e1, m1) <- leastGeneralGeneralization m e11 e21
+    (e2, m2) <- leastGeneralGeneralization m1 e12 e22
+    return (CmpOpExp op1 e1 e2, m2)
+  else
+    Just $ generalize m exp1 exp2
+leastGeneralGeneralization m exp1@(UnOpExp op1 e1) exp2@(UnOpExp op2 e2) =
+  if op1 == op2 then do
+    (e, m1) <- leastGeneralGeneralization m e1 e2
+    return (UnOpExp op1 e, m1)
+  else
+    Just $ generalize m exp1 exp2
+leastGeneralGeneralization m exp1@(ConvOpExp op1 e1) exp2@(ConvOpExp op2 e2) =
+  if op1 == op2 then do
+    (e, m1) <- leastGeneralGeneralization m e1 e2
+    return (ConvOpExp op1 e, m1)
+  else
+    Just $ generalize m exp1 exp2
+leastGeneralGeneralization m exp1@(FunExp s1 args1 t1) exp2@(FunExp s2 args2 _) =
+  if s1 == s2 && length args1 == length args2 then do
+    (args, m') <- foldM (\(arg_acc, m_acc) (a1, a2) -> do
+                            (a, m'') <- leastGeneralGeneralization m_acc a1 a2
+                            return (a : arg_acc, m'')
+                        ) ([], m) (zip args1 args2)
+    return (FunExp s1 (reverse args) t1, m')
+  else
+    Just $ generalize m exp1 exp2
+leastGeneralGeneralization m exp1 exp2 =
+  Just $ generalize m exp1 exp2
+
+generalize :: Eq v => [(PrimExp v, PrimExp v)] -> PrimExp v -> PrimExp v -> (PrimExp (Ext v), [(PrimExp v, PrimExp v)])
+generalize m exp1 exp2 =
+  let t = primExpType exp1
+  in case elemIndex (exp1, exp2) m of
+       Just i -> (LeafExp (Ext i) t, m)
+       Nothing -> (LeafExp (Ext $ length m) t, m ++ [(exp1, exp2)])

--- a/src/Futhark/CodeGen/ImpGen.hs
+++ b/src/Futhark/CodeGen/ImpGen.hs
@@ -473,9 +473,10 @@ compileBody pat (Body _ bnds ses) = do
   compileStms (freeIn ses) bnds $
     forM_ (zip dests ses) $ \(d, se) -> copyDWIMDest d [] se []
 
-compileBody' :: (ExplicitMemorish lore, attr ~ LetAttr lore)
-             => [Param attr] -> Body lore -> ImpM lore op ()
-compileBody' = compileBody . patternFromParams
+compileBody' :: [Param attr] -> Body lore -> ImpM lore op ()
+compileBody' params (Body _ bnds ses) =
+  compileStms (freeIn ses) bnds $
+    forM_ (zip params ses) $ \(param, se) -> copyDWIM (paramName param) [] se []
 
 compileLoopBody :: Typed attr => [Param attr] -> Body lore -> ImpM lore op ()
 compileLoopBody mergeparams (Body _ bnds ses) = do
@@ -902,18 +903,15 @@ lookupMemory name = do
     _              -> compilerBugS $ "Unknown memory block: " ++ pretty name
 
 destinationFromPattern :: ExplicitMemorish lore => Pattern lore -> ImpM lore op Destination
-destinationFromPattern pat = fmap (Destination (baseTag <$> maybeHead (patternNames pat))) . mapM inspect $
-                             patternElements pat
-  where ctx_names = patternContextNames pat
-        inspect patElem = do
+destinationFromPattern pat =
+  fmap (Destination (baseTag <$> maybeHead (patternNames pat))) . mapM inspect $
+  patternElements pat
+  where inspect patElem = do
           let name = patElemName patElem
           entry <- lookupVar name
           case entry of
-            ArrayVar _ (ArrayEntry (MemLocation mem shape ixfun) _) ->
-              return $ ArrayDestination $
-              if mem `elem` ctx_names
-              then Nothing
-              else Just $ MemLocation mem shape ixfun
+            ArrayVar _ (ArrayEntry MemLocation{} _) ->
+              return $ ArrayDestination Nothing
             MemVar{} ->
               return $ MemoryDestination name
 

--- a/src/Futhark/Representation/ExplicitMemory.hs
+++ b/src/Futhark/Representation/ExplicitMemory.hs
@@ -403,10 +403,6 @@ fixExtIxFun i e = fmap $ replaceInPrimExp update
 leafExp :: Int -> PrimExp (Ext a)
 leafExp i = LeafExp (Ext i) int32
 
-memReturnIxFun :: MemReturn -> ExtIxFun
-memReturnIxFun (ReturnsInBlock _ ixfun) = ixfun
-memReturnIxFun (ReturnsNewBlock _ _ ixfun) = ixfun
-
 existentialiseIxFun :: [VName] -> IxFun -> ExtIxFun
 existentialiseIxFun ctx = IxFun.substituteInIxFun ctx' . fmap (fmap Free)
   where ctx' = M.map leafExp $ M.fromList $ zip (map Free ctx) [0..]
@@ -557,25 +553,8 @@ matchReturnType rettype res ts = do
   let (ctx_ts, val_ts) = splitFromEnd (length rettype) ts
       (ctx_res, _val_res) = splitFromEnd (length rettype) res
 
-      getId :: (SubExp,Int) -> Maybe (VName,Int)
-      getId (Var ii, i) = Just (ii,i)
-      getId (Constant _, _) = Nothing
-
-      (ctx_map_ids, ctx_map_exts) =
-        getExtMaps $ mapMaybe getId $ zip ctx_res [0..length ctx_res - 1]
-
       existentialiseIxFun0 :: IxFun -> ExtIxFun
-      existentialiseIxFun0 = IxFun.substituteInIxFun ctx_map_ids . fmap (fmap Free)
-
-      getCt :: (Int,SubExp) -> Maybe (Ext VName, PrimExp (Ext VName))
-      getCt (_, Var _) = Nothing
-      getCt (i, Constant c) = Just (Ext i, ValueExp c)
-
-      ctx_map_cts = M.fromList $ mapMaybe getCt $
-                    zip [0..length ctx_res - 1] ctx_res
-
-      substConstsInExtIndFun :: ExtIxFun -> ExtIxFun
-      substConstsInExtIndFun = IxFun.substituteInIxFun (ctx_map_cts<>ctx_map_exts)
+      existentialiseIxFun0 = fmap $ fmap Free
 
       fetchCtx i = case maybeNth i $ zip ctx_res ctx_ts of
                      Nothing -> throwError $ "Cannot find context variable " ++
@@ -591,8 +570,6 @@ matchReturnType rettype res ts = do
         | x_pt == y_pt, shapeRank x_shape == shapeRank y_shape = do
             zipWithM_ checkDim (shapeDims x_shape) (shapeDims y_shape)
             checkMemReturn x_ret y_ret
-              where extDim (Ext v) = LeafExp (Ext v) int32
-                    extDim (Free se) = Free <$> primExpFromSubExp int32 se
       checkReturn x y =
         throwError $ unwords ["Expected ", pretty x, " but got ", pretty y]
 
@@ -612,23 +589,19 @@ matchReturnType rettype res ts = do
       extsInMemInfo _ = S.empty
 
       checkMemReturn (ReturnsInBlock x_mem x_ixfun) (ArrayIn y_mem y_ixfun)
-          | x_mem == y_mem = do
-              let x_ixfun' = substConstsInExtIndFun x_ixfun
-                  y_ixfun' = existentialiseIxFun0   y_ixfun
-              unless (x_ixfun' == y_ixfun') $
+          | x_mem == y_mem =
+              unless (IxFun.closeEnough x_ixfun $ existentialiseIxFun0 y_ixfun) $
                 throwError $ unwords  ["Index function unification failed (ReturnsInBlock)",
-                    "\nixfun of body result: ", pretty y_ixfun',
-                    "\nixfun of return type: ", pretty x_ixfun',
+                    "\nixfun of body result: ", pretty y_ixfun,
+                    "\nixfun of return type: ", pretty x_ixfun,
                     "\nand context elements: ", pretty ctx_res]
       checkMemReturn (ReturnsNewBlock x_space x_ext x_ixfun)
                      (ArrayIn y_mem y_ixfun) = do
         (x_mem, x_mem_type)  <- fetchCtx x_ext
-        let x_ixfun' = substConstsInExtIndFun x_ixfun
-            y_ixfun' = existentialiseIxFun0   y_ixfun
-        unless (x_ixfun' == y_ixfun') $
+        unless (IxFun.closeEnough x_ixfun $ existentialiseIxFun0 y_ixfun) $
           throwError $ unwords  ["Index function unification failed (ReturnsNewBlock)",
-            "\nixfun of body result: ", pretty y_ixfun',
-            "\nixfun of return type: ", pretty x_ixfun',
+            "\nixfun of body result: ", pretty y_ixfun,
+            "\nixfun of return type: ", pretty x_ixfun,
             "\nand context elements: ", pretty ctx_res]
         case x_mem_type of
           MemMem y_space -> do
@@ -704,7 +677,7 @@ matchPatternToExp pat e = do
              Just (ReturnsNewBlock y_space y_i y_ixfun)) ->
               let x_ixfun' = IxFun.substituteInIxFun  ctxids x_ixfun
                   y_ixfun' = IxFun.substituteInIxFun ctxexts y_ixfun
-              in  x_space == y_space && x_i == y_i && x_ixfun' == y_ixfun'
+              in  x_space == y_space && x_i == y_i && IxFun.closeEnough x_ixfun' y_ixfun'
             (_, Nothing) -> True
             _ -> False
         matches _ _ _ _ = False

--- a/src/Futhark/Representation/ExplicitMemory/IndexFunction.hs
+++ b/src/Futhark/Representation/ExplicitMemory/IndexFunction.hs
@@ -21,6 +21,8 @@ module Futhark.Representation.ExplicitMemory.IndexFunction
        , isDirect
        , isLinear
        , substituteInIxFun
+       , leastGeneralGeneralization
+       , closeEnough
        )
        where
 
@@ -34,6 +36,8 @@ import Control.Monad.Identity
 import Control.Monad.Writer
 import qualified Data.Map.Strict as M
 
+import Futhark.Analysis.PrimExp (PrimExp(..))
+import Futhark.Representation.AST.Syntax.Core (Ext(..))
 import Futhark.Transform.Substitute
 import Futhark.Transform.Rename
 import Futhark.Representation.AST.Syntax
@@ -41,8 +45,8 @@ import Futhark.Representation.AST.Syntax
 import Futhark.Representation.AST.Attributes
 import Futhark.Util.IntegralExp
 import Futhark.Util.Pretty
-import Futhark.Analysis.PrimExp.Convert
-
+import Futhark.Analysis.PrimExp.Convert (substituteInPrimExp)
+import qualified Futhark.Analysis.PrimExp.Generalize as PEG
 
 -- | LMAD's representation consists of a general offset and for each dimension a
 -- stride, rotate factor, number of elements (or shape), permutation, and
@@ -785,3 +789,68 @@ ixfunMonotonicityRots ignore_rots (IxFun (lmad :| lmads) _ _) =
                     Monotonicity -> LMADDim num -> Bool
         isMonDim mon (LMADDim s r _ _ ldmon) =
           s == 0 || ((ignore_rots || r == 0) && mon == ldmon)
+
+-- | Generalization (anti-unification)
+--
+-- Anti-unification of two index functions is supported under the following conditions:
+--   0. Both index functions are represented by ONE lmad (assumed common case!)
+--   1. The support array of the two indexfuns have the same dimensionality
+--      (we can relax this condition if we use a 1D support, as we probably should!)
+--   2. The contiguous property and the per-dimension monotonicity are the same
+--      (otherwise we might loose important information; this can be relaxed!)
+--   3. Most importantly, both index functions correspond to the same permutation
+--      (since the permutation is represented by INTs, this restriction cannot
+--       be relaxed, unless we move to a gated-LMAD representation!)
+--
+-- `k0` is the existential to use for the shape of the array.
+leastGeneralGeneralization :: Eq v => IxFun (PrimExp v) -> IxFun (PrimExp v) ->
+                              Maybe (IxFun (PrimExp (Ext v)), [(PrimExp v, PrimExp v)])
+leastGeneralGeneralization (IxFun (lmad1 :| []) oshp1 ctg1) (IxFun (lmad2 :| []) oshp2 ctg2) = do
+  guard $
+    length oshp1 == length oshp2 &&
+    ctg1 == ctg2 &&
+    map ldPerm (lmadDims lmad1) == map ldPerm (lmadDims lmad2) &&
+    lmadDMon lmad1 == lmadDMon lmad2
+  let (ctg, dperm, dmon) = (ctg1, lmadPermutation lmad1, lmadDMon lmad1)
+  (dshp, m1) <- generalize [] (lmadDShp lmad1) (lmadDShp lmad2)
+  (oshp, m2) <- generalize m1 oshp1 oshp2
+  (dstd, m3) <- generalize m2 (lmadDSrd lmad1) (lmadDSrd lmad2)
+  (drot, m4) <- generalize m3 (lmadDRot lmad1) (lmadDRot lmad2)
+  (offt, m5) <- PEG.leastGeneralGeneralization m4 (lmadOffset lmad1) (lmadOffset lmad2)
+  let lmad_dims = map (\(a,b,c,d,e) -> LMADDim a b c d e) $
+        zip5 dstd drot dshp dperm dmon
+      lmad = LMAD offt lmad_dims
+  return (IxFun (lmad :| []) oshp ctg, m5)
+  where lmadDMon = map ldMon    . lmadDims
+        lmadDSrd = map ldStride . lmadDims
+        lmadDShp = map ldShape  . lmadDims
+        lmadDRot = map ldRotate . lmadDims
+        generalize m l1 l2 =
+          foldM (\(l_acc, m') (pe1,pe2) -> do
+                    (e, m'') <- PEG.leastGeneralGeneralization m' pe1 pe2
+                    return (l_acc++[e], m'')
+                ) ([], m) (zip l1 l2)
+leastGeneralGeneralization _ _ = Nothing
+
+-- | When comparing index functions as part of the type check in ExplicitMemory,
+-- we may run into problems caused by the simplifier. As index functions can be
+-- generalized over if-then-else expressions, the simplifier might hoist some of
+-- the code from inside the if-then-else (computing the offset of an array, for
+-- instance), but now the type checker cannot verify that the generalized index
+-- function is valid, because some of the existentials are computed somewhere
+-- else. To Work around this, we've had to relax the ExplicitMemory type-checker
+-- a bit, specifically, we've introduced this function to verify whether two
+-- index functions are "close enough" that we can assume that they match. We use
+-- this instead of `ixfun1 == ixfun2` and hope that it's good enough.
+closeEnough :: IxFun num -> IxFun num -> Bool
+closeEnough ixf1 ixf2 =
+  (length (base ixf1) == length (base ixf2)) &&
+  (ixfunContig ixf1 == ixfunContig ixf2) &&
+  (NE.length (ixfunLMADs ixf1) == NE.length (ixfunLMADs ixf2)) &&
+  all closeEnoughLMADs (NE.zip (ixfunLMADs ixf1) (ixfunLMADs ixf2))
+  where
+    closeEnoughLMADs :: (LMAD num, LMAD num) -> Bool
+    closeEnoughLMADs (lmad1, lmad2) =
+      length (lmadDims lmad1) == length (lmadDims lmad2) &&
+      map ldPerm (lmadDims lmad1) ==
+      map ldPerm (lmadDims lmad2)

--- a/tests/existential-ifs/iota.fut
+++ b/tests/existential-ifs/iota.fut
@@ -1,0 +1,8 @@
+-- ==
+-- input  { true 20 }
+-- output { [11, 12, 13, 14, 15, 16, 17, 18, 19] }
+--
+-- input  { false 20 }
+-- output { empty([0]i32) }
+let main (b: bool) (n: i32) =
+    if b then filter (>10) (iota n) else []

--- a/tests/existential-ifs/ixfun-antiunif-1.fut
+++ b/tests/existential-ifs/ixfun-antiunif-1.fut
@@ -1,0 +1,13 @@
+-- A simple test for index-function anti-unification across an if-then-else
+-- ==
+-- input  { [-1.0f32, 3.0f32, 5.0f32, 7.0f32, 9.0f32, 11.0f32, 13.0f32, 15.0f32, 17.0f32, 19.0f32, 21.0f32, 23.0f32, 25.0f32]}
+-- output { [21.0f32, 23.0f32, 25.0f32] }
+--
+-- input  { [ 1.0f32, 3.0f32, 5.0f32, 7.0f32, 9.0f32, 11.0f32, 13.0f32, 15.0f32, 17.0f32, 19.0f32, 21.0f32, 23.0f32, 25.0f32]}
+-- output { [ 2.0f32, 6.0f32, 10.0f32] }
+
+let main [n] (arr: [n]f32) =
+  let x = if(arr[0] < 0.0)
+          then arr[10:n]
+          else map (*2.0f32) arr[0:n-10]
+  in x

--- a/tests/existential-ifs/ixfun-antiunif-2.fut
+++ b/tests/existential-ifs/ixfun-antiunif-2.fut
@@ -1,0 +1,12 @@
+-- Another simple test for index-function anti-unification across an if-then-else
+-- This one returns the same memory block, only the offset is existentialized.
+-- ==
+-- input  { [-1.0f32, 3.0f32, 5.0f32, 7.0f32, 9.0f32, 11.0f32, 13.0f32, 15.0f32, 17.0f32, 19.0f32, 21.0f32, 23.0f32, 25.0f32]}
+-- output { [17.0f32, 19.0f32, 21.0f32, 23.0f32, 25.0f32] }
+--
+-- input  { [ 1.0f32, 3.0f32, 5.0f32, 7.0f32, 9.0f32, 11.0f32, 13.0f32, 15.0f32, 17.0f32, 19.0f32, 21.0f32, 23.0f32, 25.0f32]}
+-- output { [11.0f32, 13.0f32, 15.0f32, 17.0f32, 19.0f32, 21.0f32, 23.0f32, 25.0f32] }
+let main [n] (arr: [n]f32) =
+  if (arr[0] < 0.0)
+  then arr[2+n/2:n]
+  else arr[2+n/4:n]

--- a/tests/existential-ifs/ixfun-antiunif-5.fut
+++ b/tests/existential-ifs/ixfun-antiunif-5.fut
@@ -1,0 +1,10 @@
+-- Another simple test for index-function anti-unification across an if-then-else
+-- This one returns the same memory block, only the offset is existentialized.
+-- ==
+-- random input  { [30000]i32 }
+-- auto output
+let main (a: []i32) =
+  let xs = if a[0] > 0
+           then a[10:30:2]
+           else a[5:20:3]
+  in reduce (+) 0 xs

--- a/tests/existential-ifs/loop-antiunif.fut
+++ b/tests/existential-ifs/loop-antiunif.fut
@@ -1,0 +1,12 @@
+-- Another simple test for index-function anti-unification across an if-then-else
+-- This one returns the same memory block, only the offset is existentialized.
+-- ==
+-- input  { [5, 3, 2, 1, 5] }
+-- output { 8 }
+--
+-- input  { [1, 2, 3, 4, 5, 6, 7] }
+-- output { 22 }
+let main [n] (arr: *[n]i32): i32 =
+  let xs = loop arr for _i < n / 2 do
+             arr[1:]
+  in reduce (+) 0 xs

--- a/tests/existential-ifs/merge_sort.fut
+++ b/tests/existential-ifs/merge_sort.fut
@@ -1,0 +1,64 @@
+-- | Bitonic merge sort.
+--
+-- Runs in *O(n log²(n))* work and *O(log²(n))* span.  Internally pads
+-- the array to the next power of two, so a poor fit for some array
+-- sizes.
+
+local let log2 (n: i32) : i32 =
+  let r = 0
+  let (r, _) = loop (r,n) while 1 < n do
+    let n = n / 2
+    let r = r + 1
+    in (r,n)
+  in r
+
+local let ensure_pow_2 [n] 't ((<=): t -> t -> bool) (xs: [n]t): (*[]t, i32) =
+  if n == 0 then (copy xs, 0) else
+  let d = log2 n
+  in if n == 2**d
+     then (copy xs, d)
+     else let largest = reduce (\x y -> if x <= y then y else x) xs[0] xs
+          in (concat xs (replicate (2**(d+1) - n) largest),
+              d+1)
+
+local let kernel_par [n] 't ((<=): t -> t -> bool) (a: *[n]t) (p: i32) (q: i32) : *[n]t =
+  let d = 1 << (p-q) in
+  map (\i -> unsafe
+             let a_i = a[i]
+             let up1 = ((i >> p) & 2) == 0
+             in
+             if (i & d) == 0
+             then let a_iord = a[i | d] in
+                  if a_iord <= a_i == up1
+                  then a_iord else a_i
+             else let a_ixord = a[i ^ d] in
+                      if a_i <= a_ixord == up1
+                      then a_ixord else a_i)
+      (iota n)
+
+-- | Sort an array in increasing order.
+let merge_sort [n] 't ((<=): t -> t -> bool) (xs: [n]t): *[n]t =
+  -- We need to pad the array so that its size is a power of 2.  We do
+  -- this by first finding the largest element in the input, and then
+  -- using that for the padding.  Then we know that the padding will
+  -- all be at the end, so we can easily cut it off.
+  let (xs, d) = ensure_pow_2 (<=) xs
+  in (loop xs for i < d do
+        loop xs for j < i+1 do kernel_par (<=) xs i j)[:n]
+
+-- | Like `merge_sort`, but sort based on key function.
+let merge_sort_by_key [n] 't 'k (key: t -> k) ((<=): k -> k -> bool) (xs: [n]t): [n]t =
+  zip (map key xs) (iota n)
+  |> merge_sort (\(x, _) (y, _) -> x <= y)
+  |> map (\(_, i) -> unsafe xs[i])
+
+-- ==
+-- entry: sort_i32
+-- input { empty([0]i32) }
+-- output { empty([0]i32) }
+-- input { [5,4,3,2,1] }
+-- output { [1,2,3,4,5] }
+-- input { [5,4,3,3,2,1] }
+-- output { [1,2,3,3,4,5] }
+
+entry sort_i32 (xs: []i32) = merge_sort (i32.<=) xs

--- a/tests/existential-ifs/merge_sort_minimized.fut
+++ b/tests/existential-ifs/merge_sort_minimized.fut
@@ -1,0 +1,5 @@
+entry ensure_pow_2 [n] (xs: [n]i32): []i32 =
+  if n == 2
+     then xs
+     else let largest = xs[0]
+          in iota largest

--- a/tests/existential-ifs/no-ext.fut
+++ b/tests/existential-ifs/no-ext.fut
@@ -1,0 +1,4 @@
+entry ensure_pow_2 [n] [m] (xs: [n][m]i32): [][]i32 =
+  if n == 2
+     then xs[0:m/2, 0:n/2]
+     else xs[0:n/2,0:m/2]

--- a/tests/existential-ifs/partition.fut
+++ b/tests/existential-ifs/partition.fut
@@ -1,0 +1,7 @@
+-- ==
+-- input  { [1, 1, 1, 1, 1] }
+-- output { [0, 1, 2, 3, 4] empty([0]i32)  }
+let main [n] (cost: *[n]i32) =
+  if opaque(true)
+  then partition (\_ -> (opaque true)) (iota n)
+  else ([], [])

--- a/tests/existential-ifs/two-exts.fut
+++ b/tests/existential-ifs/two-exts.fut
@@ -1,0 +1,5 @@
+let main [n] (xs: [n]i32): [][]i32 =
+  if n == 2
+     then map (\_ -> xs) (iota n)
+     else let largest = xs[0]
+          in map (\_ -> iota largest) (iota (largest - 1))

--- a/tests/existential-ifs/two-ixfuns.fut
+++ b/tests/existential-ifs/two-ixfuns.fut
@@ -1,0 +1,6 @@
+let main [n] (xs: [n]i32): i32 =
+  let xs' = if n > 10
+            then let ys = rotate 4 xs
+                 in ys[1:5]
+            else rotate 3 xs
+  in reduce (+) 0 xs'

--- a/tests/existential-ifs/two-returns.fut
+++ b/tests/existential-ifs/two-returns.fut
@@ -1,0 +1,7 @@
+let main [n] (xs: [n]i32): ([][]i32, [][]i32) =
+  if n == 2
+  then (map (\_ -> xs) (iota n),
+        map (\_ -> xs) (iota xs[0]))
+  else let largest = xs[0]
+       in (map (\_ -> iota largest) (iota (largest - 1)),
+           map (\_ -> iota largest) (iota xs[1]))

--- a/tests/memory-block-merging/misc/ixfun-loop.fut
+++ b/tests/memory-block-merging/misc/ixfun-loop.fut
@@ -1,0 +1,10 @@
+-- A simple test for index-function generalization across a for loop
+-- ==
+-- input { [0, 1000, 42, 1001, 50000] }
+-- output { 1249975000i32 }
+
+let main [n] (a: [n]i32): i32 =
+  let b = loop b = iota(10) for i < n do
+          let m = a[i]
+          in iota(m)
+  in reduce (+) 0 b


### PR DESCRIPTION
Well, here is take three...

The purpose of this commit is to decrease copies in if-then-else branches.

Before, if two branches of an if-then-else returned arrays with different index
functions (LMADs), the compiler would normalize the arrays in one or both of the
branches, which could result in unnecessary copying.

With this commit, the compiler will try to generalize the index functions and
return the existentials in addition to the array itself. Consider the following
expression:

```futhark
  if (arr[0] < 0.0)
  then arr[2+n/2:n]
  else arr[2+n/4:n]
```

Before, the results would be copied into fresh arrays in both branches, but
really, we could return the same array as before in addition to the computed
offsets to the index function. This way, we can avoid some unnecessary copies.

Along the way, we've had to relax the type checker for the ExplicitMemory
representation a bit. To illustrate why, consider the expression above. In some
cases the simplifier will hoist the computation of the offset to outside the
generated branches, meaning that the type checker cannot know that the offset
computed and the offset of the returned array match. We therefore introduce the
function `closeEnough` which we hope is good enough to catch future errors in
the code generation, but which is relaxed enough to let this particular case
through.

We also need to take care when generalization index functions where the same
value is used in different places: For instance, given an index function with
base and shape `x`, and another index function with base and shape `y`, the
generalization would produce two existentials `0 => (x, y)` and `1 => (x, y)`,
instead of just one. This commit first checks if a given substitution already
exists, in which case it will try to reuse it. Except for the size parameter or
shape of the MemArray, which we have separated from the shape reported in the
index function LMAD.

It is also important that the memory existential in ReturnsNewBlock are numbered
_after_ the other existentials, even when multiple blocks are being returned.
For instance, `([?0]@?1->..., [?2]@?3->...)` is not a valid return type, it
should instead be `([?0]@?2->..., [?1]@?3->...)`.

We also ran into a case in ImpGen where the assumption that all
allocations (outside of the return of lambda functions) are explicit in the IR
wasn't being respected.

The changes pass all unit tests and seem to have no regression in benchmark
performance. There doesn't seem to be any speedup either, but hopefully this
change will pave the way for future changes that have more impact on efficiency
of the generated code.