### PR TITLE
Implement binary searching in Autotuner

### DIFF
--- a/src/Futhark/Bench.hs
+++ b/src/Futhark/Bench.hs
@@ -156,6 +156,7 @@ data RunOptions =
   , runRuns :: Int
   , runExtraOptions :: [String]
   , runTimeout :: Int
+  , runVerbose :: Int
   }
 
 -- | Run the benchmark program on the indicated dataset.
@@ -185,6 +186,10 @@ benchmarkDataset opts program entry input_spec expected_spec ref_out =
   let (to_run, to_run_args)
         | null $ runRunner opts = ("." </> binaryName program, options)
         | otherwise = (runRunner opts, binaryName program : options)
+
+  when (runVerbose opts > 0) $
+    putStrLn $ unwords ["Running executable", show to_run,
+                        "with arguments", show to_run_args]
 
   run_res <-
     timeout (runTimeout opts * 1000000) $

--- a/src/Futhark/CLI/Autotune.hs
+++ b/src/Futhark/CLI/Autotune.hs
@@ -112,14 +112,8 @@ prepare opts prog = do
   fmap concat $ forM truns $ \ios ->
     forM (mapMaybe (runnableDataset $ iosEntryPoint ios)
                    (iosTestRuns ios)) $
-      \(dataset, do_run) -> do
-      res <- do_run (optTimeout opts) [] RunBenchmark
-      case res of Left err -> do
-                    putStrLn $ "Error when running " ++ prog ++ ":"
-                    putStrLn err
-                    exitFailure
-                  Right _ ->
-                    return (dataset, do_run, iosEntryPoint ios)
+      \(dataset, do_run) ->
+        return (dataset, do_run, iosEntryPoint ios)
 
   where run entry_point trun expected timeout path purpose = do
           let opts' = case purpose of RunSample -> opts { optRuns = 1 }

--- a/src/Futhark/CLI/Autotune.hs
+++ b/src/Futhark/CLI/Autotune.hs
@@ -50,6 +50,7 @@ runOptions path timeout_s opts =
              , runRuns = optRuns opts
              , runExtraOptions = "-L" : map opt path ++ optExtraOptions opts
              , runTimeout = timeout_s
+             , runVerbose = optVerbose opts
              }
   where opt (name, val) = "--size=" ++ name ++ "=" ++ show val
 

--- a/src/Futhark/CLI/Autotune.hs
+++ b/src/Futhark/CLI/Autotune.hs
@@ -276,8 +276,7 @@ tuneThreshold opts datasets already_tuned (v, _v_path) = do
 
 
     timeout :: Int -> Int
-    timeout elapsed = min (optTimeout opts) $
-                      ceiling (fromIntegral elapsed * 1.2 / 1000000 :: Double) + 1
+    timeout elapsed = optTimeout opts
 
     aggregateResults :: [Maybe Int] -> Maybe Int
     aggregateResults xs = sum <$> sequence xs

--- a/src/Futhark/CLI/Bench.hs
+++ b/src/Futhark/CLI/Bench.hs
@@ -42,11 +42,12 @@ data BenchOptions = BenchOptions
                    , optEntryPoint :: Maybe String
                    , optTuning :: Maybe String
                    , optConcurrency :: Maybe Int
+                   , optVerbose :: Int
                    }
 
 initialBenchOptions :: BenchOptions
 initialBenchOptions = BenchOptions "c" Nothing "" 10 [] [] Nothing (-1) False
-                      ["nobench", "disable"] [] Nothing (Just "tuning") Nothing
+                      ["nobench", "disable"] [] Nothing (Just "tuning") Nothing 0
 
 runBenchmarks :: BenchOptions -> [FilePath] -> IO ()
 runBenchmarks opts paths = do
@@ -162,6 +163,7 @@ runOptions opts = RunOptions { runRunner = optRunner opts
                              , runRuns = optRuns opts
                              , runExtraOptions = optExtraOptions opts
                              , runTimeout = optTimeout opts
+                             , runVerbose = optVerbose opts
                              }
 
 runBenchmarkCase :: BenchOptions -> FilePath -> T.Text -> Int -> TestRun
@@ -275,6 +277,9 @@ commandLineOptions = [
                    Left $ error $ "'" ++ n ++ "' is not a positive integer.")
     "NUM")
     "Number of benchmarks to prepare (not run) concurrently."
+  , Option "v" ["verbose"]
+    (NoArg $ Right $ \config -> config { optVerbose = optVerbose config + 1 })
+    "Enable logging.  Pass multiple times for more."
   ]
   where max_timeout :: Int
         max_timeout = maxBound `div` 1000000

--- a/src/Futhark/CodeGen/Backends/COpenCL.hs
+++ b/src/Futhark/CodeGen/Backends/COpenCL.hs
@@ -261,9 +261,12 @@ callKernel (CmpSizeLe v key x) = do
   GC.stm [C.cstm|if (ctx->logging) {
     fprintf(stderr, "Compared %s <= %d.\n", $string:(pretty key), $exp:x');
     }|]
-callKernel (GetSizeMax v size_class) =
+callKernel (GetSizeMax v size_class) = do
   let field = "max_" ++ pretty size_class
-  in GC.stm [C.cstm|$id:v = ctx->opencl.$id:field;|]
+  GC.stm [C.cstm|$id:v = ctx->opencl.$id:field;|]
+  GC.stm [C.cstm|if (ctx->logging) {
+    fprintf(stderr, "Found max_%s: %d.\n", $string:(pretty size_class), $id:v);
+    }|]
 
 callKernel (LaunchKernel safety name args num_workgroups workgroup_size) = do
 


### PR DESCRIPTION
The purpose of this PR is to improve the autotuner by taking into account
programs with changing levels of parallelism. Previous to this commit, if a
program had different levels of parallelism, called `ePar`, the autotuner would
choose the first one it encountered. In the LUD benchmark, that would always be
the highest `ePar`, since the level of parallelism is decreasing. But how do we
know that this is the best ePar to compare against?

Assuming that program performance is monotonic in the threshold value chosen, we
can instead try to find the best `ePar` by binary search over all the possible
values. Of course, autotuning will take longer if there are more `ePar`s, but
this is not the case for most of our benchmarks, and for those that it is, we
hope that we can get a better `ePar` as a result.

The runtime for the autotuner should only increase by `log(n)`, where `n` is the
number of `ePar`s in a given program. Tuning LUD goes from 163s to 300s on
gpu04.

~~Unfortunately, for LUD, this commit doesn't seem to improve the runtime.
Choosing the first `ePar` happens to be the correct choice.~~

Edit: I now seem to be consistently getting better results with the new autotuner:

```
lud.fut
  data/512.in:                                                          2.16x
  data/64.in:                                                           0.99x
  data/256.in:                                                          1.35x
  data/16by16.in:                                                       1.00x
  data/2048.in:                                                         1.47x
```