### PR TITLE
Initialise multicore stuff in new_context.

### DIFF
--- a/rts/c/scheduler.h
+++ b/rts/c/scheduler.h
@@ -9,7 +9,7 @@
 
 const int num_threads = 4;
 
-typedef int (*task_fn)(struct futhark_context*, void*, int, int, int);
+typedef int (*task_fn)(void*, int, int, int);
 
 struct task {
   task_fn fn;
@@ -29,11 +29,11 @@ enum OP {
 };
 
 static inline void *futhark_worker(void* arg) {
-  struct futhark_context *ctx = (struct futhark_context*) arg;
+  struct job_queue *q = (struct job_queue*) arg;
   while(1) {
     struct task *task;
-    if (job_queue_pop(futhark_context_get_jobqueue(ctx), (void**)&task) == 0) {
-      task->fn(ctx, task->args, task->start, task->end, task->task_id);
+    if (job_queue_pop(q, (void**)&task) == 0) {
+      task->fn(task->args, task->start, task->end, task->task_id);
        pthread_mutex_lock(task->mutex);
        (*task->counter)--;
        pthread_cond_signal(task->cond);

--- a/src/Futhark/CodeGen/Backends/GenericC.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC.hs
@@ -1482,18 +1482,6 @@ int main(int argc, char** argv) {
   struct futhark_context *ctx = futhark_context_new(cfg);
   assert (ctx != NULL);
 
-$esc:("#ifdef MULTICORE");
-  int num_threads = 4;
-  typename pthread_t *threads = calloc(num_threads, sizeof(pthread_t));
-
-  for (int i = 0; i < num_threads; i++) {
-    if (pthread_create(&threads[i], NULL, &futhark_worker, ctx) != 0) {
-      fprintf(stderr, "Failed to create thread (%d)\n", i);
-      return 1;
-    }
-  }
-$esc:("#endif");
-
   if (entry_point != NULL) {
     int num_entry_points = sizeof(entry_points) / sizeof(entry_points[0]);
     entry_point_fun *entry_point_fun = NULL;
@@ -1521,16 +1509,6 @@ $esc:("#endif");
 
     futhark_debugging_report(ctx);
   }
-
-$esc:("#ifdef MULTICORE");
-  futhark_context_kill_jobqueue(ctx);
-  for (int i = 0; i < num_threads; i++) {
-    if (pthread_join(threads[i], NULL) != 0) {
-      fprintf(stderr, "pthread_join failed on thread %d", i);
-      return 1;
-    }
-  }
-$esc:("#endif");
 
   futhark_context_free(ctx);
   futhark_context_config_free(cfg);


### PR DESCRIPTION
Also change the scheduler to not know about `futhark_context`.

This is much better than hardcoding multicore stuff in GenericC.hs.  The OpenCL backend can work without having anything OpenCL-specific in GenericC.hs, and I would be surprised if the same is not the case for the multicore backend.