### PR TITLE
Use a slightly more multicore-focused compiler pipeline.

### DIFF
--- a/src/Futhark/Passes.hs
+++ b/src/Futhark/Passes.hs
@@ -101,13 +101,19 @@ gpuPipeline =
 
 multicorePipeline :: Pipeline SOACS ExplicitMemory
 multicorePipeline =
-  kernelsPipeline >>>
+  standardPipeline >>>
+  onePass extractKernels >>>
+  passes [ simplifyKernels
+         , unstream
+         , performCSE True
+         , simplifyKernels
+         , sink
+         , inPlaceLowering
+         ] >>>
   onePass explicitAllocations >>>
   passes [ simplifyExplicitMemory
          , performCSE False
          , simplifyExplicitMemory
          , doubleBuffer
-         , simplifyExplicitMemory
-         , expandAllocations
          , simplifyExplicitMemory
          ]


### PR DESCRIPTION
With this change, I get a 2.3x speedup on LocVolCalib with 4 threads versus sequential execution.