### PR TITLE
Dynamically detect the number of threads to use.

### DIFF
--- a/rts/c/jobqueue.h
+++ b/rts/c/jobqueue.h
@@ -17,16 +17,18 @@ struct job_queue {
   pthread_mutex_t mutex; // Mutex used for synchronisation.
   pthread_cond_t cond;   // Condition variable used for synchronisation.
 
+  int num_workers;
   int dead;
 };
 
 
 // Initialise a job queue with the given capacity.  The queue starts out
 // empty.  Returns non-zero on error.
-static inline int job_queue_init(struct job_queue *job_queue, int capacity) {
+static inline int job_queue_init(struct job_queue *job_queue, int capacity, int num_workers) {
   job_queue->capacity = capacity;
   job_queue->first = 0;
   job_queue->num_used = 0;
+  job_queue->num_workers = num_workers;
   job_queue->dead = 0;
   job_queue->buffer = calloc(capacity, sizeof(void*));
 

--- a/rts/c/scheduler.h
+++ b/rts/c/scheduler.h
@@ -3,11 +3,13 @@
 #ifndef SCHEDULER_H
 #define SCHEDULER_H
 
+#include <sys/sysinfo.h>
 
 #define MULTICORE
 
-
-const int num_threads = 4;
+static int num_processors() {
+  return get_nprocs();
+}
 
 typedef int (*task_fn)(void*, int, int, int);
 
@@ -89,8 +91,8 @@ static inline int scheduler_do_task(struct job_queue *q,
 
   int task_id = 0;
   int shared_counter = 0;
-  int iter_pr_task = iterations / num_threads;
-  int remainder = iterations % num_threads;
+  int iter_pr_task = iterations / q->num_workers;
+  int remainder = iterations % q->num_workers;
 
   struct task *task = setup_task(fn, task_args, task_id,
                                  &mutex, &cond, &shared_counter,

--- a/src/Futhark/CLI/Multicore.hs
+++ b/src/Futhark/CLI/Multicore.hs
@@ -28,7 +28,7 @@ main = compilerMain () []
              liftIO $ writeFile cpath impl
            ToExecutable -> do
              liftIO $ writeFile cpath $ MulticoreC.asExecutable cprog
-             ret <- liftIO $ runProgramWithExitCode "gcc-9"
+             ret <- liftIO $ runProgramWithExitCode "gcc"
                     [cpath, "-O3", "-pthread", "-std=c99", "-lm", "-o", outpath] mempty
              case ret of
                Left err ->


### PR DESCRIPTION
This also pushes the information about thread count into the job queue
struct.  I think the notion of "scheduler" and "job queue" should be
unified, and a dedicated scheduler struct used (like the OpenCL
backend has an opencl struct).