### PR TITLE
Add verbose flag to `futhark bench`

### DIFF
--- a/docs/man/futhark-bench.rst
+++ b/docs/man/futhark-bench.rst
@@ -108,6 +108,11 @@ OPTIONS
 
   A negative timeout means to wait indefinitely.
 
+-v, --verbose
+
+  Print verbose information about what the benchmark is doing.  Pass
+  multiple times to increase the amount of information printed.
+
 --tuning=EXTENSION
 
   For each program being run, look for a tuning file with this

--- a/src/Futhark/Bench.hs
+++ b/src/Futhark/Bench.hs
@@ -156,6 +156,7 @@ data RunOptions =
   , runRuns :: Int
   , runExtraOptions :: [String]
   , runTimeout :: Int
+  , runVerbose :: Int
   }
 
 -- | Run the benchmark program on the indicated dataset.
@@ -185,6 +186,10 @@ benchmarkDataset opts program entry input_spec expected_spec ref_out =
   let (to_run, to_run_args)
         | null $ runRunner opts = ("." </> binaryName program, options)
         | otherwise = (runRunner opts, binaryName program : options)
+
+  when (runVerbose opts > 0) $
+    putStrLn $ unwords ["Running executable", show to_run,
+                        "with arguments", show to_run_args]
 
   run_res <-
     timeout (runTimeout opts * 1000000) $

--- a/src/Futhark/CLI/Autotune.hs
+++ b/src/Futhark/CLI/Autotune.hs
@@ -49,6 +49,7 @@ runOptions path timeout_s opts =
              , runRuns = optRuns opts
              , runExtraOptions = "-L" : map opt path ++ optExtraOptions opts
              , runTimeout = timeout_s
+             , runVerbose = optVerbose opts
              }
   where opt (name, val) = "--size=" ++ name ++ "=" ++ show val
 

--- a/src/Futhark/CLI/Bench.hs
+++ b/src/Futhark/CLI/Bench.hs
@@ -42,11 +42,12 @@ data BenchOptions = BenchOptions
                    , optEntryPoint :: Maybe String
                    , optTuning :: Maybe String
                    , optConcurrency :: Maybe Int
+                   , optVerbose :: Int
                    }
 
 initialBenchOptions :: BenchOptions
 initialBenchOptions = BenchOptions "c" Nothing "" 10 [] [] Nothing (-1) False
-                      ["nobench", "disable"] [] Nothing (Just "tuning") Nothing
+                      ["nobench", "disable"] [] Nothing (Just "tuning") Nothing 0
 
 runBenchmarks :: BenchOptions -> [FilePath] -> IO ()
 runBenchmarks opts paths = do
@@ -162,6 +163,7 @@ runOptions opts = RunOptions { runRunner = optRunner opts
                              , runRuns = optRuns opts
                              , runExtraOptions = optExtraOptions opts
                              , runTimeout = optTimeout opts
+                             , runVerbose = optVerbose opts
                              }
 
 runBenchmarkCase :: BenchOptions -> FilePath -> T.Text -> Int -> TestRun
@@ -275,6 +277,9 @@ commandLineOptions = [
                    Left $ error $ "'" ++ n ++ "' is not a positive integer.")
     "NUM")
     "Number of benchmarks to prepare (not run) concurrently."
+  , Option "v" ["verbose"]
+    (NoArg $ Right $ \config -> config { optVerbose = optVerbose config + 1 })
+    "Enable logging.  Pass multiple times for more."
   ]
   where max_timeout :: Int
         max_timeout = maxBound `div` 1000000


### PR DESCRIPTION
Not used for much at the moment, mainly to get the command line arguments used in each benchmark run.