### PR TITLE
 Implement binary searching in Autotuner, take 2

### DIFF
--- a/src/Futhark/Bench.hs
+++ b/src/Futhark/Bench.hs
@@ -187,7 +187,7 @@ benchmarkDataset opts program entry input_spec expected_spec ref_out =
         | null $ runRunner opts = ("." </> binaryName program, options)
         | otherwise = (runRunner opts, binaryName program : options)
 
-  when (runVerbose opts > 0) $
+  when (runVerbose opts > 1) $
     putStrLn $ unwords ["Running executable", show to_run,
                         "with arguments", show to_run_args]
 

--- a/src/Futhark/CLI/Autotune.hs
+++ b/src/Futhark/CLI/Autotune.hs
@@ -132,17 +132,17 @@ prepare opts prog = do
           let opts' = case purpose of RunSample -> opts { optRuns = 1 }
                                       RunBenchmark -> opts
 
-              averageRuntime (runres, errout) =
+              bestRuntime :: ([RunResult], T.Text) -> ([(String, Int)], Int)
+              bestRuntime (runres, errout) =
                 (comparisons (T.unpack errout),
-                 fromIntegral (sum (map runMicroseconds runres)) /
-                 fromIntegral (optRuns opts))
+                 minimum $ map runMicroseconds runres)
 
               ropts = runOptions path timeout opts'
 
           when (optVerbose opts > 1) $
             putStrLn $ "Running with options: " ++ unwords (runExtraOptions ropts)
 
-          either (Left . T.unpack) (Right . averageRuntime) <$>
+          either (Left . T.unpack) (Right . bestRuntime) <$>
             benchmarkDataset ropts prog entry_point
             (runInput trun) expected
             (testRunReferenceOutput prog entry_point trun)

--- a/src/Futhark/CLI/Autotune.hs
+++ b/src/Futhark/CLI/Autotune.hs
@@ -236,6 +236,9 @@ tuneThreshold opts datasets already_tuned (v, _v_path) = do
                     _ ->
                       return Nothing
 
+            when (optVerbose opts > 1) $
+              putStrLn $ unwords ("Got ePars: " : map show ePars)
+
             newMax <- binarySearch runner (t, tMax) ePars
             let newMinIdx = pred <$> elemIndex newMax ePars
             let newMin = maximum $ catMaybes [Just tMin, newMinIdx]


### PR DESCRIPTION
The purpose of this PR is to improve the autotuner by taking into account programs with changing levels of parallelism. Previous to this commit, if a program had different levels of parallelism, we call them `ePar`, the autotuner would choose the first one it encountered. In the LUD benchmark, that would always be the highest `ePar`, since the level of parallelism is decreasing. But how do we know that this is the best ePar to compare against?

With these changes, the autotuner will be equipped to handle such cases. It employs a binary search combined with continual refinement of the search space to efficiently find the threshold value that guarantees optimal performance across all test datasets.

The changes build upon the following realization, which also motivated not using ranges for size-invariant parallelism tuning: If, for a given program, the optimal threshold parameter value for one dataset is `x`, the optimal threshold parameter value for another dataset is `y`, and `y` < `x`, it can never hurt the performance of the program on the first dataset to use `y` as the threshold parameter. If the optimal threshold parameter value found for the first dataset is `x` and not `y` or some value in between, it's just because that amount of parallelism isn't exposed when running the program on the first dataset.

After coming to this realization, the only thing we need to do in order to tune a particular threshold in a program with size-variant parallelism, is to find the optimal threshold parameter value for each dataset and then take the minimum of those. Using a binary search is a straight-forward to find the optimal threshold parameter value for each dataset. However, because of the realization above, we can improve the heuristics of the binary search quite a bit: Every time we have tuned the threshold on a given dataset and found the optimal threshold parameter value `x`, when we tune on the next dataset, there's no need to try any possible values of `ePar` above `x`. In addition, if there were any values of `ePar` below `x` in the first dataset, there's no need to try any of those again on the second dataset. This means that after tuning the first dataset, the only candidates we have for further improving the threshold on the next dataset, are those `ePar`s that are between `y` and `x`, where `x` is the optimal threshold parameter value found for the first dataset, and `y` is the maximum `ePar` less than `x` in the first dataset. This heuristic greatly improves the time taken to tune a program with size-invariant parallelism over the naive binary tuner.

The result is a tuner that gives us optimal threshold parameter values both for size-variant and -invariant programs. It is faster when tuning size-invariant programs than the old tuner because of the heuristics described above. It is also much faster than a previous attempt at rewriting the autotuner when tuning size-variant parallelism.