### PR TITLE
Implement constants in the core language.

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -340,6 +340,11 @@ following function::
 
   struct futhark_context *futhark_context_new(struct futhark_context_config *cfg);
 
+Context creation may fail.  Immediately after
+``futhark_context_new()``, call ``futhark_context_get_error()`` (see
+below), which will return a non-NULL error string if context creation
+failed.
+
 Memory management is entirely manual.  Deallocation functions are
 provided for all types defined in the header file.  Everything
 returned by an entry point must be manually deallocated.

--- a/src/Futhark/Analysis/Alias.hs
+++ b/src/Futhark/Analysis/Alias.hs
@@ -12,7 +12,7 @@ module Futhark.Analysis.Alias
          -- * Ad-hoc utilities
        , AliasTable
        , analyseFun
-       , analyseStm
+       , analyseStms
        , analyseExp
        , analyseBody
        , analyseLambda
@@ -28,7 +28,8 @@ import Futhark.Representation.Aliases
 -- | Perform alias analysis on a Futhark program.
 aliasAnalysis :: (Attributes lore, CanBeAliased (Op lore)) =>
                  Prog lore -> Prog (Aliases lore)
-aliasAnalysis = Prog . map analyseFun . progFuns
+aliasAnalysis (Prog consts funs) =
+  Prog (fst (analyseStms mempty consts)) (map analyseFun funs)
 
 analyseFun :: (Attributes lore, CanBeAliased (Op lore)) =>
               FunDef lore -> FunDef (Aliases lore)

--- a/src/Futhark/Analysis/CallGraph.hs
+++ b/src/Futhark/Analysis/CallGraph.hs
@@ -3,12 +3,17 @@
 module Futhark.Analysis.CallGraph
   ( CallGraph
   , buildCallGraph
+  , isFunInCallGraph
+  , calls
+  , calledByConsts
+  , allCalledBy
   )
   where
 
 import Control.Monad.Writer.Strict
 import qualified Data.Map.Strict as M
-import Data.Maybe (isJust)
+import qualified Data.Set as S
+import Data.Maybe (fromMaybe)
 import Data.List (foldl')
 
 import Futhark.Representation.SOACS
@@ -19,44 +24,72 @@ buildFunctionTable :: Prog SOACS -> FunctionTable
 buildFunctionTable = foldl expand M.empty . progFuns
   where expand ftab f = M.insert (funDefName f) f ftab
 
--- | The call graph is just a mapping from a function name, i.e., the
+type FunGraph = M.Map Name (S.Set Name)
+
+-- | The call graph is a mapping from a function name, i.e., the
 -- caller, to a set of the names of functions called *directly* (not
 -- transitively!) by the function.
-type CallGraph = M.Map Name (M.Map Name ConstFun)
+--
+-- We keep track separately of the functions called by constants.
+data CallGraph = CallGraph { calledByFuns :: M.Map Name (S.Set Name)
+                           , calledInConsts :: S.Set Name
+                           }
+
+-- | Is the given function known to the call graph?
+isFunInCallGraph :: Name -> CallGraph -> Bool
+isFunInCallGraph f = M.member f . calledByFuns
+
+-- | Does the first function call the second?
+calls :: Name -> Name -> CallGraph -> Bool
+calls caller callee =
+  maybe False (S.member callee) . M.lookup caller . calledByFuns
+
+-- | Is the function called in any of the constants?
+calledByConsts :: Name -> CallGraph -> Bool
+calledByConsts f = S.member f . calledInConsts
+
+-- | All functions called by this function.
+allCalledBy :: Name -> CallGraph -> S.Set Name
+allCalledBy f = fromMaybe mempty . M.lookup f . calledByFuns
 
 -- | @buildCallGraph prog@ build the program's call graph.
 buildCallGraph :: Prog SOACS -> CallGraph
-buildCallGraph prog = foldl' (buildCGfun ftable) M.empty entry_points
-  where entry_points = map funDefName $ filter (isJust . funDefEntryPoint) $
-                       progFuns prog
+buildCallGraph prog =
+  CallGraph fg $ buildFGStms $ progConsts prog
+  where fg = foldl' (buildFGfun ftable) M.empty entry_points
+
+        entry_points = map funDefName $ progFuns prog
         ftable = buildFunctionTable prog
 
--- | @buildCallGraph ftable cg fname@ updates @cg@ with the
+-- | @buildCallGraph ftable fg fname@ updates @fg@ with the
 -- contributions of function @fname@.
-buildCGfun :: FunctionTable -> CallGraph -> Name -> CallGraph
-buildCGfun ftable cg fname  =
+buildFGfun :: FunctionTable -> FunGraph -> Name -> FunGraph
+buildFGfun ftable fg fname  =
   -- Check if function is a non-builtin that we have not already
   -- processed.
   case M.lookup fname ftable of
-    Just f | Nothing <- M.lookup fname cg -> do
-               let callees = buildCGbody $ funDefBody f
-                   cg' = M.insert fname callees cg
+    Just f | Nothing <- M.lookup fname fg -> do
+               let callees = buildFGBody $ funDefBody f
+                   fg' = M.insert fname callees fg
                -- recursively build the callees
-               foldl' (buildCGfun ftable) cg' $ M.keys callees
-    _ -> cg
+               foldl' (buildFGfun ftable) fg' callees
+    _ -> fg
 
-buildCGbody :: Body -> M.Map Name ConstFun
-buildCGbody = mconcat . map (buildCGexp . stmExp) . stmsToList . bodyStms
+buildFGStms :: Stms SOACS -> S.Set Name
+buildFGStms = mconcat . map (buildFGexp . stmExp) . stmsToList
 
-buildCGexp :: Exp -> M.Map Name ConstFun
-buildCGexp (Apply fname _ _ (constf, _, _, _)) = M.singleton fname constf
-buildCGexp (Op op) = execWriter $ mapSOACM folder op
+buildFGBody :: Body -> S.Set Name
+buildFGBody = buildFGStms . bodyStms
+
+buildFGexp :: Exp -> S.Set Name
+buildFGexp (Apply fname _ _ _) = S.singleton fname
+buildFGexp (Op op) = execWriter $ mapSOACM folder op
   where folder = identitySOACMapper {
-          mapOnSOACLambda = \lam -> do tell $ buildCGbody $ lambdaBody lam
+          mapOnSOACLambda = \lam -> do tell $ buildFGBody $ lambdaBody lam
                                        return lam
           }
-buildCGexp e = execWriter $ mapExpM folder e
+buildFGexp e = execWriter $ mapExpM folder e
   where folder = identityMapper {
-          mapOnBody = \_ body -> do tell $ buildCGbody body
+          mapOnBody = \_ body -> do tell $ buildFGBody body
                                     return body
           }

--- a/src/Futhark/Analysis/Metrics.hs
+++ b/src/Futhark/Analysis/Metrics.hs
@@ -73,7 +73,10 @@ inside what m = seen what >> censor addWhat m
         addWhat' (ctx, k) = (what : ctx, k)
 
 progMetrics :: OpMetrics (Op lore) => Prog lore -> AstMetrics
-progMetrics = actualMetrics . execWriter . runMetricsM . mapM_ funDefMetrics . progFuns
+progMetrics prog =
+  actualMetrics $ execWriter $ runMetricsM $ do
+  mapM_ funDefMetrics $ progFuns prog
+  mapM_ bindingMetrics $ progConsts prog
 
 funDefMetrics :: OpMetrics (Op lore) => FunDef lore -> MetricsM ()
 funDefMetrics = bodyMetrics . funDefBody

--- a/src/Futhark/Analysis/PrimExp/Convert.hs
+++ b/src/Futhark/Analysis/PrimExp/Convert.hs
@@ -45,7 +45,7 @@ primExpToExp _ (ValueExp v) =
   return $ BasicOp $ SubExp $ Constant v
 primExpToExp f (FunExp h args t) =
   Apply (nameFromString h) <$> args' <*> pure [primRetType t] <*>
-  pure (NotConstFun, Safe, noLoc, [])
+  pure (Safe, noLoc, [])
   where args' = zip <$> mapM (primExpToSubExp "apply_arg" f) args <*> pure (repeat Observe)
 primExpToExp f (LeafExp v _) =
   f v

--- a/src/Futhark/Analysis/Range.hs
+++ b/src/Futhark/Analysis/Range.hs
@@ -25,7 +25,8 @@ import Futhark.Analysis.AlgSimplify as AS
 -- program with embedded range annotations.
 rangeAnalysis :: (Attributes lore, CanBeRanged (Op lore)) =>
                  Prog lore -> Prog (Ranges lore)
-rangeAnalysis = Prog . map analyseFun . progFuns
+rangeAnalysis (Prog consts funs) =
+  Prog (runRangeM $ mapM analyseStm consts) (map analyseFun funs)
 
 -- Implementation
 

--- a/src/Futhark/Analysis/Rephrase.hs
+++ b/src/Futhark/Analysis/Rephrase.hs
@@ -28,7 +28,10 @@ data Rephraser m from to
               }
 
 rephraseProg :: Monad m => Rephraser m from to -> Prog from -> m (Prog to)
-rephraseProg rephraser = fmap Prog . mapM (rephraseFunDef rephraser) . progFuns
+rephraseProg rephraser (Prog consts funs) =
+  Prog
+  <$> mapM (rephraseStm rephraser) consts
+  <*> mapM (rephraseFunDef rephraser) funs
 
 rephraseFunDef :: Monad m => Rephraser m from to -> FunDef from -> m (FunDef to)
 rephraseFunDef rephraser fundec = do

--- a/src/Futhark/Analysis/SymbolTable.hs
+++ b/src/Futhark/Analysis/SymbolTable.hs
@@ -35,6 +35,7 @@ module Futhark.Analysis.SymbolTable
   , IndexOp(..)
     -- * Insertion
   , insertStm
+  , insertStms
   , insertFParams
   , insertLParam
   , insertArrayLParam
@@ -496,6 +497,12 @@ insertStm stm vtable =
                   FParam entry
                   { fparamAliases = oneName (patElemName pe) <> fparamAliases entry }
                 update e = e
+
+insertStms :: (IndexOp (Op lore), Ranged lore, Aliases.Aliased lore) =>
+              Stms lore
+           -> SymbolTable lore
+           -> SymbolTable lore
+insertStms stms vtable = foldl' (flip insertStm) vtable $ stmsToList stms
 
 expandAliases :: Names -> SymbolTable lore -> Names
 expandAliases names vtable = names <> aliasesOfAliases

--- a/src/Futhark/CLI/Dev.hs
+++ b/src/Futhark/CLI/Dev.hs
@@ -299,7 +299,6 @@ commandLineOptions =
   , typedPassOption soacsProg Kernels firstOrderTransform "f"
   , soacsPassOption fuseSOACs "o"
   , soacsPassOption inlineFunctions []
-  , soacsPassOption inlineConstants []
   , kernelsPassOption inPlaceLowering []
   , kernelsPassOption babysitKernels []
   , kernelsPassOption tileLoops []

--- a/src/Futhark/CodeGen/Backends/CCUDA/Boilerplate.hs
+++ b/src/Futhark/CodeGen/Backends/CCUDA/Boilerplate.hs
@@ -285,12 +285,19 @@ generateContextFuns cfg kernels sizes failures = do
                  $stms:final_inits
                  $stms:set_sizes
 
+                 init_constants(ctx);
+                 // Clear the free list of any deallocations that occurred while initialising constants.
+                 CUDA_SUCCEED(cuda_free_all(&ctx->cuda));
+
+                 futhark_context_sync(ctx);
+
                  return ctx;
                }|])
 
   GC.publicDef_ "context_free" GC.InitDecl $ \s ->
     ([C.cedecl|void $id:s(struct $id:ctx* ctx);|],
      [C.cedecl|void $id:s(struct $id:ctx* ctx) {
+                                 free_constants(ctx);
                                  cuda_cleanup(&ctx->cuda);
                                  free_lock(&ctx->lock);
                                  free(ctx);

--- a/src/Futhark/CodeGen/Backends/CSOpenCL.hs
+++ b/src/Futhark/CodeGen/Backends/CSOpenCL.hs
@@ -121,15 +121,16 @@ callKernel (Imp.GetSize v key) =
   CS.stm $ Reassign (Var (CS.compileName v)) $
     Field (Var "Ctx.Sizes") $ zEncodeString $ pretty key
 
-callKernel (Imp.GetSizeMax v size_class) =
-  CS.stm $ Reassign (Var (CS.compileName v)) $
-  Field (Var "Ctx.OpenCL") $
-  case size_class of Imp.SizeGroup -> "MaxGroupSize"
-                     Imp.SizeNumGroups -> "MaxNumGroups"
-                     Imp.SizeTile -> "MaxTileSize"
-                     Imp.SizeThreshold{} -> "MaxThreshold"
-                     Imp.SizeLocalMemory -> "MaxLocalMemory"
-                     Imp.SizeBespoke{} -> "MaxBespoke"
+callKernel (Imp.GetSizeMax v size_class) = do
+  v' <- CS.compileVar v
+  CS.stm $ Reassign v' $
+    Field (Var "Ctx.OpenCL") $
+    case size_class of Imp.SizeGroup -> "MaxGroupSize"
+                       Imp.SizeNumGroups -> "MaxNumGroups"
+                       Imp.SizeTile -> "MaxTileSize"
+                       Imp.SizeThreshold{} -> "MaxThreshold"
+                       Imp.SizeLocalMemory -> "MaxLocalMemory"
+                       Imp.SizeBespoke{} -> "MaxBespoke"
 
 callKernel (Imp.LaunchKernel safety name args num_workgroups workgroup_size) = do
   num_workgroups' <- mapM CS.compileExp num_workgroups
@@ -142,8 +143,9 @@ callKernel (Imp.LaunchKernel safety name args num_workgroups workgroup_size) = d
   where mult_exp = BinOp "*"
 
 callKernel (Imp.CmpSizeLe v key x) = do
+  v' <- CS.compileVar v
   x' <- CS.compileExp x
-  CS.stm $ Reassign (Var (CS.compileName v)) $
+  CS.stm $ Reassign v' $
     BinOp "<=" (Field (Var "Ctx.Sizes") (zEncodeString $ pretty key)) x'
 
 launchKernel :: Imp.Safety -> String -> [CSExp] -> [CSExp] -> [Imp.KernelArg] -> CS.CompilerM op s ()
@@ -208,8 +210,10 @@ launchKernel safety kernel_name kernel_dims workgroup_dims args = do
           err <- newVName' "setargErr"
           dest <- newVName "kArgDest"
           let err_var = Var err
-          return [ Fixed (Var $ CS.compileName dest) (Addr mem)
-                   [ Assign err_var $ getKernelCall kernel argnum (CS.sizeOf $ Primitive IntPtrT) (Var $ CS.compileName dest)]
+          dest' <- CS.compileVar dest
+          return [ Fixed dest' (Addr mem)
+                   [ Assign err_var $ getKernelCall kernel argnum
+                     (CS.sizeOf $ Primitive IntPtrT) dest']
                  ]
 
         processValueArg kernel argnum et e = do
@@ -226,9 +230,8 @@ launchKernel safety kernel_name kernel_dims workgroup_dims args = do
                          -> CS.CompilerM op s [CSStmt]
         processKernelArg kernel argnum (Imp.ValueKArg e et) =
           processValueArg kernel argnum et =<< CS.compileExp e
-
         processKernelArg kernel argnum (Imp.MemKArg v) =
-          processMemArg kernel argnum $ memblockFromMem v
+          processMemArg kernel argnum . memblockFromMem =<< CS.compileVar v
 
         processKernelArg kernel argnum (Imp.SharedMemoryKArg (Imp.Count num_bytes)) = do
           err <- newVName' "setargErr"
@@ -300,19 +303,17 @@ computeErrCodeT = CustomT "ComputeErrorCode"
 
 allocateOpenCLBuffer :: CS.Allocate Imp.OpenCL ()
 allocateOpenCLBuffer mem size "device" = do
-  let mem' = CS.compileName mem
   errcode <- CS.compileName <$> newVName "errCode"
   CS.stm $ AssignTyped computeErrCodeT (Var errcode) Nothing
-  CS.stm $ Reassign (Var mem') (CS.simpleCall "MemblockAllocDevice" [Ref $ Var "Ctx", Var mem', size, String mem'])
+  CS.stm $ Reassign mem (CS.simpleCall "MemblockAllocDevice" [Ref $ Var "Ctx", mem, size, String $ pretty mem])
 
 allocateOpenCLBuffer _ _ space =
   error $ "Cannot allocate in '" ++ space ++ "' space"
 
 copyOpenCLMemory :: CS.Copy Imp.OpenCL ()
 copyOpenCLMemory destmem destidx Imp.DefaultSpace srcmem srcidx (Imp.Space "device") nbytes _ = do
-  let destmem' = Var $ CS.compileName destmem
   ptr <- newVName' "ptr"
-  CS.stm $ Fixed (Var ptr) (Addr $ Index destmem' $ IdxExp $ Integer 0)
+  CS.stm $ Fixed (Var ptr) (Addr $ Index destmem $ IdxExp $ Integer 0)
     [ ifNotZeroSize nbytes $
       Exp $ CS.simpleCall "CL10.EnqueueReadBuffer"
       [ Var "Ctx.Opencl.Queue", memblockFromMem srcmem, Bool True
@@ -321,9 +322,8 @@ copyOpenCLMemory destmem destidx Imp.DefaultSpace srcmem srcidx (Imp.Space "devi
     ]
 
 copyOpenCLMemory destmem destidx (Imp.Space "device") srcmem srcidx Imp.DefaultSpace nbytes _ = do
-  let srcmem'  = CS.compileName srcmem
   ptr <- newVName' "ptr"
-  CS.stm $ Fixed (Var ptr) (Addr $ Index (Var srcmem') $ IdxExp $ Integer 0)
+  CS.stm $ Fixed (Var ptr) (Addr $ Index srcmem $ IdxExp $ Integer 0)
     [ ifNotZeroSize nbytes $
       Exp $ CS.simpleCall "CL10.EnqueueWriteBuffer"
         [ Var "Ctx.OpenCL.Queue", memblockFromMem destmem, Bool True
@@ -347,8 +347,8 @@ copyOpenCLMemory _ _ destspace _ _ srcspace _ _=
 
 staticOpenCLArray :: CS.StaticArray Imp.OpenCL ()
 staticOpenCLArray name "device" t vs = do
-  let name' = CS.compileName name
-  CS.staticMemDecl $ AssignTyped (CustomT "OpenCLMemblock") (Var name') Nothing
+  name' <- CS.compileVar name
+  CS.staticMemDecl $ AssignTyped (CustomT "OpenCLMemblock") name' Nothing
 
   -- Create host-side C# array with intended values.
   tmp_arr <- newVName' "tmpArr"
@@ -365,17 +365,20 @@ staticOpenCLArray name "device" t vs = do
                              Imp.ArrayZeros n -> n
       size = Integer $ toInteger num_elems * Imp.primByteSize t
 
-  CS.staticMemAlloc $ Reassign (Var name') (CS.simpleCall "EmptyMemblock" [Var "Ctx.EMPTY_MEM_HANDLE"])
+  CS.staticMemAlloc $ Reassign name' $
+    CS.simpleCall "EmptyMemblock" [Var "Ctx.EMPTY_MEM_HANDLE"]
   errcode <- CS.compileName <$> newVName "errCode"
   CS.staticMemAlloc $ AssignTyped computeErrCodeT (Var errcode) Nothing
-  CS.staticMemAlloc $ Reassign (Var name') (CS.simpleCall "MemblockAllocDevice" [Ref $ Var "Ctx", Var name', size, String name'])
+  CS.staticMemAlloc $ Reassign name' $
+    CS.simpleCall "MemblockAllocDevice"
+    [Ref $ Var "Ctx", name', size, String $ pretty name']
 
   -- Copy Numpy array to the device memory block.
   CS.staticMemAlloc $ Unsafe [
     Fixed (Var ptr) (Addr $ Index (Var tmp_arr) $ IdxExp $ Integer 0)
       [ ifNotZeroSize size $
         Exp $ CS.simpleCall "CL10.EnqueueWriteBuffer"
-          [ Var "Ctx.OpenCL.Queue", memblockFromMem name, Bool True
+          [ Var "Ctx.OpenCL.Queue", memblockFromMem name', Bool True
           , CS.toIntPtr (Integer 0),CS.toIntPtr size
           , CS.toIntPtr $ Var ptr, Integer 0, Null, Null ]
       ]
@@ -384,10 +387,8 @@ staticOpenCLArray name "device" t vs = do
 staticOpenCLArray _ space _ _ =
   error $ "CSOpenCL backend cannot create static array in memory space '" ++ space ++ "'"
 
-memblockFromMem :: VName -> CSExp
-memblockFromMem mem =
-  let mem' = Var $ CS.compileName mem
-  in Field mem' "Mem"
+memblockFromMem :: CSExp -> CSExp
+memblockFromMem mem = Field mem "Mem"
 
 packArrayOutput :: CS.EntryOutput Imp.OpenCL ()
 packArrayOutput mem "device" bt ept dims = do
@@ -411,12 +412,13 @@ unpackArrayInput mem "device" t _ dims e = do
   zipWithM_ (CS.unpackDim e) dims [0..]
   ptr <- pretty <$> newVName "ptr"
 
+  mem' <- CS.compileVar mem
   CS.stm $ CS.getDefaultDecl (Imp.MemParam mem (Imp.Space "device"))
-  allocateOpenCLBuffer mem nbytes "device"
+  allocateOpenCLBuffer mem' nbytes "device"
   CS.stm $ Unsafe [Fixed (Var ptr) (Addr $ Index (Field e "Item1") $ IdxExp $ Integer 0)
       [ ifNotZeroSize nbytes $
         Exp $ CS.simpleCall "CL10.EnqueueWriteBuffer"
-        [ Var "Ctx.OpenCL.Queue", memblockFromMem mem, Bool True
+        [ Var "Ctx.OpenCL.Queue", memblockFromMem mem', Bool True
         , CS.toIntPtr (Integer 0), CS.toIntPtr nbytes, CS.toIntPtr (Var ptr)
         , Integer 0, Null, Null]
       ]]

--- a/src/Futhark/CodeGen/Backends/GenericCSharp.hs
+++ b/src/Futhark/CodeGen/Backends/GenericCSharp.hs
@@ -11,6 +11,7 @@ module Futhark.CodeGen.Backends.GenericCSharp
   , assignScalarPointer
   , toIntPtr
   , compileName
+  , compileVar
   , compileDim
   , compileExp
   , compileCode
@@ -70,6 +71,7 @@ import Control.Monad.Writer
 import Control.Monad.RWS
 import Control.Arrow((&&&))
 import Data.Maybe
+import qualified Data.Map as M
 
 import Futhark.Representation.Primitive hiding (Bool)
 import Futhark.MonadFreshNames
@@ -86,22 +88,22 @@ type OpCompiler op s = op -> CompilerM op s ()
 
 -- | Write a scalar to the given memory block with the given index and
 -- in the given memory space.
-type WriteScalar op s = VName -> CSExp -> PrimType -> Imp.SpaceId -> CSExp
+type WriteScalar op s = CSExp -> CSExp -> PrimType -> Imp.SpaceId -> CSExp
                         -> CompilerM op s ()
 
 -- | Read a scalar from the given memory block with the given index and
 -- in the given memory space.
-type ReadScalar op s = VName -> CSExp -> PrimType -> Imp.SpaceId
+type ReadScalar op s = CSExp -> CSExp -> PrimType -> Imp.SpaceId
                        -> CompilerM op s CSExp
 
 -- | Allocate a memory block of the given size in the given memory
 -- space, saving a reference in the given variable name.
-type Allocate op s = VName -> CSExp -> Imp.SpaceId
+type Allocate op s = CSExp -> CSExp -> Imp.SpaceId
                      -> CompilerM op s ()
 
 -- | Copy from one memory block to another.
-type Copy op s = VName -> CSExp -> Imp.Space ->
-                 VName -> CSExp -> Imp.Space ->
+type Copy op s = CSExp -> CSExp -> Imp.Space ->
+                 CSExp -> CSExp -> Imp.Space ->
                  CSExp -> PrimType ->
                  CompilerM op s ()
 
@@ -109,7 +111,7 @@ type Copy op s = VName -> CSExp -> Imp.Space ->
 type StaticArray op s = VName -> Imp.SpaceId -> PrimType -> Imp.ArrayContents -> CompilerM op s ()
 
 -- | Construct the C# array being returned from an entry point.
-type EntryOutput op s = VName -> Imp.SpaceId ->
+type EntryOutput op s = CSExp -> Imp.SpaceId ->
                         PrimType -> Imp.Signedness ->
                         [Imp.DimSize] ->
                         CompilerM op s CSExp
@@ -165,9 +167,10 @@ defaultOperations = Operations { opsWriteScalar = defWriteScalar
         defSyncRun =
           Pass
 
-newtype CompilerEnv op s = CompilerEnv {
-    envOperations :: Operations op s
-}
+data CompilerEnv op s = CompilerEnv
+  { envOperations :: Operations op s
+  , envVarExp :: M.Map VName CSExp
+  }
 
 data CompilerAcc op s = CompilerAcc {
     accItems :: [CSStmt]
@@ -210,7 +213,8 @@ envSyncFun = opsSyncRun . envOperations
 
 newCompilerEnv :: Operations op s -> CompilerEnv op s
 newCompilerEnv ops =
-  CompilerEnv { envOperations = ops }
+  CompilerEnv { envOperations = ops
+              , envVarExp = mempty }
 
 data CompilerState s = CompilerState {
     compNameSrc :: VNameSource
@@ -222,7 +226,7 @@ data CompilerState s = CompilerState {
   , compUserState :: s
   , compMemberDecls :: [CSStmt]
   , compAssignedVars :: [VName]
-  , compDeclaredMem :: [(VName, Space)]
+  , compDeclaredMem :: [(CSExp, Space)]
 }
 
 newCompilerState :: VNameSource -> s -> CompilerState s
@@ -389,9 +393,9 @@ compileProg :: MonadFreshNames m =>
             -> [CSStmt]
             -> [Space]
             -> [Option]
-            -> Imp.Functions op
+            -> Imp.Definitions op
             -> m String
-compileProg module_name constructor imports defines ops userstate boilerplate pre_timing _ options (Imp.Functions funs) = do
+compileProg module_name constructor imports defines ops userstate boilerplate pre_timing _ options prog = do
   src <- getNameSource
   let prog' = runCompilerM ops src userstate compileProg'
   let imports' = [ Using Nothing "System"
@@ -408,7 +412,9 @@ compileProg module_name constructor imports defines ops userstate boilerplate pr
                  , Using Nothing "Mono.Options" ] ++ imports
 
   return $ pretty (CSProg $ imports' ++ prog')
-  where compileProg' = do
+  where Imp.Definitions consts (Imp.Functions funs) = prog
+        compileProg' = do
+          compileConstants consts
           definitions <- mapM compileFunc funs
           opencl_boilerplate <- collect boilerplate
           compBeforeParses <- gets compBeforeParse
@@ -499,6 +505,19 @@ compileProg module_name constructor imports defines ops userstate boilerplate pr
               , Exp $ simpleCall "entryPointFun.Invoke" []]
           ]
 
+compileConstants :: Imp.Constants op -> CompilerM op s ()
+compileConstants (Imp.Constants ps init_consts) = do
+  mapM_ addConstDecl ps
+  mapM_ staticMemAlloc =<< collect (compileCode init_consts)
+  where addConstDecl (Imp.ScalarParam p bt) = do
+          let t = compileType $ Imp.Scalar bt
+          addMemberDecl $ AssignTyped t (Var (compileName p)) Nothing
+        addConstDecl (Imp.MemParam p space) = do
+          let t = compileType $ Imp.Mem space
+          addMemberDecl $ AssignTyped t (Var (compileName p)) Nothing
+          case memInitExp space of
+            Nothing -> return ()
+            Just e -> atInit $ Reassign (Var (compileName p)) e
 
 compileFunc :: (Name, Imp.Function op) -> CompilerM op s CSFunDef
 compileFunc (fname, Imp.Function _ outputs inputs body _ _) = do
@@ -558,6 +577,10 @@ simpleInitClass fname =CreateObject (Var fname) . map simpleArg
 compileName :: VName -> String
 compileName = zEncodeString . pretty
 
+compileVar :: VName -> CompilerM op s CSExp
+compileVar v =
+  asks $ fromMaybe (Var $ compileName v) . M.lookup v . envVarExp
+
 compileType :: Imp.Type -> CSType
 compileType (Imp.Scalar p) = compilePrimTypeToAST p
 compileType (Imp.Mem space) = rawMemCSType space
@@ -600,7 +623,7 @@ unpackDim arr_name (Imp.Constant c) i = do
 unpackDim arr_name (Imp.Var var) i = do
   let shape_name = Field arr_name "Item2"
   let src = Index shape_name $ IdxExp $ Integer $ toInteger i
-  let dest = Var $ compileName var
+  dest <- compileVar var
   isAssigned <- getVarAssigned var
   if isAssigned
     then
@@ -614,16 +637,17 @@ entryPointOutput (Imp.OpaqueValue _ vs) =
   CreateSystemTuple <$> mapM (entryPointOutput . Imp.TransparentValue) vs
 
 entryPointOutput (Imp.TransparentValue (Imp.ScalarValue bt ept name)) =
-  return $ cast $ Var $ compileName name
+  cast <$> compileVar name
   where cast = compileTypecastExt bt ept
 
 entryPointOutput (Imp.TransparentValue (Imp.ArrayValue mem (Imp.Space sid) bt ept dims)) = do
-  unRefMem mem (Imp.Space sid)
+  mem' <- compileVar mem
+  unRefMem mem' (Imp.Space sid)
   pack_output <- asks envEntryOutput
-  pack_output mem sid bt ept dims
+  pack_output mem' sid bt ept dims
 
 entryPointOutput (Imp.TransparentValue (Imp.ArrayValue mem _ bt ept dims)) = do
-  let src = Var $ compileName mem
+  src <- compileVar mem
   let createTuple = "createTuple_" ++ compilePrimTypeExt bt ept
   return $ simpleCall createTuple [src, CreateArray (Primitive $ CSInt Int64T) $ Right $ map compileDim dims]
 
@@ -633,8 +657,8 @@ entryPointInput (i, Imp.OpaqueValue _ vs, e) =
     map (\idx -> Field e $ "Item" ++ show (idx :: Int)) [1..]
 
 entryPointInput (_, Imp.TransparentValue (Imp.ScalarValue bt _ name), e) = do
-  let vname' = Var $ compileName name
-      cast = compileTypecast bt
+  vname' <- compileVar name
+  let cast = compileTypecast bt
   stm $ Assign vname' (cast e)
 
 entryPointInput (_, Imp.TransparentValue (Imp.ArrayValue mem (Imp.Space sid) bt ept dims), e) = do
@@ -645,8 +669,8 @@ entryPointInput (_, Imp.TransparentValue (Imp.ArrayValue mem (Imp.Space sid) bt 
 entryPointInput (_, Imp.TransparentValue (Imp.ArrayValue mem _ bt _ dims), e) = do
   zipWithM_ (unpackDim e) dims [0..]
   let arrayData = Field e "Item1"
-  let dest = Var $ compileName mem
-      unwrap_call = simpleCall "unwrapArray" [arrayData, sizeOf $ compilePrimTypeToAST bt]
+  dest <- compileVar mem
+  let unwrap_call = simpleCall "unwrapArray" [arrayData, sizeOf $ compilePrimTypeToAST bt]
   stm $ Assign dest unwrap_call
 
 extValueDescName :: Imp.ExternalValue -> String
@@ -843,17 +867,16 @@ prepareEntry (fname, Imp.Function _ outputs inputs _ results args) = do
       allocate <- asks envAllocate
 
       let size = Var (compileName name ++ "_nbytes")
-          dest = name'
-          src = name
+          dest = Var $ compileName name'
+          src = Var $ compileName name
           offset = Integer 0
       case space of
         Space sid ->
-          allocate name' size sid
+          allocate dest size sid
         _ ->
-          stm $ Reassign (Var (compileName name'))
-                       (simpleCall "allocateMem" [size]) -- FIXME
+          stm $ Reassign dest (simpleCall "allocateMem" [size]) -- FIXME
       copy dest offset space src offset space size (IntType Int64) -- FIXME
-      return $ Just (compileName name')
+      return $ Just dest
     _ -> return Nothing
 
   prepareIn <- collect $ mapM_ entryPointInput $ zip3 [0..] args $
@@ -863,14 +886,14 @@ prepareEntry (fname, Imp.Function _ outputs inputs _ results args) = do
   let mem_copies = mapMaybe liftMaybe $ zip argexps_mem_copies inputs
       mem_copy_inits = map initCopy mem_copies
 
-      argexps_lib = map (compileName . Imp.paramName) inputs
+      argexps_lib = map (Var . compileName . Imp.paramName) inputs
       argexps_bin = zipWith fromMaybe argexps_lib argexps_mem_copies
       fname' = futharkFun (nameToString fname)
       arg_types = map (fst . compileTypedInput) inputs
       inputs' = zip arg_types (map extValueDescName args)
       output_type = tupleOrSingleEntryT output_types
-      call_lib = [Reassign funTuple $ simpleCall fname' (fmap Var argexps_lib)]
-      call_bin = [Reassign funTuple $ simpleCall fname' (fmap Var argexps_bin)]
+      call_lib = [Reassign funTuple $ simpleCall fname' argexps_lib]
+      call_bin = [Reassign funTuple $ simpleCall fname' argexps_bin]
       prepareIn' = prepareIn ++ mem_copy_inits ++ sizeDecls
 
   return (nameToString fname, inputs', output_type,
@@ -892,12 +915,12 @@ prepareEntry (fname, Imp.Function _ outputs inputs _ results args) = do
         declsfunction (Imp.TransparentValue v) = valueDescFun v
         declsfunction (Imp.OpaqueValue _ vs) = mapM_ valueDescFun vs
 
-copyMemoryDefaultSpace :: VName -> CSExp -> VName -> CSExp -> CSExp ->
+copyMemoryDefaultSpace :: CSExp -> CSExp -> CSExp -> CSExp -> CSExp ->
                           CompilerM op s ()
 copyMemoryDefaultSpace destmem destidx srcmem srcidx nbytes =
-  stm $ Exp $ simpleCall "Buffer.BlockCopy" [ Var (compileName srcmem), srcidx
-                                            , Var (compileName destmem), destidx,
-                                              nbytes]
+  stm $ Exp $ simpleCall "Buffer.BlockCopy" [ srcmem, srcidx
+                                            , destmem, destidx
+                                            , nbytes]
 
 compileEntryFun :: [CSStmt] -> (Name, Imp.Function op)
                 -> CompilerM op s CSFunDef
@@ -1119,26 +1142,27 @@ compileExp :: Imp.Exp -> CompilerM op s CSExp
 compileExp (Imp.ValueExp v) = return $ compilePrimValue v
 
 compileExp (Imp.LeafExp (Imp.ScalarVar vname) _) =
-  return $ Var $ compileName vname
+  compileVar vname
 
 compileExp (Imp.LeafExp (Imp.SizeOf t) _) =
   return $ (compileTypecast $ IntType Int32) (Integer $ primByteSize t)
 
 compileExp (Imp.LeafExp (Imp.Index src (Imp.Count iexp) restype (Imp.Space space) _) _) =
   join $ asks envReadScalar
-    <*> pure src <*> compileExp iexp
+    <*> compileVar src <*> compileExp iexp
     <*> pure restype <*> pure space
 
 compileExp (Imp.LeafExp (Imp.Index src (Imp.Count iexp) (IntType Int8) _ _) _) = do
-  let src' = compileName src
+  src' <- compileVar src
   iexp' <- compileExp iexp
-  return $ Cast (Primitive $ CSInt Int8T) (Index (Var src') (IdxExp iexp'))
+  return $ Cast (Primitive $ CSInt Int8T) (Index src' (IdxExp iexp'))
 
 compileExp (Imp.LeafExp (Imp.Index src (Imp.Count iexp) bt _ _) _) = do
   iexp' <- compileExp iexp
   let bt' = compilePrimType bt
       iexp'' = BinOp "*" iexp' (sizeOf (compilePrimTypeToAST bt))
-  return $ simpleCall ("indexArray_" ++ bt') [Var $ compileName src, iexp'']
+  src' <- compileVar src
+  return $ simpleCall ("indexArray_" ++ bt') [src', iexp'']
 
 compileExp (Imp.BinOpExp op x y) = do
   (x', y', simple) <- compileBinOpLike x y
@@ -1205,25 +1229,24 @@ compileCode (Imp.For i it bound body) = do
     [AssignOp "+" (Var i') (Var one)]
 
 
-compileCode (Imp.SetScalar vname exp1) = do
-  let name' = Var $ compileName vname
-  exp1' <- compileExp exp1
-  stm $ Reassign name' exp1'
+compileCode (Imp.SetScalar vname exp1) =
+  stm =<< Reassign <$> compileVar vname <*> compileExp exp1
 
 compileCode (Imp.DeclareMem v space) = declMem v space
 
 compileCode (Imp.DeclareScalar v _ Cert) =
-  stm $ Assign (Var $ compileName v) $ Bool True
+  stm =<< Assign <$> compileVar v <*> pure (Bool True)
 compileCode (Imp.DeclareScalar v _ t) =
-  stm $ AssignTyped t' (Var $ compileName v) Nothing
+  stm =<< AssignTyped t' <$> compileVar v <*> pure Nothing
   where t' = compilePrimTypeToAST t
 
 compileCode (Imp.DeclareArray name (Space space) t vs) =
   join $ asks envStaticArray <*>
   pure name <*> pure space <*> pure t <*> pure vs
 
-compileCode (Imp.DeclareArray name _ t vs) =
-  stms [Assign (Var $ "init_"++name') $
+compileCode (Imp.DeclareArray name _ t vs) = do
+  name' <- compileVar name
+  stms [Assign (Var $ "init_"++compileName name) $
         simpleCall "unwrapArray"
          [
            case vs of Imp.ArrayValues vs' ->
@@ -1232,9 +1255,8 @@ compileCode (Imp.DeclareArray name _ t vs) =
                         CreateArray (compilePrimTypeToAST t) $ Left n
          , simpleCall "sizeof" [Var $ compilePrimType t]
          ]
-       , Assign (Var name') $ Var ("init_"++name')
+       , Assign name' $ Var ("init_"++compileName name)
        ]
-  where name' = compileName name
 
 compileCode (Imp.Comment s code) = do
   code' <- blockScope $ compileCode code
@@ -1253,62 +1275,61 @@ compileCode (Imp.Assert e (Imp.ErrorMsg parts) (loc,locs)) = do
 
 compileCode (Imp.Call dests fname args) = do
   args' <- mapM compileArg args
-  let dests' = tupleOrSingle $ fmap Var (map compileName dests)
-      fname' = futharkFun (pretty fname)
+  dests' <- tupleOrSingle <$> mapM compileVar dests
+  let fname' = futharkFun (pretty fname)
       call' = simpleCall fname' args'
   -- If the function returns nothing (is called only for side
   -- effects), take care not to assign to an empty tuple.
   stm $ if null dests
         then Exp call'
         else Reassign dests' call'
-  where compileArg (Imp.MemArg m) = return $ Var $ compileName m
+  where compileArg (Imp.MemArg m) = compileVar m
         compileArg (Imp.ExpArg e) = compileExp e
 
-compileCode (Imp.SetMem dest src DefaultSpace) = do
-  let src' = Var (compileName src)
-  let dest' = Var (compileName dest)
-  stm $ Reassign dest' src'
+compileCode (Imp.SetMem dest src DefaultSpace) =
+  stm =<< Reassign <$> compileVar dest <*> compileVar src
 
 compileCode (Imp.SetMem dest src _) = do
-  let src' = Var (compileName src)
-  let dest' = Var (compileName dest)
-  stm $ Exp $ simpleCall "MemblockSetDevice" [Ref $ Var "Ctx", Ref dest', Ref src', String (compileName src)]
+  src' <- compileVar src
+  dest' <- compileVar dest
+  stm $ Exp $ simpleCall "MemblockSetDevice" [Ref $ Var "Ctx", Ref dest', Ref src', String $ pretty src']
 
 compileCode (Imp.Allocate name (Imp.Count e) (Imp.Space space)) =
   join $ asks envAllocate
-    <*> pure name
+    <*> compileVar name
     <*> compileExp e
     <*> pure space
 
 compileCode (Imp.Allocate name (Imp.Count e) _) = do
   e' <- compileExp e
   let allocate' = simpleCall "allocateMem" [e']
-      name' = Var (compileName name)
-  stm $ Reassign name' allocate'
+  stm =<< Reassign <$> compileVar name <*> pure allocate'
 
 compileCode (Imp.Free name space) = do
-  unRefMem name space
+  name' <- compileVar name
+  unRefMem name' space
   tell $ mempty { accFreedMem = [name] }
 
 compileCode (Imp.Copy dest (Imp.Count destoffset) DefaultSpace src (Imp.Count srcoffset) DefaultSpace (Imp.Count size)) = do
   destoffset' <- compileExp destoffset
   srcoffset' <- compileExp srcoffset
-  let dest' = Var (compileName dest)
-  let src' = Var (compileName src)
+  dest' <- compileVar dest
+  src' <- compileVar src
   size' <- compileExp size
-  stm $ Exp $ simpleCall "Buffer.BlockCopy" [src', srcoffset', dest', destoffset',
-                                             Cast (Primitive $ CSInt Int32T) size']
+  stm $ Exp $ simpleCall "Buffer.BlockCopy"
+    [src', srcoffset', dest', destoffset',
+     Cast (Primitive $ CSInt Int32T) size']
 
 compileCode (Imp.Copy dest (Imp.Count destoffset) destspace src (Imp.Count srcoffset) srcspace (Imp.Count size)) = do
   copy <- asks envCopy
   join $ copy
-    <$> pure dest <*> compileExp destoffset <*> pure destspace
-    <*> pure src <*> compileExp srcoffset <*> pure srcspace
+    <$> compileVar dest <*> compileExp destoffset <*> pure destspace
+    <*> compileVar src <*> compileExp srcoffset <*> pure srcspace
     <*> compileExp size <*> pure (IntType Int64) -- FIXME
 
 compileCode (Imp.Write dest (Imp.Count idx) elemtype (Imp.Space space) _ elemexp) =
   join $ asks envWriteScalar
-    <*> pure dest
+    <*> compileVar dest
     <*> compileExp idx
     <*> pure elemtype
     <*> pure space
@@ -1317,8 +1338,8 @@ compileCode (Imp.Write dest (Imp.Count idx) elemtype (Imp.Space space) _ elemexp
 compileCode (Imp.Write dest (Imp.Count idx) elemtype _ _ elemexp) = do
   idx' <- compileExp idx
   elemexp' <- compileExp elemexp
-  let dest' = Var $ compileName dest
-      elemtype' = compileTypecast elemtype
+  dest' <- compileVar dest
+  let elemtype' = compileTypecast elemtype
       ctype = elemtype' elemexp'
       idx'' = BinOp "*" idx' (sizeOf (compilePrimTypeToAST elemtype))
 
@@ -1341,11 +1362,12 @@ blockScope' m = do
   releases <- collect $ mapM_ (uncurry unRefMem) new_allocs
   return (x, items <> releases)
 
-unRefMem :: VName -> Space -> CompilerM op s ()
+unRefMem :: CSExp -> Space -> CompilerM op s ()
 unRefMem mem (Space "device") =
-  (stm . Exp) $ simpleCall "MemblockUnrefDevice" [ Ref $ Var "Ctx"
-                                                 , (Ref . Var . compileName) mem
-                                                 , (String . compileName) mem]
+  stm $ Exp $
+  simpleCall "MemblockUnrefDevice" [ Ref $ Var "Ctx"
+                                   , Ref mem
+                                   , String $ pretty mem]
 unRefMem _ DefaultSpace = stm Pass
 unRefMem _ (Space "local") = stm Pass
 unRefMem _ _ = error "The default compiler cannot compile unRefMem for other spaces"
@@ -1357,14 +1379,21 @@ publicName s = "Futhark" ++ s
 
 declMem :: VName -> Space -> CompilerM op s ()
 declMem name space = do
-  modify $ \s -> s { compDeclaredMem = (name, space) : compDeclaredMem s}
-  stm $ declMem' (compileName name) space
+  name' <- compileVar name
+  modify $ \s -> s { compDeclaredMem = (name', space) : compDeclaredMem s}
+  stm $ declMem' name' space
 
-declMem' :: String -> Space -> CSStmt
-declMem' name (Space _) =
-  AssignTyped (CustomT "OpenCLMemblock") (Var name) (Just $ simpleCall "EmptyMemblock" [Var "Ctx.EMPTY_MEM_HANDLE"])
+memInitExp :: Space -> Maybe CSExp
+memInitExp (Space _) =
+  Just $ simpleCall "EmptyMemblock" [Var "Ctx.EMPTY_MEM_HANDLE"]
+memInitExp _ =
+  Nothing
+
+declMem' :: CSExp -> Space -> CSStmt
+declMem' name space@(Space _) =
+  AssignTyped (CustomT "OpenCLMemblock") name $ memInitExp space
 declMem' name _ =
-  AssignTyped (Composite $ ArrayT $ Primitive ByteT) (Var name) Nothing
+  AssignTyped (Composite $ ArrayT $ Primitive ByteT) name Nothing
 
 rawMemCSType :: Space -> CSType
 rawMemCSType (Space _) = CustomT "OpenCLMemblock"

--- a/src/Futhark/CodeGen/Backends/GenericPython.hs
+++ b/src/Futhark/CodeGen/Backends/GenericPython.hs
@@ -9,6 +9,7 @@ module Futhark.CodeGen.Backends.GenericPython
   , emptyConstructor
 
   , compileName
+  , compileVar
   , compileDim
   , compileExp
   , compileCode
@@ -50,6 +51,7 @@ import Control.Monad.Reader
 import Control.Monad.Writer
 import Control.Monad.RWS
 import Data.Maybe
+import qualified Data.Map as M
 
 import Futhark.Representation.Primitive hiding (Bool)
 import Futhark.MonadFreshNames
@@ -67,22 +69,22 @@ type OpCompiler op s = op -> CompilerM op s ()
 
 -- | Write a scalar to the given memory block with the given index and
 -- in the given memory space.
-type WriteScalar op s = VName -> PyExp -> PrimType -> Imp.SpaceId -> PyExp
+type WriteScalar op s = PyExp -> PyExp -> PrimType -> Imp.SpaceId -> PyExp
                         -> CompilerM op s ()
 
 -- | Read a scalar from the given memory block with the given index and
 -- in the given memory space.
-type ReadScalar op s = VName -> PyExp -> PrimType -> Imp.SpaceId
+type ReadScalar op s = PyExp -> PyExp -> PrimType -> Imp.SpaceId
                        -> CompilerM op s PyExp
 
 -- | Allocate a memory block of the given size in the given memory
 -- space, saving a reference in the given variable name.
-type Allocate op s = VName -> PyExp -> Imp.SpaceId
+type Allocate op s = PyExp -> PyExp -> Imp.SpaceId
                      -> CompilerM op s ()
 
 -- | Copy from one memory block to another.
-type Copy op s = VName -> PyExp -> Imp.Space ->
-                 VName -> PyExp -> Imp.Space ->
+type Copy op s = PyExp -> PyExp -> Imp.Space ->
+                 PyExp -> PyExp -> Imp.Space ->
                  PyExp -> PrimType ->
                  CompilerM op s ()
 
@@ -96,7 +98,7 @@ type EntryOutput op s = VName -> Imp.SpaceId ->
                         CompilerM op s PyExp
 
 -- | Unpack the array being passed to an entry point.
-type EntryInput op s = VName -> Imp.SpaceId ->
+type EntryInput op s = PyExp -> Imp.SpaceId ->
                        PrimType -> Imp.Signedness ->
                        [Imp.DimSize] ->
                        PyExp ->
@@ -143,9 +145,10 @@ defaultOperations = Operations { opsWriteScalar = defWriteScalar
         defEntryInput _ _ _ _ =
           error "Cannot accept array not in default memory space"
 
-newtype CompilerEnv op s = CompilerEnv {
-    envOperations :: Operations op s
-}
+data CompilerEnv op s = CompilerEnv
+  { envOperations :: Operations op s
+  , envVarExp :: M.Map VName PyExp
+  }
 
 envOpCompiler :: CompilerEnv op s -> OpCompiler op s
 envOpCompiler = opsCompiler . envOperations
@@ -172,7 +175,8 @@ envEntryInput :: CompilerEnv op s -> EntryInput op s
 envEntryInput = opsEntryInput . envOperations
 
 newCompilerEnv :: Operations op s -> CompilerEnv op s
-newCompilerEnv ops = CompilerEnv { envOperations = ops }
+newCompilerEnv ops = CompilerEnv { envOperations = ops
+                                 , envVarExp = mempty }
 
 data CompilerState s = CompilerState {
     compNameSrc :: VNameSource
@@ -287,9 +291,9 @@ compileProg :: MonadFreshNames m =>
             -> s
             -> [PyStmt]
             -> [Option]
-            -> Imp.Functions op
+            -> Imp.Definitions op
             -> m String
-compileProg module_name constructor imports defines ops userstate pre_timing options (Imp.Functions funs) = do
+compileProg module_name constructor imports defines ops userstate pre_timing options prog = do
   src <- getNameSource
   let prog' = runCompilerM ops src userstate compileProg'
       maybe_shebang =
@@ -303,7 +307,11 @@ compileProg module_name constructor imports defines ops userstate pre_timing opt
             defines ++
             [Escape pyUtility] ++
             prog')
-  where compileProg' = do
+  where Imp.Definitions consts (Imp.Functions funs) = prog
+        compileProg' = withConstantSubsts consts $ do
+
+          compileConstants consts
+
           definitions <- mapM compileFunc funs
           at_inits <- gets compInit
 
@@ -353,12 +361,25 @@ compileProg module_name constructor imports defines ops userstate pre_timing opt
               [Exp $ simpleCall "entry_point_fun" []]
           ]
 
+withConstantSubsts :: Imp.Constants op -> CompilerM op s a -> CompilerM op s a
+withConstantSubsts (Imp.Constants ps _) =
+  local $ \env -> env { envVarExp = foldMap constExp ps }
+  where constExp p =
+          M.singleton (Imp.paramName p) $ Index (Var "self.constants") $
+          IdxExp $ String $ pretty $ Imp.paramName p
+
+compileConstants :: Imp.Constants op -> CompilerM op s ()
+compileConstants (Imp.Constants _ init_consts) = do
+  atInit $ Assign (Var "self.constants") $ Dict []
+  mapM_ atInit =<< collect (compileCode init_consts)
+
 compileFunc :: (Name, Imp.Function op) -> CompilerM op s PyFunDef
 compileFunc (fname, Imp.Function _ outputs inputs body _ _) = do
   body' <- collect $ compileCode body
   let inputs' = map (compileName . Imp.paramName) inputs
   let ret = Return $ tupleOrSingle $ compileOutput outputs
-  return $ Def (futharkFun . nameToString $ fname) ("self" : inputs') (body'++[ret])
+  return $ Def (futharkFun . nameToString $ fname) ("self" : inputs') $
+    body'++[ret]
 
 tupleOrSingle :: [PyExp] -> PyExp
 tupleOrSingle [e] = e
@@ -386,20 +407,23 @@ unpackDim arr_name (Imp.Constant c) i = do
 unpackDim arr_name (Imp.Var var) i = do
   let shape_name = Field arr_name "shape"
       src = Index shape_name $ IdxExp $ Integer $ toInteger i
-  stm $ Assign (Var $ compileName var) $ simpleCall "np.int32" [src]
+  var' <- compileVar var
+  stm $ Assign var' $ simpleCall "np.int32" [src]
 
 entryPointOutput :: Imp.ExternalValue -> CompilerM op s PyExp
 entryPointOutput (Imp.OpaqueValue desc vs) =
   simpleCall "opaque" . (String (pretty desc):) <$>
   mapM (entryPointOutput . Imp.TransparentValue) vs
-entryPointOutput (Imp.TransparentValue (Imp.ScalarValue bt ept name)) =
-  return $ simpleCall tf [Var $ compileName name]
+entryPointOutput (Imp.TransparentValue (Imp.ScalarValue bt ept name)) = do
+  name' <- compileVar name
+  return $ simpleCall tf [name']
   where tf = compilePrimToExtNp bt ept
 entryPointOutput (Imp.TransparentValue (Imp.ArrayValue mem (Imp.Space sid) bt ept dims)) = do
   pack_output <- asks envEntryOutput
   pack_output mem sid bt ept dims
 entryPointOutput (Imp.TransparentValue (Imp.ArrayValue mem _ bt ept dims)) = do
-  let cast = Cast (Var $ compileName mem) (compilePrimTypeExt bt ept)
+  mem' <- compileVar mem
+  let cast = Cast mem' (compilePrimTypeExt bt ept)
   return $ simpleCall "createArray" [cast, Tuple $ map compileDim dims]
 
 badInput :: Int -> PyExp -> String -> PyStmt
@@ -421,8 +445,8 @@ entryPointInput (i, Imp.OpaqueValue desc vs, e) = do
     map (Index (Field e "data") . IdxExp . Integer) [0..]
 
 entryPointInput (i, Imp.TransparentValue (Imp.ScalarValue bt s name), e) = do
-  let vname' = Var $ compileName name
-      -- HACK: A Numpy int64 will signal an OverflowError if we pass
+  vname' <- compileVar name
+  let -- HACK: A Numpy int64 will signal an OverflowError if we pass
       -- it a number bigger than 2**63.  This does not happen if we
       -- pass e.g. int8 a number bigger than 2**7.  As a workaround,
       -- we first go through the corresponding ctypes type, which does
@@ -437,7 +461,8 @@ entryPointInput (i, Imp.TransparentValue (Imp.ScalarValue bt s name), e) = do
 
 entryPointInput (i, Imp.TransparentValue (Imp.ArrayValue mem (Imp.Space sid) bt ept dims), e) = do
   unpack_input <- asks envEntryInput
-  unpack <- collect $ unpack_input mem sid bt ept dims e
+  mem' <- compileVar mem
+  unpack <- collect $ unpack_input mem' sid bt ept dims e
   stm $ Try unpack
     [Catch (Tuple [Var "TypeError", Var "AssertionError"])
      [badInput i e $ concat (replicate (length dims) "[]") ++
@@ -455,8 +480,8 @@ entryPointInput (i, Imp.TransparentValue (Imp.ArrayValue mem _ t s dims), e) = d
     []
 
   zipWithM_ (unpackDim e) dims [0..]
-  let dest = Var $ compileName mem
-      unwrap_call = simpleCall "unwrapArray" [e]
+  dest <- compileVar mem
+  let unwrap_call = simpleCall "unwrapArray" [e]
 
   stm $ Assign dest unwrap_call
 
@@ -545,11 +570,13 @@ prepareEntry (fname, Imp.Function _ outputs inputs _ results args) = do
           offset = Integer 0
       case space of
         Space sid ->
-          allocate name' size sid
+          allocate (Var (compileName name')) size sid
         _ ->
           stm $ Assign (Var (compileName name'))
                        (simpleCall "allocateMem" [size]) -- FIXME
-      copy dest offset space src offset space size (IntType Int32) -- FIXME
+      dest' <- compileVar dest
+      src' <- compileVar src
+      copy dest' offset space src' offset space size (IntType Int32) -- FIXME
       return $ Just $ compileName name'
     _ -> return Nothing
 
@@ -567,13 +594,13 @@ prepareEntry (fname, Imp.Function _ outputs inputs _ results args) = do
           prepareIn, call_lib, call_bin, prepareOut,
           zip results res, prepare_run)
 
-copyMemoryDefaultSpace :: VName -> PyExp -> VName -> PyExp -> PyExp ->
+copyMemoryDefaultSpace :: PyExp -> PyExp -> PyExp -> PyExp -> PyExp ->
                           CompilerM op s ()
 copyMemoryDefaultSpace destmem destidx srcmem srcidx nbytes = do
   let offset_call1 = simpleCall "addressOffset"
-                     [Var (compileName destmem), destidx, Var "ct.c_byte"]
+                     [destmem, destidx, Var "ct.c_byte"]
   let offset_call2 = simpleCall "addressOffset"
-                     [Var (compileName srcmem), srcidx, Var "ct.c_byte"]
+                     [srcmem, srcidx, Var "ct.c_byte"]
   stm $ Exp $ simpleCall "ct.memmove" [offset_call1, offset_call2, nbytes]
 
 compileEntryFun :: (Name, Imp.Function op)
@@ -754,26 +781,31 @@ compilePrimValue (FloatValue (Float64Value v))
 compilePrimValue (BoolValue v) = Bool v
 compilePrimValue Checked = Var "True"
 
+compileVar :: VName -> CompilerM op s PyExp
+compileVar v =
+  asks $ fromMaybe (Var $ compileName v) . M.lookup v . envVarExp
+
 compileExp :: Imp.Exp -> CompilerM op s PyExp
 
 compileExp (Imp.ValueExp v) = return $ compilePrimValue v
 
 compileExp (Imp.LeafExp (Imp.ScalarVar vname) _) =
-  return $ Var $ compileName vname
+  compileVar vname
 
 compileExp (Imp.LeafExp (Imp.SizeOf t) _) =
   return $ simpleCall (compilePrimToNp $ IntType Int32) [Integer $ primByteSize t]
 
 compileExp (Imp.LeafExp (Imp.Index src (Imp.Count iexp) restype (Imp.Space space) _) _) =
   join $ asks envReadScalar
-    <*> pure src <*> compileExp iexp
+    <*> compileVar src <*> compileExp iexp
     <*> pure restype <*> pure space
 
 compileExp (Imp.LeafExp (Imp.Index src (Imp.Count iexp) bt _ _) _) = do
   iexp' <- compileExp iexp
   let bt' = compilePrimType bt
-  let nptype = compilePrimToNp bt
-  return $ simpleCall "indexArray" [Var $ compileName src, iexp', Var bt', Var nptype]
+      nptype = compilePrimToNp bt
+  src' <- compileVar src
+  return $ simpleCall "indexArray" [src', iexp', Var bt', Var nptype]
 
 compileExp (Imp.BinOpExp op x y) = do
   (x', y', simple) <- compileBinOpLike x y
@@ -848,14 +880,13 @@ compileCode (Imp.For i it bound body) = do
   stm $ For counter (simpleCall "range" [bound']) $
     body' ++ [AssignOp "+" (Var i') (Var one)]
 
-compileCode (Imp.SetScalar vname exp1) = do
-  let name' = Var $ compileName vname
-  exp1' <- compileExp exp1
-  stm $ Assign name' exp1'
+compileCode (Imp.SetScalar name exp1) =
+  stm =<< Assign <$> compileVar name <*> compileExp exp1
 
 compileCode Imp.DeclareMem{} = return ()
-compileCode (Imp.DeclareScalar v _ Cert) =
-  stm $ Assign (Var $ compileName v) $ Var "True"
+compileCode (Imp.DeclareScalar v _ Cert) = do
+  v' <- compileVar v
+  stm $ Assign v' $ Var "True"
 compileCode Imp.DeclareScalar{} = return ()
 
 compileCode (Imp.DeclareArray name (Space space) t vs) =
@@ -863,6 +894,7 @@ compileCode (Imp.DeclareArray name (Space space) t vs) =
   pure name <*> pure space <*> pure t <*> pure vs
 
 compileCode (Imp.DeclareArray name _ t vs) = do
+  let arr_name = compileName name <> "_arr"
   -- It is important to store the Numpy array in a temporary variable
   -- to prevent it from going "out-of-scope" before calling
   -- unwrapArray (which internally uses the .ctype method); see
@@ -877,11 +909,10 @@ compileCode (Imp.DeclareArray name _ t vs) = do
       [Arg $ Integer $ fromIntegral n,
        ArgKeyword "dtype" $ Var $ compilePrimToNp t]
   atInit $
-    Assign (Field (Var "self") name') $
+    Assign (Field (Var "self") (compileName name)) $
     simpleCall "unwrapArray" [Field (Var "self") arr_name]
-  stm $ Assign (Var name') $ Field (Var "self") name'
-  where name' = compileName name
-        arr_name = name' <> "_arr"
+  name' <- compileVar name
+  stm $ Assign name' $ Field (Var "self") (compileName name)
 
 compileCode (Imp.Comment s code) = do
   code' <- collect $ compileCode code
@@ -899,8 +930,8 @@ compileCode (Imp.Assert e (Imp.ErrorMsg parts) (loc,locs)) = do
 
 compileCode (Imp.Call dests fname args) = do
   args' <- mapM compileArg args
-  let dests' = tupleOrSingle $ fmap Var (map compileName dests)
-      fname'
+  dests' <- tupleOrSingle <$> mapM compileVar dests
+  let fname'
         | isBuiltInFunction fname = futharkFun (pretty  fname)
         | otherwise               = "self." ++ futharkFun (pretty  fname)
       call' = simpleCall fname' args'
@@ -909,34 +940,31 @@ compileCode (Imp.Call dests fname args) = do
   stm $ if null dests
         then Exp call'
         else Assign dests' call'
-  where compileArg (Imp.MemArg m) = return $ Var $ compileName m
+  where compileArg (Imp.MemArg m) = compileVar m
         compileArg (Imp.ExpArg e) = compileExp e
 
-compileCode (Imp.SetMem dest src _) = do
-  let src' = Var (compileName src)
-  let dest' = Var (compileName dest)
-  stm $ Assign dest' src'
+compileCode (Imp.SetMem dest src _) =
+  stm =<< Assign <$> compileVar dest <*> compileVar src
 
 compileCode (Imp.Allocate name (Imp.Count e) (Imp.Space space)) =
   join $ asks envAllocate
-    <*> pure name
+    <*> compileVar name
     <*> compileExp e
     <*> pure space
 
 compileCode (Imp.Allocate name (Imp.Count e) _) = do
   e' <- compileExp e
   let allocate' = simpleCall "allocateMem" [e']
-      name' = Var (compileName name)
-  stm $ Assign name' allocate'
+  stm =<< Assign <$> compileVar name <*> pure allocate'
 
 compileCode (Imp.Free name _) =
-  stm $ Assign (Var (compileName name)) None
+  stm =<< Assign <$> compileVar name <*> pure None
 
 compileCode (Imp.Copy dest (Imp.Count destoffset) DefaultSpace src (Imp.Count srcoffset) DefaultSpace (Imp.Count size)) = do
   destoffset' <- compileExp destoffset
   srcoffset' <- compileExp srcoffset
-  let dest' = Var (compileName dest)
-  let src' = Var (compileName src)
+  dest' <- compileVar dest
+  src' <- compileVar src
   size' <- compileExp size
   let offset_call1 = simpleCall "addressOffset" [dest', destoffset', Var "ct.c_byte"]
   let offset_call2 = simpleCall "addressOffset" [src', srcoffset', Var "ct.c_byte"]
@@ -945,13 +973,13 @@ compileCode (Imp.Copy dest (Imp.Count destoffset) DefaultSpace src (Imp.Count sr
 compileCode (Imp.Copy dest (Imp.Count destoffset) destspace src (Imp.Count srcoffset) srcspace (Imp.Count size)) = do
   copy <- asks envCopy
   join $ copy
-    <$> pure dest <*> compileExp destoffset <*> pure destspace
-    <*> pure src <*> compileExp srcoffset <*> pure srcspace
+    <$> compileVar dest <*> compileExp destoffset <*> pure destspace
+    <*> compileVar src <*> compileExp srcoffset <*> pure srcspace
     <*> compileExp size <*> pure (IntType Int32) -- FIXME
 
 compileCode (Imp.Write dest (Imp.Count idx) elemtype (Imp.Space space) _ elemexp) =
   join $ asks envWriteScalar
-    <*> pure dest
+    <*> compileVar dest
     <*> compileExp idx
     <*> pure elemtype
     <*> pure space
@@ -960,9 +988,9 @@ compileCode (Imp.Write dest (Imp.Count idx) elemtype (Imp.Space space) _ elemexp
 compileCode (Imp.Write dest (Imp.Count idx) elemtype _ _ elemexp) = do
   idx' <- compileExp idx
   elemexp' <- compileExp elemexp
-  let dest' = Var $ compileName dest
+  dest' <- compileVar dest
   let elemtype' = compilePrimType elemtype
-  let ctype = simpleCall elemtype' [elemexp']
+      ctype = simpleCall elemtype' [elemexp']
   stm $ Exp $ simpleCall "writeScalarArray" [dest', idx', ctype]
 
 compileCode Imp.Skip = return ()

--- a/src/Futhark/CodeGen/Backends/PyOpenCL.hs
+++ b/src/Futhark/CodeGen/Backends/PyOpenCL.hs
@@ -128,16 +128,19 @@ asLong :: PyExp -> PyExp
 asLong x = Py.simpleCall "np.long" [x]
 
 callKernel :: Py.OpCompiler Imp.OpenCL ()
-callKernel (Imp.GetSize v key) =
-  Py.stm $ Assign (Var (Py.compileName v)) $
-  Index (Var "self.sizes") (IdxExp $ String $ pretty key)
+callKernel (Imp.GetSize v key) = do
+  v' <- Py.compileVar v
+  Py.stm $ Assign v' $
+    Index (Var "self.sizes") (IdxExp $ String $ pretty key)
 callKernel (Imp.CmpSizeLe v key x) = do
+  v' <- Py.compileVar v
   x' <- Py.compileExp x
-  Py.stm $ Assign (Var (Py.compileName v)) $
+  Py.stm $ Assign v' $
     BinOp "<=" (Index (Var "self.sizes") (IdxExp $ String $ pretty key)) x'
-callKernel (Imp.GetSizeMax v size_class) =
-  Py.stm $ Assign (Var (Py.compileName v)) $
-  Var $ "self.max_" ++ pretty size_class
+callKernel (Imp.GetSizeMax v size_class) = do
+  v' <- Py.compileVar v
+  Py.stm $ Assign v' $
+    Var $ "self.max_" ++ pretty size_class
 
 callKernel (Imp.LaunchKernel safety name args num_workgroups workgroup_size) = do
   num_workgroups' <- mapM (fmap asLong . Py.compileExp) num_workgroups
@@ -166,7 +169,8 @@ launchKernel kernel_name safety kernel_dims workgroup_dims args = do
                      [Var "self.global_failure",
                       Var "self.failure_is_an_option",
                       Var "self.global_failure_args"]
-  Py.stm $ Exp $ Py.simpleCall (kernel_name' ++ ".set_args") $ failure_args ++ args'
+  Py.stm $ Exp $ Py.simpleCall (kernel_name' ++ ".set_args") $
+    failure_args ++ args'
   Py.stm $ Exp $ Py.simpleCall "cl.enqueue_nd_range_kernel"
     [Var "self.queue", Var kernel_name', kernel_dims', workgroup_dims']
   finishIfSynchronous
@@ -174,18 +178,17 @@ launchKernel kernel_name safety kernel_dims workgroup_dims args = do
         processKernelArg (Imp.ValueKArg e bt) = do
           e' <- Py.compileExp e
           return $ Py.simpleCall (Py.compilePrimToNp bt) [e']
-        processKernelArg (Imp.MemKArg v) = return $ Var $ Py.compileName v
+        processKernelArg (Imp.MemKArg v) = Py.compileVar v
         processKernelArg (Imp.SharedMemoryKArg (Imp.Count num_bytes)) = do
           num_bytes' <- Py.compileExp num_bytes
           return $ Py.simpleCall "cl.LocalMemory" [asLong num_bytes']
 
 writeOpenCLScalar :: Py.WriteScalar Imp.OpenCL ()
 writeOpenCLScalar mem i bt "device" val = do
-  let mem' = Var $ Py.compileName mem
   let nparr = Call (Var "np.array")
               [Arg val, ArgKeyword "dtype" $ Var $ Py.compilePrimType bt]
   Py.stm $ Exp $ Call (Var "cl.enqueue_copy")
-    [Arg $ Var "self.queue", Arg mem', Arg nparr,
+    [Arg $ Var "self.queue", Arg mem, Arg nparr,
      ArgKeyword "device_offset" $ BinOp "*" (asLong i) (Integer $ Imp.primByteSize bt),
      ArgKeyword "is_blocking" $ Var "synchronous"]
 
@@ -196,13 +199,12 @@ readOpenCLScalar :: Py.ReadScalar Imp.OpenCL ()
 readOpenCLScalar mem i bt "device" = do
   val <- newVName "read_res"
   let val' = Var $ pretty val
-  let mem' = Var $ Py.compileName mem
   let nparr = Call (Var "np.empty")
               [Arg $ Integer 1,
                ArgKeyword "dtype" (Var $ Py.compilePrimType bt)]
   Py.stm $ Assign val' nparr
   Py.stm $ Exp $ Call (Var "cl.enqueue_copy")
-    [Arg $ Var "self.queue", Arg val', Arg mem',
+    [Arg $ Var "self.queue", Arg val', Arg mem,
      ArgKeyword "device_offset" $ BinOp "*" (asLong i) (Integer $ Imp.primByteSize bt),
      ArgKeyword "is_blocking" $ Var "synchronous"]
   Py.stm $ Exp $ Py.simpleCall "sync" [Var "self"]
@@ -213,7 +215,7 @@ readOpenCLScalar _ _ _ space =
 
 allocateOpenCLBuffer :: Py.Allocate Imp.OpenCL ()
 allocateOpenCLBuffer mem size "device" =
-  Py.stm $ Assign (Var $ Py.compileName mem) $
+  Py.stm $ Assign mem $
   Py.simpleCall "opencl_alloc" [Var "self", size, String $ pretty mem]
 
 allocateOpenCLBuffer _ _ space =
@@ -221,35 +223,29 @@ allocateOpenCLBuffer _ _ space =
 
 copyOpenCLMemory :: Py.Copy Imp.OpenCL ()
 copyOpenCLMemory destmem destidx Imp.DefaultSpace srcmem srcidx (Imp.Space "device") nbytes bt = do
-  let srcmem'  = Var $ Py.compileName srcmem
-  let destmem' = Var $ Py.compileName destmem
   let divide = BinOp "//" nbytes (Integer $ Imp.primByteSize bt)
-  let end = BinOp "+" destidx divide
-  let dest = Index destmem' (IdxRange destidx end)
+      end = BinOp "+" destidx divide
+      dest = Index destmem (IdxRange destidx end)
   Py.stm $ ifNotZeroSize nbytes $
     Exp $ Call (Var "cl.enqueue_copy")
-    [Arg $ Var "self.queue", Arg dest, Arg srcmem',
+    [Arg $ Var "self.queue", Arg dest, Arg srcmem,
      ArgKeyword "device_offset" $ asLong srcidx,
      ArgKeyword "is_blocking" $ Var "synchronous"]
 
 copyOpenCLMemory destmem destidx (Imp.Space "device") srcmem srcidx Imp.DefaultSpace nbytes bt = do
-  let destmem' = Var $ Py.compileName destmem
-  let srcmem'  = Var $ Py.compileName srcmem
   let divide = BinOp "//" nbytes (Integer $ Imp.primByteSize bt)
-  let end = BinOp "+" srcidx divide
-  let src = Index srcmem' (IdxRange srcidx end)
+      end = BinOp "+" srcidx divide
+      src = Index srcmem (IdxRange srcidx end)
   Py.stm $ ifNotZeroSize nbytes $
     Exp $ Call (Var "cl.enqueue_copy")
-    [Arg $ Var "self.queue", Arg destmem', Arg src,
+    [Arg $ Var "self.queue", Arg destmem, Arg src,
      ArgKeyword "device_offset" $ asLong destidx,
      ArgKeyword "is_blocking" $ Var "synchronous"]
 
 copyOpenCLMemory destmem destidx (Imp.Space "device") srcmem srcidx (Imp.Space "device") nbytes _ = do
-  let destmem' = Var $ Py.compileName destmem
-  let srcmem'  = Var $ Py.compileName srcmem
   Py.stm $ ifNotZeroSize nbytes $
     Exp $ Call (Var "cl.enqueue_copy")
-    [Arg $ Var "self.queue", Arg destmem', Arg srcmem',
+    [Arg $ Var "self.queue", Arg destmem, Arg srcmem,
      ArgKeyword "dest_offset" $ asLong destidx,
      ArgKeyword "src_offset" $ asLong srcidx,
      ArgKeyword "byte_count" $ asLong nbytes]
@@ -281,7 +277,7 @@ staticOpenCLArray name "device" t vs = do
     -- Create memory block on the device.
     static_mem <- newVName "static_mem"
     let size = Integer $ toInteger num_elems * Imp.primByteSize t
-    allocateOpenCLBuffer static_mem size "device"
+    allocateOpenCLBuffer (Var (Py.compileName static_mem)) size "device"
 
     -- Copy Numpy array to the device memory block.
     Py.stm $ ifNotZeroSize size $
@@ -301,12 +297,13 @@ staticOpenCLArray _ space _ _ =
   error $ "PyOpenCL backend cannot create static array in memory space '" ++ space ++ "'"
 
 packArrayOutput :: Py.EntryOutput Imp.OpenCL ()
-packArrayOutput mem "device" bt ept dims =
+packArrayOutput mem "device" bt ept dims = do
+  mem' <- Py.compileVar mem
   return $ Call (Var "cl.array.Array")
-  [Arg $ Var "self.queue",
-   Arg $ Tuple $ map Py.compileDim dims,
-   Arg $ Var $ Py.compilePrimTypeExt bt ept,
-   ArgKeyword "data" $ Var $ Py.compileName mem]
+    [Arg $ Var "self.queue",
+     Arg $ Tuple $ map Py.compileDim dims,
+     Arg $ Var $ Py.compilePrimTypeExt bt ept,
+     ArgKeyword "data" mem']
 packArrayOutput _ sid _ _ _ =
   error $ "Cannot return array from " ++ sid ++ " space."
 
@@ -322,20 +319,19 @@ unpackArrayInput mem "device" t s dims e = do
 
   let memsize' = Py.simpleCall "np.int64" [Field e "nbytes"]
       pyOpenCLArrayCase =
-        [Assign mem_dest $ Field e "data"]
+        [Assign mem $ Field e "data"]
   numpyArrayCase <- Py.collect $ do
     allocateOpenCLBuffer mem memsize' "device"
     Py.stm $ ifNotZeroSize memsize' $
       Exp $ Call (Var "cl.enqueue_copy")
       [Arg $ Var "self.queue",
-       Arg $ Var $ Py.compileName mem,
+       Arg mem,
        Arg $ Call (Var "normaliseArray") [Arg e],
        ArgKeyword "is_blocking" $ Var "synchronous"]
 
   Py.stm $ If (BinOp "==" (Py.simpleCall "type" [e]) (Var "cl.array.Array"))
     pyOpenCLArrayCase
     numpyArrayCase
-  where mem_dest = Var $ Py.compileName mem
 unpackArrayInput _ sid _ _ _ _ =
   error $ "Cannot accept array from " ++ sid ++ " space."
 

--- a/src/Futhark/CodeGen/Backends/SequentialC.hs
+++ b/src/Futhark/CodeGen/Backends/SequentialC.hs
@@ -90,12 +90,14 @@ compileProg =
                                   ctx->error = NULL;
                                   create_lock(&ctx->lock);
                                   $stms:init_fields
+                                  init_constants(ctx);
                                   return ctx;
                                }|])
 
           GC.publicDef_ "context_free" GC.InitDecl $ \s ->
             ([C.cedecl|void $id:s(struct $id:ctx* ctx);|],
              [C.cedecl|void $id:s(struct $id:ctx* ctx) {
+                                 free_constants(ctx);
                                  free_lock(&ctx->lock);
                                  free(ctx);
                                }|])

--- a/src/Futhark/CodeGen/ImpCode/Kernels.hs
+++ b/src/Futhark/CodeGen/ImpCode/Kernels.hs
@@ -29,7 +29,7 @@ import Futhark.Representation.AST.Attributes.Names
 import Futhark.Representation.AST.Pretty ()
 import Futhark.Util.Pretty
 
-type Program = Functions HostOp
+type Program = Imp.Definitions HostOp
 type Function = Imp.Function HostOp
 -- | Host-level code that can call kernels.
 type Code = Imp.Code HostOp

--- a/src/Futhark/CodeGen/ImpCode/OpenCL.hs
+++ b/src/Futhark/CodeGen/ImpCode/OpenCL.hs
@@ -42,7 +42,7 @@ data Program = Program { openClProgram :: String
                          -- ^ Runtime-configurable constants.
                        , openClFailures :: [FailureMsg]
                          -- ^ Assertion failure error messages.
-                       , hostFunctions :: Functions OpenCL
+                       , hostDefinitions :: Definitions OpenCL
                        }
 
 -- | Something that can go wrong in a kernel.  Part of the machinery

--- a/src/Futhark/CodeGen/ImpCode/Sequential.hs
+++ b/src/Futhark/CodeGen/ImpCode/Sequential.hs
@@ -16,7 +16,7 @@ import Futhark.Representation.AST.Attributes.Names
 import Futhark.Util.Pretty
 
 -- | An imperative program.
-type Program = Imp.Functions Sequential
+type Program = Imp.Definitions Sequential
 
 -- | An imperative function.
 type Function = Imp.Function Sequential

--- a/src/Futhark/CodeGen/SetDefaultSpace.hs
+++ b/src/Futhark/CodeGen/SetDefaultSpace.hs
@@ -5,11 +5,14 @@ module Futhark.CodeGen.SetDefaultSpace
 
 import Futhark.CodeGen.ImpCode
 
--- | Set all uses of 'DefaultSpace' in the given functions to another memory space.
-setDefaultSpace :: Space -> Functions op -> Functions op
-setDefaultSpace space (Functions fundecs) =
-  Functions [ (fname, setFunctionSpace space func)
-            | (fname, func) <- fundecs ]
+-- | Set all uses of 'DefaultSpace' in the given definitions to another
+-- memory space.
+setDefaultSpace :: Space -> Definitions op -> Definitions op
+setDefaultSpace space (Definitions (Constants ps consts) (Functions fundecs)) =
+  Definitions
+  (Constants (map (setParamSpace space) ps) (setBodySpace space consts))
+  (Functions [ (fname, setFunctionSpace space func)
+             | (fname, func) <- fundecs ])
 
 setFunctionSpace :: Space -> Function op -> Function op
 setFunctionSpace space (Function entry outputs inputs body results args) =

--- a/src/Futhark/Internalise/Monad.hs
+++ b/src/Futhark/Internalise/Monad.hs
@@ -5,20 +5,22 @@ module Futhark.Internalise.Monad
   , throwError
   , VarSubstitutions
   , InternaliseEnv (..)
-  , ConstParams
   , Closure
-  , FunInfo, ConstInfo
+  , FunInfo
 
   , substitutingVars
-  , addFunction
+  , lookupSubst
+  , addFunDef
 
   , lookupFunction
   , lookupFunction'
   , lookupConst
-  , topLevelSizes
+  , allConsts
 
   , bindFunction
   , bindConstant
+
+  , localConstsScope
 
   , asserting
   , assertingOne
@@ -47,25 +49,16 @@ import Futhark.Representation.SOACS
 import Futhark.MonadFreshNames
 import Futhark.Tools
 
-type ConstParams = [(Name,VName)]
-
 -- | Extra parameters to pass when calling this function.  This
 -- corresponds to the closure of a locally defined function.
 type Closure = [VName]
 
-type FunInfo = (Name, ConstParams, Closure,
+type FunInfo = (Name, Closure,
                 [VName], [DeclType],
                 [FParam],
                 [(SubExp,Type)] -> Maybe [DeclExtType])
 
 type FunTable = M.Map VName FunInfo
-
-type ConstInfo = (Name, ConstParams,
-                  [(SubExp,Type)] -> Maybe [DeclExtType],
-                  [SubExp] -> InternaliseM (),
-                  Names)
-
-type ConstTable = M.Map VName ConstInfo
 
 -- | A mapping from external variable names to the corresponding
 -- internalised subexpressions.
@@ -80,12 +73,19 @@ data InternaliseEnv = InternaliseEnv {
 data InternaliseState = InternaliseState {
     stateNameSource :: VNameSource
   , stateFunTable :: FunTable
-  , stateConstTable :: ConstTable
-  , stateTopLevelSizes :: Names
+  , stateConstSubsts :: VarSubstitutions
+  , stateConstScope :: Scope SOACS
+  , stateConsts :: Names
   }
 
-newtype InternaliseResult = InternaliseResult [FunDef SOACS]
-  deriving (Semigroup, Monoid)
+data InternaliseResult = InternaliseResult (Stms SOACS) [FunDef SOACS]
+
+instance Semigroup InternaliseResult where
+  InternaliseResult xs1 ys1 <> InternaliseResult xs2 ys2 =
+    InternaliseResult (xs1<>xs2) (ys1<>ys2)
+
+instance Monoid InternaliseResult where
+  mempty = InternaliseResult mempty mempty
 
 newtype InternaliseM  a = InternaliseM (BinderT SOACS
                                         (RWS
@@ -116,12 +116,12 @@ instance MonadBinder InternaliseM where
 
 runInternaliseM :: MonadFreshNames m =>
                    Bool -> InternaliseM ()
-                -> m [FunDef SOACS]
+                -> m (Stms SOACS, [FunDef SOACS])
 runInternaliseM safe (InternaliseM m) =
   modifyNameSource $ \src ->
-  let (_, s, InternaliseResult funs) =
+  let ((_, consts), s, InternaliseResult _ funs) =
         runRWS (runBinderT m mempty) newEnv (newState src)
-  in (funs, stateNameSource s)
+  in ((consts, funs), stateNameSource s)
   where newEnv = InternaliseEnv {
                    envSubsts = mempty
                  , envDoBoundsChecks = True
@@ -130,16 +130,24 @@ runInternaliseM safe (InternaliseM m) =
         newState src =
           InternaliseState { stateNameSource = src
                            , stateFunTable = mempty
-                           , stateConstTable = mempty
-                           , stateTopLevelSizes = mempty
+                           , stateConstSubsts = mempty
+                           , stateConsts = mempty
+                           , stateConstScope = mempty
                            }
 
 substitutingVars :: VarSubstitutions -> InternaliseM a -> InternaliseM a
 substitutingVars substs = local $ \env -> env { envSubsts = substs <> envSubsts env }
 
+lookupSubst :: VName -> InternaliseM (Maybe [SubExp])
+lookupSubst v = do
+  env_substs <- asks $ M.lookup v . envSubsts
+  const_substs <- gets $ M.lookup v . stateConstSubsts
+  return $ env_substs `mplus` const_substs
+
 -- | Add a function definition to the program being constructed.
-addFunction :: FunDef SOACS -> InternaliseM ()
-addFunction = InternaliseM . lift . tell . InternaliseResult . pure
+addFunDef :: FunDef SOACS -> InternaliseM ()
+addFunDef fd =
+  InternaliseM $ lift $ tell $ InternaliseResult mempty [fd]
 
 lookupFunction' :: VName -> InternaliseM (Maybe FunInfo)
 lookupFunction' fname = gets $ M.lookup fname . stateFunTable
@@ -148,23 +156,33 @@ lookupFunction :: VName -> InternaliseM FunInfo
 lookupFunction fname = maybe bad return =<< lookupFunction' fname
   where bad = error $ "Internalise.lookupFunction: Function '" ++ pretty fname ++ "' not found."
 
-lookupConst :: VName -> InternaliseM (Maybe ConstInfo)
-lookupConst fname = gets $ M.lookup fname . stateConstTable
+lookupConst :: VName -> InternaliseM (Maybe [SubExp])
+lookupConst fname = gets $ M.lookup fname . stateConstSubsts
 
-bindFunction :: VName -> FunInfo -> InternaliseM ()
-bindFunction fname info =
+allConsts :: InternaliseM Names
+allConsts = gets stateConsts
+
+bindFunction :: VName -> FunDef SOACS -> FunInfo -> InternaliseM ()
+bindFunction fname fd info = do
+  addFunDef fd
   modify $ \s -> s { stateFunTable = M.insert fname info $ stateFunTable s }
 
-bindConstant :: VName -> ConstInfo -> InternaliseM ()
-bindConstant cname info =
-  modify $ \s -> s { stateConstTable = M.insert cname info $ stateConstTable s }
+bindConstant :: VName -> FunDef SOACS -> InternaliseM ()
+bindConstant cname fd = do
+  let stms = bodyStms $ funDefBody fd
+      substs = bodyResult $ funDefBody fd
+      const_names = namesFromList $ M.keys $ scopeOf stms
+  addStms stms
+  modify $ \s ->
+    s { stateConstSubsts = M.insert cname substs $ stateConstSubsts s
+      , stateConstScope = scopeOf stms <> stateConstScope s
+      , stateConsts = const_names <> stateConsts s
+      }
 
--- | Size names implicitly created by existential top-level constant
--- definitions.  These need special treatment because such a thing
--- does not exist in the core language.
-topLevelSizes :: InternaliseM Names
-topLevelSizes = gets $ foldMap sizes . stateConstTable
-  where sizes (_, _, _, _, x) = x
+localConstsScope :: InternaliseM a -> InternaliseM a
+localConstsScope m = do
+  scope <- gets stateConstScope
+  localScope scope m
 
 -- | Execute the given action if 'envDoBoundsChecks' is true, otherwise
 -- just return an empty list.
@@ -186,7 +204,7 @@ type DimTable = M.Map VName ExtSize
 
 newtype TypeEnv = TypeEnv { typeEnvDims  :: DimTable }
 
-type TypeState = (Int, ConstParams)
+type TypeState = Int
 
 newtype InternaliseTypeM a =
   InternaliseTypeM (ReaderT TypeEnv (StateT TypeState InternaliseM) a)
@@ -198,12 +216,9 @@ liftInternaliseM :: InternaliseM a -> InternaliseTypeM a
 liftInternaliseM = InternaliseTypeM . lift . lift
 
 runInternaliseTypeM :: InternaliseTypeM a
-                    -> InternaliseM (a, ConstParams)
-runInternaliseTypeM (InternaliseTypeM m) = do
-  let new_env = TypeEnv mempty
-      new_state = (0, mempty)
-  (x, (_, cm)) <- runStateT (runReaderT m new_env) new_state
-  return (x, cm)
+                    -> InternaliseM a
+runInternaliseTypeM (InternaliseTypeM m) =
+  evalStateT (runReaderT m (TypeEnv mempty)) 0
 
 withDims :: DimTable -> InternaliseTypeM a -> InternaliseTypeM a
 withDims dtable = local $ \env -> env { typeEnvDims = dtable <> typeEnvDims env }

--- a/src/Futhark/Optimise/CSE.hs
+++ b/src/Futhark/Optimise/CSE.hs
@@ -29,6 +29,7 @@
 module Futhark.Optimise.CSE
        ( performCSE
        , performCSEOnFunDef
+       , performCSEOnStms
        , CSEInOp
        )
        where
@@ -40,7 +41,8 @@ import Futhark.Analysis.Alias
 import Futhark.Representation.AST
 import Futhark.Representation.AST.Attributes.Aliases
 import Futhark.Representation.Aliases
-  (removeFunDefAliases, Aliases, consumedInStms)
+  (removeProgAliases, removeFunDefAliases, removeStmAliases,
+   Aliases, consumedInStms)
 import qualified Futhark.Representation.Kernels.Kernel as Kernel
 import qualified Futhark.Representation.SOACS.SOAC as SOAC
 import qualified Futhark.Representation.ExplicitMemory as ExplicitMemory
@@ -53,8 +55,14 @@ performCSE :: (Attributes lore, CanBeAliased (Op lore),
               Bool -> Pass lore lore
 performCSE cse_arrays =
   Pass "CSE" "Combine common subexpressions." $
-  intraproceduralTransformation $
-  return . removeFunDefAliases . cseInFunDef cse_arrays . analyseFun
+  fmap removeProgAliases .
+  intraproceduralTransformationWithConsts onConsts onFun .
+  aliasAnalysis
+  where onConsts stms =
+          pure $ fst $
+          runReader (cseInStms (consumedInStms stms) (stmsToList stms) (return ()))
+          (newCSEState cse_arrays)
+        onFun _ = pure . cseInFunDef cse_arrays
 
 -- | Perform CSE on a single function.
 performCSEOnFunDef :: (Attributes lore, CanBeAliased (Op lore),
@@ -62,6 +70,17 @@ performCSEOnFunDef :: (Attributes lore, CanBeAliased (Op lore),
                       Bool -> FunDef lore -> FunDef lore
 performCSEOnFunDef cse_arrays =
   removeFunDefAliases . cseInFunDef cse_arrays . analyseFun
+
+-- | Perform CSE on some statements.
+performCSEOnStms :: (Attributes lore, CanBeAliased (Op lore),
+                     CSEInOp (OpWithAliases (Op lore))) =>
+                    Bool -> Stms lore -> Stms lore
+performCSEOnStms cse_arrays =
+  fmap removeStmAliases . f . fst . analyseStms mempty
+  where f stms =
+          fst $ runReader (cseInStms (consumedInStms stms)
+                           (stmsToList stms) (return ()))
+          (newCSEState cse_arrays)
 
 cseInFunDef :: (Attributes lore, Aliased lore, CSEInOp (Op lore)) =>
                Bool -> FunDef lore -> FunDef lore
@@ -75,10 +94,12 @@ type CSEM lore = Reader (CSEState lore)
 
 cseInBody :: (Attributes lore, Aliased lore, CSEInOp (Op lore)) =>
              [Diet] -> Body lore -> CSEM lore (Body lore)
-cseInBody ds (Body bodyattr bnds res) =
-  cseInStms (res_cons <> consumedInStms bnds) (stmsToList bnds) $ do
+cseInBody ds (Body bodyattr bnds res) = do
+  (bnds', res') <-
+    cseInStms (res_cons <> consumedInStms bnds) (stmsToList bnds) $ do
     CSEState (_, nsubsts) _ <- ask
-    return $ Body bodyattr mempty $ substituteNames nsubsts res
+    return $ substituteNames nsubsts res
+  return $ Body bodyattr bnds' res'
   where res_cons = mconcat $ zipWith consumeResult ds res
         consumeResult Consume se = freeIn se
         consumeResult _ _ = mempty
@@ -91,14 +112,15 @@ cseInLambda lam = do
 
 cseInStms :: (Attributes lore, Aliased lore, CSEInOp (Op lore)) =>
              Names -> [Stm lore]
-          -> CSEM lore (Body lore)
-          -> CSEM lore (Body lore)
-cseInStms _ [] m = m
+          -> CSEM lore a
+          -> CSEM lore (Stms lore, a)
+cseInStms _ [] m = do a <- m
+                      return (mempty, a)
 cseInStms consumed (bnd:bnds) m =
   cseInStm consumed bnd $ \bnd' -> do
-    Body bodyattr bnds' es <- cseInStms consumed bnds m
+    (bnds', a) <- cseInStms consumed bnds m
     bnd'' <- mapM nestedCSE bnd'
-    return $ Body bodyattr (stmsFromList bnd''<>bnds') es
+    return (stmsFromList bnd''<>bnds', a)
   where nestedCSE bnd' = do
           let ds = map patElemDiet $ patternValueElements $ stmPattern bnd'
           e <- mapExpM (cse ds) $ stmExp bnd'

--- a/src/Futhark/Optimise/Simplify.hs
+++ b/src/Futhark/Optimise/Simplify.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE TupleSections #-}
 module Futhark.Optimise.Simplify
   ( simplifyProg
   , simplifySomething
@@ -18,10 +19,12 @@ module Futhark.Optimise.Simplify
   )
   where
 
+import Data.Bifunctor (second)
 import Futhark.Representation.AST
 import Futhark.MonadFreshNames
 import qualified Futhark.Optimise.Simplify.Engine as Engine
 import qualified Futhark.Analysis.SymbolTable as ST
+import qualified Futhark.Analysis.UsageTable as UT
 import Futhark.Optimise.Simplify.Rule
 import Futhark.Optimise.Simplify.Lore
 import Futhark.Pass
@@ -35,22 +38,48 @@ simplifyProg :: Engine.SimplifiableLore lore =>
              -> Engine.HoistBlockers lore
              -> Prog lore
              -> PassM (Prog lore)
-simplifyProg simpl rules blockers =
-  intraproceduralTransformation $ simplifyFun simpl rules blockers
+simplifyProg simpl rules blockers (Prog consts funs) = do
+  (consts_vtable, consts') <-
+    simplifyConsts (UT.usages $ foldMap (freeIn . funDefBody) funs)
+                   (mempty, consts)
+
+  funs' <- parPass (simplifyFun' consts_vtable) funs
+  let funs_uses = UT.usages $ foldMap (freeIn . funDefBody) funs'
+
+  (_, consts'') <- simplifyConsts funs_uses (mempty, consts')
+
+  return $ Prog consts'' funs'
+
+  where simplifyFun' consts_vtable =
+          simplifySomething
+          (Engine.localVtable (consts_vtable<>) . Engine.simplifyFun)
+          removeFunDefWisdom
+          simpl rules blockers mempty
+
+        simplifyConsts uses =
+          simplifySomething (onConsts uses . snd)
+          (second (removeStmWisdom<$>))
+          simpl rules blockers mempty
+
+        onConsts uses consts' = do
+          (_, consts'') <-
+            Engine.simplifyStms consts' (pure ((), mempty))
+          (consts''', _) <-
+            Engine.hoistStms rules (Engine.isFalse False) mempty uses consts''
+          return (ST.insertStms consts''' mempty, consts''')
 
 -- | Run a simplification operation to convergence.
-simplifySomething :: (MonadFreshNames m, HasScope lore m,
-                      Engine.SimplifiableLore lore) =>
+simplifySomething :: (MonadFreshNames m, Engine.SimplifiableLore lore) =>
                      (a -> Engine.SimpleM lore b)
                   -> (b -> a)
                   -> Engine.SimpleOps lore
                   -> RuleBook (Wise lore)
                   -> Engine.HoistBlockers lore
+                  -> ST.SymbolTable (Wise lore)
                   -> a
                   -> m a
-simplifySomething f g simpl rules blockers x = do
-  scope <- askScope
-  let f' x' = Engine.localVtable (ST.fromScope (addScopeWisdom scope)<>) $ f x'
+simplifySomething f g simpl rules blockers vtable x = do
+  let f' x' = Engine.localVtable (vtable<>) $ f x'
   loopUntilConvergence env simpl f' g x
   where env = Engine.emptyEnv rules blockers
 
@@ -62,33 +91,38 @@ simplifyFun :: (MonadFreshNames m, Engine.SimplifiableLore lore) =>
                 Engine.SimpleOps lore
              -> RuleBook (Engine.Wise lore)
              -> Engine.HoistBlockers lore
+             -> ST.SymbolTable (Wise lore)
              -> FunDef lore
              -> m (FunDef lore)
-simplifyFun simpl rules blockers =
-  loopUntilConvergence env simpl Engine.simplifyFun removeFunDefWisdom
-  where env = Engine.emptyEnv rules blockers
+simplifyFun = simplifySomething Engine.simplifyFun removeFunDefWisdom
 
 -- | Simplify just a single 'Lambda'.
-simplifyLambda :: (MonadFreshNames m, HasScope lore m, Engine.SimplifiableLore lore) =>
+simplifyLambda :: (MonadFreshNames m, HasScope lore m,
+                   Engine.SimplifiableLore lore) =>
                   Engine.SimpleOps lore
                -> RuleBook (Engine.Wise lore)
                -> Engine.HoistBlockers lore
                -> Lambda lore -> [Maybe VName]
                -> m (Lambda lore)
-simplifyLambda simpl rules blockers orig_lam args =
-  simplifySomething f removeLambdaWisdom simpl rules blockers orig_lam
+simplifyLambda simpl rules blockers orig_lam args = do
+  vtable <- ST.fromScope . addScopeWisdom <$> askScope
+  simplifySomething f removeLambdaWisdom simpl rules blockers vtable orig_lam
   where f lam' = Engine.simplifyLambdaNoHoisting lam' args
 
 -- | Simplify a list of 'Stm's.
-simplifyStms :: (MonadFreshNames m, HasScope lore m, Engine.SimplifiableLore lore) =>
+simplifyStms :: (MonadFreshNames m, Engine.SimplifiableLore lore) =>
                 Engine.SimpleOps lore
              -> RuleBook (Engine.Wise lore)
              -> Engine.HoistBlockers lore
+             -> Scope lore
              -> Stms lore
-             -> m (Stms lore)
-simplifyStms = simplifySomething f g
-  where f stms = fmap snd $ Engine.simplifyStms stms $ return ((), mempty)
-        g = fmap removeStmWisdom
+             -> m (ST.SymbolTable (Wise lore), Stms lore)
+simplifyStms simpl rules blockers scope =
+  simplifySomething f g simpl rules blockers vtable . (mempty,)
+  where vtable = ST.fromScope $ addScopeWisdom scope
+        f (_, stms) =
+          Engine.simplifyStms stms ((,mempty) <$> Engine.askVtable)
+        g = second $ fmap removeStmWisdom
 
 loopUntilConvergence :: (MonadFreshNames m, Engine.SimplifiableLore lore) =>
                         Engine.Env lore

--- a/src/Futhark/Optimise/TileLoops.hs
+++ b/src/Futhark/Optimise/TileLoops.hs
@@ -22,7 +22,8 @@ import Futhark.Tools
 
 tileLoops :: Pass Kernels Kernels
 tileLoops = Pass "tile loops" "Tile stream loops inside kernels" $
-            fmap Prog . mapM optimiseFunDef . progFuns
+            \(Prog consts funs) ->
+              Prog consts <$> mapM optimiseFunDef funs
 
 optimiseFunDef :: MonadFreshNames m => FunDef Kernels -> m (FunDef Kernels)
 optimiseFunDef fundec = do

--- a/src/Futhark/Pass/ExtractKernels/DistributeNests.hs
+++ b/src/Futhark/Pass/ExtractKernels/DistributeNests.hs
@@ -252,8 +252,8 @@ distributeMapBodyStms orig_acc = distribute <=< onStms orig_acc . stmsToList
       types <- asksScope scopeForSOACs
       stream_stms <-
         snd <$> runBinderT (sequentialStreamWholeArray pat w accs lam arrs) types
-      stream_stms' <-
-        runReaderT (copyPropagateInStms simpleSOACS stream_stms) types
+      (_, stream_stms') <-
+        runReaderT (copyPropagateInStms simpleSOACS types stream_stms) types
       onStms acc $ stmsToList (fmap (certify cs) stream_stms') ++ stms
 
     onStms acc (stm:stms) =

--- a/src/Futhark/Pass/FirstOrderTransform.hs
+++ b/src/Futhark/Pass/FirstOrderTransform.hs
@@ -2,8 +2,8 @@ module Futhark.Pass.FirstOrderTransform
   ( firstOrderTransform )
   where
 
-import Futhark.Transform.FirstOrderTransform (transformFunDef)
-import Futhark.Representation.SOACS (SOACS)
+import Futhark.Transform.FirstOrderTransform (transformFunDef, transformStms)
+import Futhark.Representation.SOACS (SOACS, scopeOf)
 import Futhark.Representation.Kernels (Kernels)
 import Futhark.Pass
 
@@ -12,4 +12,5 @@ firstOrderTransform =
   Pass
   "first order transform"
   "Transform all second-order array combinators to for-loops." $
-  intraproceduralTransformation transformFunDef
+  intraproceduralTransformationWithConsts
+  transformStms (transformFunDef . scopeOf)

--- a/src/Futhark/Passes.hs
+++ b/src/Futhark/Passes.hs
@@ -37,9 +37,6 @@ standardPipeline =
          , inlineFunctions
          , simplifySOACS
          , performCSE True
-         , inlineConstants
-         , simplifySOACS
-         , performCSE True
          , simplifySOACS
            -- We run fusion twice
          , fuseSOACs

--- a/src/Futhark/Representation/AST/Attributes.hs
+++ b/src/Futhark/Representation/AST/Attributes.hs
@@ -107,8 +107,8 @@ safeExp (BasicOp op) = safeBasicOp op
         safeBasicOp _ = False
 
 safeExp (DoLoop _ _ _ body) = safeBody body
-safeExp (Apply fname _ _ (constf, _, _, _)) =
-  isBuiltInFunction fname || constf == ConstFun
+safeExp (Apply fname _ _ _) =
+  isBuiltInFunction fname
 safeExp (If _ tbranch fbranch _) =
   all (safeExp . stmExp) (bodyStms tbranch) &&
   all (safeExp . stmExp) (bodyStms fbranch)

--- a/src/Futhark/Representation/ExplicitMemory/Simplify.hs
+++ b/src/Futhark/Representation/ExplicitMemory/Simplify.hs
@@ -43,9 +43,12 @@ simplifyExplicitMemory =
         blockAllocs _ _ _ = False
 
 simplifyStms :: (HasScope ExplicitMemory m, MonadFreshNames m) =>
-                Stms ExplicitMemory -> m (Stms ExplicitMemory)
-simplifyStms =
+                Stms ExplicitMemory -> m (ST.SymbolTable (Wise ExplicitMemory),
+                                          Stms ExplicitMemory)
+simplifyStms stms = do
+  scope <- askScope
   Simplify.simplifyStms simpleExplicitMemory callKernelRules blockers
+    scope stms
 
 isResultAlloc :: Op lore ~ MemOp op => Engine.BlockPred lore
 isResultAlloc _ usage (Let (AST.Pattern [] [bindee]) _ (Op Alloc{})) =

--- a/src/Futhark/Representation/Ranges.hs
+++ b/src/Futhark/Representation/Ranges.hs
@@ -21,6 +21,7 @@ module Futhark.Representation.Ranges
        , mkPatternRanges
        , mkBodyRanges
          -- * Removing ranges
+       , removeProgRanges
        , removeExpRanges
        , removeBodyRanges
        , removeStmRanges
@@ -106,6 +107,10 @@ removeRanges = Rephraser { rephraseExpLore = return
                          , rephraseBranchType = return
                          , rephraseOp = return . removeOpRanges
                          }
+
+removeProgRanges :: CanBeRanged (Op lore) =>
+                    Prog (Ranges lore) -> Prog lore
+removeProgRanges = runIdentity . rephraseProg removeRanges
 
 removeExpRanges :: CanBeRanged (Op lore) =>
                    Exp (Ranges lore) -> Exp lore

--- a/src/Futhark/Transform/CopyPropagate.hs
+++ b/src/Futhark/Transform/CopyPropagate.hs
@@ -4,24 +4,38 @@
 -- simplifier with no rules, so hoisting and dead-code elimination may
 -- also take place.
 module Futhark.Transform.CopyPropagate
-       ( copyPropagateInStms
-       , copyPropagateInFun)
-       where
+       ( copyPropagateInProg
+       , copyPropagateInStms
+       , copyPropagateInFun
+       )
+where
 
+import Futhark.Pass
 import Futhark.MonadFreshNames
 import Futhark.Representation.AST
 import Futhark.Optimise.Simplify
+import qualified Futhark.Analysis.SymbolTable as ST
+import Futhark.Optimise.Simplify.Lore (Wise)
+
+-- | Run copy propagation on an entire program.
+copyPropagateInProg :: SimplifiableLore lore =>
+                       SimpleOps lore
+                    -> Prog lore
+                    -> PassM (Prog lore)
+copyPropagateInProg simpl = simplifyProg simpl mempty noExtraHoistBlockers
 
 -- | Run copy propagation on some statements.
-copyPropagateInStms :: (MonadFreshNames m, SimplifiableLore lore, HasScope lore m) =>
+copyPropagateInStms :: (MonadFreshNames m, SimplifiableLore lore) =>
                        SimpleOps lore
+                    -> Scope lore
                     -> Stms lore
-                    -> m (Stms lore)
+                    -> m (ST.SymbolTable (Wise lore), Stms lore)
 copyPropagateInStms simpl = simplifyStms simpl mempty noExtraHoistBlockers
 
 -- | Run copy propagation on a function.
 copyPropagateInFun :: (MonadFreshNames m, SimplifiableLore lore) =>
                        SimpleOps lore
-                    -> FunDef lore
-                    -> m (FunDef lore)
+                   -> ST.SymbolTable (Wise lore)
+                   -> FunDef lore
+                   -> m (FunDef lore)
 copyPropagateInFun simpl = simplifyFun simpl mempty noExtraHoistBlockers

--- a/src/Futhark/Transform/Rename.hs
+++ b/src/Futhark/Transform/Rename.hs
@@ -56,8 +56,10 @@ runRenamer (RenameM m) src = runReader (runStateT m src) env
 -- invalid program valid.
 renameProg :: (Renameable lore, MonadFreshNames m) =>
               Prog lore -> m (Prog lore)
-renameProg prog = modifyNameSource $
-                  runRenamer $ Prog <$> mapM rename (progFuns prog)
+renameProg prog = modifyNameSource $ runRenamer $
+  renamingStms (progConsts prog) $ \consts -> do
+  funs <- mapM rename (progFuns prog)
+  return prog { progConsts = consts, progFuns = funs }
 
 -- | Rename bound variables such that each is unique.  The semantics
 -- of the expression is unaffected, under the assumption that the


### PR DESCRIPTION
With this commit, the core AST now has a distinct notion of constants,
as something separate from function definitions.  All constants are in
scope in all functions.  At run-time, the constants are only computed
once.

This is a rather major change, that required modifications to
essentially all compiler passes, and all code generation backends.
Compile times seem mostly unaffected on large programs, with small
regressions on small programs.  The advantage is that programs that
make heavy use of complex constants will now run much faster in
library mode.