### PR TITLE
Print TypeError "Error" in red

### DIFF
--- a/src/Futhark/CLI/Test.hs
+++ b/src/Futhark/CLI/Test.hs
@@ -29,7 +29,7 @@ import Text.Regex.TDFA
 import Futhark.Analysis.Metrics
 import Futhark.Test
 import Futhark.Util.Options
-import Futhark.Util.Pretty (prettyText)
+import Futhark.Util.Pretty (prettyText, inRed)
 import Futhark.Util.Table
 
 --- Test execution
@@ -472,9 +472,6 @@ runTests config paths = do
   putStr excluded_str
   exitWith $ case testStatusFail ts of 0 -> ExitSuccess
                                        _ -> ExitFailure 1
-
-inRed :: String -> String
-inRed s = setSGRCode [SetColor Foreground Vivid Red] ++ s ++ setSGRCode [Reset]
 
 ---
 --- Configuration and command line parsing

--- a/src/Futhark/Util/Pretty.hs
+++ b/src/Futhark/Util/Pretty.hs
@@ -1,5 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
--- | A re-export of the prettyprinting library, along with a convenience function.
+-- | A re-export of the prettyprinting library, along with some convenience functions.
 module Futhark.Util.Pretty
        ( module Text.PrettyPrint.Mainland
        , module Text.PrettyPrint.Mainland.Class
@@ -15,11 +15,16 @@ module Futhark.Util.Pretty
        , nestedBlock
        , textwrap
        , shorten
+
+       , color
+       , inRed
+       , inGreen
        )
        where
 
 import Data.Text (Text)
 import qualified Data.Text.Lazy as LT
+import System.Console.ANSI
 
 import Text.PrettyPrint.Mainland hiding (pretty)
 import Text.PrettyPrint.Mainland.Class
@@ -82,3 +87,12 @@ shorten :: Pretty a => a -> Doc
 shorten a | length s > 70 = text (take 70 s) <> text "..."
           | otherwise = text s
   where s = pretty a
+
+color :: [SGR] -> String -> String
+color sgr s = setSGRCode sgr ++ s ++ setSGRCode [Reset]
+
+inRed :: String -> String
+inRed s = setSGRCode [SetColor Foreground Vivid Red] ++ s ++ setSGRCode [Reset]
+
+inGreen :: String -> String
+inGreen s = setSGRCode [SetColor Foreground Vivid Red] ++ s ++ setSGRCode [Reset]

--- a/src/Futhark/Util/Table.hs
+++ b/src/Futhark/Util/Table.hs
@@ -8,6 +8,8 @@ module Futhark.Util.Table
 import Data.List (intercalate, transpose)
 import System.Console.ANSI
 
+import Futhark.Util.Pretty (color)
+
 data RowTemplate = RowTemplate [Int] Int deriving (Show)
 
 -- | A table entry. Consists of the content as well a list of
@@ -17,9 +19,6 @@ type Entry = (String, [SGR])
 -- | Makes a table entry with the default SGR mode.
 mkEntry :: String -> (String, [SGR])
 mkEntry s = (s, [])
-
-color :: [SGR] -> String -> String
-color sgr s = setSGRCode sgr ++ s ++ setSGRCode [Reset]
 
 buildRowTemplate :: [[Entry]] -> Int -> RowTemplate
 

--- a/src/Language/Futhark/TypeChecker/Monad.hs
+++ b/src/Language/Futhark/TypeChecker/Monad.hs
@@ -97,7 +97,7 @@ data TypeError = TypeError SrcLoc Notes Doc
 
 instance Pretty TypeError where
   ppr (TypeError loc notes msg) =
-    "Error at" <+> text (locStr loc) <> ":" </>
+    text (inRed "Error") <+> "at" <+> text (locStr loc) <> ":" </>
     msg <> ppr notes
 
 unexpectedType :: MonadTypeChecker m => SrcLoc -> StructType -> [StructType] -> m a


### PR DESCRIPTION
Print the "Error" part of a TypeError in red with the error message right after it. 
(c.f. #912)

For [duplicate parameters](https://github.com/diku-dk/futhark/blob/master/tests/errors/duplicate-params.fut), the error message is: 
```text
Error: Name "x" also bound at .\tests\errors\duplicate-params.fut:6:11-11.                                
at: .\tests\errors\duplicate-params.fut:6:20-20                          
```
![image](https://user-images.githubusercontent.com/40000585/79082746-e2609180-7cf6-11ea-993a-2ee18b8b5d7f.png)

(paths are weird because I'm on windows, double "at" is a little clunky)

instead of 

```text
Error at .\tests\errors\duplicate-params.fut:6:20-20:
Name x also bound at .\tests\errors\duplicate-params.fut:6:11-11
If you find this error message confusing, uninformative, or wrong, please open an issue at https://github.com/diku-dk/futhark/issues.
```

![image](https://user-images.githubusercontent.com/40000585/79082761-11770300-7cf7-11ea-88a4-b7e50530251a.png)
