### PR TITLE
Enable GCC output colorization by default.

### DIFF
--- a/src/Futhark/CLI/C.hs
+++ b/src/Futhark/CLI/C.hs
@@ -27,7 +27,8 @@ main = compilerMain () []
            ToExecutable -> do
              liftIO $ writeFile cpath $ SequentialC.asExecutable cprog
              ret <- liftIO $ runProgramWithExitCode "gcc"
-                    [cpath, "-O3", "-std=c99", "-lm", "-o", outpath] mempty
+                    [cpath, "-O3", "-std=c99", "-lm", "-o",
+                     "-fdiagnostics-color=always", outpath] mempty
              case ret of
                Left err ->
                  externalErrorS $ "Failed to run gcc: " ++ show err

--- a/src/Futhark/CLI/C.hs
+++ b/src/Futhark/CLI/C.hs
@@ -27,8 +27,8 @@ main = compilerMain () []
            ToExecutable -> do
              liftIO $ writeFile cpath $ SequentialC.asExecutable cprog
              ret <- liftIO $ runProgramWithExitCode "gcc"
-                    [cpath, "-O3", "-std=c99", "-lm", "-o",
-                     "-fdiagnostics-color=always", outpath] mempty
+                    [cpath, "-O3", "-std=c99", "-lm",
+                     "-fdiagnostics-color=always", "-o", outpath] mempty
              case ret of
                Left err ->
                  externalErrorS $ "Failed to run gcc: " ++ show err

--- a/src/Futhark/CLI/CUDA.hs
+++ b/src/Futhark/CLI/CUDA.hs
@@ -20,6 +20,7 @@ main = compilerMain () []
              hpath = outpath `addExtension` "h"
              extra_options = [ "-lcuda"
                              , "-lnvrtc"
+                             , "-fdiagnostics-color=always"
                              ]
          case mode of
            ToLibrary -> do

--- a/src/Futhark/CLI/OpenCL.hs
+++ b/src/Futhark/CLI/OpenCL.hs
@@ -35,8 +35,9 @@ main = compilerMain () []
            ToExecutable -> do
              liftIO $ writeFile cpath $ COpenCL.asExecutable cprog
              ret <- liftIO $ runProgramWithExitCode "gcc"
-                    ([cpath, "-O", "-std=c99", "-lm", "-o",
-                      "-fdiagnostics-color=always", outpath] ++ extra_options) mempty
+                    ([cpath, "-O", "-std=c99", "-lm",
+                       "-fdiagnostics-color=always", "-o", outpath]
+                     ++ extra_options) mempty
              case ret of
                Left err ->
                  externalErrorS $ "Failed to run gcc: " ++ show err

--- a/src/Futhark/CLI/OpenCL.hs
+++ b/src/Futhark/CLI/OpenCL.hs
@@ -35,7 +35,8 @@ main = compilerMain () []
            ToExecutable -> do
              liftIO $ writeFile cpath $ COpenCL.asExecutable cprog
              ret <- liftIO $ runProgramWithExitCode "gcc"
-                    ([cpath, "-O", "-std=c99", "-lm", "-o", outpath] ++ extra_options) mempty
+                    ([cpath, "-O", "-std=c99", "-lm", "-o",
+                      "-fdiagnostics-color=always", outpath] ++ extra_options) mempty
              case ret of
                Left err ->
                  externalErrorS $ "Failed to run gcc: " ++ show err


### PR DESCRIPTION
This makes debugging GCC output more readable.