### PR TITLE
Use invariants provided by assertions

### DIFF
--- a/tests/invariant.fut
+++ b/tests/invariant.fut
@@ -1,0 +1,7 @@
+-- ==
+-- input { 63 }
+-- output { 42 }
+-- structure { If 0 }
+
+let main(x: i32): i32 =
+  assert(x > 32) (if x > 32 then 42 else 1337)


### PR DESCRIPTION
This is an attempt to fix #26.

The implementation is very simplistic right now, and I'm not even sure if I'm going about it in the right way, but it seems to pass my test and not mess up any of the other tests.

To be clear, it handles something like this:

```
let main(x: i32): i32 =
  assert(x > 32) (if x > 32 then 42 else 1337)
```

But not something like this:

```
let main(x: i32): i32 =
  assert(x <= 32) (if x > 32 then 42 else 1337)
```

Any pointer on how to improve the PR would be greatly appreciated.