### PR TITLE
Add opencl-headers, ocl-icd and hlint to shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -2,5 +2,5 @@
 with nixpkgs;
 stdenv.mkDerivation {
   name = "futhark";
-  buildInputs = [ zlib zlib.out pkgconfig haskell.compiler.ghc8101 cabal-install ];
+  buildInputs = [ zlib zlib.out pkgconfig haskell.compiler.ghc8101 cabal-install opencl-headers ocl-icd hlint ];
 }


### PR DESCRIPTION
This should make it easier to drop into a development environment using `nix-shell`.