### PR TITLE
Refactor memory representation.

### DIFF
--- a/futhark.cabal
+++ b/futhark.cabal
@@ -157,6 +157,8 @@ library
       Futhark.Pass
       Futhark.Pass.ExpandAllocations
       Futhark.Pass.ExplicitAllocations
+      Futhark.Pass.ExplicitAllocations.Kernels
+      Futhark.Pass.ExplicitAllocations.Seq
       Futhark.Pass.ExtractKernels
       Futhark.Pass.ExtractKernels.BlockedKernel
       Futhark.Pass.ExtractKernels.DistributeNests
@@ -192,15 +194,18 @@ library
       Futhark.Representation.AST.Syntax
       Futhark.Representation.AST.Syntax.Core
       Futhark.Representation.AST.Traversals
-      Futhark.Representation.ExplicitMemory
-      Futhark.Representation.ExplicitMemory.IndexFunction
-      Futhark.Representation.ExplicitMemory.Simplify
+      Futhark.Representation.Mem
+      Futhark.Representation.Mem.IxFun
+      Futhark.Representation.Mem.Simplify
       Futhark.Representation.Kernels
       Futhark.Representation.Kernels.Kernel
       Futhark.Representation.Kernels.Simplify
       Futhark.Representation.Kernels.Sizes
+      Futhark.Representation.KernelsMem
       Futhark.Representation.Primitive
       Futhark.Representation.Ranges
+      Futhark.Representation.Seq
+      Futhark.Representation.SeqMem
       Futhark.Representation.SOACS
       Futhark.Representation.SOACS.Simplify
       Futhark.Representation.SOACS.SOAC
@@ -319,9 +324,9 @@ test-suite unit
       Futhark.Representation.AST.AttributesTests
       Futhark.Representation.AST.Syntax.CoreTests
       Futhark.Representation.AST.SyntaxTests
-      Futhark.Representation.ExplicitMemory.IndexFunction.Alg
-      Futhark.Representation.ExplicitMemory.IndexFunctionTests
-      Futhark.Representation.ExplicitMemory.IndexFunctionWrapper
+      Futhark.Representation.Mem.IxFun.Alg
+      Futhark.Representation.Mem.IxFunTests
+      Futhark.Representation.Mem.IxFunWrapper
       Futhark.Representation.PrimitiveTests
       Language.Futhark.CoreTests
       Language.Futhark.SyntaxTests

--- a/src/Futhark/Actions.hs
+++ b/src/Futhark/Actions.hs
@@ -16,7 +16,8 @@ import Futhark.Analysis.Alias
 import Futhark.Analysis.Range
 import Futhark.Representation.AST
 import Futhark.Representation.AST.Attributes.Aliases
-import Futhark.Representation.ExplicitMemory (ExplicitMemory)
+import Futhark.Representation.KernelsMem (KernelsMem)
+import Futhark.Representation.SeqMem (SeqMem)
 import qualified Futhark.CodeGen.ImpGen.Sequential as ImpGenSequential
 import qualified Futhark.CodeGen.ImpGen.Kernels as ImpGenKernels
 import Futhark.Representation.AST.Attributes.Ranges (CanBeRanged)
@@ -43,14 +44,14 @@ metricsAction =
          , actionProcedure = liftIO . putStr . show . progMetrics
          }
 
-impCodeGenAction :: Action ExplicitMemory
+impCodeGenAction :: Action SeqMem
 impCodeGenAction =
   Action { actionName = "Compile imperative"
          , actionDescription = "Translate program into imperative IL and write it on standard output."
          , actionProcedure = liftIO . putStrLn . pretty <=< ImpGenSequential.compileProg
          }
 
-kernelImpCodeGenAction :: Action ExplicitMemory
+kernelImpCodeGenAction :: Action KernelsMem
 kernelImpCodeGenAction =
   Action { actionName = "Compile imperative kernels"
          , actionDescription = "Translate program into imperative IL with kernels and write it on standard output."

--- a/src/Futhark/CLI/Dev.hs
+++ b/src/Futhark/CLI/Dev.hs
@@ -21,11 +21,10 @@ import Language.Futhark.Parser (parseFuthark)
 import Futhark.Util.Options
 import Futhark.Pipeline
 import qualified Futhark.Representation.SOACS as SOACS
-import Futhark.Representation.SOACS (SOACS)
 import qualified Futhark.Representation.Kernels as Kernels
-import Futhark.Representation.Kernels (Kernels)
-import qualified Futhark.Representation.ExplicitMemory as ExplicitMemory
-import Futhark.Representation.ExplicitMemory (ExplicitMemory)
+import qualified Futhark.Representation.Seq as Seq
+import qualified Futhark.Representation.KernelsMem as KernelsMem
+import qualified Futhark.Representation.SeqMem as SeqMem
 import Futhark.Representation.AST (Prog, pretty)
 import Futhark.TypeCheck (Checkable)
 import qualified Futhark.Util.Pretty as PP
@@ -46,7 +45,8 @@ import Futhark.Optimise.Unstream
 import Futhark.Pass.KernelBabysitting
 import Futhark.Pass.ExtractKernels
 import Futhark.Pass.ExpandAllocations
-import Futhark.Pass.ExplicitAllocations
+import qualified Futhark.Pass.ExplicitAllocations.Kernels as Kernels
+import qualified Futhark.Pass.ExplicitAllocations.Seq as Seq
 import Futhark.Passes
 
 -- | What to do with the program after it has been read.
@@ -83,7 +83,9 @@ getFutharkPipeline = toPipeline . futharkPipeline
 
 data UntypedPassState = SOACS (Prog SOACS.SOACS)
                       | Kernels (Prog Kernels.Kernels)
-                      | ExplicitMemory (Prog ExplicitMemory.ExplicitMemory)
+                      | Seq (Prog Seq.Seq)
+                      | KernelsMem (Prog KernelsMem.KernelsMem)
+                      | SeqMem (Prog SeqMem.SeqMem)
 
 getSOACSProg :: UntypedPassState -> Maybe (Prog SOACS.SOACS)
 getSOACSProg (SOACS prog) = Just prog
@@ -97,37 +99,52 @@ class Representation s where
 instance Representation UntypedPassState where
   representation (SOACS _) = "SOACS"
   representation (Kernels _) = "Kernels"
-  representation (ExplicitMemory _) = "ExplicitMemory"
+  representation (Seq _) = "Seq"
+  representation (KernelsMem _) = "KernelsMem"
+  representation (SeqMem _) = "SeqMEm"
 
 instance PP.Pretty UntypedPassState where
   ppr (SOACS prog) = PP.ppr prog
   ppr (Kernels prog) = PP.ppr prog
-  ppr (ExplicitMemory prog) = PP.ppr prog
+  ppr (Seq prog) = PP.ppr prog
+  ppr (SeqMem prog) = PP.ppr prog
+  ppr (KernelsMem prog) = PP.ppr prog
 
 newtype UntypedPass = UntypedPass (UntypedPassState
                                   -> PipelineConfig
                                   -> FutharkM UntypedPassState)
 
-data UntypedAction = SOACSAction (Action SOACS)
-                   | KernelsAction (Action Kernels)
-                   | ExplicitMemoryAction (Action ExplicitMemory)
-                   | PolyAction (Action SOACS) (Action Kernels) (Action ExplicitMemory)
+data AllActions = AllActions
+  { actionSOACS :: Action SOACS.SOACS
+  , actionKernels :: Action Kernels.Kernels
+  , actionSeq :: Action Seq.Seq
+  , actionKernelsMem :: Action KernelsMem.KernelsMem
+  , actionSeqMem :: Action SeqMem.SeqMem
+  }
+
+data UntypedAction = SOACSAction (Action SOACS.SOACS)
+                   | KernelsAction (Action Kernels.Kernels)
+                   | KernelsMemAction (Action KernelsMem.KernelsMem)
+                   | SeqMemAction (Action SeqMem.SeqMem)
+                   | PolyAction AllActions
 
 untypedActionName :: UntypedAction -> String
 untypedActionName (SOACSAction a) = actionName a
 untypedActionName (KernelsAction a) = actionName a
-untypedActionName (ExplicitMemoryAction a) = actionName a
-untypedActionName (PolyAction a _ _) = actionName a
+untypedActionName (SeqMemAction a) = actionName a
+untypedActionName (KernelsMemAction a) = actionName a
+untypedActionName (PolyAction a) = actionName (actionSOACS a)
 
 instance Representation UntypedAction where
   representation (SOACSAction _) = "SOACS"
   representation (KernelsAction _) = "Kernels"
-  representation (ExplicitMemoryAction _) = "ExplicitMemory"
+  representation (KernelsMemAction _) = "KernelsMem"
+  representation (SeqMemAction _) = "SeqMem"
   representation PolyAction{} = "<any>"
 
 newConfig :: Config
-newConfig = Config newFutharkConfig (Pipeline [])
-            (PolyAction printAction printAction printAction) False
+newConfig = Config newFutharkConfig (Pipeline []) action False
+  where action = PolyAction $ AllActions printAction printAction printAction printAction printAction
 
 changeFutharkConfig :: (FutharkConfig -> FutharkConfig)
                     -> Config -> Config
@@ -142,12 +159,13 @@ passOption desc pass short long =
    cfg { futharkPipeline = Pipeline $ getFutharkPipeline cfg ++ [pass] })
   desc
 
-explicitMemoryProg :: String -> UntypedPassState -> FutharkM (Prog ExplicitMemory.ExplicitMemory)
-explicitMemoryProg _ (ExplicitMemory prog) =
+kernelsMemProg :: String -> UntypedPassState
+               -> FutharkM (Prog KernelsMem.KernelsMem)
+kernelsMemProg _ (KernelsMem prog) =
   return prog
-explicitMemoryProg name rep =
+kernelsMemProg name rep =
   externalErrorS $ "Pass " ++ name ++
-  " expects ExplicitMemory representation, but got " ++ representation rep
+  " expects KernelsMem representation, but got " ++ representation rep
 
 soacsProg :: String -> UntypedPassState -> FutharkM (Prog SOACS.SOACS)
 soacsProg _ (SOACS prog) =
@@ -177,17 +195,19 @@ typedPassOption getProg putProg pass short =
 
         long = [passLongOption pass]
 
-soacsPassOption :: Pass SOACS SOACS -> String -> FutharkOption
+soacsPassOption :: Pass SOACS.SOACS SOACS.SOACS -> String -> FutharkOption
 soacsPassOption =
   typedPassOption soacsProg SOACS
 
-kernelsPassOption :: Pass Kernels Kernels -> String -> FutharkOption
+kernelsPassOption :: Pass Kernels.Kernels Kernels.Kernels
+                  -> String -> FutharkOption
 kernelsPassOption =
   typedPassOption kernelsProg Kernels
 
-explicitMemoryPassOption :: Pass ExplicitMemory ExplicitMemory -> String -> FutharkOption
-explicitMemoryPassOption =
-  typedPassOption explicitMemoryProg ExplicitMemory
+kernelsMemPassOption :: Pass KernelsMem.KernelsMem KernelsMem.KernelsMem
+                     -> String -> FutharkOption
+kernelsMemPassOption =
+  typedPassOption kernelsMemProg KernelsMem
 
 simplifyOption :: String -> FutharkOption
 simplifyOption short =
@@ -196,11 +216,31 @@ simplifyOption short =
           SOACS <$> runPasses (onePass simplifySOACS) config prog
         perform (Kernels prog) config =
           Kernels <$> runPasses (onePass simplifyKernels) config prog
-        perform (ExplicitMemory prog) config =
-          ExplicitMemory <$> runPasses (onePass simplifyExplicitMemory) config prog
+        perform (Seq prog) config =
+          Seq <$> runPasses (onePass simplifySeq) config prog
+        perform (SeqMem prog) config =
+          SeqMem <$> runPasses (onePass simplifySeqMem) config prog
+        perform (KernelsMem prog) config =
+          KernelsMem <$> runPasses (onePass simplifyKernelsMem) config prog
 
         long = [passLongOption pass]
         pass = simplifySOACS
+
+allocateOption :: String -> FutharkOption
+allocateOption short =
+  passOption (passDescription pass) (UntypedPass perform) short long
+  where perform (Kernels prog) config =
+          KernelsMem <$>
+          runPasses (onePass Kernels.explicitAllocations) config prog
+        perform (Seq prog) config =
+          SeqMem <$>
+          runPasses (onePass Seq.explicitAllocations) config prog
+        perform s _ =
+          externalErrorS $
+          "Pass '" ++ passDescription pass ++ "' cannot operate on " ++ representation s
+
+        long = [passLongOption pass]
+        pass = Seq.explicitAllocations
 
 cseOption :: String -> FutharkOption
 cseOption short =
@@ -209,11 +249,15 @@ cseOption short =
           SOACS <$> runPasses (onePass $ performCSE True) config prog
         perform (Kernels prog) config =
           Kernels <$> runPasses (onePass $ performCSE True) config prog
-        perform (ExplicitMemory prog) config =
-          ExplicitMemory <$> runPasses (onePass $ performCSE False) config prog
+        perform (Seq prog) config =
+          Seq <$> runPasses (onePass $ performCSE True) config prog
+        perform (SeqMem prog) config =
+          SeqMem <$> runPasses (onePass $ performCSE False) config prog
+        perform (KernelsMem prog) config =
+          KernelsMem <$> runPasses (onePass $ performCSE False) config prog
 
         long = [passLongOption pass]
-        pass = performCSE True :: Pass SOACS SOACS
+        pass = performCSE True :: Pass SOACS.SOACS SOACS.SOACS
 
 pipelineOption :: (UntypedPassState -> Maybe (Prog fromlore))
                -> String
@@ -233,17 +277,9 @@ pipelineOption getprog repdesc repf desc pipeline =
               externalErrorS $ "Expected " ++ repdesc ++ " representation, but got " ++
               representation rep
 
-soacsPipelineOption :: String -> Pipeline SOACS SOACS -> String -> [String]
+soacsPipelineOption :: String -> Pipeline SOACS.SOACS SOACS.SOACS -> String -> [String]
                     -> FutharkOption
 soacsPipelineOption = pipelineOption getSOACSProg "SOACS" SOACS
-
-kernelsPipelineOption :: String -> Pipeline SOACS Kernels -> String -> [String]
-                    -> FutharkOption
-kernelsPipelineOption = pipelineOption getSOACSProg "Kernels" Kernels
-
-explicitMemoryPipelineOption :: String -> Pipeline SOACS ExplicitMemory -> String -> [String]
-                             -> FutharkOption
-explicitMemoryPipelineOption = pipelineOption getSOACSProg "ExplicitMemory" ExplicitMemory
 
 commandLineOptions :: [FutharkOption]
 commandLineOptions =
@@ -266,20 +302,23 @@ commandLineOptions =
 
   , Option [] ["compile-imperative"]
     (NoArg $ Right $ \opts ->
-       opts { futharkAction = ExplicitMemoryAction impCodeGenAction })
+       opts { futharkAction = SeqMemAction impCodeGenAction })
     "Translate program into the imperative IL and write it on standard output."
   , Option [] ["compile-imperative-kernels"]
     (NoArg $ Right $ \opts ->
-       opts { futharkAction = ExplicitMemoryAction kernelImpCodeGenAction })
+       opts { futharkAction = KernelsMemAction kernelImpCodeGenAction })
     "Translate program into the imperative IL with kernels and write it on standard output."
   , Option [] ["range-analysis"]
-       (NoArg $ Right $ \opts -> opts { futharkAction = PolyAction rangeAction rangeAction rangeAction })
-       "Print the program with range annotations added."
+    (NoArg $ Right $ \opts ->
+        opts { futharkAction = PolyAction $ AllActions rangeAction rangeAction rangeAction rangeAction rangeAction })
+    "Print the program with range annotations added."
   , Option "p" ["print"]
-    (NoArg $ Right $ \opts -> opts { futharkAction = PolyAction printAction printAction printAction })
+    (NoArg $ Right $ \opts ->
+        opts { futharkAction = PolyAction $ AllActions printAction printAction printAction printAction printAction })
     "Prettyprint the resulting internal representation on standard output (default action)."
   , Option "m" ["metrics"]
-    (NoArg $ Right $ \opts -> opts { futharkAction = PolyAction metricsAction metricsAction metricsAction })
+    (NoArg $ Right $ \opts ->
+        opts { futharkAction = PolyAction $ AllActions metricsAction metricsAction metricsAction metricsAction metricsAction })
     "Print AST metrics of the resulting internal representation on standard output."
   , Option [] ["defunctorise"]
     (NoArg $ Right $ \opts -> opts { futharkPipeline = Defunctorise })
@@ -296,31 +335,34 @@ commandLineOptions =
   , Option [] ["safe"]
     (NoArg $ Right $ changeFutharkConfig $ \opts -> opts { futharkSafe = True })
     "Ignore 'unsafe'."
-  , typedPassOption soacsProg Kernels firstOrderTransform "f"
+  , typedPassOption soacsProg Seq firstOrderTransform "f"
   , soacsPassOption fuseSOACs "o"
   , soacsPassOption inlineFunctions []
-  , kernelsPassOption inPlaceLowering []
+  , kernelsPassOption inPlaceLoweringKernels []
   , kernelsPassOption babysitKernels []
   , kernelsPassOption tileLoops []
   , kernelsPassOption unstream []
   , kernelsPassOption sink []
   , typedPassOption soacsProg Kernels extractKernels []
 
-  , typedPassOption kernelsProg ExplicitMemory explicitAllocations "a"
+  , allocateOption "a"
 
-  , explicitMemoryPassOption doubleBuffer []
-  , explicitMemoryPassOption expandAllocations []
+  , kernelsMemPassOption doubleBuffer []
+  , kernelsMemPassOption expandAllocations []
 
   , cseOption []
   , simplifyOption "e"
 
   , soacsPipelineOption "Run the default optimised pipeline"
     standardPipeline "s" ["standard"]
-  , kernelsPipelineOption "Run the default optimised kernels pipeline"
+  , pipelineOption getSOACSProg "Kernels" Kernels
+    "Run the default optimised kernels pipeline"
     kernelsPipeline [] ["kernels"]
-  , explicitMemoryPipelineOption "Run the full GPU compilation pipeline"
+  , pipelineOption getSOACSProg "KernelsMem" KernelsMem
+    "Run the full GPU compilation pipeline"
     gpuPipeline [] ["gpu"]
-  , explicitMemoryPipelineOption "Run the sequential CPU compilation pipeline"
+  , pipelineOption getSOACSProg "KernelsMem" SeqMem
+    "Run the sequential CPU compilation pipeline"
     sequentialCpuPipeline [] ["cpu"]
   ]
 
@@ -386,29 +428,36 @@ main = mainWithOptions newConfig commandLineOptions "options... program" compile
               prog <- runPipelineOnProgram (futharkConfig config) id file
               runPolyPasses config prog
 
-runPolyPasses :: Config -> Prog SOACS -> FutharkM ()
-runPolyPasses config prog = do
-    prog' <- foldM (runPolyPass pipeline_config) (SOACS prog) (getFutharkPipeline config)
-    case (prog', futharkAction config) of
-      (SOACS soacs_prog, SOACSAction action) ->
-        actionProcedure action soacs_prog
-      (Kernels kernels_prog, KernelsAction action) ->
-        actionProcedure action kernels_prog
-      (ExplicitMemory mem_prog, ExplicitMemoryAction action) ->
-        actionProcedure action mem_prog
+runPolyPasses :: Config -> Prog SOACS.SOACS -> FutharkM ()
+runPolyPasses config initial_prog = do
+    end_prog <- foldM (runPolyPass pipeline_config) (SOACS initial_prog)
+                (getFutharkPipeline config)
+    case (end_prog, futharkAction config) of
+      (SOACS prog, SOACSAction action) ->
+        actionProcedure action prog
+      (Kernels prog, KernelsAction action) ->
+        actionProcedure action prog
+      (SeqMem prog, SeqMemAction action) ->
+        actionProcedure action prog
+      (KernelsMem prog, KernelsMemAction action) ->
+        actionProcedure action prog
 
-      (SOACS soacs_prog, PolyAction soacs_action _ _) ->
-        actionProcedure soacs_action soacs_prog
-      (Kernels kernels_prog, PolyAction _ kernels_action _) ->
-        actionProcedure kernels_action kernels_prog
-      (ExplicitMemory mem_prog, PolyAction _ _ mem_action) ->
-        actionProcedure mem_action mem_prog
+      (SOACS soacs_prog, PolyAction acs) ->
+        actionProcedure (actionSOACS acs) soacs_prog
+      (Kernels kernels_prog, PolyAction acs) ->
+        actionProcedure (actionKernels acs) kernels_prog
+      (Seq seq_prog, PolyAction acs) ->
+        actionProcedure (actionSeq acs) seq_prog
+      (KernelsMem mem_prog, PolyAction acs) ->
+        actionProcedure (actionKernelsMem acs) mem_prog
+      (SeqMem mem_prog, PolyAction acs) ->
+        actionProcedure (actionSeqMem acs) mem_prog
 
       (_, action) ->
         externalErrorS $ "Action " <>
         untypedActionName action <>
         " expects " ++ representation action ++ " representation, but got " ++
-        representation prog' ++ "."
+        representation end_prog ++ "."
   where pipeline_config =
           PipelineConfig { pipelineVerbose = fst (futharkVerbose $ futharkConfig config) > NotVerbose
                          , pipelineValidate = True

--- a/src/Futhark/CodeGen/Backends/CCUDA.hs
+++ b/src/Futhark/CodeGen/Backends/CCUDA.hs
@@ -14,14 +14,15 @@ import qualified Language.C.Quote.OpenCL as C
 
 import qualified Futhark.CodeGen.Backends.GenericC as GC
 import qualified Futhark.CodeGen.ImpGen.CUDA as ImpGen
-import Futhark.Representation.ExplicitMemory hiding (GetSize, CmpSizeLe, GetSizeMax)
+import Futhark.Representation.KernelsMem
+  hiding (GetSize, CmpSizeLe, GetSizeMax)
 import Futhark.MonadFreshNames
 import Futhark.CodeGen.ImpCode.OpenCL
 import Futhark.CodeGen.Backends.COpenCL.Boilerplate (commonOptions)
 import Futhark.CodeGen.Backends.CCUDA.Boilerplate
 import Futhark.CodeGen.Backends.GenericC.Options
 
-compileProg :: MonadFreshNames m => Prog ExplicitMemory -> m GC.CParts
+compileProg :: MonadFreshNames m => Prog KernelsMem -> m GC.CParts
 compileProg prog = do
   (Program cuda_code cuda_prelude kernel_names _ sizes failures prog') <-
     ImpGen.compileProg prog

--- a/src/Futhark/CodeGen/Backends/COpenCL.hs
+++ b/src/Futhark/CodeGen/Backends/COpenCL.hs
@@ -13,7 +13,8 @@ import qualified Data.Map as M
 import qualified Language.C.Syntax as C
 import qualified Language.C.Quote.OpenCL as C
 
-import Futhark.Representation.ExplicitMemory hiding (GetSize, CmpSizeLe, GetSizeMax)
+import Futhark.Representation.KernelsMem
+  hiding (GetSize, CmpSizeLe, GetSizeMax)
 import Futhark.CodeGen.Backends.COpenCL.Boilerplate
 import qualified Futhark.CodeGen.Backends.GenericC as GC
 import Futhark.CodeGen.Backends.GenericC.Options
@@ -21,7 +22,7 @@ import Futhark.CodeGen.ImpCode.OpenCL
 import qualified Futhark.CodeGen.ImpGen.OpenCL as ImpGen
 import Futhark.MonadFreshNames
 
-compileProg :: MonadFreshNames m => Prog ExplicitMemory -> m GC.CParts
+compileProg :: MonadFreshNames m => Prog KernelsMem -> m GC.CParts
 compileProg prog = do
   (Program opencl_code opencl_prelude kernels
     types sizes failures prog') <- ImpGen.compileProg prog

--- a/src/Futhark/CodeGen/Backends/CSOpenCL.hs
+++ b/src/Futhark/CodeGen/Backends/CSOpenCL.hs
@@ -6,7 +6,7 @@ module Futhark.CodeGen.Backends.CSOpenCL
 import Control.Monad
 import Data.List (intersperse)
 
-import Futhark.Representation.ExplicitMemory (Prog, ExplicitMemory, int32)
+import Futhark.Representation.KernelsMem (Prog, KernelsMem, int32)
 import Futhark.CodeGen.Backends.CSOpenCL.Boilerplate
 import qualified Futhark.CodeGen.Backends.GenericCSharp as CS
 import qualified Futhark.CodeGen.ImpCode.OpenCL as Imp
@@ -19,7 +19,7 @@ import Futhark.MonadFreshNames
 
 
 compileProg :: MonadFreshNames m =>
-               Maybe String -> Prog ExplicitMemory -> m String
+               Maybe String -> Prog KernelsMem -> m String
 compileProg module_name prog = do
   Imp.Program opencl_code opencl_prelude kernel_names types sizes failures prog' <-
     ImpGen.compileProg prog

--- a/src/Futhark/CodeGen/Backends/PyOpenCL.hs
+++ b/src/Futhark/CodeGen/Backends/PyOpenCL.hs
@@ -6,7 +6,7 @@ module Futhark.CodeGen.Backends.PyOpenCL
 import Control.Monad
 import qualified Data.Map as M
 
-import Futhark.Representation.ExplicitMemory (Prog, ExplicitMemory)
+import Futhark.Representation.KernelsMem (Prog, KernelsMem)
 import Futhark.CodeGen.Backends.PyOpenCL.Boilerplate
 import qualified Futhark.CodeGen.Backends.GenericPython as Py
 import qualified Futhark.CodeGen.ImpCode.OpenCL as Imp
@@ -18,7 +18,7 @@ import Futhark.MonadFreshNames
 
 --maybe pass the config file rather than multiple arguments
 compileProg :: MonadFreshNames m =>
-               Maybe String -> Prog ExplicitMemory ->  m String
+               Maybe String -> Prog KernelsMem -> m String
 compileProg module_name prog = do
   Imp.Program opencl_code opencl_prelude kernels types sizes failures prog' <-
     ImpGen.compileProg prog

--- a/src/Futhark/CodeGen/Backends/SequentialC.hs
+++ b/src/Futhark/CodeGen/Backends/SequentialC.hs
@@ -13,13 +13,13 @@ import Control.Monad
 
 import qualified Language.C.Quote.OpenCL as C
 
-import Futhark.Representation.ExplicitMemory
+import Futhark.Representation.SeqMem
 import qualified Futhark.CodeGen.ImpCode.Sequential as Imp
 import qualified Futhark.CodeGen.ImpGen.Sequential as ImpGen
 import qualified Futhark.CodeGen.Backends.GenericC as GC
 import Futhark.MonadFreshNames
 
-compileProg :: MonadFreshNames m => Prog ExplicitMemory -> m GC.CParts
+compileProg :: MonadFreshNames m => Prog SeqMem -> m GC.CParts
 compileProg =
   GC.compileProg operations generateContext "" [DefaultSpace] [] <=<
   ImpGen.compileProg

--- a/src/Futhark/CodeGen/Backends/SequentialCSharp.hs
+++ b/src/Futhark/CodeGen/Backends/SequentialCSharp.hs
@@ -3,7 +3,8 @@ module Futhark.CodeGen.Backends.SequentialCSharp
      ) where
 
 import Control.Monad
-import Futhark.Representation.ExplicitMemory
+
+import Futhark.Representation.SeqMem
 import qualified Futhark.CodeGen.ImpCode.Sequential as Imp
 import qualified Futhark.CodeGen.ImpGen.Sequential as ImpGen
 import qualified Futhark.CodeGen.Backends.GenericCSharp as CS
@@ -11,7 +12,7 @@ import Futhark.CodeGen.Backends.GenericCSharp.AST ()
 import Futhark.MonadFreshNames
 
 compileProg :: MonadFreshNames m =>
-               Maybe String -> Prog ExplicitMemory -> m String
+               Maybe String -> Prog SeqMem -> m String
 compileProg module_name =
   ImpGen.compileProg >=>
   CS.compileProg

--- a/src/Futhark/CodeGen/Backends/SequentialPython.hs
+++ b/src/Futhark/CodeGen/Backends/SequentialPython.hs
@@ -4,7 +4,7 @@ module Futhark.CodeGen.Backends.SequentialPython
 
 import Control.Monad
 
-import Futhark.Representation.ExplicitMemory
+import Futhark.Representation.SeqMem
 import qualified Futhark.CodeGen.ImpCode.Sequential as Imp
 import qualified Futhark.CodeGen.ImpGen.Sequential as ImpGen
 import qualified Futhark.CodeGen.Backends.GenericPython as GenericPython
@@ -13,7 +13,7 @@ import Futhark.CodeGen.Backends.GenericPython.AST
 import Futhark.MonadFreshNames
 
 compileProg :: MonadFreshNames m =>
-               Maybe String -> Prog ExplicitMemory -> m String
+               Maybe String -> Prog SeqMem -> m String
 compileProg module_name =
   ImpGen.compileProg >=>
   GenericPython.compileProg

--- a/src/Futhark/CodeGen/ImpGen/CUDA.hs
+++ b/src/Futhark/CodeGen/ImpGen/CUDA.hs
@@ -2,11 +2,11 @@ module Futhark.CodeGen.ImpGen.CUDA
   ( compileProg
   ) where
 
-import Futhark.Representation.ExplicitMemory
+import Futhark.Representation.KernelsMem
 import qualified Futhark.CodeGen.ImpCode.OpenCL as OpenCL
 import qualified Futhark.CodeGen.ImpGen.Kernels as ImpGenKernels
 import Futhark.CodeGen.ImpGen.Kernels.ToOpenCL
 import Futhark.MonadFreshNames
 
-compileProg :: MonadFreshNames m => Prog ExplicitMemory -> m OpenCL.Program
+compileProg :: MonadFreshNames m => Prog KernelsMem -> m OpenCL.Program
 compileProg prog = kernelsToCUDA <$> ImpGenKernels.compileProgCUDA prog

--- a/src/Futhark/CodeGen/ImpGen/Kernels/Base.hs
+++ b/src/Futhark/CodeGen/ImpGen/Kernels/Base.hs
@@ -42,8 +42,8 @@ import Prelude hiding (quot, rem)
 import Futhark.Error
 import Futhark.MonadFreshNames
 import Futhark.Transform.Rename
-import Futhark.Representation.ExplicitMemory
-import qualified Futhark.Representation.ExplicitMemory.IndexFunction as IxFun
+import Futhark.Representation.KernelsMem
+import qualified Futhark.Representation.Mem.IxFun as IxFun
 import qualified Futhark.CodeGen.ImpCode.Kernels as Imp
 import Futhark.CodeGen.ImpGen
 import Futhark.Util.IntegralExp (quotRoundingUp, quot, rem)
@@ -57,8 +57,8 @@ data KernelEnv = KernelEnv
   , kernelConstants :: KernelConstants
   }
 
-type CallKernelGen = ImpM ExplicitMemory HostEnv Imp.HostOp
-type InKernelGen = ImpM ExplicitMemory KernelEnv Imp.KernelOp
+type CallKernelGen = ImpM KernelsMem HostEnv Imp.HostOp
+type InKernelGen = ImpM KernelsMem KernelEnv Imp.KernelOp
 
 data KernelConstants = KernelConstants
                        { kernelGlobalThreadId :: Imp.Exp
@@ -78,11 +78,11 @@ keyWithEntryPoint :: Maybe Name -> Name -> Name
 keyWithEntryPoint fname key =
   nameFromString $ maybe "" ((++".") . nameToString) fname ++ nameToString key
 
-allocLocal :: AllocCompiler ExplicitMemory r Imp.KernelOp
+allocLocal :: AllocCompiler KernelsMem r Imp.KernelOp
 allocLocal mem size =
   sOp $ Imp.LocalAlloc mem size
 
-kernelAlloc :: Pattern ExplicitMemory
+kernelAlloc :: Pattern KernelsMem
             -> SubExp -> Space
             -> InKernelGen ()
 kernelAlloc (Pattern _ [_]) _ ScalarSpace{} =
@@ -98,7 +98,7 @@ kernelAlloc dest _ _ =
   error $ "Invalid target for in-kernel allocation: " ++ show dest
 
 splitSpace :: (ToExp w, ToExp i, ToExp elems_per_thread) =>
-              Pattern ExplicitMemory -> SplitOrdering -> w -> i -> elems_per_thread
+              Pattern KernelsMem -> SplitOrdering -> w -> i -> elems_per_thread
            -> ImpM lore r op ()
 splitSpace (Pattern [] [size]) o w i elems_per_thread = do
   num_elements <- Imp.elements <$> toExp w
@@ -108,7 +108,7 @@ splitSpace (Pattern [] [size]) o w i elems_per_thread = do
 splitSpace pat _ _ _ _ =
   error $ "Invalid target for splitSpace: " ++ pretty pat
 
-compileThreadExp :: ExpCompiler ExplicitMemory KernelEnv Imp.KernelOp
+compileThreadExp :: ExpCompiler KernelsMem KernelEnv Imp.KernelOp
 compileThreadExp (Pattern _ [dest]) (BasicOp (ArrayLit es _)) =
   forM_ (zip [0..] es) $ \(i,e) ->
   copyDWIMFix (patElemName dest) [fromIntegral (i::Int32)] e []
@@ -151,7 +151,7 @@ groupCoverSpace :: [Imp.Exp]
 groupCoverSpace ds f =
   groupLoop (product ds) $ f . unflattenIndex ds
 
-compileGroupExp :: ExpCompiler ExplicitMemory KernelEnv Imp.KernelOp
+compileGroupExp :: ExpCompiler KernelsMem KernelEnv Imp.KernelOp
 -- The static arrays stuff does not work inside kernels.
 compileGroupExp (Pattern _ [dest]) (BasicOp (ArrayLit es _)) =
   forM_ (zip [0..] es) $ \(i,e) ->
@@ -192,7 +192,7 @@ compileGroupSpace lvl space = do
 
 -- Construct the necessary lock arrays for an intra-group histogram.
 prepareIntraGroupSegHist :: Count GroupSize SubExp
-                         -> [HistOp ExplicitMemory]
+                         -> [HistOp KernelsMem]
                          -> InKernelGen [[Imp.Exp] -> InKernelGen ()]
 prepareIntraGroupSegHist group_size =
   fmap snd . mapAccumLM onOp Nothing
@@ -229,7 +229,7 @@ prepareIntraGroupSegHist group_size =
 
           return (Just l', f l' (Space "local") local_subhistos)
 
-compileGroupOp :: OpCompiler ExplicitMemory KernelEnv Imp.KernelOp
+compileGroupOp :: OpCompiler KernelsMem KernelEnv Imp.KernelOp
 
 compileGroupOp pat (Alloc size space) =
   kernelAlloc pat size space
@@ -380,7 +380,7 @@ compileGroupOp pat (Inner (SegOp (SegHist lvl space ops _ kbody))) = do
 compileGroupOp pat _ =
   compilerBugS $ "compileGroupOp: cannot compile rhs of binding " ++ pretty pat
 
-compileThreadOp :: OpCompiler ExplicitMemory KernelEnv Imp.KernelOp
+compileThreadOp :: OpCompiler KernelsMem KernelEnv Imp.KernelOp
 compileThreadOp pat (Alloc size space) =
   kernelAlloc pat size space
 compileThreadOp pat (Inner (SizeOp (SplitSpace o w i elems_per_thread))) =
@@ -427,8 +427,8 @@ type AtomicBinOp =
 
 -- | 'atomicUpdate', but where it is explicitly visible whether a
 -- locking strategy is necessary.
-atomicUpdateLocking :: AtomicBinOp -> Lambda ExplicitMemory
-                    -> AtomicUpdate ExplicitMemory KernelEnv
+atomicUpdateLocking :: AtomicBinOp -> Lambda KernelsMem
+                    -> AtomicUpdate KernelsMem KernelEnv
 
 atomicUpdateLocking atomicBinOp lam
   | Just ops_and_ts <- splitOp lam,
@@ -621,7 +621,7 @@ readsFromSet free =
           Nothing | bt == Cert -> return Nothing
                   | otherwise  -> return $ Just $ Imp.ScalarUse var bt
 
-isConstExp :: VTable ExplicitMemory -> Imp.Exp
+isConstExp :: VTable KernelsMem -> Imp.Exp
            -> ImpM lore r op (Maybe Imp.KernelConstExp)
 isConstExp vtable size = do
   fname <- askFunction
@@ -727,7 +727,7 @@ makeAllMemoryGlobal =
           entry
 
 groupReduce :: Imp.Exp
-            -> Lambda ExplicitMemory
+            -> Lambda KernelsMem
             -> [VName]
             -> InKernelGen ()
 groupReduce w lam arrs = do
@@ -736,7 +736,7 @@ groupReduce w lam arrs = do
 
 groupReduceWithOffset :: VName
                       -> Imp.Exp
-                      -> Lambda ExplicitMemory
+                      -> Lambda KernelsMem
                       -> [VName]
                       -> InKernelGen ()
 groupReduceWithOffset offset w lam arrs = do
@@ -823,7 +823,7 @@ groupReduceWithOffset offset w lam arrs = do
 groupScan :: Maybe (Imp.Exp -> Imp.Exp -> Imp.Exp)
           -> Imp.Exp
           -> Imp.Exp
-          -> Lambda ExplicitMemory
+          -> Lambda KernelsMem
           -> [VName]
           -> InKernelGen ()
 groupScan seg_flag arrs_full_size w lam arrs = do
@@ -960,7 +960,7 @@ inBlockScan :: KernelConstants
             -> Imp.Exp
             -> [VName]
             -> InKernelGen ()
-            -> Lambda ExplicitMemory
+            -> Lambda KernelsMem
             -> InKernelGen ()
 inBlockScan constants seg_flag arrs_full_size lockstep_width block_size active arrs barrier scan_lam = everythingVolatile $ do
   skip_threads <- dPrim "skip_threads" int32
@@ -1116,7 +1116,7 @@ sKernelGroup :: String
 sKernelGroup = sKernel groupOperations kernelGroupId
 
 sKernelFailureTolerant :: Bool
-                       -> Operations ExplicitMemory KernelEnv Imp.KernelOp
+                       -> Operations KernelsMem KernelEnv Imp.KernelOp
                        -> KernelConstants
                        -> Name
                        -> InKernelGen ()
@@ -1134,7 +1134,7 @@ sKernelFailureTolerant tol ops constants name m = do
     , Imp.kernelFailureTolerant = tol
     }
 
-sKernel :: Operations ExplicitMemory KernelEnv Imp.KernelOp
+sKernel :: Operations KernelsMem KernelEnv Imp.KernelOp
         -> (KernelConstants -> Imp.Exp)
         -> String
         -> Count NumGroups Imp.Exp
@@ -1150,7 +1150,7 @@ sKernel ops flatf name num_groups group_size v f = do
     dPrimV_ v $ flatf constants
     f
 
-copyInGroup :: CopyCompiler ExplicitMemory KernelEnv Imp.KernelOp
+copyInGroup :: CopyCompiler KernelsMem KernelEnv Imp.KernelOp
 copyInGroup pt destloc destslice srcloc srcslice = do
   dest_space <- entryMemSpace <$> lookupMemory (memLocationName destloc)
   src_space <- entryMemSpace <$> lookupMemory (memLocationName srcloc)
@@ -1171,7 +1171,7 @@ copyInGroup pt destloc destslice srcloc srcslice = do
       destloc (map DimFix $ fixSlice destslice is)
       srcloc (map DimFix $ fixSlice srcslice is)
 
-threadOperations, groupOperations :: Operations ExplicitMemory KernelEnv Imp.KernelOp
+threadOperations, groupOperations :: Operations KernelsMem KernelEnv Imp.KernelOp
 threadOperations =
   (defaultOperations compileThreadOp)
   { opsCopyCompiler = copyElementWise
@@ -1280,7 +1280,7 @@ sIota arr n x s et = do
         Imp.Write destmem destidx (IntType et) destspace Imp.Nonvolatile $
         Imp.ConvOpExp (SExt Int32 et) gtid * s + x
 
-sCopy :: CopyCompiler ExplicitMemory HostEnv Imp.HostOp
+sCopy :: CopyCompiler KernelsMem HostEnv Imp.HostOp
 sCopy bt
   destloc@(MemLocation destmem _ _) destslice
   srcloc@(MemLocation srcmem _ _) srcslice
@@ -1312,7 +1312,7 @@ sCopy bt
       Imp.index srcmem srcidx bt srcspace Imp.Nonvolatile
 
 compileGroupResult :: SegSpace
-                   -> PatElem ExplicitMemory -> KernelResult
+                   -> PatElem KernelsMem -> KernelResult
                    -> InKernelGen ()
 
 compileGroupResult _ pe (TileReturns [(w,per_group_elems)] what) = do
@@ -1367,7 +1367,7 @@ compileGroupResult _ _ ConcatReturns{} =
   compilerLimitationS "compileGroupResult: ConcatReturns not handled yet."
 
 compileThreadResult :: SegSpace
-                    -> PatElem ExplicitMemory -> KernelResult
+                    -> PatElem KernelsMem -> KernelResult
                     -> InKernelGen ()
 
 compileThreadResult space pe (Returns _ what) = do

--- a/src/Futhark/CodeGen/ImpGen/Kernels/SegHist.hs
+++ b/src/Futhark/CodeGen/ImpGen/Kernels/SegHist.hs
@@ -48,8 +48,8 @@ import Data.List (foldl', genericLength, zip4, zip6)
 import Prelude hiding (quot, rem)
 
 import Futhark.MonadFreshNames
-import Futhark.Representation.ExplicitMemory
-import qualified Futhark.Representation.ExplicitMemory.IndexFunction as IxFun
+import Futhark.Representation.KernelsMem
+import qualified Futhark.Representation.Mem.IxFun as IxFun
 import Futhark.Pass.ExplicitAllocations()
 import qualified Futhark.CodeGen.ImpCode.Kernels as Imp
 import Futhark.CodeGen.ImpGen
@@ -67,13 +67,13 @@ data SubhistosInfo = SubhistosInfo { subhistosArray :: VName
                                    }
 
 data SegHistSlug = SegHistSlug
-                   { slugOp :: HistOp ExplicitMemory
+                   { slugOp :: HistOp KernelsMem
                    , slugNumSubhistos :: VName
                    , slugSubhistos :: [SubhistosInfo]
-                   , slugAtomicUpdate :: AtomicUpdate ExplicitMemory KernelEnv
+                   , slugAtomicUpdate :: AtomicUpdate KernelsMem KernelEnv
                    }
 
-histoSpaceUsage :: HistOp ExplicitMemory
+histoSpaceUsage :: HistOp KernelsMem
                 -> Imp.Count Imp.Bytes Imp.Exp
 histoSpaceUsage op =
   sum $
@@ -86,7 +86,7 @@ histoSpaceUsage op =
 -- segmented and unsegmented,, and compute some other auxiliary
 -- information.
 computeHistoUsage :: SegSpace
-                  -> HistOp ExplicitMemory
+                  -> HistOp KernelsMem
                   -> CallKernelGen (Imp.Count Imp.Bytes Imp.Exp,
                                     Imp.Count Imp.Bytes Imp.Exp,
                                     SegHistSlug)
@@ -178,7 +178,7 @@ prepareAtomicUpdateGlobal l dests slug =
 -- multiple times.
 data Passage = MustBeSinglePass | MayBeMultiPass deriving (Eq, Ord)
 
-bodyPassage :: KernelBody ExplicitMemory -> Passage
+bodyPassage :: KernelBody KernelsMem -> Passage
 bodyPassage kbody
   | mempty == consumedInKernelBody (aliasAnalyseKernelBody kbody) =
       MayBeMultiPass
@@ -343,12 +343,12 @@ prepareIntermediateArraysGlobal passage hist_T hist_N slugs = do
 
       return (l', do_op')
 
-histKernelGlobalPass :: [PatElem ExplicitMemory]
+histKernelGlobalPass :: [PatElem KernelsMem]
                      -> Count NumGroups Imp.Exp
                      -> Count GroupSize Imp.Exp
                      -> SegSpace
                      -> [SegHistSlug]
-                     -> KernelBody ExplicitMemory
+                     -> KernelBody KernelsMem
                      -> [[Imp.Exp] -> InKernelGen ()]
                      -> Imp.Exp -> Imp.Exp
                      -> CallKernelGen ()
@@ -425,11 +425,11 @@ histKernelGlobalPass map_pes num_groups group_size space slugs kbody histograms 
                 do_op (bucket_is ++ is)
 
 
-histKernelGlobal :: [PatElem ExplicitMemory]
+histKernelGlobal :: [PatElem KernelsMem]
                  -> Count NumGroups SubExp -> Count GroupSize SubExp
                  -> SegSpace
                  -> [SegHistSlug]
-                 -> KernelBody ExplicitMemory
+                 -> KernelBody KernelsMem
                  -> CallKernelGen ()
 histKernelGlobal map_pes num_groups group_size space slugs kbody = do
   num_groups' <- traverse toExp num_groups
@@ -511,11 +511,11 @@ prepareIntermediateArraysLocal num_subhistos_per_group groups_per_segment space 
       return (glob_subhistos, init_local_subhistos)
 
 histKernelLocalPass :: VName -> Count NumGroups Imp.Exp
-                    -> [PatElem ExplicitMemory]
+                    -> [PatElem KernelsMem]
                     -> Count NumGroups Imp.Exp -> Count GroupSize Imp.Exp
                     -> SegSpace
                     -> [SegHistSlug]
-                    -> KernelBody ExplicitMemory
+                    -> KernelBody KernelsMem
                     -> InitLocalHistograms -> Imp.Exp -> Imp.Exp
                     -> CallKernelGen ()
 histKernelLocalPass num_subhistos_per_group_var groups_per_segment map_pes num_groups group_size space slugs kbody
@@ -705,12 +705,12 @@ histKernelLocalPass num_subhistos_per_group_var groups_per_segment map_pes num_g
               copyDWIMFix global_dest global_is (Var $ paramName xp) []
 
 histKernelLocal :: VName -> Count NumGroups Imp.Exp
-                -> [PatElem ExplicitMemory]
+                -> [PatElem KernelsMem]
                 -> Count NumGroups SubExp -> Count GroupSize SubExp
                 -> SegSpace
                 -> Imp.Exp
                 -> [SegHistSlug]
-                -> KernelBody ExplicitMemory
+                -> KernelBody KernelsMem
                 -> CallKernelGen ()
 histKernelLocal num_subhistos_per_group_var groups_per_segment map_pes num_groups group_size space hist_S slugs kbody = do
   num_groups' <- traverse toExp num_groups
@@ -736,12 +736,12 @@ slugMaxLocalMemPasses slug =
     AtomicCAS _  -> 4
     AtomicLocking _ -> 6
 
-localMemoryCase :: [PatElem ExplicitMemory]
+localMemoryCase :: [PatElem KernelsMem]
                 -> Imp.Exp
                 -> SegSpace
                 -> Imp.Exp -> Imp.Exp -> Imp.Exp -> Imp.Exp
                 -> [SegHistSlug]
-                -> KernelBody ExplicitMemory
+                -> KernelBody KernelsMem
                 -> CallKernelGen (Imp.Exp, CallKernelGen ())
 localMemoryCase map_pes hist_T space hist_H hist_el_size hist_N _ slugs kbody = do
   let space_sizes = segSpaceDims space
@@ -870,11 +870,11 @@ localMemoryCase map_pes hist_T space hist_H hist_el_size hist_N _ slugs kbody = 
 -- figuring out whether to use a local or global memory strategy, as
 -- well as collapsing the subhistograms produced (which are always in
 -- global memory, but their number may vary).
-compileSegHist :: Pattern ExplicitMemory
+compileSegHist :: Pattern KernelsMem
                -> Count NumGroups SubExp -> Count GroupSize SubExp
                -> SegSpace
-               -> [HistOp ExplicitMemory]
-               -> KernelBody ExplicitMemory
+               -> [HistOp KernelsMem]
+               -> KernelBody KernelsMem
                -> CallKernelGen ()
 compileSegHist (Pattern _ pes) num_groups group_size space ops kbody = do
   num_groups' <- traverse toExp num_groups

--- a/src/Futhark/CodeGen/ImpGen/Kernels/SegMap.hs
+++ b/src/Futhark/CodeGen/ImpGen/Kernels/SegMap.hs
@@ -8,17 +8,17 @@ import Control.Monad.Except
 
 import Prelude hiding (quot, rem)
 
-import Futhark.Representation.ExplicitMemory
+import Futhark.Representation.KernelsMem
 import Futhark.CodeGen.ImpGen.Kernels.Base
 import Futhark.CodeGen.ImpGen
 import qualified Futhark.CodeGen.ImpCode.Kernels as Imp
 import Futhark.Util.IntegralExp (quotRoundingUp)
 
 -- | Compile 'SegMap' instance code.
-compileSegMap :: Pattern ExplicitMemory
+compileSegMap :: Pattern KernelsMem
               -> SegLevel
               -> SegSpace
-              -> KernelBody ExplicitMemory
+              -> KernelBody KernelsMem
               -> CallKernelGen ()
 
 compileSegMap pat lvl space kbody = do

--- a/src/Futhark/CodeGen/ImpGen/OpenCL.hs
+++ b/src/Futhark/CodeGen/ImpGen/OpenCL.hs
@@ -2,11 +2,11 @@ module Futhark.CodeGen.ImpGen.OpenCL
   ( compileProg
   ) where
 
-import Futhark.Representation.ExplicitMemory
+import Futhark.Representation.KernelsMem
 import qualified Futhark.CodeGen.ImpCode.OpenCL as OpenCL
 import qualified Futhark.CodeGen.ImpGen.Kernels as ImpGenKernels
 import Futhark.CodeGen.ImpGen.Kernels.ToOpenCL
 import Futhark.MonadFreshNames
 
-compileProg :: MonadFreshNames m => Prog ExplicitMemory -> m OpenCL.Program
+compileProg :: MonadFreshNames m => Prog KernelsMem -> m OpenCL.Program
 compileProg prog = kernelsToOpenCL <$> ImpGenKernels.compileProgOpenCL prog

--- a/src/Futhark/CodeGen/ImpGen/Sequential.hs
+++ b/src/Futhark/CodeGen/ImpGen/Sequential.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleContexts #-}
 module Futhark.CodeGen.ImpGen.Sequential
   ( compileProg
   )
@@ -6,14 +7,12 @@ module Futhark.CodeGen.ImpGen.Sequential
 
 import qualified Futhark.CodeGen.ImpCode.Sequential as Imp
 import qualified Futhark.CodeGen.ImpGen as ImpGen
-import Futhark.Representation.ExplicitMemory
+import Futhark.Representation.SeqMem
 import Futhark.MonadFreshNames
 
-compileProg :: MonadFreshNames m => Prog ExplicitMemory -> m Imp.Program
+compileProg :: MonadFreshNames m => Prog SeqMem -> m Imp.Program
 compileProg = ImpGen.compileProg () ops Imp.DefaultSpace
   where ops = ImpGen.defaultOperations opCompiler
-        opCompiler :: ImpGen.OpCompiler ExplicitMemory () Imp.Sequential
         opCompiler dest (Alloc e space) =
           ImpGen.compileAlloc dest e space
-        opCompiler _ (Inner _) =
-          error "Cannot handle kernels in sequential code generator."
+        opCompiler _ (Inner ()) = pure ()

--- a/src/Futhark/Doc/Generator.hs
+++ b/src/Futhark/Doc/Generator.hs
@@ -46,7 +46,7 @@ data Context = Context { ctxCurrent :: String
 type FileMap = M.Map VName (String, Namespace)
 type DocM = ReaderT Context (WriterT Documented (Writer Warnings))
 
-data IndexWhat = IndexValue | IndexFunction | IndexModule | IndexModuleType | IndexType
+data IndexWhat = IndexValue | IxFun | IndexModule | IndexModuleType | IndexType
 
 -- | We keep a mapping of the names we have actually documented, so we
 -- can generate an index.
@@ -218,7 +218,7 @@ indexPage important_imports imports documented fm =
           let link = (H.a ! A.href (fromString (makeRelative "/" $ "doc" </> vnameLink' name "" file))) $
                      fromString $ baseString name
               what' = case what of IndexValue -> "value"
-                                   IndexFunction -> "function"
+                                   IxFun -> "function"
                                    IndexType -> "type"
                                    IndexModuleType -> "module type"
                                    IndexModule -> "module"
@@ -706,7 +706,7 @@ valBindWhat vb | null (valBindParams vb),
                  orderZero (fst $ unInfo $ valBindRetType vb) =
                    IndexValue
                | otherwise =
-                   IndexFunction
+                   IxFun
 
 describeSpecs :: [Spec] -> DocM Html
 describeSpecs specs =
@@ -720,7 +720,7 @@ describeSpec (ValSpec name tparams t doc _) =
           typeExpHtml $ declaredType t
     return $ keyword "val " <>  name' <> tparams' <> ": " <> t'
   where what = if orderZero (unInfo $ expandedType t)
-               then IndexValue else IndexFunction
+               then IndexValue else IxFun
 describeSpec (TypeAbbrSpec vb) =
   describeGeneric (typeAlias vb) IndexType (typeDoc vb) (`typeBindHtml` vb)
 describeSpec (TypeSpec l name tparams doc _) =

--- a/src/Futhark/Optimise/CSE.hs
+++ b/src/Futhark/Optimise/CSE.hs
@@ -45,7 +45,7 @@ import Futhark.Representation.Aliases
    Aliases, consumedInStms)
 import qualified Futhark.Representation.Kernels.Kernel as Kernel
 import qualified Futhark.Representation.SOACS.SOAC as SOAC
-import qualified Futhark.Representation.ExplicitMemory as ExplicitMemory
+import qualified Futhark.Representation.Mem as Memory
 import Futhark.Transform.Substitute
 import Futhark.Pass
 
@@ -220,9 +220,9 @@ cseInKernelBody (Kernel.KernelBody bodyattr bnds res) = do
   Body _ bnds' _ <- cseInBody (map (const Observe) res) $ Body bodyattr bnds []
   return $ Kernel.KernelBody bodyattr bnds' res
 
-instance CSEInOp op => CSEInOp (ExplicitMemory.MemOp op) where
-  cseInOp o@ExplicitMemory.Alloc{} = return o
-  cseInOp (ExplicitMemory.Inner k) = ExplicitMemory.Inner <$> subCSE (cseInOp k)
+instance CSEInOp op => CSEInOp (Memory.MemOp op) where
+  cseInOp o@Memory.Alloc{} = return o
+  cseInOp (Memory.Inner k) = Memory.Inner <$> subCSE (cseInOp k)
 
 instance (Attributes lore,
           CanBeAliased (Op lore),

--- a/src/Futhark/Optimise/InPlaceLowering/LowerIntoStm.hs
+++ b/src/Futhark/Optimise/InPlaceLowering/LowerIntoStm.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE TypeFamilies #-}
 module Futhark.Optimise.InPlaceLowering.LowerIntoStm
   ( lowerUpdateKernels
+  , lowerUpdate
   , LowerUpdate
   , DesiredUpdate (..)
   ) where

--- a/src/Futhark/Optimise/Simplify/Engine.hs
+++ b/src/Futhark/Optimise/Simplify/Engine.hs
@@ -56,6 +56,7 @@ module Futhark.Optimise.Simplify.Engine
        , bindLParams
        , simplifyBody
        , SimplifiedBody
+       , ST.SymbolTable
 
        , hoistStms
        , blockIf

--- a/src/Futhark/Pass/ExplicitAllocations/Kernels.hs
+++ b/src/Futhark/Pass/ExplicitAllocations/Kernels.hs
@@ -1,0 +1,202 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeFamilies #-}
+module Futhark.Pass.ExplicitAllocations.Kernels
+       ( explicitAllocations
+       , explicitAllocationsInStms
+       )
+where
+
+import qualified Futhark.Representation.Mem.IxFun as IxFun
+import Futhark.Representation.KernelsMem
+import Futhark.Representation.Kernels
+import Futhark.Pass.ExplicitAllocations
+
+allocAtLevel :: SegLevel -> AllocM fromlore tlore a -> AllocM fromlore tlore a
+allocAtLevel lvl = local $ \env -> env { allocSpace = space
+                                       , aggressiveReuse = True
+                                       }
+  where space = case lvl of SegThread{} -> DefaultSpace
+                            SegGroup{} -> Space "local"
+
+allocInBinOpLambda :: SegLevel -> SegSpace -> Lambda Kernels
+                   -> AllocM Kernels KernelsMem (Lambda KernelsMem)
+allocInBinOpLambda lvl (SegSpace flat _) lam = do
+  num_threads <- letSubExp "num_threads" $ BasicOp $ BinOp (Mul Int32)
+                 (unCount (segNumGroups lvl)) (unCount (segGroupSize lvl))
+  let (acc_params, arr_params) =
+        splitAt (length (lambdaParams lam) `div` 2) $ lambdaParams lam
+      index_x = LeafExp flat int32
+      index_y = index_x + primExpFromSubExp int32 num_threads
+  (acc_params', arr_params') <-
+    allocInBinOpParams num_threads index_x index_y acc_params arr_params
+
+  local (\env -> env { envExpHints = inThreadExpHints }) $
+    allocInLambda (acc_params' ++ arr_params')
+    (lambdaBody lam) (lambdaReturnType lam)
+
+allocInBinOpParams :: SubExp
+                   -> PrimExp VName -> PrimExp VName
+                   -> [LParam Kernels]
+                   -> [LParam Kernels]
+                   -> AllocM Kernels KernelsMem ([LParam KernelsMem], [LParam KernelsMem])
+allocInBinOpParams num_threads my_id other_id xs ys = unzip <$> zipWithM alloc xs ys
+  where alloc x y =
+          case paramType x of
+            Array bt shape u -> do
+              twice_num_threads <-
+                letSubExp "twice_num_threads" $
+                BasicOp $ BinOp (Mul Int32) num_threads $ intConst Int32 2
+              let t = paramType x `arrayOfRow` twice_num_threads
+              mem <- allocForArray t DefaultSpace
+              -- XXX: this iota ixfun is a bit inefficient; leading to uncoalesced access.
+              let base_dims = map (primExpFromSubExp int32) (arrayDims t)
+                  ixfun_base = IxFun.iota base_dims
+                  ixfun_x = IxFun.slice ixfun_base $
+                            fullSliceNum base_dims [DimFix my_id]
+                  ixfun_y = IxFun.slice ixfun_base $
+                            fullSliceNum base_dims [DimFix other_id]
+              return (x { paramAttr = MemArray bt shape u $ ArrayIn mem ixfun_x },
+                      y { paramAttr = MemArray bt shape u $ ArrayIn mem ixfun_y })
+            Prim bt ->
+              return (x { paramAttr = MemPrim bt },
+                      y { paramAttr = MemPrim bt })
+            Mem space ->
+              return (x { paramAttr = MemMem space },
+                      y { paramAttr = MemMem space })
+
+allocInLambda :: [LParam KernelsMem] -> Body Kernels -> [Type]
+              -> AllocM Kernels KernelsMem (Lambda KernelsMem)
+allocInLambda params body rettype = do
+  body' <- localScope (scopeOfLParams params) $
+           allocInStms (bodyStms body) $ \bnds' ->
+           return $ Body () bnds' $ bodyResult body
+  return $ Lambda params body' rettype
+
+allocInKernelBody :: SegLevel -> KernelBody Kernels
+                  -> AllocM Kernels KernelsMem (KernelBody KernelsMem)
+allocInKernelBody lvl (KernelBody () stms res) =
+  local f $ allocInStms stms $ \stms' -> return $ KernelBody () stms' res
+  where f = case lvl of SegThread{} -> inThread
+                        SegGroup{} -> inGroup
+        inThread env = env { envExpHints = inThreadExpHints }
+        inGroup env = env { envExpHints = inGroupExpHints }
+
+handleSegOp :: SegOp Kernels
+            -> AllocM Kernels KernelsMem (SegOp KernelsMem)
+handleSegOp op = allocAtLevel (segLevel op) $ mapSegOpM mapper op
+  where scope = scopeOfSegSpace $ segSpace op
+        mapper = identitySegOpMapper
+             { mapOnSegOpBody = localScope scope . allocInKernelBody (segLevel op)
+             , mapOnSegOpLambda = allocInBinOpLambda (segLevel op) $ segSpace op
+             }
+
+handleHostOp :: HostOp Kernels (SOAC Kernels)
+             -> AllocM Kernels KernelsMem (MemOp (HostOp KernelsMem ()))
+handleHostOp (SizeOp op) =
+  return $ Inner $ SizeOp op
+handleHostOp (OtherOp op) =
+  error $ "Cannot allocate memory in SOAC: " ++ pretty op
+handleHostOp (SegOp op) =
+  Inner . SegOp <$> handleSegOp op
+
+kernelExpHints :: Allocator KernelsMem m => Exp KernelsMem -> m [ExpHint]
+kernelExpHints (BasicOp (Manifest perm v)) = do
+  dims <- arrayDims <$> lookupType v
+  let perm_inv = rearrangeInverse perm
+      dims' = rearrangeShape perm dims
+      ixfun = IxFun.permute (IxFun.iota $ map (primExpFromSubExp int32) dims')
+              perm_inv
+  return [Hint ixfun DefaultSpace]
+
+kernelExpHints (Op (Inner (SegOp (SegMap lvl@SegThread{} space ts body)))) =
+  zipWithM (mapResultHint lvl space) ts $ kernelBodyResult body
+
+kernelExpHints (Op (Inner (SegOp (SegRed lvl@SegThread{} space reds ts body)))) =
+  (map (const NoHint) red_res <>) <$> zipWithM (mapResultHint lvl space) (drop num_reds ts) map_res
+  where num_reds = segRedResults reds
+        (red_res, map_res) = splitAt num_reds $ kernelBodyResult body
+
+kernelExpHints e =
+  return $ replicate (expExtTypeSize e) NoHint
+
+mapResultHint :: Allocator lore m =>
+                 SegLevel -> SegSpace -> Type -> KernelResult -> m ExpHint
+mapResultHint lvl space = hint
+  where num_threads = primExpFromSubExp int32 (unCount $ segNumGroups lvl) *
+                      primExpFromSubExp int32 (unCount $ segGroupSize lvl)
+
+        -- Heuristic: do not rearrange for returned arrays that are
+        -- sufficiently small.
+        coalesceReturnOfShape _ [] = False
+        coalesceReturnOfShape bs [Constant (IntValue (Int32Value d))] = bs * d > 4
+        coalesceReturnOfShape _ _ = True
+
+        hint t Returns{}
+          | coalesceReturnOfShape (primByteSize (elemType t)) $ arrayDims t = do
+              let space_dims = segSpaceDims space
+              t_dims <- mapM dimAllocationSize $ arrayDims t
+              return $ Hint (innermost space_dims t_dims) DefaultSpace
+
+        hint t (ConcatReturns SplitStrided{} w _ _) = do
+          t_dims <- mapM dimAllocationSize $ arrayDims t
+          return $ Hint (innermost [w] t_dims) DefaultSpace
+
+        hint Prim{} (ConcatReturns SplitContiguous w elems_per_thread _) = do
+          let ixfun_base = IxFun.iota [num_threads, primExpFromSubExp int32 elems_per_thread]
+              ixfun_tr = IxFun.permute ixfun_base [1,0]
+              ixfun = IxFun.reshape ixfun_tr $ map (DimNew . primExpFromSubExp int32) [w]
+          return $ Hint ixfun DefaultSpace
+
+        hint _ _ = return NoHint
+
+innermost :: [SubExp] -> [SubExp] -> IxFun
+innermost space_dims t_dims =
+  let r = length t_dims
+      dims = space_dims ++ t_dims
+      perm = [length space_dims..length space_dims+r-1] ++
+             [0..length space_dims-1]
+      perm_inv = rearrangeInverse perm
+      dims_perm = rearrangeShape perm dims
+      ixfun_base = IxFun.iota $ map (primExpFromSubExp int32) dims_perm
+      ixfun_rearranged = IxFun.permute ixfun_base perm_inv
+  in ixfun_rearranged
+
+inGroupExpHints :: Exp KernelsMem -> AllocM Kernels KernelsMem [ExpHint]
+inGroupExpHints (Op (Inner (SegOp (SegMap _ space ts body))))
+  | any private $ kernelBodyResult body = return $ do
+      (t, r) <- zip ts $ kernelBodyResult body
+      return $
+        if private r
+        then let seg_dims = map (primExpFromSubExp int32) $ segSpaceDims space
+                 dims = seg_dims ++ map (primExpFromSubExp int32) (arrayDims t)
+                 nilSlice d = DimSlice 0 d 0
+           in Hint (IxFun.slice (IxFun.iota dims) $
+                    fullSliceNum dims $ map nilSlice seg_dims) $
+              ScalarSpace (arrayDims t) $ elemType t
+        else NoHint
+  where private (Returns ResultPrivate _) = True
+        private _                         = False
+inGroupExpHints e = return $ replicate (expExtTypeSize e) NoHint
+
+inThreadExpHints :: Allocator KernelsMem m => Exp KernelsMem -> m [ExpHint]
+inThreadExpHints e =
+  mapM maybePrivate =<< expExtType e
+  where maybePrivate t
+          | Just (Array pt shape _) <- hasStaticShape t,
+            all semiStatic $ shapeDims shape = do
+              let ixfun = IxFun.iota $ map (primExpFromSubExp int32) $
+                          shapeDims shape
+              return $ Hint ixfun $ ScalarSpace (shapeDims shape) pt
+          | otherwise =
+              return NoHint
+
+        semiStatic Constant{} = True
+        semiStatic _ = False
+
+explicitAllocations :: Pass Kernels KernelsMem
+explicitAllocations = explicitAllocationsGeneric handleHostOp kernelExpHints
+
+explicitAllocationsInStms :: (MonadFreshNames m, HasScope KernelsMem m) =>
+                             Stms Kernels -> m (Stms KernelsMem)
+explicitAllocationsInStms = explicitAllocationsInStmsGeneric handleHostOp kernelExpHints

--- a/src/Futhark/Pass/ExplicitAllocations/Seq.hs
+++ b/src/Futhark/Pass/ExplicitAllocations/Seq.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Futhark.Pass.ExplicitAllocations.Seq
+       ( explicitAllocations
+       , simplifiable
+       )
+where
+
+import Futhark.Pass
+import Futhark.Representation.SeqMem
+import Futhark.Representation.Seq
+import Futhark.Pass.ExplicitAllocations
+
+explicitAllocations :: Pass Seq SeqMem
+explicitAllocations = explicitAllocationsGeneric undefined defaultExpHints

--- a/src/Futhark/Pass/FirstOrderTransform.hs
+++ b/src/Futhark/Pass/FirstOrderTransform.hs
@@ -1,16 +1,17 @@
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleContexts #-}
 module Futhark.Pass.FirstOrderTransform
   ( firstOrderTransform )
   where
 
-import Futhark.Transform.FirstOrderTransform (transformFunDef, transformStms)
+import Futhark.Transform.FirstOrderTransform (FirstOrderLore, transformFunDef, transformStms)
 import Futhark.Representation.SOACS (SOACS, scopeOf)
-import Futhark.Representation.Kernels (Kernels)
 import Futhark.Pass
 
-firstOrderTransform :: Pass SOACS Kernels
+firstOrderTransform :: FirstOrderLore lore => Pass SOACS lore
 firstOrderTransform =
   Pass
   "first order transform"
-  "Transform all second-order array combinators to for-loops." $
+  "Transform all SOACs to for-loops." $
   intraproceduralTransformationWithConsts
   transformStms (transformFunDef . scopeOf)

--- a/src/Futhark/Pass/Simplify.hs
+++ b/src/Futhark/Pass/Simplify.hs
@@ -2,8 +2,10 @@
 module Futhark.Pass.Simplify
   ( simplify
   , simplifySOACS
+  , simplifySeq
   , simplifyKernels
-  , simplifyExplicitMemory
+  , simplifyKernelsMem
+  , simplifySeqMem
   )
   where
 
@@ -11,8 +13,9 @@ import qualified Futhark.Representation.SOACS as R
 import qualified Futhark.Representation.SOACS.Simplify as R
 import qualified Futhark.Representation.Kernels as R
 import qualified Futhark.Representation.Kernels.Simplify as R
-import qualified Futhark.Representation.ExplicitMemory as R
-import qualified Futhark.Representation.ExplicitMemory.Simplify as R
+import qualified Futhark.Representation.Seq as R
+import qualified Futhark.Representation.KernelsMem as KernelsMem
+import qualified Futhark.Representation.SeqMem as SeqMem
 
 import Futhark.Pass
 import Futhark.Representation.AST.Syntax
@@ -27,5 +30,11 @@ simplifySOACS = simplify R.simplifySOACS
 simplifyKernels :: Pass R.Kernels R.Kernels
 simplifyKernels = simplify R.simplifyKernels
 
-simplifyExplicitMemory :: Pass R.ExplicitMemory R.ExplicitMemory
-simplifyExplicitMemory = simplify R.simplifyExplicitMemory
+simplifySeq :: Pass R.Seq R.Seq
+simplifySeq = simplify R.simplifyProg
+
+simplifyKernelsMem :: Pass KernelsMem.KernelsMem KernelsMem.KernelsMem
+simplifyKernelsMem = simplify KernelsMem.simplifyProg
+
+simplifySeqMem :: Pass SeqMem.SeqMem SeqMem.SeqMem
+simplifySeqMem = simplify SeqMem.simplifyProg

--- a/src/Futhark/Passes.hs
+++ b/src/Futhark/Passes.hs
@@ -20,15 +20,18 @@ import Futhark.Optimise.TileLoops
 import Futhark.Optimise.DoubleBuffer
 import Futhark.Optimise.Unstream
 import Futhark.Pass.ExpandAllocations
-import Futhark.Pass.ExplicitAllocations
+import qualified Futhark.Pass.ExplicitAllocations.Kernels as Kernels
+import qualified Futhark.Pass.ExplicitAllocations.Seq as Seq
 import Futhark.Pass.ExtractKernels
 import Futhark.Pass.FirstOrderTransform
 import Futhark.Pass.KernelBabysitting
 import Futhark.Pass.ResolveAssertions
 import Futhark.Pass.Simplify
 import Futhark.Pipeline
-import Futhark.Representation.ExplicitMemory (ExplicitMemory)
+import Futhark.Representation.KernelsMem (KernelsMem)
+import Futhark.Representation.SeqMem (SeqMem)
 import Futhark.Representation.Kernels (Kernels)
+import Futhark.Representation.Seq (Seq)
 import Futhark.Representation.SOACS (SOACS)
 
 standardPipeline :: Pipeline SOACS SOACS
@@ -60,37 +63,35 @@ kernelsPipeline =
          , performCSE True
          , simplifyKernels
          , sink
-         , inPlaceLowering
+         , inPlaceLoweringKernels
          ]
 
-sequentialPipeline :: Pipeline SOACS Kernels
+sequentialPipeline :: Pipeline SOACS Seq
 sequentialPipeline =
   standardPipeline >>>
   onePass firstOrderTransform >>>
-  passes [ simplifyKernels
-         , sink
-         , inPlaceLowering
+  passes [ simplifySeq
+         , inPlaceLoweringSeq
          ]
 
-sequentialCpuPipeline :: Pipeline SOACS ExplicitMemory
+sequentialCpuPipeline :: Pipeline SOACS SeqMem
 sequentialCpuPipeline =
   sequentialPipeline >>>
-  onePass explicitAllocations >>>
+  onePass Seq.explicitAllocations >>>
   passes [ performCSE False
-         , simplifyExplicitMemory
-         , doubleBuffer
-         , simplifyExplicitMemory
+         , simplifySeqMem
+         , simplifySeqMem
          ]
 
-gpuPipeline :: Pipeline SOACS ExplicitMemory
+gpuPipeline :: Pipeline SOACS KernelsMem
 gpuPipeline =
   kernelsPipeline >>>
-  onePass explicitAllocations >>>
-  passes [ simplifyExplicitMemory
+  onePass Kernels.explicitAllocations >>>
+  passes [ simplifyKernelsMem
          , performCSE False
-         , simplifyExplicitMemory
+         , simplifyKernelsMem
          , doubleBuffer
-         , simplifyExplicitMemory
+         , simplifyKernelsMem
          , expandAllocations
-         , simplifyExplicitMemory
+         , simplifyKernelsMem
          ]

--- a/src/Futhark/Representation/AST/Attributes/TypeOf.hs
+++ b/src/Futhark/Representation/AST/Attributes/TypeOf.hs
@@ -13,7 +13,7 @@
 --
 -- Some representations may have more specialised facilities enabling
 -- even more information - for example,
--- "Futhark.Representation.ExplicitMemory" exposes functionality for
+-- "Futhark.Representation.Mem" exposes functionality for
 -- also obtaining information about the storage location of results.
 module Futhark.Representation.AST.Attributes.TypeOf
        (

--- a/src/Futhark/Representation/KernelsMem.hs
+++ b/src/Futhark/Representation/KernelsMem.hs
@@ -1,0 +1,115 @@
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ConstraintKinds #-}
+module Futhark.Representation.KernelsMem
+  ( KernelsMem
+
+  -- * Simplification
+  , simplifyProg
+  , simplifyStms
+  , simpleKernelsMem
+
+    -- * Module re-exports
+  , module Futhark.Representation.Mem
+  , module Futhark.Representation.Kernels.Kernel
+  )
+  where
+
+import Control.Monad
+
+import Futhark.Analysis.PrimExp.Convert
+import Futhark.MonadFreshNames
+import Futhark.Pass
+import Futhark.Representation.AST.Syntax
+import Futhark.Representation.AST.Attributes
+import Futhark.Representation.AST.Traversals
+import Futhark.Representation.AST.Pretty
+import Futhark.Representation.Kernels.Kernel
+import Futhark.Representation.Kernels.Simplify (simplifyKernelOp)
+import qualified Futhark.TypeCheck as TC
+import Futhark.Representation.Mem
+import Futhark.Representation.Mem.Simplify
+import Futhark.Pass.ExplicitAllocations (BinderOps(..), mkLetNamesB', mkLetNamesB'')
+import qualified Futhark.Optimise.Simplify.Engine as Engine
+
+data KernelsMem
+
+instance Annotations KernelsMem where
+  type LetAttr    KernelsMem = LetAttrMem
+  type FParamAttr KernelsMem = FParamMem
+  type LParamAttr KernelsMem = LParamMem
+  type RetType    KernelsMem = RetTypeMem
+  type BranchType KernelsMem = BranchTypeMem
+  type Op         KernelsMem = MemOp (HostOp KernelsMem ())
+
+segOpReturns :: (Monad m, HasScope KernelsMem m) =>
+                SegOp KernelsMem -> m [ExpReturns]
+segOpReturns k@(SegMap _ _ _ kbody) =
+  kernelBodyReturns kbody =<< (extReturns <$> opType k)
+segOpReturns k@(SegRed _ _ _ _ kbody) =
+  kernelBodyReturns kbody =<< (extReturns <$> opType k)
+segOpReturns k@(SegScan _ _ _ _ _ kbody) =
+  kernelBodyReturns kbody =<< (extReturns <$> opType k)
+segOpReturns (SegHist _ _ ops _ _) =
+  concat <$> mapM (mapM varReturns . histDest) ops
+
+kernelBodyReturns :: (HasScope KernelsMem m, Monad m) =>
+                     KernelBody KernelsMem -> [ExpReturns] -> m [ExpReturns]
+kernelBodyReturns = zipWithM correct . kernelBodyResult
+  where correct (WriteReturns _ arr _) _ = varReturns arr
+        correct _ ret = return ret
+
+instance Attributes KernelsMem where
+  expTypesFromPattern = return . map snd . snd . bodyReturnsFromPattern
+
+instance OpReturns KernelsMem where
+  opReturns (Alloc _ space) =
+    return [MemMem space]
+  opReturns (Inner (SegOp op)) = segOpReturns op
+  opReturns k = extReturns <$> opType k
+
+instance PrettyLore KernelsMem where
+
+instance TC.CheckableOp KernelsMem where
+  checkOp = typeCheckMemoryOp Nothing
+    where typeCheckMemoryOp _ (Alloc size _) =
+            TC.require [Prim int64] size
+          typeCheckMemoryOp lvl (Inner op) =
+            typeCheckHostOp (typeCheckMemoryOp . Just) lvl (const $ return ()) op
+
+instance TC.Checkable KernelsMem where
+  checkFParamLore = checkMemInfo
+  checkLParamLore = checkMemInfo
+  checkLetBoundLore = checkMemInfo
+  checkRetType = mapM_ TC.checkExtType . retTypeValues
+  primFParam name t = return $ Param name (MemPrim t)
+  matchPattern = matchPatternToExp
+  matchReturnType = matchFunctionReturnType
+  matchBranchType = matchBranchReturnType
+
+instance BinderOps KernelsMem where
+  mkExpAttrB _ _ = return ()
+  mkBodyB stms res = return $ Body () stms res
+  mkLetNamesB = mkLetNamesB' ()
+
+instance BinderOps (Engine.Wise KernelsMem) where
+  mkExpAttrB pat e = return $ Engine.mkWiseExpAttr pat () e
+  mkBodyB stms res = return $ Engine.mkWiseBody () stms res
+  mkLetNamesB = mkLetNamesB''
+
+simplifyProg :: Prog KernelsMem -> PassM (Prog KernelsMem)
+simplifyProg =
+  simplifyProgGeneric $ simplifyKernelOp $ const $ return ((), mempty)
+
+simplifyStms :: (HasScope KernelsMem m, MonadFreshNames m) =>
+                 Stms KernelsMem
+             -> m (Engine.SymbolTable (Engine.Wise KernelsMem),
+                   Stms KernelsMem)
+simplifyStms =
+  simplifyStmsGeneric $ simplifyKernelOp $ const $ return ((), mempty)
+
+simpleKernelsMem :: Engine.SimpleOps KernelsMem
+simpleKernelsMem =
+  simpleGeneric $ simplifyKernelOp $ const $ return ((), mempty)

--- a/src/Futhark/Representation/Mem/IxFun.hs
+++ b/src/Futhark/Representation/Mem/IxFun.hs
@@ -1,7 +1,7 @@
 {-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 -- | This module contains a representation for the index function based on
 -- linear-memory accessor descriptors; see Zhu, Hoeflinger and David work.
-module Futhark.Representation.ExplicitMemory.IndexFunction
+module Futhark.Representation.Mem.IxFun
        ( IxFun(..)
        , index
        , iota
@@ -817,13 +817,13 @@ leastGeneralGeneralization (IxFun (lmad1 :| []) oshp1 ctg1) (IxFun (lmad2 :| [])
                 ) ([], m) (zip l1 l2)
 leastGeneralGeneralization _ _ = Nothing
 
--- | When comparing index functions as part of the type check in ExplicitMemory,
+-- | When comparing index functions as part of the type check in KernelsMem,
 -- we may run into problems caused by the simplifier. As index functions can be
 -- generalized over if-then-else expressions, the simplifier might hoist some of
 -- the code from inside the if-then-else (computing the offset of an array, for
 -- instance), but now the type checker cannot verify that the generalized index
 -- function is valid, because some of the existentials are computed somewhere
--- else. To Work around this, we've had to relax the ExplicitMemory type-checker
+-- else. To Work around this, we've had to relax the KernelsMem type-checker
 -- a bit, specifically, we've introduced this function to verify whether two
 -- index functions are "close enough" that we can assume that they match. We use
 -- this instead of `ixfun1 == ixfun2` and hope that it's good enough.

--- a/src/Futhark/Representation/Mem/Simplify.hs
+++ b/src/Futhark/Representation/Mem/Simplify.hs
@@ -3,10 +3,11 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ConstraintKinds #-}
-module Futhark.Representation.ExplicitMemory.Simplify
-       ( simplifyExplicitMemory
-       , simplifyStms
-       , simpleExplicitMemory
+module Futhark.Representation.Mem.Simplify
+       ( simplifyProgGeneric
+       , simplifyStmsGeneric
+       , simpleGeneric
+       , SimplifyMemory
        )
 where
 
@@ -17,8 +18,7 @@ import qualified Futhark.Representation.AST.Syntax as AST
 import Futhark.Representation.AST.Syntax
   hiding (Prog, BasicOp, Exp, Body, Stm,
           Pattern, PatElem, Lambda, FunDef, FParam, LParam, RetType)
-import Futhark.Representation.ExplicitMemory
-import Futhark.Representation.Kernels.Simplify (simplifyKernelOp)
+import Futhark.Representation.Mem
 import Futhark.Pass.ExplicitAllocations
   (simplifiable, arraySizeInBytesExp)
 import qualified Futhark.Analysis.SymbolTable as ST
@@ -32,17 +32,22 @@ import Futhark.Optimise.Simplify.Rule
 import Futhark.Optimise.Simplify.Lore
 import Futhark.Util
 
-simpleExplicitMemory :: Simplify.SimpleOps ExplicitMemory
-simpleExplicitMemory = simplifiable $ simplifyKernelOp $ const $ return ((), mempty)
+simpleGeneric :: (SimplifyMemory lore, Op lore ~ MemOp inner) =>
+                 Simplify.SimplifyOp lore inner
+              -> Simplify.SimpleOps lore
+simpleGeneric = simplifiable
 
-simplifyExplicitMemory :: Prog ExplicitMemory -> PassM (Prog ExplicitMemory)
-simplifyExplicitMemory =
-  Simplify.simplifyProg simpleExplicitMemory callKernelRules
+simplifyProgGeneric :: (SimplifyMemory lore,
+                        Op lore ~ MemOp inner) =>
+                       Simplify.SimplifyOp lore inner
+                    -> Prog lore -> PassM (Prog lore)
+simplifyProgGeneric onInner =
+  Simplify.simplifyProg (simpleGeneric onInner) callKernelRules
   blockers { Engine.blockHoistBranch = blockAllocs }
   where blockAllocs vtable _ (Let _ _ (Op Alloc{})) =
           not $ ST.simplifyMemory vtable
         -- Do not hoist statements that produce arrays.  This is
-        -- because in the ExplicitMemory representation, multiple
+        -- because in the KernelsMem representation, multiple
         -- arrays can be located in the same memory block, and moving
         -- their creation out of a branch can thus cause memory
         -- corruption.  At this point in the compiler we have probably
@@ -50,12 +55,13 @@ simplifyExplicitMemory =
         blockAllocs _ _ (Let pat _ _) =
           not $ all primType $ patternTypes pat
 
-simplifyStms :: (HasScope ExplicitMemory m, MonadFreshNames m) =>
-                Stms ExplicitMemory -> m (ST.SymbolTable (Wise ExplicitMemory),
-                                          Stms ExplicitMemory)
-simplifyStms stms = do
+simplifyStmsGeneric :: (HasScope lore m, MonadFreshNames m,
+                        SimplifyMemory lore, Op lore ~ MemOp inner) =>
+                       Simplify.SimplifyOp lore inner -> Stms lore
+                    -> m (ST.SymbolTable (Wise lore), Stms lore)
+simplifyStmsGeneric onInner stms = do
   scope <- askScope
-  Simplify.simplifyStms simpleExplicitMemory callKernelRules blockers
+  Simplify.simplifyStms (simpleGeneric onInner) callKernelRules blockers
     scope stms
 
 isResultAlloc :: Op lore ~ MemOp op => Engine.BlockPred lore
@@ -65,7 +71,7 @@ isResultAlloc _ _ _ = False
 
 -- | Getting the roots of what to hoist, for now only variable
 -- names that represent array and memory-block sizes.
-getShapeNames :: (ExplicitMemorish lore, Op lore ~ MemOp op) =>
+getShapeNames :: (Mem lore, Op lore ~ MemOp op) =>
                  Stm (Wise lore) -> Names
 getShapeNames stm =
   let ts = map patElemType $ patternElements $ stmPattern stm
@@ -77,7 +83,8 @@ isAlloc :: Op lore ~ MemOp op => Engine.BlockPred lore
 isAlloc _ _ (Let _ _ (Op Alloc{})) = True
 isAlloc _ _ _                      = False
 
-blockers :: Simplify.HoistBlockers ExplicitMemory
+blockers :: (Mem lore, Op lore ~ MemOp inner) =>
+            Simplify.HoistBlockers lore
 blockers = Engine.noExtraHoistBlockers {
     Engine.blockHoistPar    = isAlloc
   , Engine.blockHoistSeq    = isResultAlloc
@@ -85,7 +92,17 @@ blockers = Engine.noExtraHoistBlockers {
   , Engine.isAllocation     = isAlloc mempty mempty
   }
 
-callKernelRules :: RuleBook (Wise ExplicitMemory)
+-- | Some constraints that must hold for the simplification rules to work.
+type SimplifyMemory lore =
+  (Simplify.SimplifiableLore lore,
+   ExpAttr lore ~ (),
+   BodyAttr lore ~ (),
+   AllocOp (Op (Wise lore)),
+   CanBeWise (Op lore),
+   BinderOps (Wise lore),
+   Mem lore)
+
+callKernelRules :: SimplifyMemory lore => RuleBook (Wise lore)
 callKernelRules = standardRules <>
                   ruleBook [RuleBasicOp copyCopyToCopy,
                             RuleBasicOp removeIdentityCopy,
@@ -94,7 +111,7 @@ callKernelRules = standardRules <>
 -- | If a branch is returning some existential memory, but the size of
 -- the array is not existential, then we can create a block of the
 -- proper size and always return there.
-unExistentialiseMemory :: TopDownRuleIf (Wise ExplicitMemory)
+unExistentialiseMemory :: SimplifyMemory lore => TopDownRuleIf (Wise lore)
 unExistentialiseMemory vtable pat _ (cond, tbranch, fbranch, ifattr)
   | ST.simplifyMemory vtable,
     fixable <- foldl hasConcretisableMemory mempty $ patternElements pat,
@@ -106,7 +123,7 @@ unExistentialiseMemory vtable pat _ (cond, tbranch, fbranch, ifattr)
         fmap unzip $ forM fixable $ \(arr_pe, oldmem, space) -> do
           size <- letSubExp "size" =<<
                   toExp (arraySizeInBytesExp $ patElemType arr_pe)
-          mem <- letExp "mem" $ Op $ Alloc size space
+          mem <- letExp "mem" $ Op $ allocOp size space
           return ((patElemName arr_pe, mem), (oldmem, mem))
 
       -- Update the branches to contain Copy expressions putting the

--- a/src/Futhark/Representation/Seq.hs
+++ b/src/Futhark/Representation/Seq.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleInstances #-}
+-- | A sequential representation.
+module Futhark.Representation.Seq
+       ( -- * The Lore definition
+         Seq
+
+         -- * Simplification
+       , simpleSeq
+       , simplifyProg
+
+         -- * Module re-exports
+       , module Futhark.Representation.AST.Attributes
+       , module Futhark.Representation.AST.Traversals
+       , module Futhark.Representation.AST.Pretty
+       , module Futhark.Representation.AST.Syntax
+       )
+where
+
+import Futhark.Pass
+import Futhark.Representation.AST.Syntax
+import Futhark.Representation.AST.Attributes
+import Futhark.Representation.AST.Traversals
+import Futhark.Representation.AST.Pretty
+import Futhark.Binder
+import Futhark.Construct
+import qualified Futhark.TypeCheck as TypeCheck
+import qualified Futhark.Optimise.Simplify.Engine as Engine
+import qualified Futhark.Optimise.Simplify as Simplify
+import Futhark.Optimise.Simplify.Rules
+
+data Seq
+
+instance Annotations Seq where
+  type Op Seq = ()
+
+instance Attributes Seq where
+  expTypesFromPattern = return . expExtTypesFromPattern
+
+instance TypeCheck.CheckableOp Seq where
+  checkOp = pure
+
+instance TypeCheck.Checkable Seq where
+
+instance Bindable Seq where
+  mkBody = Body ()
+  mkExpPat ctx val _ = basicPattern ctx val
+  mkExpAttr _ _ = ()
+  mkLetNames = simpleMkLetNames
+
+instance BinderOps Seq where
+  mkExpAttrB = bindableMkExpAttrB
+  mkBodyB = bindableMkBodyB
+  mkLetNamesB = bindableMkLetNamesB
+
+instance PrettyLore Seq where
+
+instance BinderOps (Engine.Wise Seq) where
+  mkExpAttrB = bindableMkExpAttrB
+  mkBodyB = bindableMkBodyB
+  mkLetNamesB = bindableMkLetNamesB
+
+simpleSeq :: Simplify.SimpleOps Seq
+simpleSeq = Simplify.bindableSimpleOps (const $ pure ((), mempty))
+
+simplifyProg :: Prog Seq -> PassM (Prog Seq)
+simplifyProg = Simplify.simplifyProg simpleSeq standardRules blockers
+  where blockers = Engine.noExtraHoistBlockers

--- a/src/Futhark/Representation/SeqMem.hs
+++ b/src/Futhark/Representation/SeqMem.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ConstraintKinds #-}
+module Futhark.Representation.SeqMem
+  ( SeqMem
+
+  -- * Simplification
+  , simplifyProg
+  , simplifyStms
+  , simpleSeqMem
+
+    -- * Module re-exports
+  , module Futhark.Representation.Mem
+  , module Futhark.Representation.Kernels.Kernel
+  )
+  where
+
+import Futhark.Analysis.PrimExp.Convert
+import Futhark.MonadFreshNames
+import Futhark.Pass
+import Futhark.Representation.AST.Syntax
+import Futhark.Representation.AST.Attributes
+import Futhark.Representation.AST.Traversals
+import Futhark.Representation.AST.Pretty
+import Futhark.Representation.Kernels.Kernel
+import qualified Futhark.TypeCheck as TC
+import Futhark.Representation.Mem
+import Futhark.Representation.Mem.Simplify
+import Futhark.Pass.ExplicitAllocations (BinderOps(..), mkLetNamesB', mkLetNamesB'')
+import qualified Futhark.Optimise.Simplify.Engine as Engine
+
+data SeqMem
+
+instance Annotations SeqMem where
+  type LetAttr    SeqMem = LetAttrMem
+  type FParamAttr SeqMem = FParamMem
+  type LParamAttr SeqMem = LParamMem
+  type RetType    SeqMem = RetTypeMem
+  type BranchType SeqMem = BranchTypeMem
+  type Op         SeqMem = MemOp ()
+
+instance Attributes SeqMem where
+  expTypesFromPattern = return . map snd . snd . bodyReturnsFromPattern
+
+instance OpReturns SeqMem where
+  opReturns (Alloc _ space) = return [MemMem space]
+  opReturns (Inner ()) = pure []
+
+instance PrettyLore SeqMem where
+
+instance TC.CheckableOp SeqMem where
+  checkOp (Alloc size _) =
+    TC.require [Prim int64] size
+  checkOp (Inner ()) =
+    pure ()
+
+instance TC.Checkable SeqMem where
+  checkFParamLore = checkMemInfo
+  checkLParamLore = checkMemInfo
+  checkLetBoundLore = checkMemInfo
+  checkRetType = mapM_ TC.checkExtType . retTypeValues
+  primFParam name t = return $ Param name (MemPrim t)
+  matchPattern = matchPatternToExp
+  matchReturnType = matchFunctionReturnType
+  matchBranchType = matchBranchReturnType
+
+instance BinderOps SeqMem where
+  mkExpAttrB _ _ = return ()
+  mkBodyB stms res = return $ Body () stms res
+  mkLetNamesB = mkLetNamesB' ()
+
+instance BinderOps (Engine.Wise SeqMem) where
+  mkExpAttrB pat e = return $ Engine.mkWiseExpAttr pat () e
+  mkBodyB stms res = return $ Engine.mkWiseBody () stms res
+  mkLetNamesB = mkLetNamesB''
+
+simplifyProg :: Prog SeqMem -> PassM (Prog SeqMem)
+simplifyProg =
+  simplifyProgGeneric $ const $ return ((), mempty)
+
+simplifyStms :: (HasScope SeqMem m, MonadFreshNames m) =>
+                 Stms SeqMem
+             -> m (Engine.SymbolTable (Engine.Wise SeqMem),
+                   Stms SeqMem)
+simplifyStms =
+  simplifyStmsGeneric $ const $ return ((), mempty)
+
+simpleSeqMem :: Engine.SimpleOps SeqMem
+simpleSeqMem =
+  simpleGeneric $ const $ return ((), mempty)

--- a/unittests/Futhark/Representation/Mem/IxFun/Alg.hs
+++ b/unittests/Futhark/Representation/Mem/IxFun/Alg.hs
@@ -1,6 +1,6 @@
 -- | A simple index operation representation.  Every operation corresponds to a
 -- constructor.
-module Futhark.Representation.ExplicitMemory.IndexFunction.Alg
+module Futhark.Representation.Mem.IxFun.Alg
   ( IxFun(..)
   , iota
   , offsetIndex

--- a/unittests/Futhark/Representation/Mem/IxFunTests.hs
+++ b/unittests/Futhark/Representation/Mem/IxFunTests.hs
@@ -1,5 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-module Futhark.Representation.ExplicitMemory.IndexFunctionTests
+module Futhark.Representation.Mem.IxFunTests
   ( tests
   )
 where
@@ -15,11 +15,11 @@ import Futhark.Representation.AST.Syntax
 import Futhark.Representation.AST.Syntax.Core()
 import qualified Futhark.Util.Pretty as PR
 import qualified Futhark.Util.IntegralExp as IE
-import qualified Futhark.Representation.ExplicitMemory.IndexFunction as IxFunLMAD
-import qualified Futhark.Representation.ExplicitMemory.IndexFunction.Alg as IxFunAlg
+import qualified Futhark.Representation.Mem.IxFun as IxFunLMAD
+import qualified Futhark.Representation.Mem.IxFun.Alg as IxFunAlg
 
-import qualified Futhark.Representation.ExplicitMemory.IndexFunctionWrapper as IxFunWrap
-import Futhark.Representation.ExplicitMemory.IndexFunctionWrapper
+import qualified Futhark.Representation.Mem.IxFunWrapper as IxFunWrap
+import Futhark.Representation.Mem.IxFunWrapper
 
 
 instance IE.IntegralExp Int where
@@ -77,7 +77,7 @@ slice3 = [ DimSlice 2 (n `P.div` 3) 3
 
 -- Actual tests.
 tests :: TestTree
-tests = testGroup "IndexFunctionTests"
+tests = testGroup "IxFunTests"
         $ concat
         [ test_iota
         , test_slice_iota

--- a/unittests/Futhark/Representation/Mem/IxFunWrapper.hs
+++ b/unittests/Futhark/Representation/Mem/IxFunWrapper.hs
@@ -1,6 +1,6 @@
 -- | Perform index function operations in both algebraic and LMAD
 -- representations.
-module Futhark.Representation.ExplicitMemory.IndexFunctionWrapper
+module Futhark.Representation.Mem.IxFunWrapper
   ( IxFun
   , iota
   , permute
@@ -16,8 +16,8 @@ import Prelude hiding (repeat)
 
 import Futhark.Util.IntegralExp
 import Futhark.Representation.AST.Syntax (ShapeChange, Slice)
-import qualified Futhark.Representation.ExplicitMemory.IndexFunction as I
-import qualified Futhark.Representation.ExplicitMemory.IndexFunction.Alg as IA
+import qualified Futhark.Representation.Mem.IxFun as I
+import qualified Futhark.Representation.Mem.IxFun.Alg as IA
 
 
 type Shape num = [num]

--- a/unittests/futhark_tests.hs
+++ b/unittests/futhark_tests.hs
@@ -4,7 +4,7 @@ import qualified Language.Futhark.SyntaxTests
 import qualified Futhark.BenchTests
 import qualified Futhark.Representation.AST.Syntax.CoreTests
 import qualified Futhark.Representation.AST.AttributesTests
-import qualified Futhark.Representation.ExplicitMemory.IndexFunctionTests
+import qualified Futhark.Representation.Mem.IxFunTests
 import qualified Futhark.Optimise.AlgSimplifyTests
 import qualified Futhark.Pkg.SolveTests
 import qualified Futhark.Representation.PrimitiveTests
@@ -21,7 +21,7 @@ allTests =
   , Futhark.Optimise.AlgSimplifyTests.tests
   , Futhark.Representation.AST.Syntax.CoreTests.tests
   , Futhark.Pkg.SolveTests.tests
-  , Futhark.Representation.ExplicitMemory.IndexFunctionTests.tests
+  , Futhark.Representation.Mem.IxFunTests.tests
   , Futhark.Representation.PrimitiveTests.tests
   , Futhark.Analysis.ScalExpTests.tests
   ]


### PR DESCRIPTION
ExplicitMemory is gone.  Instead we have two successor representations,
SeqMem and KernelsMem, built on the same foundation.