### PR TITLE
Assign a dedicated IR to multicore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+  * Fixed some errors regarding constants (#941).
+
+  * Fixed a few missing type checker cases for sum types (#938).
+
 ## [0.15.5]
 
 ### Added

--- a/futhark.cabal
+++ b/futhark.cabal
@@ -168,6 +168,8 @@ library
       Futhark.Pass.ExplicitAllocations
       Futhark.Pass.ExplicitAllocations.Kernels
       Futhark.Pass.ExplicitAllocations.Seq
+      Futhark.Pass.ExplicitAllocations.MC
+      Futhark.Pass.ExplicitAllocations.SegOp
       Futhark.Pass.ExtractKernels
       Futhark.Pass.ExtractKernels.BlockedKernel
       Futhark.Pass.ExtractKernels.DistributeNests
@@ -175,6 +177,7 @@ library
       Futhark.Pass.ExtractKernels.Interchange
       Futhark.Pass.ExtractKernels.Intragroup
       Futhark.Pass.ExtractKernels.ISRWIM
+      Futhark.Pass.ExtractMulticore
       Futhark.Pass.FirstOrderTransform
       Futhark.Pass.KernelBabysitting
       Futhark.Pass.ResolveAssertions
@@ -203,6 +206,8 @@ library
       Futhark.Representation.AST.Syntax
       Futhark.Representation.AST.Syntax.Core
       Futhark.Representation.AST.Traversals
+      Futhark.Representation.MC
+      Futhark.Representation.MCMem
       Futhark.Representation.Mem
       Futhark.Representation.Mem.IxFun
       Futhark.Representation.Mem.Simplify

--- a/futhark.cabal
+++ b/futhark.cabal
@@ -167,9 +167,9 @@ library
       Futhark.Pass.ExpandAllocations
       Futhark.Pass.ExplicitAllocations
       Futhark.Pass.ExplicitAllocations.Kernels
+      Futhark.Pass.ExplicitAllocations.SegOp
       Futhark.Pass.ExplicitAllocations.Seq
       Futhark.Pass.ExplicitAllocations.MC
-      Futhark.Pass.ExplicitAllocations.SegOp
       Futhark.Pass.ExtractKernels
       Futhark.Pass.ExtractKernels.BlockedKernel
       Futhark.Pass.ExtractKernels.DistributeNests

--- a/futhark.cabal
+++ b/futhark.cabal
@@ -213,6 +213,7 @@ library
       Futhark.Representation.KernelsMem
       Futhark.Representation.Primitive
       Futhark.Representation.Ranges
+      Futhark.Representation.SegOp
       Futhark.Representation.Seq
       Futhark.Representation.SeqMem
       Futhark.Representation.SOACS

--- a/src/Futhark/Actions.hs
+++ b/src/Futhark/Actions.hs
@@ -19,6 +19,7 @@ import Futhark.Representation.AST
 import Futhark.Representation.AST.Attributes.Aliases
 import Futhark.Representation.KernelsMem (KernelsMem)
 import Futhark.Representation.SeqMem (SeqMem)
+import Futhark.Representation.MCMem (MCMem)
 import qualified Futhark.CodeGen.ImpGen.Sequential as ImpGenSequential
 import qualified Futhark.CodeGen.ImpGen.Kernels as ImpGenKernels
 import qualified Futhark.CodeGen.ImpGen.Multicore as ImpGenMulticore
@@ -60,7 +61,7 @@ kernelImpCodeGenAction =
          , actionProcedure = liftIO . putStrLn . pretty <=< ImpGenKernels.compileProgOpenCL
          }
 
-multicoreImpCodeGenAction :: Action KernelsMem
+multicoreImpCodeGenAction :: Action MCMem
 multicoreImpCodeGenAction =
   Action { actionName = "Compile to imperative multicore"
          , actionDescription = "Translate program into imperative multicore IL and write it on standard output."

--- a/src/Futhark/CLI/Multicore.hs
+++ b/src/Futhark/CLI/Multicore.hs
@@ -13,7 +13,7 @@ import Futhark.Util
 
 main :: String -> [String] -> IO ()
 main = compilerMain () []
-       "Compile to mulcitore C" "Generate multicore C code from optimised Futhark program."
+       "Compile to multicore C" "Generate multicore C code from optimised Futhark program."
        multicorePipeline $ \() mode outpath prog -> do
          cprog <- MulticoreC.compileProg prog
          let cpath = outpath `addExtension` "c"

--- a/src/Futhark/CodeGen/Backends/GenericC.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC.hs
@@ -34,6 +34,7 @@ module Futhark.CodeGen.Backends.GenericC
   , contextContents
   , contextFinalInits
   , runCompilerM
+  , inNewFunction
   , blockScope
   , compileFun
   , compileCode
@@ -346,6 +347,17 @@ collect' m = pass $ do
   (x, w) <- listen m
   return ((x, DL.toList $ accItems w),
           const w { accItems = mempty})
+
+-- | Used when we, inside an existing 'CompilerM' action, want to
+-- generate code for a new function.  Use this so that the compiler
+-- understands that previously declared memory doesn't need to be
+-- freed inside this action.
+inNewFunction :: CompilerM op s a -> CompilerM op s a
+inNewFunction m = do
+  old_mem <- gets compDeclaredMem
+  x <- m
+  modify $ \s -> s { compDeclaredMem = old_mem }
+  return x
 
 item :: C.BlockItem -> CompilerM op s ()
 item x = tell $ mempty { accItems = DL.singleton x }

--- a/src/Futhark/CodeGen/Backends/GenericC.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC.hs
@@ -355,6 +355,7 @@ collect' m = pass $ do
 inNewFunction :: CompilerM op s a -> CompilerM op s a
 inNewFunction m = do
   old_mem <- gets compDeclaredMem
+  modify $ \s -> s { compDeclaredMem = mempty }
   x <- m
   modify $ \s -> s { compDeclaredMem = old_mem }
   return x

--- a/src/Futhark/CodeGen/Backends/GenericC.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC.hs
@@ -28,7 +28,7 @@ module Futhark.CodeGen.Backends.GenericC
 
   -- * Monadic compiler interface
   , CompilerM
-  , CompilerState (compUserState)
+  , CompilerState (compUserState, compNameSrc)
   , getUserState
   , modifyUserState
   , contextContents

--- a/src/Futhark/CodeGen/Backends/MulticoreC.hs
+++ b/src/Futhark/CodeGen/Backends/MulticoreC.hs
@@ -290,13 +290,10 @@ compileOp (ParLoop scheduling ntasks i e (MulticoreFunc params prebody body tid)
   e' <- GC.compileExp e
   granularity <- compileSchedulingVal scheduling
 
-  (prebody', body') <- modifyNameSource $ \src ->
-    let (code, s) =
-          GC.runCompilerM operations src () $
-          (,)
-          <$> GC.blockScope (GC.compileCode prebody)
-          <*> GC.blockScope (GC.compileCode body)
-    in (code, GC.compNameSrc s)
+  (prebody', body') <-
+    GC.inNewFunction $ (,)
+    <$> GC.blockScope (GC.compileCode prebody)
+    <*> GC.blockScope (GC.compileCode body)
 
   fstruct <- multicoreDef "parloop_struct" $ \s ->
      return [C.cedecl|struct $id:s {

--- a/src/Futhark/CodeGen/ImpCode/Multicore.hs
+++ b/src/Futhark/CodeGen/ImpCode/Multicore.hs
@@ -60,5 +60,6 @@ instance FreeIn MulticoreFunc where
   freeIn' (MulticoreFunc _ prebody body _) = freeIn' prebody <> freeIn' body
 
 instance FreeIn Multicore where
-  freeIn' (ParLoop _ ntask _ e func) = freeIn' ntask <> freeIn' e <> freeIn' func
+  freeIn' (ParLoop _ ntask i e func) =
+    fvBind (oneName i) $ freeIn' ntask <> freeIn' e <> freeIn' func
   freeIn' (MulticoreCall dests _ ) = freeIn' dests

--- a/src/Futhark/CodeGen/ImpGen/Kernels.hs
+++ b/src/Futhark/CodeGen/ImpGen/Kernels.hs
@@ -118,7 +118,8 @@ sizeClassWithEntryPoint fname (Imp.SizeThreshold path) =
   where f (name, x) = (keyWithEntryPoint fname name, x)
 sizeClassWithEntryPoint _ size_class = size_class
 
-segOpCompiler :: Pattern KernelsMem -> SegOp KernelsMem -> CallKernelGen ()
+segOpCompiler :: Pattern KernelsMem -> SegOp SegLevel KernelsMem
+              -> CallKernelGen ()
 segOpCompiler pat (SegMap lvl space _ kbody) =
   compileSegMap pat lvl space kbody
 segOpCompiler pat (SegRed lvl@SegThread{} space reds _ kbody) =

--- a/src/Futhark/CodeGen/ImpGen/Multicore.hs
+++ b/src/Futhark/CodeGen/ImpGen/Multicore.hs
@@ -5,85 +5,28 @@ module Futhark.CodeGen.ImpGen.Multicore
   )
   where
 
-import Control.Monad
 import Prelude hiding (quot, rem)
 
 import qualified Futhark.CodeGen.ImpCode.Multicore as Imp
 
-import Futhark.CodeGen.ImpGen.Multicore.Base
 import Futhark.CodeGen.ImpGen.Multicore.SegMap
 import Futhark.CodeGen.ImpGen.Multicore.SegRed
 import Futhark.CodeGen.ImpGen.Multicore.SegScan
 import Futhark.CodeGen.ImpGen.Multicore.SegHist
 
 import Futhark.CodeGen.ImpGen
-import Futhark.Representation.KernelsMem
+import Futhark.Representation.MCMem
 import Futhark.MonadFreshNames
-import Futhark.Util.IntegralExp (quotRoundingUp)
 
-
-computeThreadChunkSize :: SplitOrdering
-                       -> Imp.Exp
-                       -> Imp.Count Imp.Elements Imp.Exp
-                       -> Imp.Count Imp.Elements Imp.Exp
-                       -> VName
-                       -> ImpM lore r op ()
-computeThreadChunkSize (SplitStrided stride) thread_index elements_per_thread num_elements chunk_var = do
-  stride' <- toExp stride
-  chunk_var <--
-    Imp.BinOpExp (SMin Int32)
-    (Imp.unCount elements_per_thread)
-    ((Imp.unCount num_elements - thread_index) `quotRoundingUp` stride')
-
-
-computeThreadChunkSize SplitContiguous thread_index elements_per_thread num_elements chunk_var = do
-  starting_point <- dPrimV "starting_point" $
-    thread_index * Imp.unCount elements_per_thread
-  remaining_elements <- dPrimV "remaining_elements" $
-    Imp.unCount num_elements - Imp.var starting_point int32
-
-  let no_remaining_elements = Imp.var remaining_elements int32 .<=. 0
-      beyond_bounds = Imp.unCount num_elements .<=. Imp.var starting_point int32
-
-  sIf (no_remaining_elements .||. beyond_bounds)
-    (chunk_var <-- 0)
-    (sIf is_last_thread
-       (chunk_var <-- Imp.unCount last_thread_elements)
-       (chunk_var <-- Imp.unCount elements_per_thread))
-  where last_thread_elements =
-          num_elements - Imp.elements thread_index * elements_per_thread
-        is_last_thread =
-          Imp.unCount num_elements .<.
-          (thread_index + 1) * Imp.unCount elements_per_thread
-
-
-compileProg :: MonadFreshNames m => Prog KernelsMem
+compileProg :: MonadFreshNames m => Prog MCMem
             -> m (Imp.Definitions Imp.Multicore)
 compileProg = Futhark.CodeGen.ImpGen.compileProg () ops Imp.DefaultSpace
   where ops = defaultOperations opCompiler
-        opCompiler :: OpCompiler KernelsMem () Imp.Multicore
-        opCompiler dest (Alloc e space) =
-          compileAlloc dest e space
-        opCompiler dest (Inner (SegOp op)) =
-          compileSegOp dest op
-        opCompiler  (Pattern _ [pe]) (Inner (SizeOp GetSize{})) =
-          getNumThreads' $ patElemName pe
-        opCompiler (Pattern _ [pe]) (Inner (SizeOp CalcNumGroups{})) = do
-          let dest = patElemName pe
-          dest <-- 1
-        opCompiler (Pattern _ [size])(Inner (SizeOp (SplitSpace o w i elems_per_thread))) = do
-          num_elements <- Imp.elements <$> toExp w
-          i' <- toExp i
-          elems_per_thread' <- Imp.elements <$> toExp elems_per_thread
-          computeThreadChunkSize o i' elems_per_thread' num_elements (patElemName size)
-        opCompiler _ (Inner SizeOp{}) =
-          return ()
-        opCompiler _ (Inner (OtherOp ())) =
-          return ()
+        opCompiler dest (Alloc e space) = compileAlloc dest e space
+        opCompiler dest (Inner op) = compileSegOp dest op
 
-
-compileSegOp :: Pattern KernelsMem -> SegOp KernelsMem
-             -> ImpM KernelsMem () Imp.Multicore ()
+compileSegOp :: Pattern MCMem -> SegOp () MCMem
+             -> ImpM MCMem () Imp.Multicore ()
 compileSegOp pat  (SegHist _ space histops _ kbody) =
   compileSegHist pat space histops kbody
 

--- a/src/Futhark/CodeGen/ImpGen/Multicore/Base.hs
+++ b/src/Futhark/CodeGen/ImpGen/Multicore/Base.hs
@@ -15,10 +15,10 @@ import Prelude hiding (quot, rem)
 import Futhark.Error
 import qualified Futhark.CodeGen.ImpCode.Multicore as Imp
 import Futhark.CodeGen.ImpGen
-import Futhark.Representation.KernelsMem
+import Futhark.Representation.MCMem
 
 
-type MulticoreGen = ImpM KernelsMem () Imp.Multicore
+type MulticoreGen = ImpM MCMem () Imp.Multicore
 
 
 toParam :: VName -> TypeBase shape u -> Imp.Param
@@ -27,9 +27,9 @@ toParam name (Mem space) = Imp.MemParam name space
 toParam _     Array{}    = error "Cannot make Array into Imp.Param"
 
 
-compileKBody :: KernelBody KernelsMem
-             -> ([(SubExp, [Imp.Exp])] -> ImpM KernelsMem () Imp.Multicore ())
-             -> ImpM KernelsMem () Imp.Multicore ()
+compileKBody :: KernelBody MCMem
+             -> ([(SubExp, [Imp.Exp])] -> ImpM MCMem () Imp.Multicore ())
+             -> ImpM MCMem () Imp.Multicore ()
 compileKBody kbody red_cont =
   compileStms (freeIn $ kernelBodyResult kbody) (kernelBodyStms kbody) $ do
     let red_res = kernelBodyResult kbody
@@ -38,7 +38,7 @@ compileKBody kbody red_cont =
 
 
 compileThreadResult :: SegSpace
-                    -> PatElem KernelsMem -> KernelResult
+                    -> PatElem MCMem -> KernelResult
                     -> MulticoreGen ()
 compileThreadResult space pe (Returns _ what) = do
   let is = map (Imp.vi32 . fst) $ unSegSpace space

--- a/src/Futhark/CodeGen/ImpGen/Multicore/SegHist.hs
+++ b/src/Futhark/CodeGen/ImpGen/Multicore/SegHist.hs
@@ -10,7 +10,7 @@ import Prelude hiding (quot, rem)
 import qualified Futhark.CodeGen.ImpCode.Multicore as Imp
 import Futhark.Util (chunks, splitFromEnd, takeLast)
 import Futhark.CodeGen.ImpGen
-import Futhark.Representation.KernelsMem
+import Futhark.Representation.MCMem
 
 import Futhark.CodeGen.ImpGen.Multicore.Base
 import Futhark.CodeGen.ImpGen.Multicore.SegRed (compileSegRed')
@@ -18,9 +18,9 @@ import Futhark.MonadFreshNames
 
 
 newtype MySegHistSlug = MySegHistSlug
-                       { mySlugOp :: HistOp KernelsMem }
+                       { mySlugOp :: HistOp MCMem }
 
-computeHistoUsage :: HistOp KernelsMem
+computeHistoUsage :: HistOp MCMem
                   -> MulticoreGen MySegHistSlug
 computeHistoUsage op =
   return $ MySegHistSlug op
@@ -72,10 +72,10 @@ prepareIntermediateArrays num_subhistos_per_group =
     writeArray bucket arr val = copyDWIMFix arr bucket val []
 
 
-compileSegHist  :: Pattern KernelsMem
+compileSegHist  :: Pattern MCMem
                 -> SegSpace
-                -> [HistOp KernelsMem]
-                -> KernelBody KernelsMem
+                -> [HistOp MCMem]
+                -> KernelBody MCMem
                 -> MulticoreGen ()
 compileSegHist pat space histops kbody
   | segment_depth <- unSegSpace space,
@@ -85,10 +85,10 @@ compileSegHist pat space histops kbody
       segmentedHist pat space histops kbody
 
 
-segmentedHist :: Pattern KernelsMem
+segmentedHist :: Pattern MCMem
                 -> SegSpace
-                -> [HistOp KernelsMem]
-                -> KernelBody KernelsMem
+                -> [HistOp MCMem]
+                -> KernelBody MCMem
                 -> MulticoreGen ()
 segmentedHist pat space histops kbody = do
   emit $ Imp.DebugPrint "Segmented segHist" Nothing
@@ -162,10 +162,10 @@ segmentedHist pat space histops kbody = do
 
 
 
-nonsegmentedHist :: Pattern KernelsMem
+nonsegmentedHist :: Pattern MCMem
                 -> SegSpace
-                -> [HistOp KernelsMem]
-                -> KernelBody KernelsMem
+                -> [HistOp MCMem]
+                -> KernelBody MCMem
                 -> MulticoreGen ()
 nonsegmentedHist pat space histops kbody = do
   emit $ Imp.DebugPrint "nonsegmented segHist" Nothing
@@ -188,11 +188,11 @@ nonsegmentedHist pat space histops kbody = do
 -- is computed and finally merged through a reduction
 -- across the histogram indicies.
 -- This is expected to be fast if len(histDest) is small
-smallDestHistogram :: Pattern KernelsMem
+smallDestHistogram :: Pattern MCMem
                    -> SegSpace
-                   -> [HistOp KernelsMem]
+                   -> [HistOp MCMem]
                    -> VName
-                   -> KernelBody KernelsMem
+                   -> KernelBody MCMem
                    -> MulticoreGen ()
 smallDestHistogram pat space histops num_threads kbody = do
   emit $ Imp.DebugPrint "smallDestHistogram segHist" Nothing
@@ -331,10 +331,10 @@ smallDestHistogram pat space histops num_threads kbody = do
 -- Takes sequential version and simpley chunks is
 -- Implementation does currently not ensure amotic updates
 -- but just doing it sequentially, single threaded seems faster
-largeDestHistogram :: Pattern KernelsMem
+largeDestHistogram :: Pattern MCMem
                    -> SegSpace
-                   -> [HistOp KernelsMem]
-                   -> KernelBody KernelsMem
+                   -> [HistOp MCMem]
+                   -> KernelBody MCMem
                    -> MulticoreGen ()
 largeDestHistogram pat space histops kbody = do
   emit $ Imp.DebugPrint "largeDestHistogram segHist" Nothing

--- a/src/Futhark/CodeGen/ImpGen/Multicore/SegMap.hs
+++ b/src/Futhark/CodeGen/ImpGen/Multicore/SegMap.hs
@@ -7,13 +7,13 @@ import Control.Monad
 
 import qualified Futhark.CodeGen.ImpCode.Multicore as Imp
 import Futhark.CodeGen.ImpGen
-import Futhark.Representation.KernelsMem
+import Futhark.Representation.MCMem
 import Futhark.CodeGen.ImpGen.Multicore.Base
 
 
-compileSegMap :: Pattern KernelsMem
+compileSegMap :: Pattern MCMem
               -> SegSpace
-              -> KernelBody KernelsMem
+              -> KernelBody MCMem
               -> MulticoreGen ()
 compileSegMap pat space (KernelBody _ kstms kres) = do
   emit $ Imp.DebugPrint "SegMap " Nothing
@@ -42,8 +42,7 @@ compileSegMap pat space (KernelBody _ kstms kres) = do
          writeResult _ res =
            error $ "writeResult: cannot handle " ++ pretty res
      zipWithM_ writeResult (patternElements pat) kres
-
-  let freeVariables = namesToList (freeIn body' `namesSubtract` freeIn [segFlat space])
+  let freeVariables = namesToList (freeIn body' `namesSubtract` oneName (segFlat space))
   ts <- mapM lookupType freeVariables
   let freeParams = zipWith toParam freeVariables ts
   let scheduling = decideScheduling body'

--- a/src/Futhark/CodeGen/ImpGen/Multicore/SegScan.hs
+++ b/src/Futhark/CodeGen/ImpGen/Multicore/SegScan.hs
@@ -11,13 +11,13 @@ import qualified Futhark.CodeGen.ImpCode.Multicore as Imp
 import qualified Futhark.Representation.Mem.IxFun as IxFun
 
 import Futhark.CodeGen.ImpGen
-import Futhark.Representation.KernelsMem
+import Futhark.Representation.MCMem
 import Futhark.CodeGen.ImpGen.Multicore.Base
 
 import Futhark.Transform.Rename
 
 
-createTemporaryArrays :: SubExp -> [SubExp] -> Lambda KernelsMem
+createTemporaryArrays :: SubExp -> [SubExp] -> Lambda MCMem
                 -> MulticoreGen [VName]
 createTemporaryArrays num_threads nes scan_op = do
   let (scan_x_params, _scan_y_params) =
@@ -33,11 +33,11 @@ createTemporaryArrays num_threads nes scan_op = do
             shape = Shape [num_threads]
         sAllocArray "scan_arr_p" pt shape DefaultSpace
 
-compileSegScan :: Pattern KernelsMem
+compileSegScan :: Pattern MCMem
                 -> SegSpace
-                -> Lambda KernelsMem
+                -> Lambda MCMem
                 -> [SubExp]
-                -> KernelBody KernelsMem
+                -> KernelBody MCMem
                 -> MulticoreGen ()
 compileSegScan pat space scan_op nes kbody
   | segment_depth <- unSegSpace space,
@@ -47,11 +47,11 @@ compileSegScan pat space scan_op nes kbody
       segmentedScan pat space scan_op nes kbody
 
 
-segmentedScan :: Pattern KernelsMem
+segmentedScan :: Pattern MCMem
                 -> SegSpace
-                -> Lambda KernelsMem
+                -> Lambda MCMem
                 -> [SubExp]
-                -> KernelBody KernelsMem
+                -> KernelBody MCMem
                 -> MulticoreGen ()
 segmentedScan pat space scan_op nes kbody = do
   emit $ Imp.DebugPrint "segmented segScan" Nothing
@@ -114,16 +114,16 @@ segmentedScan pat space scan_op nes kbody = do
 -- | A SegScanOp with auxiliary information.
 data SegScanOpSlug =
   SegScanOpSlug
-  { slugOp :: Lambda KernelsMem
+  { slugOp :: Lambda MCMem
   , slugAccs :: [(VName, [Imp.Exp])]
     -- ^ Places to store accumulator in stage 1 reduction.
   }
 
-slugParams :: SegScanOpSlug -> [LParam KernelsMem]
+slugParams :: SegScanOpSlug -> [LParam MCMem]
 slugParams = lambdaParams . slugOp
 
 segScanOpSlug :: Imp.Exp
-             -> Lambda KernelsMem
+             -> Lambda MCMem
              -> [VName]
              -> MulticoreGen SegScanOpSlug
 segScanOpSlug local_tid op param_arrs =
@@ -132,11 +132,11 @@ segScanOpSlug local_tid op param_arrs =
   where mkAcc param_arr = return (param_arr, [local_tid])
 
 
-nonsegmentedScan :: Pattern KernelsMem
+nonsegmentedScan :: Pattern MCMem
                  -> SegSpace
-                 -> Lambda KernelsMem
+                 -> Lambda MCMem
                  -> [SubExp]
-                 -> KernelBody KernelsMem
+                 -> KernelBody MCMem
                  -> MulticoreGen ()
 nonsegmentedScan pat space scan_op nes kbody = do
   emit $ Imp.DebugPrint "nonsegmented segScan " Nothing

--- a/src/Futhark/Internalise/Monad.hs
+++ b/src/Futhark/Internalise/Monad.hs
@@ -48,6 +48,7 @@ import qualified Data.Map.Strict as M
 import Futhark.Representation.SOACS
 import Futhark.MonadFreshNames
 import Futhark.Tools
+import Futhark.Util (takeLast)
 
 -- | Extra parameters to pass when calling this function.  This
 -- corresponds to the closure of a locally defined function.
@@ -170,7 +171,8 @@ bindFunction fname fd info = do
 bindConstant :: VName -> FunDef SOACS -> InternaliseM ()
 bindConstant cname fd = do
   let stms = bodyStms $ funDefBody fd
-      substs = bodyResult $ funDefBody fd
+      substs = takeLast (length (funDefRetType fd)) $
+               bodyResult $ funDefBody fd
       const_names = namesFromList $ M.keys $ scopeOf stms
   addStms stms
   modify $ \s ->

--- a/src/Futhark/Optimise/CSE.hs
+++ b/src/Futhark/Optimise/CSE.hs
@@ -209,10 +209,11 @@ instance (Attributes lore, Aliased lore,
   cseInOp (Kernel.OtherOp op) = Kernel.OtherOp <$> cseInOp op
   cseInOp x = return x
 
-instance (Attributes lore, Aliased lore, CSEInOp (Op lore)) => CSEInOp (Kernel.SegOp lore) where
+instance (Attributes lore, Aliased lore, CSEInOp (Op lore)) =>
+         CSEInOp (Kernel.SegOp lvl lore) where
   cseInOp = subCSE .
             Kernel.mapSegOpM
-            (Kernel.SegOpMapper return cseInLambda cseInKernelBody return)
+            (Kernel.SegOpMapper return cseInLambda cseInKernelBody return return)
 
 cseInKernelBody :: (Attributes lore, Aliased lore, CSEInOp (Op lore)) =>
                    Kernel.KernelBody lore -> CSEM lore (Kernel.KernelBody lore)

--- a/src/Futhark/Optimise/Simplify/Engine.hs
+++ b/src/Futhark/Optimise/Simplify/Engine.hs
@@ -793,6 +793,9 @@ simplifyParam :: (attr -> SimpleM lore attr) -> Param attr -> SimpleM lore (Para
 simplifyParam simplifyAttribute (Param name attr) =
   Param name <$> simplifyAttribute attr
 
+instance Simplifiable () where
+  simplify = pure
+
 instance Simplifiable VName where
   simplify v = do
     se <- ST.lookupSubExp v <$> askVtable

--- a/src/Futhark/Pass/ExplicitAllocations.hs
+++ b/src/Futhark/Pass/ExplicitAllocations.hs
@@ -17,6 +17,7 @@ module Futhark.Pass.ExplicitAllocations
        , ExpHint(..)
        , defaultExpHints
 
+       , Allocable
        , Allocator(..)
        , AllocM
        , AllocEnv(..)
@@ -834,6 +835,9 @@ instance SizeSubst () where
 instance SizeSubst (HostOp lore op) where
   opSizeSubst (Pattern _ [size]) (SizeOp (SplitSpace _ _ _ elems_per_thread)) =
     M.singleton (patElemName size) elems_per_thread
+  opSizeSubst _ _ = mempty
+
+instance SizeSubst (SegOp lvl lore) where
   opSizeSubst _ _ = mempty
 
 instance SizeSubst op => SizeSubst (MemOp op) where

--- a/src/Futhark/Pass/ExplicitAllocations/Kernels.hs
+++ b/src/Futhark/Pass/ExplicitAllocations/Kernels.hs
@@ -82,8 +82,8 @@ allocInKernelBody lvl (KernelBody () stms res) =
         inThread env = env { envExpHints = inThreadExpHints }
         inGroup env = env { envExpHints = inGroupExpHints }
 
-handleSegOp :: SegOp Kernels
-            -> AllocM Kernels KernelsMem (SegOp KernelsMem)
+handleSegOp :: SegOp SegLevel Kernels
+            -> AllocM Kernels KernelsMem (SegOp SegLevel KernelsMem)
 handleSegOp op = allocAtLevel (segLevel op) $ mapSegOpM mapper op
   where scope = scopeOfSegSpace $ segSpace op
         mapper = identitySegOpMapper

--- a/src/Futhark/Pass/ExplicitAllocations/Kernels.hs
+++ b/src/Futhark/Pass/ExplicitAllocations/Kernels.hs
@@ -1,17 +1,25 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 module Futhark.Pass.ExplicitAllocations.Kernels
        ( explicitAllocations
        , explicitAllocationsInStms
        )
 where
 
+import qualified Data.Map as M
+
 import qualified Futhark.Representation.Mem.IxFun as IxFun
 import Futhark.Representation.KernelsMem
 import Futhark.Representation.Kernels
 import Futhark.Pass.ExplicitAllocations
 import Futhark.Pass.ExplicitAllocations.SegOp
+
+instance SizeSubst (HostOp lore op) where
+  opSizeSubst (Pattern _ [size]) (SizeOp (SplitSpace _ _ _ elems_per_thread)) =
+    M.singleton (patElemName size) elems_per_thread
+  opSizeSubst _ _ = mempty
 
 allocAtLevel :: SegLevel -> AllocM fromlore tlore a -> AllocM fromlore tlore a
 allocAtLevel lvl = local $ \env -> env { allocSpace = space

--- a/src/Futhark/Pass/ExplicitAllocations/MC.hs
+++ b/src/Futhark/Pass/ExplicitAllocations/MC.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeFamilies #-}
+module Futhark.Pass.ExplicitAllocations.MC
+  ( explicitAllocations )
+where
+
+import Futhark.Representation.MCMem
+import Futhark.Representation.MC
+import Futhark.Pass.ExplicitAllocations
+import Futhark.Pass.ExplicitAllocations.SegOp
+
+handleSegOp :: SegOp () MC -> AllocM MC MCMem (MemOp (SegOp () MCMem))
+handleSegOp op = do
+  let num_threads = intConst Int32 256 -- FIXME
+  Inner <$> mapSegOpM (mapper num_threads) op
+  where scope = scopeOfSegSpace $ segSpace op
+        mapper num_threads =
+          identitySegOpMapper
+          { mapOnSegOpBody =
+              localScope scope . allocInKernelBody
+          , mapOnSegOpLambda =
+              allocInBinOpLambda num_threads (segSpace op)
+          }
+
+explicitAllocations :: Pass MC MCMem
+explicitAllocations = explicitAllocationsGeneric handleSegOp defaultExpHints

--- a/src/Futhark/Pass/ExplicitAllocations/SegOp.hs
+++ b/src/Futhark/Pass/ExplicitAllocations/SegOp.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 module Futhark.Pass.ExplicitAllocations.SegOp
        ( allocInKernelBody
        , allocInBinOpLambda
@@ -10,6 +11,9 @@ where
 import qualified Futhark.Representation.Mem.IxFun as IxFun
 import Futhark.Representation.KernelsMem
 import Futhark.Pass.ExplicitAllocations
+
+instance SizeSubst (SegOp lvl lore) where
+  opSizeSubst _ _ = mempty
 
 allocInKernelBody :: Allocable fromlore tolore =>
                      KernelBody fromlore

--- a/src/Futhark/Pass/ExplicitAllocations/SegOp.hs
+++ b/src/Futhark/Pass/ExplicitAllocations/SegOp.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeFamilies #-}
+module Futhark.Pass.ExplicitAllocations.SegOp
+       ( allocInKernelBody
+       , allocInBinOpLambda
+       )
+where
+
+import qualified Futhark.Representation.Mem.IxFun as IxFun
+import Futhark.Representation.KernelsMem
+import Futhark.Pass.ExplicitAllocations
+
+allocInKernelBody :: Allocable fromlore tolore =>
+                     KernelBody fromlore
+                  -> AllocM fromlore tolore (KernelBody tolore)
+allocInKernelBody (KernelBody () stms res) =
+  allocInStms stms $ \stms' -> return $ KernelBody () stms' res
+
+allocInLambda :: Allocable fromlore tolore =>
+                 [LParam tolore] -> Body fromlore -> [Type]
+              -> AllocM fromlore tolore (Lambda tolore)
+allocInLambda params body rettype = do
+  body' <- localScope (scopeOfLParams params) $
+           allocInStms (bodyStms body) $ \bnds' ->
+           return $ Body () bnds' $ bodyResult body
+  return $ Lambda params body' rettype
+
+allocInBinOpParams :: Allocable fromlore tolore =>
+                      SubExp
+                   -> PrimExp VName -> PrimExp VName
+                   -> [LParam fromlore]
+                   -> [LParam fromlore]
+                   -> AllocM fromlore tolore ([LParam tolore], [LParam tolore])
+allocInBinOpParams num_threads my_id other_id xs ys = unzip <$> zipWithM alloc xs ys
+  where alloc x y =
+          case paramType x of
+            Array bt shape u -> do
+              twice_num_threads <-
+                letSubExp "twice_num_threads" $
+                BasicOp $ BinOp (Mul Int32) num_threads $ intConst Int32 2
+              let t = paramType x `arrayOfRow` twice_num_threads
+              mem <- allocForArray t DefaultSpace
+              -- XXX: this iota ixfun is a bit inefficient; leading to
+              -- uncoalesced access.
+              let base_dims = map (primExpFromSubExp int32) (arrayDims t)
+                  ixfun_base = IxFun.iota base_dims
+                  ixfun_x = IxFun.slice ixfun_base $
+                            fullSliceNum base_dims [DimFix my_id]
+                  ixfun_y = IxFun.slice ixfun_base $
+                            fullSliceNum base_dims [DimFix other_id]
+              return (x { paramAttr = MemArray bt shape u $ ArrayIn mem ixfun_x },
+                      y { paramAttr = MemArray bt shape u $ ArrayIn mem ixfun_y })
+            Prim bt ->
+              return (x { paramAttr = MemPrim bt },
+                      y { paramAttr = MemPrim bt })
+            Mem space ->
+              return (x { paramAttr = MemMem space },
+                      y { paramAttr = MemMem space })
+
+allocInBinOpLambda :: Allocable fromlore tolore =>
+                      SubExp -> SegSpace -> Lambda fromlore
+                   -> AllocM fromlore tolore (Lambda tolore)
+allocInBinOpLambda num_threads (SegSpace flat _) lam = do
+  let (acc_params, arr_params) =
+        splitAt (length (lambdaParams lam) `div` 2) $ lambdaParams lam
+      index_x = LeafExp flat int32
+      index_y = index_x + primExpFromSubExp int32 num_threads
+  (acc_params', arr_params') <-
+    allocInBinOpParams num_threads index_x index_y acc_params arr_params
+
+  allocInLambda (acc_params' ++ arr_params')
+    (lambdaBody lam) (lambdaReturnType lam)

--- a/src/Futhark/Pass/ExplicitAllocations/Seq.hs
+++ b/src/Futhark/Pass/ExplicitAllocations/Seq.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 module Futhark.Pass.ExplicitAllocations.Seq
        ( explicitAllocations
        , simplifiable

--- a/src/Futhark/Pass/ExplicitAllocations/Seq.hs
+++ b/src/Futhark/Pass/ExplicitAllocations/Seq.hs
@@ -12,4 +12,4 @@ import Futhark.Representation.Seq
 import Futhark.Pass.ExplicitAllocations
 
 explicitAllocations :: Pass Seq SeqMem
-explicitAllocations = explicitAllocationsGeneric undefined defaultExpHints
+explicitAllocations = explicitAllocationsGeneric (pure . Inner) defaultExpHints

--- a/src/Futhark/Pass/ExtractKernels/BlockedKernel.hs
+++ b/src/Futhark/Pass/ExtractKernels/BlockedKernel.hs
@@ -418,7 +418,7 @@ mapKernel :: (HasScope Kernels m, MonadFreshNames m) =>
              MkSegLevel m
           -> [(VName, SubExp)] -> [KernelInput]
           -> [Type] -> KernelBody Kernels
-          -> m (SegOp Kernels, Stms Kernels)
+          -> m (SegOp SegLevel Kernels, Stms Kernels)
 mapKernel mk_lvl ispace inputs rts (KernelBody () kstms krets) = runBinderT' $ do
   (space, read_input_stms) <- mapKernelSkeleton ispace inputs
 

--- a/src/Futhark/Pass/ExtractMulticore.hs
+++ b/src/Futhark/Pass/ExtractMulticore.hs
@@ -1,0 +1,107 @@
+module Futhark.Pass.ExtractMulticore (extractMulticore) where
+
+import Control.Monad.Reader
+import Control.Monad.State
+
+import Futhark.Analysis.Rephrase
+import Futhark.Tools
+import Futhark.MonadFreshNames
+import Futhark.Pass
+import Futhark.Representation.AST
+import Futhark.Representation.MC
+import Futhark.Representation.SOACS hiding (Body, Exp, Lambda, LParam, Stm)
+{-
+type ExtractM = ReaderT (Scope MC) (State VNameSource)
+
+transformExp :: Exp SOACS -> ExtractM (Exp MC)
+transformExp (BasicOp op) = return $ BasicOp op
+
+transformStm :: Stm SOACS -> ExtractM (Stm MC)
+transformStm (Let pat aux e) = Let pat aux <$> transformExp e
+
+transformStms :: Stms SOACS -> ExtractM (Stms MC)
+transformStms stms =
+  case stmsHead stms of
+    Nothing -> return mempty
+    Just (stm, stms') -> do
+      stm' <- transformStm stm
+      inScopeOf stm' $ (oneStm stm'<>) <$> transformStms stms'
+
+transformBody :: Body SOACS -> ExtractM (Body MC)
+transformBody (Body () stms res) =
+  Body () <$> transformStms stms <*> pure res
+
+transformFunDef :: FunDef SOACS -> ExtractM (FunDef MC)
+transformFunDef (FunDef entry name rettype params body) = do
+  body' <- localScope (scopeOfFParams params) $
+           transformBody body
+  return $ FunDef entry name rettype params body'
+
+transformProg :: Prog SOACS -> PassM (Prog MC)
+transformProg (Prog consts funs) =
+  modifyNameSource $ runState (runReaderT m mempty)
+  where m = do
+          consts' <- transformStms consts
+          funs' <- inScopeOf consts' $ mapM transformFunDef funs
+          return $ Prog consts' funs'
+-}
+
+indexArray :: VName -> LParam SOACS -> VName -> Stm MC
+indexArray i (Param p t) arr =
+  Let (Pattern [] [PatElem p t]) (defAux ()) $
+  BasicOp $ Index arr $ DimFix (Var i) : map sliceDim (arrayDims t)
+
+mapLambdaToKernelBody :: MonadFreshNames m =>
+                         VName -> Lambda SOACS -> [VName] -> m (KernelBody MC)
+mapLambdaToKernelBody i lam arrs = do
+  Body () stms res <- rephraseBody rephraser $ lambdaBody lam
+  let indexings = zipWith (indexArray i) (lambdaParams lam) arrs
+  return $ KernelBody () (stmsFromList indexings <> stms) $
+    map (Returns ResultMaySimplify) res
+
+reduceToSegRedOp :: MonadFreshNames m => Reduce SOACS -> m (SegRedOp MC)
+reduceToSegRedOp (Reduce comm lam nes) =
+  SegRedOp comm <$> rephraseLambda rephraser lam <*> pure nes <*> pure mempty
+
+soacToSegOp :: MonadFreshNames m => SOAC SOACS -> m (SegOp () MC)
+soacToSegOp screma@(Screma w form arrs) = do
+  flat <- newVName "flat_tid"
+  gtid <- newVName "gtid"
+  let space = SegSpace flat [(gtid, w)]
+
+  case () of
+    _ | Just map_lam <- isMapSOAC form -> do
+          kbody <- mapLambdaToKernelBody gtid map_lam arrs
+          pure $ SegMap () space (lambdaReturnType map_lam) kbody
+
+      | Just (reds, map_lam) <- isRedomapSOAC form -> do
+          kbody <- mapLambdaToKernelBody gtid map_lam arrs
+          reds' <- mapM reduceToSegRedOp reds
+          pure $ SegRed () space reds' (lambdaReturnType map_lam) kbody
+
+      | Just (lam, nes, map_lam) <- isScanomapSOAC form -> do
+          kbody <- mapLambdaToKernelBody gtid map_lam arrs
+          lam' <- rephraseLambda rephraser lam
+          pure $ SegScan () space lam' nes (lambdaReturnType map_lam) kbody
+
+      | otherwise -> error $ "Too complex Screma: " ++ pretty screma
+
+rephraser :: MonadFreshNames m => Rephraser m SOACS MC
+rephraser =
+  Rephraser
+  { rephraseExpLore = pure
+  , rephraseLetBoundLore = pure
+  , rephraseFParamLore = pure
+  , rephraseLParamLore = pure
+  , rephraseBodyLore = pure
+  , rephraseRetType = pure
+  , rephraseBranchType = pure
+  , rephraseOp = soacToSegOp
+  }
+
+extractMulticore :: Pass SOACS MC
+extractMulticore =
+  Pass { passName = "extract multicore parallelism"
+       , passDescription = "Extract multicore parallelism"
+       , passFunction = rephraseProg rephraser
+       }

--- a/src/Futhark/Pass/Simplify.hs
+++ b/src/Futhark/Pass/Simplify.hs
@@ -3,9 +3,11 @@ module Futhark.Pass.Simplify
   ( simplify
   , simplifySOACS
   , simplifySeq
+  , simplifyMC
   , simplifyKernels
   , simplifyKernelsMem
   , simplifySeqMem
+  , simplifyMCMem
   )
   where
 
@@ -14,8 +16,10 @@ import qualified Futhark.Representation.SOACS.Simplify as R
 import qualified Futhark.Representation.Kernels as R
 import qualified Futhark.Representation.Kernels.Simplify as R
 import qualified Futhark.Representation.Seq as R
+import qualified Futhark.Representation.MC as MC
 import qualified Futhark.Representation.KernelsMem as KernelsMem
 import qualified Futhark.Representation.SeqMem as SeqMem
+import qualified Futhark.Representation.MCMem as MCMem
 
 import Futhark.Pass
 import Futhark.Representation.AST.Syntax
@@ -33,8 +37,14 @@ simplifyKernels = simplify R.simplifyKernels
 simplifySeq :: Pass R.Seq R.Seq
 simplifySeq = simplify R.simplifyProg
 
+simplifyMC :: Pass MC.MC MC.MC
+simplifyMC = simplify MC.simplifyProg
+
 simplifyKernelsMem :: Pass KernelsMem.KernelsMem KernelsMem.KernelsMem
 simplifyKernelsMem = simplify KernelsMem.simplifyProg
 
 simplifySeqMem :: Pass SeqMem.SeqMem SeqMem.SeqMem
 simplifySeqMem = simplify SeqMem.simplifyProg
+
+simplifyMCMem :: Pass MCMem.MCMem MCMem.MCMem
+simplifyMCMem = simplify MCMem.simplifyProg

--- a/src/Futhark/Representation/AST/Attributes.hs
+++ b/src/Futhark/Representation/AST/Attributes.hs
@@ -31,6 +31,7 @@ module Futhark.Representation.AST.Attributes
   , certify
   , expExtTypesFromPattern
 
+  , ASTConstraints
   , IsOp (..)
   , Attributes (..)
   )
@@ -175,13 +176,13 @@ stmCerts = stmAuxCerts . stmAux
 certify :: Certificates -> Stm lore -> Stm lore
 certify cs1 (Let pat (StmAux cs2 attr) e) = Let pat (StmAux (cs2<>cs1) attr) e
 
+-- | A handy shorthand for properties that we usually want to things
+-- we stuff into ASTs.
+type ASTConstraints a =
+  (Eq a, Ord a, Show a, Rename a, Substitute a, FreeIn a, Pretty a)
+
 -- | A type class for operations.
-class (Eq op, Ord op, Show op,
-       TypedOp op,
-       Rename op,
-       Substitute op,
-       FreeIn op,
-       Pretty op) => IsOp op where
+class (ASTConstraints op, TypedOp op) => IsOp op where
   -- | Like 'safeExp', but for arbitrary ops.
   safeOp :: op -> Bool
   -- | Should we try to hoist this out of branches?

--- a/src/Futhark/Representation/AST/Attributes/Types.hs
+++ b/src/Futhark/Representation/AST/Attributes/Types.hs
@@ -43,6 +43,7 @@ module Futhark.Representation.AST.Attributes.Types
        , toDecl
        , fromDecl
 
+       , isExt
        , extractShapeContext
        , shapeContext
        , hasStaticShape
@@ -325,6 +326,10 @@ fromDecl :: TypeBase shape Uniqueness
 fromDecl (Prim bt) = Prim bt
 fromDecl (Array et shape _) = Array et shape NoUniqueness
 fromDecl (Mem space) = Mem space
+
+isExt :: Ext a -> Maybe Int
+isExt (Ext i) = Just i
+isExt _ = Nothing
 
 -- | Given the existential return type of a function, and the shapes
 -- of the values returned by the function, return the existential

--- a/src/Futhark/Representation/Kernels/Kernel.hs
+++ b/src/Futhark/Representation/Kernels/Kernel.hs
@@ -3,358 +3,46 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 module Futhark.Representation.Kernels.Kernel
-       ( HistOp(..)
-       , histType
-       , SegRedOp(..)
-       , segRedResults
-       , KernelBody(..)
-       , aliasAnalyseKernelBody
-       , consumedInKernelBody
-       , ResultManifest(..)
-       , KernelResult(..)
-       , kernelResultSubExp
-       , SplitOrdering(..)
+  ( -- * Size operations
+    SizeOp(..)
 
-       -- * Segmented operations
-       , SegOp(..)
-       , SegLevel(..)
-       , SegVirt(..)
-       , segLevel
-       , segSpace
-       , typeCheckSegOp
-       , SegSpace(..)
-       , scopeOfSegSpace
-       , segSpaceDims
+    -- * Host operations
+  , HostOp(..)
+  , typeCheckHostOp
 
-       -- ** Generic traversal
-       , SegOpMapper(..)
-       , identitySegOpMapper
-       , mapSegOpM
+    -- * SegOp refinements
+  , SegLevel(..)
 
-       -- * Size operations
-       , SizeOp(..)
-
-       -- * Host operations
-       , HostOp(..)
-       , typeCheckHostOp
-
-       -- * Reexports
-       , module Futhark.Representation.Kernels.Sizes
-       )
-       where
-
-import Control.Arrow (first)
-import Control.Monad.State.Strict
-import Control.Monad.Writer hiding (mapM_)
-import Control.Monad.Identity hiding (mapM_)
-import qualified Data.Map.Strict as M
-import Data.List (intersperse)
+    -- * Reexports
+  , module Futhark.Representation.Kernels.Sizes
+  , module Futhark.Representation.SegOp
+  )
+where
 
 import Futhark.Representation.AST
-import qualified Futhark.Analysis.Alias as Alias
 import qualified Futhark.Analysis.ScalExp as SE
 import qualified Futhark.Analysis.SymbolTable as ST
-import Futhark.Analysis.PrimExp.Convert
 import qualified Futhark.Util.Pretty as PP
 import Futhark.Util.Pretty
-  ((</>), (<+>), ppr, commasep, Pretty, parens, text)
+  ((</>), (<+>), ppr, commasep, parens, text)
 import Futhark.Transform.Substitute
 import Futhark.Transform.Rename
 import Futhark.Optimise.Simplify.Lore
+import qualified Futhark.Optimise.Simplify.Engine as Engine
 import Futhark.Representation.Ranges
-  (Ranges, removeLambdaRanges, removeStmRanges, mkBodyRanges)
+  (Ranges)
 import Futhark.Representation.AST.Attributes.Ranges
 import Futhark.Representation.AST.Attributes.Aliases
 import Futhark.Representation.Aliases
-  (Aliases, removeLambdaAliases, removeStmAliases)
+  (Aliases)
+import Futhark.Representation.SegOp
 import Futhark.Representation.Kernels.Sizes
 import qualified Futhark.TypeCheck as TC
 import Futhark.Analysis.Metrics
-import qualified Futhark.Analysis.Range as Range
-import Futhark.Util (maybeNth)
-
--- | How an array is split into chunks.
-data SplitOrdering = SplitContiguous
-                   | SplitStrided SubExp
-                   deriving (Eq, Ord, Show)
-
-instance FreeIn SplitOrdering where
-  freeIn' SplitContiguous = mempty
-  freeIn' (SplitStrided stride) = freeIn' stride
-
-instance Substitute SplitOrdering where
-  substituteNames _ SplitContiguous =
-    SplitContiguous
-  substituteNames subst (SplitStrided stride) =
-    SplitStrided $ substituteNames subst stride
-
-instance Rename SplitOrdering where
-  rename SplitContiguous =
-    pure SplitContiguous
-  rename (SplitStrided stride) =
-    SplitStrided <$> rename stride
-
-data HistOp lore =
-  HistOp { histWidth :: SubExp
-         , histRaceFactor :: SubExp
-         , histDest :: [VName]
-         , histNeutral :: [SubExp]
-         , histShape :: Shape
-           -- ^ In case this operator is semantically a vectorised
-           -- operator (corresponding to a perfect map nest in the
-           -- SOACS representation), these are the logical
-           -- "dimensions".  This is used to generate more efficient
-           -- code.
-         , histOp :: Lambda lore
-         }
-  deriving (Eq, Ord, Show)
-
--- | The type of a histogram produced by a 'HistOp'.  This can be
--- different from the type of the 'HistDest's in case we are
--- dealing with a segmented histogram.
-histType :: HistOp lore -> [Type]
-histType op = map ((`arrayOfRow` histWidth op) .
-                        (`arrayOfShape` histShape op)) $
-                   lambdaReturnType $ histOp op
-
-data SegRedOp lore =
-  SegRedOp { segRedComm :: Commutativity
-           , segRedLambda :: Lambda lore
-           , segRedNeutral :: [SubExp]
-           , segRedShape :: Shape
-             -- ^ In case this operator is semantically a vectorised
-             -- operator (corresponding to a perfect map nest in the
-             -- SOACS representation), these are the logical
-             -- "dimensions".  This is used to generate more efficient
-             -- code.
-           }
-  deriving (Eq, Ord, Show)
-
--- | How many reduction results are produced by these 'SegRedOp's?
-segRedResults :: [SegRedOp lore] -> Int
-segRedResults = sum . map (length . segRedNeutral)
--- | The body of a 'Kernel'.
-data KernelBody lore = KernelBody { kernelBodyLore :: BodyAttr lore
-                                  , kernelBodyStms :: Stms lore
-                                  , kernelBodyResult :: [KernelResult]
-                                  }
-
-deriving instance Annotations lore => Ord (KernelBody lore)
-deriving instance Annotations lore => Show (KernelBody lore)
-deriving instance Annotations lore => Eq (KernelBody lore)
-
--- | Metadata about whether there is a subtle point to this
--- 'KernelResult'.  This is used to protect things like tiling, which
--- might otherwise be removed by the simplifier because they're
--- semantically redundant.  This has no semantic effect and can be
--- ignored at code generation.
-data ResultManifest
-  = ResultNoSimplify
-    -- ^ Don't simplify this one!
-  | ResultMaySimplify
-    -- ^ Go nuts.
-  | ResultPrivate
-    -- ^ The results produced are only used within the
-    -- same physical thread later on, and can thus be
-    -- kept in registers.
-  deriving (Eq, Show, Ord)
-
-data KernelResult = Returns ResultManifest SubExp
-                    -- ^ Each "worker" in the kernel returns this.
-                    -- Whether this is a result-per-thread or a
-                    -- result-per-group depends on the 'SegLevel'.
-                  | WriteReturns
-                    [SubExp] -- Size of array.  Must match number of dims.
-                    VName -- Which array
-                    [([SubExp], SubExp)]
-                    -- Arbitrary number of index/value pairs.
-                  | ConcatReturns
-                    SplitOrdering -- Permuted?
-                    SubExp -- The final size.
-                    SubExp -- Per-thread/group (max) chunk size.
-                    VName -- Chunk by this worker.
-                  | TileReturns
-                    [(SubExp, SubExp)] -- Total/tile for each dimension
-                    VName -- Tile written by this worker.
-                    -- The TileReturns must not expect more than one
-                    -- result to be written per physical thread.
-                  deriving (Eq, Show, Ord)
-
-kernelResultSubExp :: KernelResult -> SubExp
-kernelResultSubExp (Returns _ se) = se
-kernelResultSubExp (WriteReturns _ arr _) = Var arr
-kernelResultSubExp (ConcatReturns _ _ _ v) = Var v
-kernelResultSubExp (TileReturns _ v) = Var v
-
-instance FreeIn KernelResult where
-  freeIn' (Returns _ what) = freeIn' what
-  freeIn' (WriteReturns rws arr res) = freeIn' rws <> freeIn' arr <> freeIn' res
-  freeIn' (ConcatReturns o w per_thread_elems v) =
-    freeIn' o <> freeIn' w <> freeIn' per_thread_elems <> freeIn' v
-  freeIn' (TileReturns dims v) =
-    freeIn' dims <> freeIn' v
-
-instance Attributes lore => FreeIn (KernelBody lore) where
-  freeIn' (KernelBody attr stms res) =
-    fvBind bound_in_stms $ freeIn' attr <> freeIn' stms <> freeIn' res
-    where bound_in_stms = foldMap boundByStm stms
-
-instance Attributes lore => Substitute (KernelBody lore) where
-  substituteNames subst (KernelBody attr stms res) =
-    KernelBody
-    (substituteNames subst attr)
-    (substituteNames subst stms)
-    (substituteNames subst res)
-
-instance Substitute KernelResult where
-  substituteNames subst (Returns manifest se) =
-    Returns manifest (substituteNames subst se)
-  substituteNames subst (WriteReturns rws arr res) =
-    WriteReturns
-    (substituteNames subst rws) (substituteNames subst arr)
-    (substituteNames subst res)
-  substituteNames subst (ConcatReturns o w per_thread_elems v) =
-    ConcatReturns
-    (substituteNames subst o)
-    (substituteNames subst w)
-    (substituteNames subst per_thread_elems)
-    (substituteNames subst v)
-  substituteNames subst (TileReturns dims v) =
-    TileReturns (substituteNames subst dims) (substituteNames subst v)
-
-instance Attributes lore => Rename (KernelBody lore) where
-  rename (KernelBody attr stms res) = do
-    attr' <- rename attr
-    renamingStms stms $ \stms' ->
-      KernelBody attr' stms' <$> rename res
-
-instance Rename KernelResult where
-  rename = substituteRename
-
-aliasAnalyseKernelBody :: (Attributes lore,
-                           CanBeAliased (Op lore)) =>
-                          KernelBody lore
-                       -> KernelBody (Aliases lore)
-aliasAnalyseKernelBody (KernelBody attr stms res) =
-  let Body attr' stms' _ = Alias.analyseBody mempty $ Body attr stms []
-  in KernelBody attr' stms' res
-
-removeKernelBodyAliases :: CanBeAliased (Op lore) =>
-                           KernelBody (Aliases lore) -> KernelBody lore
-removeKernelBodyAliases (KernelBody (_, attr) stms res) =
-  KernelBody attr (fmap removeStmAliases stms) res
-
-addKernelBodyRanges :: (Attributes lore, CanBeRanged (Op lore)) =>
-                       KernelBody lore -> Range.RangeM (KernelBody (Ranges lore))
-addKernelBodyRanges (KernelBody attr stms res) =
-  Range.analyseStms stms $ \stms' -> do
-  let attr' = (mkBodyRanges stms $ map kernelResultSubExp res, attr)
-  return $ KernelBody attr' stms' res
-
-removeKernelBodyRanges :: CanBeRanged (Op lore) =>
-                          KernelBody (Ranges lore) -> KernelBody lore
-removeKernelBodyRanges (KernelBody (_, attr) stms res) =
-  KernelBody attr (fmap removeStmRanges stms) res
-
-removeKernelBodyWisdom :: CanBeWise (Op lore) =>
-                          KernelBody (Wise lore) -> KernelBody lore
-removeKernelBodyWisdom (KernelBody attr stms res) =
-  let Body attr' stms' _ = removeBodyWisdom $ Body attr stms []
-  in KernelBody attr' stms' res
-
-consumedInKernelBody :: Aliased lore =>
-                        KernelBody lore -> Names
-consumedInKernelBody (KernelBody attr stms res) =
-  consumedInBody (Body attr stms []) <> mconcat (map consumedByReturn res)
-  where consumedByReturn (WriteReturns _ a _) = oneName a
-        consumedByReturn _                    = mempty
-
-checkKernelBody :: TC.Checkable lore =>
-                   [Type] -> KernelBody (Aliases lore) -> TC.TypeM lore ()
-checkKernelBody ts (KernelBody (_, attr) stms kres) = do
-  TC.checkBodyLore attr
-  TC.checkStms stms $ do
-    unless (length ts == length kres) $
-      TC.bad $ TC.TypeError $ "Kernel return type is " ++ prettyTuple ts ++
-      ", but body returns " ++ show (length kres) ++ " values."
-    zipWithM_ checkKernelResult kres ts
-
-  where checkKernelResult (Returns _ what) t =
-          TC.require [t] what
-        checkKernelResult (WriteReturns rws arr res) t = do
-          mapM_ (TC.require [Prim int32]) rws
-          arr_t <- lookupType arr
-          forM_ res $ \(is, e) -> do
-            mapM_ (TC.require [Prim int32]) is
-            TC.require [t] e
-            unless (arr_t == t `arrayOfShape` Shape rws) $
-              TC.bad $ TC.TypeError $ "WriteReturns returning " ++
-              pretty e ++ " of type " ++ pretty t ++ ", shape=" ++ pretty rws ++
-              ", but destination array has type " ++ pretty arr_t
-          TC.consume =<< TC.lookupAliases arr
-        checkKernelResult (ConcatReturns o w per_thread_elems v) t = do
-          case o of
-            SplitContiguous     -> return ()
-            SplitStrided stride -> TC.require [Prim int32] stride
-          TC.require [Prim int32] w
-          TC.require [Prim int32] per_thread_elems
-          vt <- lookupType v
-          unless (vt == t `arrayOfRow` arraySize 0 vt) $
-            TC.bad $ TC.TypeError $ "Invalid type for ConcatReturns " ++ pretty v
-        checkKernelResult (TileReturns dims v) t = do
-          forM_ dims $ \(dim, tile) -> do
-            TC.require [Prim int32] dim
-            TC.require [Prim int32] tile
-          vt <- lookupType v
-          unless (vt == t `arrayOfShape` Shape (map snd dims)) $
-            TC.bad $ TC.TypeError $ "Invalid type for TileReturns " ++ pretty v
-
-kernelBodyMetrics :: OpMetrics (Op lore) => KernelBody lore -> MetricsM ()
-kernelBodyMetrics = mapM_ bindingMetrics . kernelBodyStms
-
-instance PrettyLore lore => Pretty (KernelBody lore) where
-  ppr (KernelBody _ stms res) =
-    PP.stack (map ppr (stmsToList stms)) </>
-    text "return" <+> PP.braces (PP.commasep $ map ppr res)
-
-instance Pretty KernelResult where
-  ppr (Returns ResultNoSimplify what) =
-    text "returns (manifest)" <+> ppr what
-  ppr (Returns ResultPrivate what) =
-    text "returns (private)" <+> ppr what
-  ppr (Returns ResultMaySimplify what) =
-    text "returns" <+> ppr what
-  ppr (WriteReturns rws arr res) =
-    ppr arr <+> text "with" <+> PP.apply (map ppRes res)
-    where ppRes (is, e) =
-            PP.brackets (PP.commasep $ zipWith f is rws) <+> text "<-" <+> ppr e
-          f i rw = ppr i <+> text "<" <+> ppr rw
-  ppr (ConcatReturns o w per_thread_elems v) =
-    text "concat" <> suff <>
-    parens (commasep [ppr w, ppr per_thread_elems]) <+> ppr v
-    where suff = case o of SplitContiguous     -> mempty
-                           SplitStrided stride -> text "Strided" <> parens (ppr stride)
-  ppr (TileReturns dims v) =
-    text "tile" <>
-    parens (commasep $ map onDim dims) <+> ppr v
-    where onDim (dim, tile) = ppr dim <+> text "/" <+> ppr tile
-
---- Segmented operations
-
--- | Do we need group-virtualisation when generating code for the
--- segmented operation?  In most cases, we do, but for some simple
--- kernels, we compute the full number of groups in advance, and then
--- virtualisation is an unnecessary (but generally very small)
--- overhead.  This only really matters for fairly trivial but very
--- wide @map@ kernels where each thread performs constant-time work on
--- scalars.
-data SegVirt = SegVirt | SegNoVirt
-             deriving (Eq, Ord, Show)
 
 -- | At which level the *body* of a 'SegOp' executes.
 data SegLevel = SegThread { segNumGroups :: Count NumGroups SubExp
@@ -365,468 +53,42 @@ data SegLevel = SegThread { segNumGroups :: Count NumGroups SubExp
                          , segVirt :: SegVirt }
               deriving (Eq, Ord, Show)
 
--- | Index space of a 'SegOp'.
-data SegSpace = SegSpace { segFlat :: VName
-                         -- ^ Flat physical index corresponding to the
-                         -- dimensions (at code generation used for a
-                         -- thread ID or similar).
-                         , unSegSpace :: [(VName, SubExp)]
-                         }
-              deriving (Eq, Ord, Show)
-
-
-segSpaceDims :: SegSpace -> [SubExp]
-segSpaceDims (SegSpace _ space) = map snd space
-
-scopeOfSegSpace :: SegSpace -> Scope lore
-scopeOfSegSpace (SegSpace phys space) =
-  M.fromList $ zip (phys : map fst space) $ repeat $ IndexInfo Int32
-
-checkSegSpace :: TC.Checkable lore => SegSpace -> TC.TypeM lore ()
-checkSegSpace (SegSpace _ dims) =
-  mapM_ (TC.require [Prim int32] . snd) dims
-
-data SegOp lore = SegMap SegLevel SegSpace [Type] (KernelBody lore)
-                | SegRed SegLevel SegSpace [SegRedOp lore] [Type] (KernelBody lore)
-                  -- ^ The KernelSpace must always have at least two dimensions,
-                  -- implying that the result of a SegRed is always an array.
-                | SegScan SegLevel SegSpace (Lambda lore) [SubExp] [Type] (KernelBody lore)
-                | SegHist SegLevel SegSpace [HistOp lore] [Type] (KernelBody lore)
-                deriving (Eq, Ord, Show)
-
-segLevel :: SegOp lore -> SegLevel
-segLevel (SegMap lvl _ _ _) = lvl
-segLevel (SegRed lvl _ _ _ _) = lvl
-segLevel (SegScan lvl _ _ _ _ _) = lvl
-segLevel (SegHist lvl _ _ _ _) = lvl
-
-segSpace :: SegOp lore -> SegSpace
-segSpace (SegMap _ lvl _ _) = lvl
-segSpace (SegRed _ lvl _ _ _) = lvl
-segSpace (SegScan _ lvl _ _ _ _) = lvl
-segSpace (SegHist _ lvl _ _ _) = lvl
-
-segResultShape :: SegSpace -> Type -> KernelResult -> Type
-segResultShape _ t (WriteReturns rws _ _) =
-  t `arrayOfShape` Shape rws
-segResultShape space t (Returns _ _) =
-  foldr (flip arrayOfRow) t $ segSpaceDims space
-segResultShape _ t (ConcatReturns _ w _ _) =
-  t `arrayOfRow` w
-segResultShape _ t (TileReturns dims _) =
-  t `arrayOfShape` Shape (map fst dims)
-
-segOpType :: SegOp lore -> [Type]
-segOpType (SegMap _ space ts kbody) =
-  zipWith (segResultShape space) ts $ kernelBodyResult kbody
-segOpType (SegRed _ space reds ts kbody) =
-  red_ts ++
-  zipWith (segResultShape space) map_ts
-  (drop (length red_ts) $ kernelBodyResult kbody)
-  where map_ts = drop (length red_ts) ts
-        segment_dims = init $ segSpaceDims space
-        red_ts = do
-          op <- reds
-          let shape = Shape segment_dims <> segRedShape op
-          map (`arrayOfShape` shape) (lambdaReturnType $ segRedLambda op)
-segOpType (SegScan _ space _ nes ts kbody) =
-  map (`arrayOfShape` Shape dims) scan_ts ++
-  zipWith (segResultShape space) map_ts
-  (drop (length scan_ts) $ kernelBodyResult kbody)
-  where dims = segSpaceDims space
-        (scan_ts, map_ts) = splitAt (length nes) ts
-segOpType (SegHist _ space ops _ _) = do
-  op <- ops
-  let shape = Shape (segment_dims <> [histWidth op]) <> histShape op
-  map (`arrayOfShape` shape) (lambdaReturnType $ histOp op)
-  where dims = segSpaceDims space
-        segment_dims = init dims
-
-instance TypedOp (SegOp lore) where
-  opType = pure . staticShapes . segOpType
-
-instance (Attributes lore, Aliased lore) => AliasedOp (SegOp lore) where
-  opAliases = map (const mempty) . segOpType
-
-  consumedInOp (SegMap _ _ _ kbody) =
-    consumedInKernelBody kbody
-  consumedInOp (SegRed _ _ _ _ kbody) =
-    consumedInKernelBody kbody
-  consumedInOp (SegScan _ _ _ _ _ kbody) =
-    consumedInKernelBody kbody
-  consumedInOp (SegHist _ _ ops _ kbody) =
-    namesFromList (concatMap histDest ops) <> consumedInKernelBody kbody
-
-checkSegLevel :: Maybe SegLevel -> SegLevel -> TC.TypeM lore ()
-checkSegLevel Nothing _ =
-  return ()
-checkSegLevel (Just SegThread{}) _ =
-  TC.bad $ TC.TypeError "SegOps cannot occur when already at thread level."
-checkSegLevel (Just x) y
-  | x == y = TC.bad $ TC.TypeError $ "Already at at level " ++ pretty x
-  | segNumGroups x /= segNumGroups y || segGroupSize x /= segGroupSize y =
-      TC.bad $ TC.TypeError "Physical layout for SegLevel does not match parent SegLevel."
-  | otherwise =
-      return ()
-
-checkSegBasics :: TC.Checkable lore =>
-                  Maybe SegLevel -> SegLevel -> SegSpace -> [Type] -> TC.TypeM lore ()
-checkSegBasics cur_lvl lvl space ts = do
-  checkSegLevel cur_lvl lvl
-  checkSegSpace space
-  mapM_ TC.checkType ts
-
-typeCheckSegOp :: TC.Checkable lore =>
-                  Maybe SegLevel -> SegOp (Aliases lore) -> TC.TypeM lore ()
-typeCheckSegOp cur_lvl (SegMap lvl space ts kbody) =
-  checkScanRed cur_lvl lvl space [] ts kbody
-
-typeCheckSegOp cur_lvl (SegRed lvl space reds ts body) =
-  checkScanRed cur_lvl lvl space reds' ts body
-  where reds' = zip3
-                (map segRedLambda reds)
-                (map segRedNeutral reds)
-                (map segRedShape reds)
-
-typeCheckSegOp cur_lvl (SegScan lvl space scan_op nes ts body) =
-  checkScanRed cur_lvl lvl space [(scan_op, nes, mempty)] ts body
-
-typeCheckSegOp cur_lvl (SegHist lvl space ops ts kbody) = do
-  checkSegBasics cur_lvl lvl space ts
-
-  TC.binding (scopeOfSegSpace space) $ do
-    nes_ts <- forM ops $ \(HistOp dest_w rf dests nes shape op) -> do
-      TC.require [Prim int32] dest_w
-      TC.require [Prim int32] rf
-      nes' <- mapM TC.checkArg nes
-      mapM_ (TC.require [Prim int32]) $ shapeDims shape
-
-      -- Operator type must match the type of neutral elements.
-      let stripVecDims = stripArray $ shapeRank shape
-      TC.checkLambda op $ map (TC.noArgAliases . first stripVecDims) $ nes' ++ nes'
-      let nes_t = map TC.argType nes'
-      unless (nes_t == lambdaReturnType op) $
-        TC.bad $ TC.TypeError $ "SegHist operator has return type " ++
-        prettyTuple (lambdaReturnType op) ++ " but neutral element has type " ++
-        prettyTuple nes_t
-
-      -- Arrays must have proper type.
-      let dest_shape = Shape (segment_dims <> [dest_w]) <> shape
-      forM_ (zip nes_t dests) $ \(t, dest) -> do
-        TC.requireI [t `arrayOfShape` dest_shape] dest
-        TC.consume =<< TC.lookupAliases dest
-
-      return $ map (`arrayOfShape` shape) nes_t
-
-    checkKernelBody ts kbody
-
-    -- Return type of bucket function must be an index for each
-    -- operation followed by the values to write.
-    let bucket_ret_t = replicate (length ops) (Prim int32) ++ concat nes_ts
-    unless (bucket_ret_t == ts) $
-      TC.bad $ TC.TypeError $ "SegHist body has return type " ++
-      prettyTuple ts ++ " but should have type " ++
-      prettyTuple bucket_ret_t
-
-  where segment_dims = init $ segSpaceDims space
-
-checkScanRed :: TC.Checkable lore =>
-                Maybe SegLevel -> SegLevel
-             -> SegSpace
-             -> [(Lambda (Aliases lore), [SubExp], Shape)]
-             -> [Type]
-             -> KernelBody (Aliases lore)
-             -> TC.TypeM lore ()
-checkScanRed cur_lvl lvl space ops ts kbody = do
-  checkSegBasics cur_lvl lvl space ts
-
-  TC.binding (scopeOfSegSpace space) $ do
-    ne_ts <- forM ops $ \(lam, nes, shape) -> do
-      mapM_ (TC.require [Prim int32]) $ shapeDims shape
-      nes' <- mapM TC.checkArg nes
-
-      -- Operator type must match the type of neutral elements.
-      let stripVecDims = stripArray $ shapeRank shape
-      TC.checkLambda lam $ map (TC.noArgAliases . first stripVecDims) $ nes' ++ nes'
-      let nes_t = map TC.argType nes'
-
-      unless (lambdaReturnType lam == nes_t) $
-        TC.bad $ TC.TypeError "wrong type for operator or neutral elements."
-
-      return $ map (`arrayOfShape` shape) nes_t
-
-    let expecting = concat ne_ts
-        got = take (length expecting) ts
-    unless (expecting == got) $
-      TC.bad $ TC.TypeError $
-      "Wrong return for body (does not match neutral elements; expected " ++
-      pretty expecting ++ "; found " ++
-      pretty got ++ ")"
-
-    checkKernelBody ts kbody
-
--- | Like 'Mapper', but just for 'SegOp's.
-data SegOpMapper flore tlore m = SegOpMapper {
-    mapOnSegOpSubExp :: SubExp -> m SubExp
-  , mapOnSegOpLambda :: Lambda flore -> m (Lambda tlore)
-  , mapOnSegOpBody :: KernelBody flore -> m (KernelBody tlore)
-  , mapOnSegOpVName :: VName -> m VName
-  }
-
--- | A mapper that simply returns the 'SegOp' verbatim.
-identitySegOpMapper :: Monad m => SegOpMapper lore lore m
-identitySegOpMapper = SegOpMapper { mapOnSegOpSubExp = return
-                                  , mapOnSegOpLambda = return
-                                  , mapOnSegOpBody = return
-                                  , mapOnSegOpVName = return
-                                  }
-
-mapOnSegSpace :: Monad f =>
-                 SegOpMapper flore tlore f -> SegSpace -> f SegSpace
-mapOnSegSpace tv (SegSpace phys dims) =
-  SegSpace phys <$> traverse (traverse $ mapOnSegOpSubExp tv) dims
-
-mapSegOpM :: (Applicative m, Monad m) =>
-              SegOpMapper flore tlore m -> SegOp flore -> m (SegOp tlore)
-mapSegOpM tv (SegMap lvl space ts body) =
-  SegMap
-  <$> mapOnSegLevel tv lvl
-  <*> mapOnSegSpace tv space
-  <*> mapM (mapOnSegOpType tv) ts
-  <*> mapOnSegOpBody tv body
-mapSegOpM tv (SegRed lvl space reds ts lam) =
-  SegRed
-  <$> mapOnSegLevel tv lvl
-  <*> mapOnSegSpace tv space
-  <*> mapM onSegOp reds
-  <*> mapM (mapOnType $ mapOnSegOpSubExp tv) ts
-  <*> mapOnSegOpBody tv lam
-  where onSegOp (SegRedOp comm red_op nes shape) =
-          SegRedOp comm
-          <$> mapOnSegOpLambda tv red_op
-          <*> mapM (mapOnSegOpSubExp tv) nes
-          <*> (Shape <$> mapM (mapOnSegOpSubExp tv) (shapeDims shape))
-mapSegOpM tv (SegScan lvl space scan_op nes ts body) =
-  SegScan
-  <$> mapOnSegLevel tv lvl
-  <*> mapOnSegSpace tv space
-  <*> mapOnSegOpLambda tv scan_op
-  <*> mapM (mapOnSegOpSubExp tv) nes
-  <*> mapM (mapOnType $ mapOnSegOpSubExp tv) ts
-  <*> mapOnSegOpBody tv body
-mapSegOpM tv (SegHist lvl space ops ts body) =
-  SegHist
-  <$> mapOnSegLevel tv lvl
-  <*> mapOnSegSpace tv space
-  <*> mapM onHistOp ops
-  <*> mapM (mapOnType $ mapOnSegOpSubExp tv) ts
-  <*> mapOnSegOpBody tv body
-  where onHistOp (HistOp w rf arrs nes shape op) =
-          HistOp <$> mapOnSegOpSubExp tv w
-          <*> mapOnSegOpSubExp tv rf
-          <*> mapM (mapOnSegOpVName tv) arrs
-          <*> mapM (mapOnSegOpSubExp tv) nes
-          <*> (Shape <$> mapM (mapOnSegOpSubExp tv) (shapeDims shape))
-          <*> mapOnSegOpLambda tv op
-
-mapOnSegLevel :: Monad m =>
-                 SegOpMapper flore tlore m -> SegLevel -> m SegLevel
-mapOnSegLevel tv (SegThread num_groups group_size virt) =
-  SegThread
-  <$> traverse (mapOnSegOpSubExp tv) num_groups
-  <*> traverse (mapOnSegOpSubExp tv) group_size
-  <*> pure virt
-mapOnSegLevel tv (SegGroup num_groups group_size virt) =
-  SegGroup
-  <$> traverse (mapOnSegOpSubExp tv) num_groups
-  <*> traverse (mapOnSegOpSubExp tv) group_size
-  <*> pure virt
-
-mapOnSegOpType :: Monad m =>
-                  SegOpMapper flore tlore m -> Type -> m Type
-mapOnSegOpType _tv (Prim pt) = pure $ Prim pt
-mapOnSegOpType tv (Array pt shape u) = Array pt <$> f shape <*> pure u
-  where f (Shape dims) = Shape <$> mapM (mapOnSegOpSubExp tv) dims
-mapOnSegOpType _tv (Mem s) = pure $ Mem s
-
-instance Attributes lore => Substitute (SegOp lore) where
-  substituteNames subst = runIdentity . mapSegOpM substitute
-    where substitute =
-            SegOpMapper { mapOnSegOpSubExp = return . substituteNames subst
-                        , mapOnSegOpLambda = return . substituteNames subst
-                        , mapOnSegOpBody = return . substituteNames subst
-                        , mapOnSegOpVName = return . substituteNames subst
-                        }
-
-instance Attributes lore => Rename (SegOp lore) where
-  rename = mapSegOpM renamer
-    where renamer = SegOpMapper rename rename rename rename
-
-instance (Attributes lore, FreeIn (LParamAttr lore)) =>
-         FreeIn (SegOp lore) where
-  freeIn' e = flip execState mempty $ mapSegOpM free e
-    where walk f x = modify (<>f x) >> return x
-          free = SegOpMapper { mapOnSegOpSubExp = walk freeIn'
-                             , mapOnSegOpLambda = walk freeIn'
-                             , mapOnSegOpBody = walk freeIn'
-                             , mapOnSegOpVName = walk freeIn'
-                             }
-
-instance OpMetrics (Op lore) => OpMetrics (SegOp lore) where
-  opMetrics (SegMap _ _ _ body) =
-    inside "SegMap" $ kernelBodyMetrics body
-  opMetrics (SegRed _ _ reds _ body) =
-    inside "SegRed" $ do mapM_ (lambdaMetrics . segRedLambda) reds
-                         kernelBodyMetrics body
-  opMetrics (SegScan _ _ scan_op _ _ body) =
-    inside "SegScan" $ lambdaMetrics scan_op >> kernelBodyMetrics body
-  opMetrics (SegHist _ _ ops _ body) =
-    inside "SegHist" $ do mapM_ (lambdaMetrics . histOp) ops
-                          kernelBodyMetrics body
-
-instance Pretty SegSpace where
-  ppr (SegSpace phys dims) = parens (commasep $ do (i,d) <- dims
-                                                   return $ ppr i <+> "<" <+> ppr d) <+>
-                             parens (text "~" <> ppr phys)
-
 instance PP.Pretty SegLevel where
-  ppr SegThread{} = "thread"
-  ppr SegGroup{} = "group"
+  ppr lvl =
+    lvl' </>
+    PP.parens (text "#groups=" <> ppr (segNumGroups lvl) <> PP.semi <+>
+               text "groupsize=" <> ppr (segGroupSize lvl) <>
+               case segVirt lvl of
+                 SegNoVirt -> mempty
+                 SegVirt -> PP.semi <+> text "virtualise")
 
-ppSegLevel :: SegLevel -> PP.Doc
-ppSegLevel lvl =
-  PP.parens $
-  text "#groups=" <> ppr (segNumGroups lvl) <> PP.semi <+>
-  text "groupsize=" <> ppr (segGroupSize lvl) <>
-  case segVirt lvl of
-    SegNoVirt -> mempty
-    SegVirt -> PP.semi <+> text "virtualise"
+    where lvl' = case lvl of SegThread{} -> "_thread"
+                             SegGroup{} -> "_group"
 
-instance PrettyLore lore => PP.Pretty (SegOp lore) where
-  ppr (SegMap lvl space ts body) =
-    text "segmap_" <> ppr lvl </>
-    ppSegLevel lvl </>
-    PP.align (ppr space) <+>
-    PP.colon <+> ppTuple' ts <+> PP.nestedBlock "{" "}" (ppr body)
+instance Engine.Simplifiable SegLevel where
+  simplify (SegThread num_groups group_size virt) =
+    SegThread <$> traverse Engine.simplify num_groups <*>
+    traverse Engine.simplify group_size <*> pure virt
+  simplify (SegGroup num_groups group_size virt) =
+    SegGroup <$> traverse Engine.simplify num_groups <*>
+    traverse Engine.simplify group_size <*> pure virt
 
-  ppr (SegRed lvl space reds ts body) =
-    text "segred_" <> ppr lvl </>
-    ppSegLevel lvl </>
-    PP.parens (PP.braces (mconcat $ intersperse (PP.comma <> PP.line) $ map ppOp reds)) </>
-    PP.align (ppr space) <+> PP.colon <+> ppTuple' ts <+>
-    PP.nestedBlock "{" "}" (ppr body)
-    where ppOp (SegRedOp comm lam nes shape) =
-            PP.braces (PP.commasep $ map ppr nes) <> PP.comma </>
-            ppr shape <> PP.comma </>
-            comm' <> ppr lam
-            where comm' = case comm of Commutative -> text "commutative "
-                                       Noncommutative -> mempty
+instance Substitute SegLevel where
+  substituteNames substs (SegThread num_groups group_size virt) =
+    SegThread
+    (substituteNames substs num_groups) (substituteNames substs group_size) virt
+  substituteNames substs (SegGroup num_groups group_size virt) =
+    SegGroup
+    (substituteNames substs num_groups) (substituteNames substs group_size) virt
 
-  ppr (SegScan lvl space scan_op nes ts body) =
-    text "segscan_" <> ppr lvl </>
-    ppSegLevel lvl </>
-    PP.parens (ppr scan_op <> PP.comma </>
-               PP.braces (PP.commasep $ map ppr nes)) </>
-    PP.align (ppr space) <+> PP.colon <+> ppTuple' ts <+>
-    PP.nestedBlock "{" "}" (ppr body)
+instance Rename SegLevel where
+  rename = substituteRename
 
-  ppr (SegHist lvl space ops ts body) =
-    text "seghist_" <> ppr lvl </>
-    ppSegLevel lvl </>
-    PP.parens (PP.braces (mconcat $ intersperse (PP.comma <> PP.line) $ map ppOp ops)) </>
-    PP.align (ppr space) <+> PP.colon <+> ppTuple' ts <+>
-    PP.nestedBlock "{" "}" (ppr body)
-    where ppOp (HistOp w rf dests nes shape op) =
-            ppr w <> PP.comma <+> ppr rf <> PP.comma </>
-            PP.braces (PP.commasep $ map ppr dests) <> PP.comma </>
-            PP.braces (PP.commasep $ map ppr nes) <> PP.comma </>
-            ppr shape <> PP.comma </>
-            ppr op
-
-instance Attributes inner => RangedOp (SegOp inner) where
-  opRanges op = replicate (length $ segOpType op) unknownRange
-
-instance (Attributes lore, CanBeRanged (Op lore)) => CanBeRanged (SegOp lore) where
-  type OpWithRanges (SegOp lore) = SegOp (Ranges lore)
-
-  removeOpRanges = runIdentity . mapSegOpM remove
-    where remove = SegOpMapper return (return . removeLambdaRanges)
-                   (return . removeKernelBodyRanges) return
-  addOpRanges = Range.runRangeM . mapSegOpM add
-    where add = SegOpMapper return Range.analyseLambda
-                addKernelBodyRanges return
-
-instance (Attributes lore,
-          Attributes (Aliases lore),
-          CanBeAliased (Op lore)) => CanBeAliased (SegOp lore) where
-  type OpWithAliases (SegOp lore) = SegOp (Aliases lore)
-
-  addOpAliases = runIdentity . mapSegOpM alias
-    where alias = SegOpMapper return (return . Alias.analyseLambda)
-                  (return . aliasAnalyseKernelBody) return
-
-  removeOpAliases = runIdentity . mapSegOpM remove
-    where remove = SegOpMapper return (return . removeLambdaAliases)
-                   (return . removeKernelBodyAliases) return
-
-instance (CanBeWise (Op lore), Attributes lore) => CanBeWise (SegOp lore) where
-  type OpWithWisdom (SegOp lore) = SegOp (Wise lore)
-
-  removeOpWisdom = runIdentity . mapSegOpM remove
-    where remove = SegOpMapper return
-                   (return . removeLambdaWisdom)
-                   (return . removeKernelBodyWisdom)
-                   return
-
-instance Attributes lore => ST.IndexOp (SegOp lore) where
-  indexOp vtable k (SegMap _ space _ kbody) is = do
-    Returns ResultMaySimplify se <- maybeNth k $ kernelBodyResult kbody
-    guard $ length gtids <= length is
-    let idx_table = M.fromList $ zip gtids $ map (ST.Indexed mempty) is
-        idx_table' = foldl expandIndexedTable idx_table $ kernelBodyStms kbody
-    case se of
-      Var v -> M.lookup v idx_table'
-      _ -> Nothing
-
-    where (gtids, _) = unzip $ unSegSpace space
-          -- Indexes in excess of what is used to index through the
-          -- segment dimensions.
-          excess_is = drop (length gtids) is
-
-          expandIndexedTable table stm
-            | [v] <- patternNames $ stmPattern stm,
-              Just (pe,cs) <-
-                  runWriterT $ primExpFromExp (asPrimExp table) $ stmExp stm =
-                M.insert v (ST.Indexed (stmCerts stm <> cs) pe) table
-
-            | [v] <- patternNames $ stmPattern stm,
-              BasicOp (Index arr slice) <- stmExp stm,
-              length (sliceDims slice) == length excess_is,
-              arr `ST.elem` vtable,
-              Just (slice', cs) <- asPrimExpSlice table slice =
-                let idx = ST.IndexedArray (stmCerts stm <> cs)
-                          arr (fixSlice slice' excess_is)
-                in M.insert v idx table
-
-            | otherwise =
-                table
-
-          asPrimExpSlice table =
-            runWriterT . mapM (traverse (primExpFromSubExpM (asPrimExp table)))
-
-          asPrimExp table v
-            | Just (ST.Indexed cs e) <- M.lookup v table = tell cs >> return e
-            | Just (Prim pt) <- ST.lookupType v vtable =
-                return $ LeafExp v pt
-            | otherwise = lift Nothing
-
-  indexOp _ _ _ _ = Nothing
-
-instance Attributes lore => IsOp (SegOp lore) where
-  cheapOp _ = False
-  safeOp _ = True
-
---- Host operations
+instance FreeIn SegLevel where
+  freeIn' (SegThread num_groups group_size _) =
+    freeIn' num_groups <> freeIn' group_size
+  freeIn' (SegGroup num_groups group_size _) =
+    freeIn' num_groups <> freeIn' group_size
 
 -- | A simple size-level query or computation.
 data SizeOp
@@ -963,7 +225,7 @@ typeCheckSizeOp (CalcNumGroups w _ group_size) = do TC.require [Prim int64] w
 
 -- | A host-level operation; parameterised by what else it can do.
 data HostOp lore op
-  = SegOp (SegOp lore)
+  = SegOp (SegOp SegLevel lore)
     -- ^ A segmented operation.
   | SizeOp SizeOp
   | OtherOp op
@@ -1059,6 +321,18 @@ instance (OpMetrics (Op lore), OpMetrics op) => OpMetrics (HostOp lore op) where
   opMetrics (OtherOp op) = opMetrics op
   opMetrics (SizeOp op) = opMetrics op
 
+checkSegLevel :: Maybe SegLevel -> SegLevel -> TC.TypeM lore ()
+checkSegLevel Nothing _ =
+  return ()
+checkSegLevel (Just SegThread{}) _ =
+  TC.bad $ TC.TypeError "SegOps cannot occur when already at thread level."
+checkSegLevel (Just x) y
+  | x == y = TC.bad $ TC.TypeError $ "Already at at level " ++ pretty x
+  | segNumGroups x /= segNumGroups y || segGroupSize x /= segGroupSize y =
+      TC.bad $ TC.TypeError "Physical layout for SegLevel does not match parent SegLevel."
+  | otherwise =
+      return ()
+
 typeCheckHostOp :: TC.Checkable lore =>
                    (SegLevel -> OpWithAliases (Op lore) -> TC.TypeM lore ())
                 -> Maybe SegLevel
@@ -1067,6 +341,6 @@ typeCheckHostOp :: TC.Checkable lore =>
                 -> TC.TypeM lore ()
 typeCheckHostOp checker lvl _ (SegOp op) =
   TC.checkOpWith (checker $ segLevel op) $
-  typeCheckSegOp lvl op
+  typeCheckSegOp (checkSegLevel lvl) op
 typeCheckHostOp _ _ f (OtherOp op) = f op
 typeCheckHostOp _ _ _ (SizeOp op) = typeCheckSizeOp op

--- a/src/Futhark/Representation/Kernels/Simplify.hs
+++ b/src/Futhark/Representation/Kernels/Simplify.hs
@@ -13,12 +13,6 @@ module Futhark.Representation.Kernels.Simplify
        )
 where
 
-import Control.Monad
-import Data.Foldable
-import Data.List (isPrefixOf, groupBy, partition)
-import Data.Maybe
-import qualified Data.Map.Strict as M
-
 import Futhark.Representation.Kernels
 import qualified Futhark.Optimise.Simplify.Engine as Engine
 import Futhark.Optimise.Simplify.Rules
@@ -30,8 +24,6 @@ import Futhark.Representation.SOACS.Simplify (simplifySOAC)
 import qualified Futhark.Optimise.Simplify as Simplify
 import Futhark.Optimise.Simplify.Rule
 import qualified Futhark.Analysis.SymbolTable as ST
-import qualified Futhark.Analysis.UsageTable as UT
-import Futhark.Util (chunks)
 import qualified Futhark.Transform.FirstOrderTransform as FOT
 
 simpleKernels :: Simplify.SimpleOps Kernels
@@ -56,63 +48,9 @@ simplifyKernelOp f (OtherOp op) = do
   (op', stms) <- f op
   return (OtherOp op', stms)
 
-simplifyKernelOp _ (SegOp (SegMap lvl space ts kbody)) = do
-  (lvl', space', ts') <- Engine.simplify (lvl, space, ts)
-  (kbody', body_hoisted) <- simplifyKernelBody space kbody
-  return (SegOp $ SegMap lvl' space' ts' kbody',
-          body_hoisted)
-
-simplifyKernelOp _ (SegOp (SegRed lvl space reds ts kbody)) = do
-  (lvl', space', ts') <- Engine.simplify (lvl, space, ts)
-  (reds', reds_hoisted) <- fmap unzip $ forM reds $ \(SegRedOp comm lam nes shape) -> do
-    (lam', hoisted) <-
-      Engine.localVtable (<>scope_vtable) $
-      Engine.localVtable (\vtable -> vtable { ST.simplifyMemory = True }) $
-      Engine.simplifyLambda lam $ replicate (length nes * 2) Nothing
-    shape' <- Engine.simplify shape
-    nes' <- mapM Engine.simplify nes
-    return (SegRedOp comm lam' nes' shape', hoisted)
-
-  (kbody', body_hoisted) <- simplifyKernelBody space kbody
-
-  return (SegOp $ SegRed lvl' space' reds' ts' kbody',
-          mconcat reds_hoisted <> body_hoisted)
-  where scope = scopeOfSegSpace space
-        scope_vtable = ST.fromScope scope
-
-simplifyKernelOp _ (SegOp (SegScan lvl space scan_op nes ts kbody)) = do
-  lvl' <- Engine.simplify lvl
-  (space', scan_op', nes', ts', kbody', hoisted) <-
-    simplifyRedOrScan space scan_op nes ts kbody
-
-  return (SegOp $ SegScan lvl' space' scan_op' nes' ts' kbody',
-          hoisted)
-
-simplifyKernelOp _ (SegOp (SegHist lvl space ops ts kbody)) = do
-  (lvl', space', ts') <- Engine.simplify (lvl, space, ts)
-
-  (ops', ops_hoisted) <- fmap unzip $ forM ops $
-    \(HistOp w rf arrs nes dims lam) -> do
-      w' <- Engine.simplify w
-      rf' <- Engine.simplify rf
-      arrs' <- Engine.simplify arrs
-      nes' <- Engine.simplify nes
-      dims' <- Engine.simplify dims
-      (lam', op_hoisted) <-
-        Engine.localVtable (<>scope_vtable) $
-        Engine.localVtable (\vtable -> vtable { ST.simplifyMemory = True }) $
-        Engine.simplifyLambda lam $
-        replicate (length nes * 2) Nothing
-      return (HistOp w' rf' arrs' nes' dims' lam',
-              op_hoisted)
-
-  (kbody', body_hoisted) <- simplifyKernelBody space kbody
-
-  return (SegOp $ SegHist lvl' space' ops' ts' kbody',
-          mconcat ops_hoisted <> body_hoisted)
-
-  where scope = scopeOfSegSpace space
-        scope_vtable = ST.fromScope scope
+simplifyKernelOp _ (SegOp op) = do
+  (op', hoisted) <- simplifySegOp op
+  return (SegOp op', hoisted)
 
 simplifyKernelOp _ (SizeOp (SplitSpace o w i elems_per_thread)) =
   (,) <$> (SizeOp <$>
@@ -130,249 +68,21 @@ simplifyKernelOp _ (SizeOp (CalcNumGroups w max_num_groups group_size)) = do
   w' <- Engine.simplify w
   return (SizeOp $ CalcNumGroups w' max_num_groups group_size, mempty)
 
-simplifyRedOrScan :: (Engine.SimplifiableLore lore, BodyAttr lore ~ ()) =>
-                     SegSpace
-                  -> Lambda lore -> [SubExp] -> [Type]
-                  -> KernelBody lore
-                  -> Simplify.SimpleM lore
-                  (SegSpace, Lambda (Wise lore), [SubExp], [Type], KernelBody (Wise lore),
-                   Stms (Wise lore))
-simplifyRedOrScan space scan_op nes ts kbody = do
-  space' <- Engine.simplify space
-  nes' <- mapM Engine.simplify nes
-  ts' <- mapM Engine.simplify ts
-
-  (scan_op', scan_op_hoisted) <-
-    Engine.localVtable (<>scope_vtable) $
-    Engine.localVtable (\vtable -> vtable { ST.simplifyMemory = True }) $
-    Engine.simplifyLambda scan_op $ replicate (length nes * 2) Nothing
-
-  (kbody', body_hoisted) <- simplifyKernelBody space kbody
-
-  return (space', scan_op', nes', ts', kbody',
-          scan_op_hoisted <> body_hoisted)
-
-  where scope = scopeOfSegSpace space
-        scope_vtable = ST.fromScope scope
-
-simplifyKernelBody :: (Engine.SimplifiableLore lore, BodyAttr lore ~ ()) =>
-                      SegSpace -> KernelBody lore
-                   -> Engine.SimpleM lore (KernelBody (Wise lore), Stms (Wise lore))
-simplifyKernelBody space (KernelBody _ stms res) = do
-  par_blocker <- Engine.asksEngineEnv $ Engine.blockHoistPar . Engine.envHoistBlockers
-
-  ((body_stms, body_res), hoisted) <-
-    Engine.localVtable (<>scope_vtable) $
-    Engine.localVtable (\vtable -> vtable { ST.simplifyMemory = True }) $
-    Engine.blockIf (Engine.hasFree bound_here
-                    `Engine.orIf` Engine.isOp
-                    `Engine.orIf` par_blocker
-                    `Engine.orIf` Engine.isConsumed) $
-    Engine.simplifyStms stms $ do
-    res' <- Engine.localVtable (ST.hideCertified $ namesFromList $ M.keys $ scopeOf stms) $
-            mapM Engine.simplify res
-    return ((res', UT.usages $ freeIn res'), mempty)
-
-  return (mkWiseKernelBody () body_stms body_res,
-          hoisted)
-
-  where scope_vtable = ST.fromScope $ scopeOfSegSpace space
-        bound_here = namesFromList $ M.keys $ scopeOfSegSpace space
-
-mkWiseKernelBody :: (Attributes lore, CanBeWise (Op lore)) =>
-                    BodyAttr lore -> Stms (Wise lore) -> [KernelResult] -> KernelBody (Wise lore)
-mkWiseKernelBody attr bnds res =
-  let Body attr' _ _ = mkWiseBody attr bnds res_vs
-  in KernelBody attr' bnds res
-  where res_vs = map kernelResultSubExp res
-
-instance Engine.Simplifiable SplitOrdering where
-  simplify SplitContiguous =
-    return SplitContiguous
-  simplify (SplitStrided stride) =
-    SplitStrided <$> Engine.simplify stride
-
-instance Engine.Simplifiable SegLevel where
-  simplify (SegThread num_groups group_size virt) =
-    SegThread <$> traverse Engine.simplify num_groups <*>
-    traverse Engine.simplify group_size <*> pure virt
-  simplify (SegGroup num_groups group_size virt) =
-    SegGroup <$> traverse Engine.simplify num_groups <*>
-    traverse Engine.simplify group_size <*> pure virt
-
-instance Engine.Simplifiable SegSpace where
-  simplify (SegSpace phys dims) =
-    SegSpace phys <$> mapM (traverse Engine.simplify) dims
-
-instance Engine.Simplifiable KernelResult where
-  simplify (Returns manifest what) =
-    Returns manifest <$> Engine.simplify what
-  simplify (WriteReturns ws a res) =
-    WriteReturns <$> Engine.simplify ws <*> Engine.simplify a <*> Engine.simplify res
-  simplify (ConcatReturns o w pte what) =
-    ConcatReturns
-    <$> Engine.simplify o
-    <*> Engine.simplify w
-    <*> Engine.simplify pte
-    <*> Engine.simplify what
-  simplify (TileReturns dims what) =
-    TileReturns <$> Engine.simplify dims <*> Engine.simplify what
-
 instance BinderOps (Wise Kernels) where
   mkExpAttrB = bindableMkExpAttrB
   mkBodyB = bindableMkBodyB
   mkLetNamesB = bindableMkLetNamesB
 
+instance HasSegOp SegLevel (Wise Kernels) where
+  asSegOp (SegOp op) = Just op
+  asSegOp _ = Nothing
+  segOp = SegOp
+
 kernelRules :: RuleBook (Wise Kernels)
-kernelRules = standardRules <>
-              ruleBook [ RuleOp removeInvariantKernelResults
-                       , RuleOp mergeSegRedOps
-                       , RuleOp redomapIotaToLoop
-                       ]
-                       [ RuleOp distributeKernelResults
-                       , RuleBasicOp removeUnnecessaryCopy
-                       ]
-
--- If a kernel produces something invariant to the kernel, turn it
--- into a replicate.
-removeInvariantKernelResults :: TopDownRuleOp (Wise Kernels)
-removeInvariantKernelResults vtable (Pattern [] kpes) attr
-                             (SegOp (SegMap lvl space ts (KernelBody _ kstms kres))) = Simplify $ do
-
-  (ts', kpes', kres') <-
-    unzip3 <$> filterM checkForInvarianceResult (zip3 ts kpes kres)
-
-  -- Check if we did anything at all.
-  when (kres == kres')
-    cannotSimplify
-
-  addStm $ Let (Pattern [] kpes') attr $ Op $ SegOp $ SegMap lvl space ts' $
-    mkWiseKernelBody () kstms kres'
-  where isInvariant Constant{} = True
-        isInvariant (Var v) = isJust $ ST.lookup v vtable
-
-        checkForInvarianceResult (_, pe, Returns rm se)
-          | rm == ResultMaySimplify,
-            isInvariant se = do
-              letBindNames_ [patElemName pe] $
-                BasicOp $ Replicate (Shape $ segSpaceDims space) se
-              return False
-        checkForInvarianceResult _ =
-          return True
-removeInvariantKernelResults _ _ _ _ = Skip
-
--- Some kernel results can be moved outside the kernel, which can
--- simplify further analysis.
-distributeKernelResults :: BottomUpRuleOp (Wise Kernels)
-distributeKernelResults (vtable, used)
-  (Pattern [] kpes) attr (SegOp (SegMap lvl space kts (KernelBody _ kstms kres))) = Simplify $ do
-  -- Iterate through the bindings.  For each, we check whether it is
-  -- in kres and can be moved outside.  If so, we remove it from kres
-  -- and kpes and make it a binding outside.
-  (kpes', kts', kres', kstms') <- localScope (scopeOfSegSpace space) $
-    foldM distribute (kpes, kts, kres, mempty) kstms
-
-  when (kpes' == kpes)
-    cannotSimplify
-
-  addStm $ Let (Pattern [] kpes') attr $ Op $ SegOp $
-    SegMap lvl space kts' $ mkWiseKernelBody () kstms' kres'
-  where
-    free_in_kstms = foldMap freeIn kstms
-
-    sliceWithGtidsFixed stm
-      | Let _ _ (BasicOp (Index arr slice)) <- stm,
-        space_slice <- map (DimFix . Var . fst) $ unSegSpace space,
-        space_slice `isPrefixOf` slice,
-        remaining_slice <- drop (length space_slice) slice,
-        all (isJust . flip ST.lookup vtable) $ namesToList $
-          freeIn arr <> freeIn remaining_slice =
-          Just (remaining_slice, arr)
-
-      | otherwise =
-          Nothing
-
-    distribute (kpes', kts', kres', kstms') stm
-      | Let (Pattern [] [pe]) _ _ <- stm,
-        Just (remaining_slice, arr) <- sliceWithGtidsFixed stm,
-        Just (kpe, kpes'', kts'', kres'') <- isResult kpes' kts' kres' pe = do
-          let outer_slice = map (\d -> DimSlice
-                                       (constant (0::Int32))
-                                       d
-                                       (constant (1::Int32))) $
-                            segSpaceDims space
-              index kpe' = letBind_ (Pattern [] [kpe']) $ BasicOp $ Index arr $
-                           outer_slice <> remaining_slice
-          if patElemName kpe `UT.isConsumed` used
-            then do precopy <- newVName $ baseString (patElemName kpe) <> "_precopy"
-                    index kpe { patElemName = precopy }
-                    letBind_ (Pattern [] [kpe]) $ BasicOp $ Copy precopy
-            else index kpe
-          return (kpes'', kts'', kres'',
-                  if patElemName pe `nameIn` free_in_kstms
-                  then kstms' <> oneStm stm
-                  else kstms')
-
-    distribute (kpes', kts', kres', kstms') stm =
-      return (kpes', kts', kres', kstms' <> oneStm stm)
-
-    isResult kpes' kts' kres' pe =
-      case partition matches $ zip3 kpes' kts' kres' of
-        ([(kpe,_,_)], kpes_and_kres)
-          | (kpes'', kts'', kres'') <- unzip3 kpes_and_kres ->
-              Just (kpe, kpes'', kts'', kres'')
-        _ -> Nothing
-      where matches (_, _, Returns _ (Var v)) = v == patElemName pe
-            matches _ = False
-distributeKernelResults _ _ _ _ = Skip
-
--- If a SegRed contains two reduction operations that have the same
--- vector shape, merge them together.  This saves on communication
--- overhead, but can in principle lead to more local memory usage.
-mergeSegRedOps :: TopDownRuleOp (Wise Kernels)
-mergeSegRedOps _ (Pattern [] pes) _ (SegOp (SegRed lvl space ops ts kbody))
-  | length ops > 1,
-    op_groupings <- groupBy sameShape $ zip ops $ chunks (map (length . segRedNeutral) ops) $
-                    zip3 red_pes red_ts red_res,
-    any ((>1) . length) op_groupings = Simplify $ do
-      let (ops', aux) = unzip $ mapMaybe combineOps op_groupings
-          (red_pes', red_ts', red_res') = unzip3 $ concat aux
-          pes' = red_pes' ++ map_pes
-          ts' = red_ts' ++ map_ts
-          kbody' = kbody { kernelBodyResult = red_res' ++ map_res }
-      letBind_ (Pattern [] pes') $ Op $ SegOp $ SegRed lvl space ops' ts' kbody'
-  where (red_pes, map_pes) = splitAt (segRedResults ops) pes
-        (red_ts, map_ts) = splitAt (segRedResults ops) ts
-        (red_res, map_res) = splitAt (segRedResults ops) $ kernelBodyResult kbody
-
-        sameShape (op1, _) (op2, _) = segRedShape op1 == segRedShape op2
-
-        combineOps :: [(SegRedOp (Wise Kernels), [a])]
-                   -> Maybe (SegRedOp (Wise Kernels), [a])
-        combineOps [] = Nothing
-        combineOps (x:xs) = Just $ foldl' combine x xs
-
-        combine (op1, op1_aux) (op2, op2_aux) =
-          let lam1 = segRedLambda op1
-              lam2 = segRedLambda op2
-              (op1_xparams, op1_yparams) =
-                splitAt (length (segRedNeutral op1)) $ lambdaParams lam1
-              (op2_xparams, op2_yparams) =
-                splitAt (length (segRedNeutral op2)) $ lambdaParams lam2
-              lam = Lambda { lambdaParams = op1_xparams ++ op2_xparams ++
-                                            op1_yparams ++ op2_yparams
-                           , lambdaReturnType = lambdaReturnType lam1 ++ lambdaReturnType lam2
-                           , lambdaBody =
-                               mkBody (bodyStms (lambdaBody lam1) <> bodyStms (lambdaBody lam2)) $
-                               bodyResult (lambdaBody lam1) <> bodyResult (lambdaBody lam2)
-                           }
-          in (SegRedOp { segRedComm = segRedComm op1 <> segRedComm op2
-                       , segRedLambda = lam
-                       , segRedNeutral = segRedNeutral op1 ++ segRedNeutral op2
-                       , segRedShape = segRedShape op1 -- Same as shape of op2 due to the grouping.
-                       },
-               op1_aux ++ op2_aux)
-mergeSegRedOps _ _ _ _ = Skip
+kernelRules = standardRules <> segOpRules <>
+              ruleBook
+              [ RuleOp redomapIotaToLoop ]
+              [ RuleBasicOp removeUnnecessaryCopy ]
 
 -- We turn reductions over (solely) iotas into do-loops, because there
 -- is no useful structure here anyway.  This is mostly a hack to work

--- a/src/Futhark/Representation/Kernels/Sizes.hs
+++ b/src/Futhark/Representation/Kernels/Sizes.hs
@@ -11,6 +11,7 @@ import Data.Int (Int32)
 import Data.Traversable
 
 import Futhark.Util.Pretty
+import Futhark.Transform.Substitute
 import Language.Futhark.Core (Name)
 import Futhark.Util.IntegralExp (IntegralExp)
 import Futhark.Representation.AST.Attributes.Names (FreeIn)
@@ -44,7 +45,7 @@ instance Pretty SizeClass where
 
 -- | A wrapper supporting a phantom type for indicating what we are counting.
 newtype Count u e = Count { unCount :: e }
-                deriving (Eq, Ord, Show, Num, IntegralExp, FreeIn, Pretty)
+  deriving (Eq, Ord, Show, Num, IntegralExp, FreeIn, Pretty, Substitute)
 
 instance Functor (Count u) where
   fmap = fmapDefault

--- a/src/Futhark/Representation/KernelsMem.hs
+++ b/src/Futhark/Representation/KernelsMem.hs
@@ -45,7 +45,7 @@ instance Annotations KernelsMem where
   type Op         KernelsMem = MemOp (HostOp KernelsMem ())
 
 segOpReturns :: (Monad m, HasScope KernelsMem m) =>
-                SegOp KernelsMem -> m [ExpReturns]
+                SegOp SegLevel KernelsMem -> m [ExpReturns]
 segOpReturns k@(SegMap _ _ _ kbody) =
   kernelBodyReturns kbody =<< (extReturns <$> opType k)
 segOpReturns k@(SegRed _ _ _ _ kbody) =

--- a/src/Futhark/Representation/KernelsMem.hs
+++ b/src/Futhark/Representation/KernelsMem.hs
@@ -17,8 +17,6 @@ module Futhark.Representation.KernelsMem
   )
   where
 
-import Control.Monad
-
 import Futhark.Analysis.PrimExp.Convert
 import Futhark.MonadFreshNames
 import Futhark.Pass
@@ -43,23 +41,6 @@ instance Annotations KernelsMem where
   type RetType    KernelsMem = RetTypeMem
   type BranchType KernelsMem = BranchTypeMem
   type Op         KernelsMem = MemOp (HostOp KernelsMem ())
-
-segOpReturns :: (Monad m, HasScope KernelsMem m) =>
-                SegOp SegLevel KernelsMem -> m [ExpReturns]
-segOpReturns k@(SegMap _ _ _ kbody) =
-  kernelBodyReturns kbody =<< (extReturns <$> opType k)
-segOpReturns k@(SegRed _ _ _ _ kbody) =
-  kernelBodyReturns kbody =<< (extReturns <$> opType k)
-segOpReturns k@(SegScan _ _ _ _ _ kbody) =
-  kernelBodyReturns kbody =<< (extReturns <$> opType k)
-segOpReturns (SegHist _ _ ops _ _) =
-  concat <$> mapM (mapM varReturns . histDest) ops
-
-kernelBodyReturns :: (HasScope KernelsMem m, Monad m) =>
-                     KernelBody KernelsMem -> [ExpReturns] -> m [ExpReturns]
-kernelBodyReturns = zipWithM correct . kernelBodyResult
-  where correct (WriteReturns _ arr _) _ = varReturns arr
-        correct _ ret = return ret
 
 instance Attributes KernelsMem where
   expTypesFromPattern = return . map snd . snd . bodyReturnsFromPattern

--- a/src/Futhark/Representation/MCMem.hs
+++ b/src/Futhark/Representation/MCMem.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ConstraintKinds #-}
+module Futhark.Representation.MCMem
+  ( MCMem
+
+  -- * Simplification
+  , simplifyProg
+
+    -- * Module re-exports
+  , module Futhark.Representation.Mem
+  , module Futhark.Representation.SegOp
+  )
+  where
+
+import Futhark.Analysis.PrimExp.Convert
+import Futhark.Pass
+import Futhark.Representation.AST.Syntax
+import Futhark.Representation.AST.Attributes
+import Futhark.Representation.AST.Traversals
+import Futhark.Representation.AST.Pretty
+import Futhark.Representation.SegOp
+import qualified Futhark.TypeCheck as TC
+import Futhark.Representation.Mem
+import Futhark.Representation.Mem.Simplify
+import Futhark.Pass.ExplicitAllocations (BinderOps(..), mkLetNamesB', mkLetNamesB'')
+import qualified Futhark.Optimise.Simplify.Engine as Engine
+
+data MCMem
+
+instance Annotations MCMem where
+  type LetAttr    MCMem = LetAttrMem
+  type FParamAttr MCMem = FParamMem
+  type LParamAttr MCMem = LParamMem
+  type RetType    MCMem = RetTypeMem
+  type BranchType MCMem = BranchTypeMem
+  type Op         MCMem = MemOp (SegOp () MCMem)
+
+instance Attributes MCMem where
+  expTypesFromPattern = return . map snd . snd . bodyReturnsFromPattern
+
+instance OpReturns MCMem where
+  opReturns (Alloc _ space) = return [MemMem space]
+  opReturns (Inner op) = segOpReturns op
+
+instance PrettyLore MCMem where
+
+instance TC.CheckableOp MCMem where
+  checkOp = typeCheckMemoryOp
+    where typeCheckMemoryOp (Alloc size _) =
+            TC.require [Prim int64] size
+          typeCheckMemoryOp (Inner op) =
+            typeCheckSegOp pure op
+
+instance TC.Checkable MCMem where
+  checkFParamLore = checkMemInfo
+  checkLParamLore = checkMemInfo
+  checkLetBoundLore = checkMemInfo
+  checkRetType = mapM_ TC.checkExtType . retTypeValues
+  primFParam name t = return $ Param name (MemPrim t)
+  matchPattern = matchPatternToExp
+  matchReturnType = matchFunctionReturnType
+  matchBranchType = matchBranchReturnType
+
+instance BinderOps MCMem where
+  mkExpAttrB _ _ = return ()
+  mkBodyB stms res = return $ Body () stms res
+  mkLetNamesB = mkLetNamesB' ()
+
+instance BinderOps (Engine.Wise MCMem) where
+  mkExpAttrB pat e = return $ Engine.mkWiseExpAttr pat () e
+  mkBodyB stms res = return $ Engine.mkWiseBody () stms res
+  mkLetNamesB = mkLetNamesB''
+
+simplifyProg :: Prog MCMem -> PassM (Prog MCMem)
+simplifyProg = simplifyProgGeneric simplifySegOp

--- a/src/Futhark/Representation/Mem.hs
+++ b/src/Futhark/Representation/Mem.hs
@@ -495,13 +495,11 @@ bodyReturnsToExpReturns = noUniquenessReturns . maybeReturns
 matchFunctionReturnType :: Mem lore =>
                            [FunReturns] -> Result -> TC.TypeM lore ()
 matchFunctionReturnType rettype result = do
-  TC.matchExtReturnType (fromDecl <$> ts) result
   scope <- askScope
   result_ts <- runReaderT (mapM subExpMemInfo result) $ removeScopeAliases scope
   matchReturnType rettype result result_ts
   mapM_ checkResultSubExp result
-  where ts = map declExtTypeOf rettype
-        checkResultSubExp Constant{} =
+  where checkResultSubExp Constant{} =
           return ()
         checkResultSubExp (Var v) = do
           attr <- varMemInfo v
@@ -698,11 +696,6 @@ extInMemReturn (ReturnsNewBlock _ i extixfn) =
 
 extInIxFn :: ExtIxFun -> S.Set Int
 extInIxFn ixfun = S.fromList $ concatMap (mapMaybe isExt . toList) ixfun
-
-isExt :: Ext a -> Maybe Int
-isExt (Ext i) = Just i
-isExt _ = Nothing
-
 
 varMemInfo :: Mem lore =>
               VName -> TC.TypeM lore (MemInfo SubExp NoUniqueness MemBind)

--- a/src/Futhark/Representation/SegOp.hs
+++ b/src/Futhark/Representation/SegOp.hs
@@ -1,0 +1,1128 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+-- | Segmented operations.
+module Futhark.Representation.SegOp
+  ( SegOp(..)
+  , SegVirt(..)
+  , segLevel
+  , segSpace
+  , typeCheckSegOp
+  , SegSpace(..)
+  , scopeOfSegSpace
+  , segSpaceDims
+
+    -- * Details
+  , HistOp(..)
+  , histType
+  , SegRedOp(..)
+  , segRedResults
+  , KernelBody(..)
+  , aliasAnalyseKernelBody
+  , consumedInKernelBody
+  , ResultManifest(..)
+  , KernelResult(..)
+  , kernelResultSubExp
+  , SplitOrdering(..)
+
+    -- ** Generic traversal
+  , SegOpMapper(..)
+  , identitySegOpMapper
+  , mapSegOpM
+
+    -- * Simplification
+  , simplifyKernelBody
+  , simplifySegOp
+  , HasSegOp(..)
+  , segOpRules
+  )
+where
+
+import Control.Monad.State.Strict
+import Control.Monad.Writer hiding (mapM_)
+import Control.Monad.Identity hiding (mapM_)
+import Data.Bifunctor (first)
+import qualified Data.Map.Strict as M
+import Data.Maybe
+import Data.List
+  (intersperse, foldl', partition, isPrefixOf, groupBy)
+
+import Futhark.Representation.AST
+import qualified Futhark.Analysis.Alias as Alias
+import qualified Futhark.Analysis.SymbolTable as ST
+import qualified Futhark.Analysis.UsageTable as UT
+import Futhark.Analysis.PrimExp.Convert
+import qualified Futhark.Util.Pretty as PP
+import Futhark.Util.Pretty
+  ((</>), (<+>), ppr, commasep, Pretty, parens, text)
+import Futhark.Transform.Substitute
+import Futhark.Transform.Rename
+import Futhark.Optimise.Simplify.Lore
+import Futhark.Representation.Ranges
+  (Ranges, removeLambdaRanges, removeStmRanges, mkBodyRanges)
+import Futhark.Representation.AST.Attributes.Ranges
+import Futhark.Representation.AST.Attributes.Aliases
+import Futhark.Representation.Aliases
+  (Aliases, removeLambdaAliases, removeStmAliases)
+import qualified Futhark.TypeCheck as TC
+import Futhark.Analysis.Metrics
+import qualified Futhark.Analysis.Range as Range
+import Futhark.Util (maybeNth, chunks)
+import Futhark.Optimise.Simplify.Rule
+import qualified Futhark.Optimise.Simplify.Engine as Engine
+import Futhark.Tools
+
+-- | How an array is split into chunks.
+data SplitOrdering = SplitContiguous
+                   | SplitStrided SubExp
+                   deriving (Eq, Ord, Show)
+
+instance FreeIn SplitOrdering where
+  freeIn' SplitContiguous = mempty
+  freeIn' (SplitStrided stride) = freeIn' stride
+
+instance Substitute SplitOrdering where
+  substituteNames _ SplitContiguous =
+    SplitContiguous
+  substituteNames subst (SplitStrided stride) =
+    SplitStrided $ substituteNames subst stride
+
+instance Rename SplitOrdering where
+  rename SplitContiguous =
+    pure SplitContiguous
+  rename (SplitStrided stride) =
+    SplitStrided <$> rename stride
+
+data HistOp lore =
+  HistOp { histWidth :: SubExp
+         , histRaceFactor :: SubExp
+         , histDest :: [VName]
+         , histNeutral :: [SubExp]
+         , histShape :: Shape
+           -- ^ In case this operator is semantically a vectorised
+           -- operator (corresponding to a perfect map nest in the
+           -- SOACS representation), these are the logical
+           -- "dimensions".  This is used to generate more efficient
+           -- code.
+         , histOp :: Lambda lore
+         }
+  deriving (Eq, Ord, Show)
+
+-- | The type of a histogram produced by a 'HistOp'.  This can be
+-- different from the type of the 'HistDest's in case we are
+-- dealing with a segmented histogram.
+histType :: HistOp lore -> [Type]
+histType op = map ((`arrayOfRow` histWidth op) .
+                        (`arrayOfShape` histShape op)) $
+                   lambdaReturnType $ histOp op
+
+data SegRedOp lore =
+  SegRedOp { segRedComm :: Commutativity
+           , segRedLambda :: Lambda lore
+           , segRedNeutral :: [SubExp]
+           , segRedShape :: Shape
+             -- ^ In case this operator is semantically a vectorised
+             -- operator (corresponding to a perfect map nest in the
+             -- SOACS representation), these are the logical
+             -- "dimensions".  This is used to generate more efficient
+             -- code.
+           }
+  deriving (Eq, Ord, Show)
+
+-- | How many reduction results are produced by these 'SegRedOp's?
+segRedResults :: [SegRedOp lore] -> Int
+segRedResults = sum . map (length . segRedNeutral)
+-- | The body of a 'Kernel'.
+data KernelBody lore = KernelBody { kernelBodyLore :: BodyAttr lore
+                                  , kernelBodyStms :: Stms lore
+                                  , kernelBodyResult :: [KernelResult]
+                                  }
+
+deriving instance Annotations lore => Ord (KernelBody lore)
+deriving instance Annotations lore => Show (KernelBody lore)
+deriving instance Annotations lore => Eq (KernelBody lore)
+
+-- | Metadata about whether there is a subtle point to this
+-- 'KernelResult'.  This is used to protect things like tiling, which
+-- might otherwise be removed by the simplifier because they're
+-- semantically redundant.  This has no semantic effect and can be
+-- ignored at code generation.
+data ResultManifest
+  = ResultNoSimplify
+    -- ^ Don't simplify this one!
+  | ResultMaySimplify
+    -- ^ Go nuts.
+  | ResultPrivate
+    -- ^ The results produced are only used within the
+    -- same physical thread later on, and can thus be
+    -- kept in registers.
+  deriving (Eq, Show, Ord)
+
+data KernelResult = Returns ResultManifest SubExp
+                    -- ^ Each "worker" in the kernel returns this.
+                    -- Whether this is a result-per-thread or a
+                    -- result-per-group depends on the 'SegLevel'.
+                  | WriteReturns
+                    [SubExp] -- Size of array.  Must match number of dims.
+                    VName -- Which array
+                    [([SubExp], SubExp)]
+                    -- Arbitrary number of index/value pairs.
+                  | ConcatReturns
+                    SplitOrdering -- Permuted?
+                    SubExp -- The final size.
+                    SubExp -- Per-thread/group (max) chunk size.
+                    VName -- Chunk by this worker.
+                  | TileReturns
+                    [(SubExp, SubExp)] -- Total/tile for each dimension
+                    VName -- Tile written by this worker.
+                    -- The TileReturns must not expect more than one
+                    -- result to be written per physical thread.
+                  deriving (Eq, Show, Ord)
+
+kernelResultSubExp :: KernelResult -> SubExp
+kernelResultSubExp (Returns _ se) = se
+kernelResultSubExp (WriteReturns _ arr _) = Var arr
+kernelResultSubExp (ConcatReturns _ _ _ v) = Var v
+kernelResultSubExp (TileReturns _ v) = Var v
+
+instance FreeIn KernelResult where
+  freeIn' (Returns _ what) = freeIn' what
+  freeIn' (WriteReturns rws arr res) = freeIn' rws <> freeIn' arr <> freeIn' res
+  freeIn' (ConcatReturns o w per_thread_elems v) =
+    freeIn' o <> freeIn' w <> freeIn' per_thread_elems <> freeIn' v
+  freeIn' (TileReturns dims v) =
+    freeIn' dims <> freeIn' v
+
+instance Attributes lore => FreeIn (KernelBody lore) where
+  freeIn' (KernelBody attr stms res) =
+    fvBind bound_in_stms $ freeIn' attr <> freeIn' stms <> freeIn' res
+    where bound_in_stms = foldMap boundByStm stms
+
+instance Attributes lore => Substitute (KernelBody lore) where
+  substituteNames subst (KernelBody attr stms res) =
+    KernelBody
+    (substituteNames subst attr)
+    (substituteNames subst stms)
+    (substituteNames subst res)
+
+instance Substitute KernelResult where
+  substituteNames subst (Returns manifest se) =
+    Returns manifest (substituteNames subst se)
+  substituteNames subst (WriteReturns rws arr res) =
+    WriteReturns
+    (substituteNames subst rws) (substituteNames subst arr)
+    (substituteNames subst res)
+  substituteNames subst (ConcatReturns o w per_thread_elems v) =
+    ConcatReturns
+    (substituteNames subst o)
+    (substituteNames subst w)
+    (substituteNames subst per_thread_elems)
+    (substituteNames subst v)
+  substituteNames subst (TileReturns dims v) =
+    TileReturns (substituteNames subst dims) (substituteNames subst v)
+
+instance Attributes lore => Rename (KernelBody lore) where
+  rename (KernelBody attr stms res) = do
+    attr' <- rename attr
+    renamingStms stms $ \stms' ->
+      KernelBody attr' stms' <$> rename res
+
+instance Rename KernelResult where
+  rename = substituteRename
+
+aliasAnalyseKernelBody :: (Attributes lore,
+                           CanBeAliased (Op lore)) =>
+                          KernelBody lore
+                       -> KernelBody (Aliases lore)
+aliasAnalyseKernelBody (KernelBody attr stms res) =
+  let Body attr' stms' _ = Alias.analyseBody mempty $ Body attr stms []
+  in KernelBody attr' stms' res
+
+removeKernelBodyAliases :: CanBeAliased (Op lore) =>
+                           KernelBody (Aliases lore) -> KernelBody lore
+removeKernelBodyAliases (KernelBody (_, attr) stms res) =
+  KernelBody attr (fmap removeStmAliases stms) res
+
+addKernelBodyRanges :: (Attributes lore, CanBeRanged (Op lore)) =>
+                       KernelBody lore -> Range.RangeM (KernelBody (Ranges lore))
+addKernelBodyRanges (KernelBody attr stms res) =
+  Range.analyseStms stms $ \stms' -> do
+  let attr' = (mkBodyRanges stms $ map kernelResultSubExp res, attr)
+  return $ KernelBody attr' stms' res
+
+removeKernelBodyRanges :: CanBeRanged (Op lore) =>
+                          KernelBody (Ranges lore) -> KernelBody lore
+removeKernelBodyRanges (KernelBody (_, attr) stms res) =
+  KernelBody attr (fmap removeStmRanges stms) res
+
+removeKernelBodyWisdom :: CanBeWise (Op lore) =>
+                          KernelBody (Wise lore) -> KernelBody lore
+removeKernelBodyWisdom (KernelBody attr stms res) =
+  let Body attr' stms' _ = removeBodyWisdom $ Body attr stms []
+  in KernelBody attr' stms' res
+
+consumedInKernelBody :: Aliased lore =>
+                        KernelBody lore -> Names
+consumedInKernelBody (KernelBody attr stms res) =
+  consumedInBody (Body attr stms []) <> mconcat (map consumedByReturn res)
+  where consumedByReturn (WriteReturns _ a _) = oneName a
+        consumedByReturn _                    = mempty
+
+checkKernelBody :: TC.Checkable lore =>
+                   [Type] -> KernelBody (Aliases lore) -> TC.TypeM lore ()
+checkKernelBody ts (KernelBody (_, attr) stms kres) = do
+  TC.checkBodyLore attr
+  TC.checkStms stms $ do
+    unless (length ts == length kres) $
+      TC.bad $ TC.TypeError $ "Kernel return type is " ++ prettyTuple ts ++
+      ", but body returns " ++ show (length kres) ++ " values."
+    zipWithM_ checkKernelResult kres ts
+
+  where checkKernelResult (Returns _ what) t =
+          TC.require [t] what
+        checkKernelResult (WriteReturns rws arr res) t = do
+          mapM_ (TC.require [Prim int32]) rws
+          arr_t <- lookupType arr
+          forM_ res $ \(is, e) -> do
+            mapM_ (TC.require [Prim int32]) is
+            TC.require [t] e
+            unless (arr_t == t `arrayOfShape` Shape rws) $
+              TC.bad $ TC.TypeError $ "WriteReturns returning " ++
+              pretty e ++ " of type " ++ pretty t ++ ", shape=" ++ pretty rws ++
+              ", but destination array has type " ++ pretty arr_t
+          TC.consume =<< TC.lookupAliases arr
+        checkKernelResult (ConcatReturns o w per_thread_elems v) t = do
+          case o of
+            SplitContiguous     -> return ()
+            SplitStrided stride -> TC.require [Prim int32] stride
+          TC.require [Prim int32] w
+          TC.require [Prim int32] per_thread_elems
+          vt <- lookupType v
+          unless (vt == t `arrayOfRow` arraySize 0 vt) $
+            TC.bad $ TC.TypeError $ "Invalid type for ConcatReturns " ++ pretty v
+        checkKernelResult (TileReturns dims v) t = do
+          forM_ dims $ \(dim, tile) -> do
+            TC.require [Prim int32] dim
+            TC.require [Prim int32] tile
+          vt <- lookupType v
+          unless (vt == t `arrayOfShape` Shape (map snd dims)) $
+            TC.bad $ TC.TypeError $ "Invalid type for TileReturns " ++ pretty v
+
+kernelBodyMetrics :: OpMetrics (Op lore) => KernelBody lore -> MetricsM ()
+kernelBodyMetrics = mapM_ bindingMetrics . kernelBodyStms
+
+instance PrettyLore lore => Pretty (KernelBody lore) where
+  ppr (KernelBody _ stms res) =
+    PP.stack (map ppr (stmsToList stms)) </>
+    text "return" <+> PP.braces (PP.commasep $ map ppr res)
+
+instance Pretty KernelResult where
+  ppr (Returns ResultNoSimplify what) =
+    text "returns (manifest)" <+> ppr what
+  ppr (Returns ResultPrivate what) =
+    text "returns (private)" <+> ppr what
+  ppr (Returns ResultMaySimplify what) =
+    text "returns" <+> ppr what
+  ppr (WriteReturns rws arr res) =
+    ppr arr <+> text "with" <+> PP.apply (map ppRes res)
+    where ppRes (is, e) =
+            PP.brackets (PP.commasep $ zipWith f is rws) <+> text "<-" <+> ppr e
+          f i rw = ppr i <+> text "<" <+> ppr rw
+  ppr (ConcatReturns o w per_thread_elems v) =
+    text "concat" <> suff <>
+    parens (commasep [ppr w, ppr per_thread_elems]) <+> ppr v
+    where suff = case o of SplitContiguous     -> mempty
+                           SplitStrided stride -> text "Strided" <> parens (ppr stride)
+  ppr (TileReturns dims v) =
+    text "tile" <>
+    parens (commasep $ map onDim dims) <+> ppr v
+    where onDim (dim, tile) = ppr dim <+> text "/" <+> ppr tile
+
+
+-- | Do we need group-virtualisation when generating code for the
+-- segmented operation?  In most cases, we do, but for some simple
+-- kernels, we compute the full number of groups in advance, and then
+-- virtualisation is an unnecessary (but generally very small)
+-- overhead.  This only really matters for fairly trivial but very
+-- wide @map@ kernels where each thread performs constant-time work on
+-- scalars.
+data SegVirt = SegVirt | SegNoVirt
+             deriving (Eq, Ord, Show)
+
+-- | Index space of a 'SegOp'.
+data SegSpace = SegSpace { segFlat :: VName
+                         -- ^ Flat physical index corresponding to the
+                         -- dimensions (at code generation used for a
+                         -- thread ID or similar).
+                         , unSegSpace :: [(VName, SubExp)]
+                         }
+              deriving (Eq, Ord, Show)
+
+
+segSpaceDims :: SegSpace -> [SubExp]
+segSpaceDims (SegSpace _ space) = map snd space
+
+scopeOfSegSpace :: SegSpace -> Scope lore
+scopeOfSegSpace (SegSpace phys space) =
+  M.fromList $ zip (phys : map fst space) $ repeat $ IndexInfo Int32
+
+checkSegSpace :: TC.Checkable lore => SegSpace -> TC.TypeM lore ()
+checkSegSpace (SegSpace _ dims) =
+  mapM_ (TC.require [Prim int32] . snd) dims
+
+data SegOp lvl lore
+  = SegMap lvl SegSpace [Type] (KernelBody lore)
+  | SegRed lvl SegSpace [SegRedOp lore] [Type] (KernelBody lore)
+    -- ^ The KernelSpace must always have at least two dimensions,
+    -- implying that the result of a SegRed is always an array.
+  | SegScan lvl SegSpace (Lambda lore) [SubExp] [Type] (KernelBody lore)
+  | SegHist lvl SegSpace [HistOp lore] [Type] (KernelBody lore)
+  deriving (Eq, Ord, Show)
+
+segLevel :: SegOp lvl lore -> lvl
+segLevel (SegMap lvl _ _ _) = lvl
+segLevel (SegRed lvl _ _ _ _) = lvl
+segLevel (SegScan lvl _ _ _ _ _) = lvl
+segLevel (SegHist lvl _ _ _ _) = lvl
+
+segSpace :: SegOp lvl lore -> SegSpace
+segSpace (SegMap _ lvl _ _) = lvl
+segSpace (SegRed _ lvl _ _ _) = lvl
+segSpace (SegScan _ lvl _ _ _ _) = lvl
+segSpace (SegHist _ lvl _ _ _) = lvl
+
+segResultShape :: SegSpace -> Type -> KernelResult -> Type
+segResultShape _ t (WriteReturns rws _ _) =
+  t `arrayOfShape` Shape rws
+segResultShape space t (Returns _ _) =
+  foldr (flip arrayOfRow) t $ segSpaceDims space
+segResultShape _ t (ConcatReturns _ w _ _) =
+  t `arrayOfRow` w
+segResultShape _ t (TileReturns dims _) =
+  t `arrayOfShape` Shape (map fst dims)
+
+segOpType :: SegOp lvl lore -> [Type]
+segOpType (SegMap _ space ts kbody) =
+  zipWith (segResultShape space) ts $ kernelBodyResult kbody
+segOpType (SegRed _ space reds ts kbody) =
+  red_ts ++
+  zipWith (segResultShape space) map_ts
+  (drop (length red_ts) $ kernelBodyResult kbody)
+  where map_ts = drop (length red_ts) ts
+        segment_dims = init $ segSpaceDims space
+        red_ts = do
+          op <- reds
+          let shape = Shape segment_dims <> segRedShape op
+          map (`arrayOfShape` shape) (lambdaReturnType $ segRedLambda op)
+segOpType (SegScan _ space _ nes ts kbody) =
+  map (`arrayOfShape` Shape dims) scan_ts ++
+  zipWith (segResultShape space) map_ts
+  (drop (length scan_ts) $ kernelBodyResult kbody)
+  where dims = segSpaceDims space
+        (scan_ts, map_ts) = splitAt (length nes) ts
+segOpType (SegHist _ space ops _ _) = do
+  op <- ops
+  let shape = Shape (segment_dims <> [histWidth op]) <> histShape op
+  map (`arrayOfShape` shape) (lambdaReturnType $ histOp op)
+  where dims = segSpaceDims space
+        segment_dims = init dims
+
+instance TypedOp (SegOp lvl lore) where
+  opType = pure . staticShapes . segOpType
+
+instance (Attributes lore, Aliased lore, ASTConstraints lvl) =>
+         AliasedOp (SegOp lvl lore) where
+  opAliases = map (const mempty) . segOpType
+
+  consumedInOp (SegMap _ _ _ kbody) =
+    consumedInKernelBody kbody
+  consumedInOp (SegRed _ _ _ _ kbody) =
+    consumedInKernelBody kbody
+  consumedInOp (SegScan _ _ _ _ _ kbody) =
+    consumedInKernelBody kbody
+  consumedInOp (SegHist _ _ ops _ kbody) =
+    namesFromList (concatMap histDest ops) <> consumedInKernelBody kbody
+
+typeCheckSegOp :: TC.Checkable lore =>
+                  (lvl -> TC.TypeM lore ())
+               -> SegOp lvl (Aliases lore) -> TC.TypeM lore ()
+typeCheckSegOp checkLvl (SegMap lvl space ts kbody) = do
+  checkLvl lvl
+  checkScanRed space [] ts kbody
+
+typeCheckSegOp checkLvl (SegRed lvl space reds ts body) = do
+  checkLvl lvl
+  checkScanRed space reds' ts body
+  where reds' = zip3
+                (map segRedLambda reds)
+                (map segRedNeutral reds)
+                (map segRedShape reds)
+
+typeCheckSegOp checkLvl (SegScan lvl space scan_op nes ts body) = do
+  checkLvl lvl
+  checkScanRed space [(scan_op, nes, mempty)] ts body
+
+typeCheckSegOp checkLvl (SegHist lvl space ops ts kbody) = do
+  checkLvl lvl
+  checkSegSpace space
+  mapM_ TC.checkType ts
+
+  TC.binding (scopeOfSegSpace space) $ do
+    nes_ts <- forM ops $ \(HistOp dest_w rf dests nes shape op) -> do
+      TC.require [Prim int32] dest_w
+      TC.require [Prim int32] rf
+      nes' <- mapM TC.checkArg nes
+      mapM_ (TC.require [Prim int32]) $ shapeDims shape
+
+      -- Operator type must match the type of neutral elements.
+      let stripVecDims = stripArray $ shapeRank shape
+      TC.checkLambda op $ map (TC.noArgAliases . first stripVecDims) $ nes' ++ nes'
+      let nes_t = map TC.argType nes'
+      unless (nes_t == lambdaReturnType op) $
+        TC.bad $ TC.TypeError $ "SegHist operator has return type " ++
+        prettyTuple (lambdaReturnType op) ++ " but neutral element has type " ++
+        prettyTuple nes_t
+
+      -- Arrays must have proper type.
+      let dest_shape = Shape (segment_dims <> [dest_w]) <> shape
+      forM_ (zip nes_t dests) $ \(t, dest) -> do
+        TC.requireI [t `arrayOfShape` dest_shape] dest
+        TC.consume =<< TC.lookupAliases dest
+
+      return $ map (`arrayOfShape` shape) nes_t
+
+    checkKernelBody ts kbody
+
+    -- Return type of bucket function must be an index for each
+    -- operation followed by the values to write.
+    let bucket_ret_t = replicate (length ops) (Prim int32) ++ concat nes_ts
+    unless (bucket_ret_t == ts) $
+      TC.bad $ TC.TypeError $ "SegHist body has return type " ++
+      prettyTuple ts ++ " but should have type " ++
+      prettyTuple bucket_ret_t
+
+  where segment_dims = init $ segSpaceDims space
+
+checkScanRed :: TC.Checkable lore =>
+                SegSpace
+             -> [(Lambda (Aliases lore), [SubExp], Shape)]
+             -> [Type]
+             -> KernelBody (Aliases lore)
+             -> TC.TypeM lore ()
+checkScanRed space ops ts kbody = do
+  checkSegSpace space
+  mapM_ TC.checkType ts
+
+  TC.binding (scopeOfSegSpace space) $ do
+    ne_ts <- forM ops $ \(lam, nes, shape) -> do
+      mapM_ (TC.require [Prim int32]) $ shapeDims shape
+      nes' <- mapM TC.checkArg nes
+
+      -- Operator type must match the type of neutral elements.
+      let stripVecDims = stripArray $ shapeRank shape
+      TC.checkLambda lam $ map (TC.noArgAliases . first stripVecDims) $ nes' ++ nes'
+      let nes_t = map TC.argType nes'
+
+      unless (lambdaReturnType lam == nes_t) $
+        TC.bad $ TC.TypeError "wrong type for operator or neutral elements."
+
+      return $ map (`arrayOfShape` shape) nes_t
+
+    let expecting = concat ne_ts
+        got = take (length expecting) ts
+    unless (expecting == got) $
+      TC.bad $ TC.TypeError $
+      "Wrong return for body (does not match neutral elements; expected " ++
+      pretty expecting ++ "; found " ++
+      pretty got ++ ")"
+
+    checkKernelBody ts kbody
+
+-- | Like 'Mapper', but just for 'SegOp's.
+data SegOpMapper lvl flore tlore m = SegOpMapper {
+    mapOnSegOpSubExp :: SubExp -> m SubExp
+  , mapOnSegOpLambda :: Lambda flore -> m (Lambda tlore)
+  , mapOnSegOpBody :: KernelBody flore -> m (KernelBody tlore)
+  , mapOnSegOpVName :: VName -> m VName
+  , mapOnSegOpLevel :: lvl -> m lvl
+  }
+
+-- | A mapper that simply returns the 'SegOp' verbatim.
+identitySegOpMapper :: Monad m => SegOpMapper lvl lore lore m
+identitySegOpMapper = SegOpMapper { mapOnSegOpSubExp = return
+                                  , mapOnSegOpLambda = return
+                                  , mapOnSegOpBody = return
+                                  , mapOnSegOpVName = return
+                                  , mapOnSegOpLevel = return
+                                  }
+
+mapOnSegSpace :: Monad f =>
+                 SegOpMapper lvl flore tlore f -> SegSpace -> f SegSpace
+mapOnSegSpace tv (SegSpace phys dims) =
+  SegSpace phys <$> traverse (traverse $ mapOnSegOpSubExp tv) dims
+
+mapSegOpM :: (Applicative m, Monad m) =>
+             SegOpMapper lvl flore tlore m
+          -> SegOp lvl flore -> m (SegOp lvl tlore)
+mapSegOpM tv (SegMap lvl space ts body) =
+  SegMap
+  <$> mapOnSegOpLevel tv lvl
+  <*> mapOnSegSpace tv space
+  <*> mapM (mapOnSegOpType tv) ts
+  <*> mapOnSegOpBody tv body
+mapSegOpM tv (SegRed lvl space reds ts lam) =
+  SegRed
+  <$> mapOnSegOpLevel tv lvl
+  <*> mapOnSegSpace tv space
+  <*> mapM onSegOp reds
+  <*> mapM (mapOnType $ mapOnSegOpSubExp tv) ts
+  <*> mapOnSegOpBody tv lam
+  where onSegOp (SegRedOp comm red_op nes shape) =
+          SegRedOp comm
+          <$> mapOnSegOpLambda tv red_op
+          <*> mapM (mapOnSegOpSubExp tv) nes
+          <*> (Shape <$> mapM (mapOnSegOpSubExp tv) (shapeDims shape))
+mapSegOpM tv (SegScan lvl space scan_op nes ts body) =
+  SegScan
+  <$> mapOnSegOpLevel tv lvl
+  <*> mapOnSegSpace tv space
+  <*> mapOnSegOpLambda tv scan_op
+  <*> mapM (mapOnSegOpSubExp tv) nes
+  <*> mapM (mapOnType $ mapOnSegOpSubExp tv) ts
+  <*> mapOnSegOpBody tv body
+mapSegOpM tv (SegHist lvl space ops ts body) =
+  SegHist
+  <$> mapOnSegOpLevel tv lvl
+  <*> mapOnSegSpace tv space
+  <*> mapM onHistOp ops
+  <*> mapM (mapOnType $ mapOnSegOpSubExp tv) ts
+  <*> mapOnSegOpBody tv body
+  where onHistOp (HistOp w rf arrs nes shape op) =
+          HistOp <$> mapOnSegOpSubExp tv w
+          <*> mapOnSegOpSubExp tv rf
+          <*> mapM (mapOnSegOpVName tv) arrs
+          <*> mapM (mapOnSegOpSubExp tv) nes
+          <*> (Shape <$> mapM (mapOnSegOpSubExp tv) (shapeDims shape))
+          <*> mapOnSegOpLambda tv op
+
+mapOnSegOpType :: Monad m =>
+                  SegOpMapper lvl flore tlore m -> Type -> m Type
+mapOnSegOpType _tv (Prim pt) = pure $ Prim pt
+mapOnSegOpType tv (Array pt shape u) = Array pt <$> f shape <*> pure u
+  where f (Shape dims) = Shape <$> mapM (mapOnSegOpSubExp tv) dims
+mapOnSegOpType _tv (Mem s) = pure $ Mem s
+
+instance (Attributes lore, Substitute lvl) =>
+         Substitute (SegOp lvl lore) where
+  substituteNames subst = runIdentity . mapSegOpM substitute
+    where substitute =
+            SegOpMapper { mapOnSegOpSubExp = return . substituteNames subst
+                        , mapOnSegOpLambda = return . substituteNames subst
+                        , mapOnSegOpBody = return . substituteNames subst
+                        , mapOnSegOpVName = return . substituteNames subst
+                        , mapOnSegOpLevel = return . substituteNames subst
+                        }
+
+instance (Attributes lore, ASTConstraints lvl) =>
+         Rename (SegOp lvl lore) where
+  rename = mapSegOpM renamer
+    where renamer = SegOpMapper rename rename rename rename rename
+
+instance (Attributes lore, FreeIn (LParamAttr lore), FreeIn lvl) =>
+         FreeIn (SegOp lvl lore) where
+  freeIn' e = flip execState mempty $ mapSegOpM free e
+    where walk f x = modify (<>f x) >> return x
+          free = SegOpMapper { mapOnSegOpSubExp = walk freeIn'
+                             , mapOnSegOpLambda = walk freeIn'
+                             , mapOnSegOpBody = walk freeIn'
+                             , mapOnSegOpVName = walk freeIn'
+                             , mapOnSegOpLevel = walk freeIn'
+                             }
+
+instance OpMetrics (Op lore) => OpMetrics (SegOp lvl lore) where
+  opMetrics (SegMap _ _ _ body) =
+    inside "SegMap" $ kernelBodyMetrics body
+  opMetrics (SegRed _ _ reds _ body) =
+    inside "SegRed" $ do mapM_ (lambdaMetrics . segRedLambda) reds
+                         kernelBodyMetrics body
+  opMetrics (SegScan _ _ scan_op _ _ body) =
+    inside "SegScan" $ lambdaMetrics scan_op >> kernelBodyMetrics body
+  opMetrics (SegHist _ _ ops _ body) =
+    inside "SegHist" $ do mapM_ (lambdaMetrics . histOp) ops
+                          kernelBodyMetrics body
+
+instance Pretty SegSpace where
+  ppr (SegSpace phys dims) = parens (commasep $ do (i,d) <- dims
+                                                   return $ ppr i <+> "<" <+> ppr d) <+>
+                             parens (text "~" <> ppr phys)
+
+instance (PrettyLore lore, PP.Pretty lvl) => PP.Pretty (SegOp lvl lore) where
+  ppr (SegMap lvl space ts body) =
+    text "segmap" <> ppr lvl </>
+    PP.align (ppr space) <+>
+    PP.colon <+> ppTuple' ts <+> PP.nestedBlock "{" "}" (ppr body)
+
+  ppr (SegRed lvl space reds ts body) =
+    text "segred" <> ppr lvl </>
+    PP.parens (PP.braces (mconcat $ intersperse (PP.comma <> PP.line) $ map ppOp reds)) </>
+    PP.align (ppr space) <+> PP.colon <+> ppTuple' ts <+>
+    PP.nestedBlock "{" "}" (ppr body)
+    where ppOp (SegRedOp comm lam nes shape) =
+            PP.braces (PP.commasep $ map ppr nes) <> PP.comma </>
+            ppr shape <> PP.comma </>
+            comm' <> ppr lam
+            where comm' = case comm of Commutative -> text "commutative "
+                                       Noncommutative -> mempty
+
+  ppr (SegScan lvl space scan_op nes ts body) =
+    text "segscan" <> ppr lvl </>
+    ppr lvl </>
+    PP.parens (ppr scan_op <> PP.comma </>
+               PP.braces (PP.commasep $ map ppr nes)) </>
+    PP.align (ppr space) <+> PP.colon <+> ppTuple' ts <+>
+    PP.nestedBlock "{" "}" (ppr body)
+
+  ppr (SegHist lvl space ops ts body) =
+    text "seghist" <> ppr lvl </>
+    ppr lvl </>
+    PP.parens (PP.braces (mconcat $ intersperse (PP.comma <> PP.line) $ map ppOp ops)) </>
+    PP.align (ppr space) <+> PP.colon <+> ppTuple' ts <+>
+    PP.nestedBlock "{" "}" (ppr body)
+    where ppOp (HistOp w rf dests nes shape op) =
+            ppr w <> PP.comma <+> ppr rf <> PP.comma </>
+            PP.braces (PP.commasep $ map ppr dests) <> PP.comma </>
+            PP.braces (PP.commasep $ map ppr nes) <> PP.comma </>
+            ppr shape <> PP.comma </>
+            ppr op
+
+instance (Attributes inner, ASTConstraints lvl) =>
+         RangedOp (SegOp lvl inner) where
+  opRanges op = replicate (length $ segOpType op) unknownRange
+
+instance (Attributes lore, CanBeRanged (Op lore), ASTConstraints lvl) =>
+         CanBeRanged (SegOp lvl lore) where
+  type OpWithRanges (SegOp lvl lore) = SegOp lvl (Ranges lore)
+
+  removeOpRanges = runIdentity . mapSegOpM remove
+    where remove = SegOpMapper return (return . removeLambdaRanges)
+                   (return . removeKernelBodyRanges) return return
+  addOpRanges = Range.runRangeM . mapSegOpM add
+    where add = SegOpMapper return Range.analyseLambda
+                addKernelBodyRanges return return
+
+instance (Attributes lore, Attributes (Aliases lore),
+          CanBeAliased (Op lore), ASTConstraints lvl) =>
+         CanBeAliased (SegOp lvl lore) where
+  type OpWithAliases (SegOp lvl lore) = SegOp lvl (Aliases lore)
+
+  addOpAliases = runIdentity . mapSegOpM alias
+    where alias = SegOpMapper return (return . Alias.analyseLambda)
+                  (return . aliasAnalyseKernelBody) return return
+
+  removeOpAliases = runIdentity . mapSegOpM remove
+    where remove = SegOpMapper return (return . removeLambdaAliases)
+                   (return . removeKernelBodyAliases) return return
+
+instance (CanBeWise (Op lore), Attributes lore, ASTConstraints lvl) =>
+         CanBeWise (SegOp lvl lore) where
+  type OpWithWisdom (SegOp lvl lore) = SegOp lvl (Wise lore)
+
+  removeOpWisdom = runIdentity . mapSegOpM remove
+    where remove = SegOpMapper return
+                   (return . removeLambdaWisdom)
+                   (return . removeKernelBodyWisdom)
+                   return return
+
+instance Attributes lore => ST.IndexOp (SegOp lvl lore) where
+  indexOp vtable k (SegMap _ space _ kbody) is = do
+    Returns ResultMaySimplify se <- maybeNth k $ kernelBodyResult kbody
+    guard $ length gtids <= length is
+    let idx_table = M.fromList $ zip gtids $ map (ST.Indexed mempty) is
+        idx_table' = foldl expandIndexedTable idx_table $ kernelBodyStms kbody
+    case se of
+      Var v -> M.lookup v idx_table'
+      _ -> Nothing
+
+    where (gtids, _) = unzip $ unSegSpace space
+          -- Indexes in excess of what is used to index through the
+          -- segment dimensions.
+          excess_is = drop (length gtids) is
+
+          expandIndexedTable table stm
+            | [v] <- patternNames $ stmPattern stm,
+              Just (pe,cs) <-
+                  runWriterT $ primExpFromExp (asPrimExp table) $ stmExp stm =
+                M.insert v (ST.Indexed (stmCerts stm <> cs) pe) table
+
+            | [v] <- patternNames $ stmPattern stm,
+              BasicOp (Index arr slice) <- stmExp stm,
+              length (sliceDims slice) == length excess_is,
+              arr `ST.elem` vtable,
+              Just (slice', cs) <- asPrimExpSlice table slice =
+                let idx = ST.IndexedArray (stmCerts stm <> cs)
+                          arr (fixSlice slice' excess_is)
+                in M.insert v idx table
+
+            | otherwise =
+                table
+
+          asPrimExpSlice table =
+            runWriterT . mapM (traverse (primExpFromSubExpM (asPrimExp table)))
+
+          asPrimExp table v
+            | Just (ST.Indexed cs e) <- M.lookup v table = tell cs >> return e
+            | Just (Prim pt) <- ST.lookupType v vtable =
+                return $ LeafExp v pt
+            | otherwise = lift Nothing
+
+  indexOp _ _ _ _ = Nothing
+
+instance (Attributes lore, ASTConstraints lvl) =>
+         IsOp (SegOp lvl lore) where
+  cheapOp _ = False
+  safeOp _ = True
+
+--- Simplification
+
+instance Engine.Simplifiable SplitOrdering where
+  simplify SplitContiguous =
+    return SplitContiguous
+  simplify (SplitStrided stride) =
+    SplitStrided <$> Engine.simplify stride
+
+instance Engine.Simplifiable SegSpace where
+  simplify (SegSpace phys dims) =
+    SegSpace phys <$> mapM (traverse Engine.simplify) dims
+
+instance Engine.Simplifiable KernelResult where
+  simplify (Returns manifest what) =
+    Returns manifest <$> Engine.simplify what
+  simplify (WriteReturns ws a res) =
+    WriteReturns <$> Engine.simplify ws <*> Engine.simplify a <*> Engine.simplify res
+  simplify (ConcatReturns o w pte what) =
+    ConcatReturns
+    <$> Engine.simplify o
+    <*> Engine.simplify w
+    <*> Engine.simplify pte
+    <*> Engine.simplify what
+  simplify (TileReturns dims what) =
+    TileReturns <$> Engine.simplify dims <*> Engine.simplify what
+
+mkWiseKernelBody :: (Attributes lore, CanBeWise (Op lore)) =>
+                    BodyAttr lore -> Stms (Wise lore) -> [KernelResult] -> KernelBody (Wise lore)
+mkWiseKernelBody attr bnds res =
+  let Body attr' _ _ = mkWiseBody attr bnds res_vs
+  in KernelBody attr' bnds res
+  where res_vs = map kernelResultSubExp res
+
+mkKernelBodyM :: MonadBinder m =>
+                 Stms (Lore m) -> [KernelResult]
+              -> m (KernelBody (Lore m))
+mkKernelBodyM stms kres = do
+  Body attr' _ _ <- mkBodyM stms res_ses
+  return $ KernelBody attr' stms kres
+  where res_ses = map kernelResultSubExp kres
+
+simplifyKernelBody :: (Engine.SimplifiableLore lore, BodyAttr lore ~ ()) =>
+                      SegSpace -> KernelBody lore
+                   -> Engine.SimpleM lore (KernelBody (Wise lore), Stms (Wise lore))
+simplifyKernelBody space (KernelBody _ stms res) = do
+  par_blocker <- Engine.asksEngineEnv $ Engine.blockHoistPar . Engine.envHoistBlockers
+
+  ((body_stms, body_res), hoisted) <-
+    Engine.localVtable (<>scope_vtable) $
+    Engine.localVtable (\vtable -> vtable { ST.simplifyMemory = True }) $
+    Engine.blockIf (Engine.hasFree bound_here
+                    `Engine.orIf` Engine.isOp
+                    `Engine.orIf` par_blocker
+                    `Engine.orIf` Engine.isConsumed) $
+    Engine.simplifyStms stms $ do
+    res' <- Engine.localVtable (ST.hideCertified $ namesFromList $ M.keys $ scopeOf stms) $
+            mapM Engine.simplify res
+    return ((res', UT.usages $ freeIn res'), mempty)
+
+  return (mkWiseKernelBody () body_stms body_res, hoisted)
+
+  where scope_vtable = ST.fromScope $ scopeOfSegSpace space
+        bound_here = namesFromList $ M.keys $ scopeOfSegSpace space
+
+simplifyRedOrScan :: (Engine.SimplifiableLore lore, BodyAttr lore ~ ()) =>
+                     SegSpace
+                  -> Lambda lore -> [SubExp] -> [Type]
+                  -> KernelBody lore
+                  -> Engine.SimpleM lore
+                  (SegSpace, Lambda (Wise lore), [SubExp], [Type], KernelBody (Wise lore),
+                   Stms (Wise lore))
+simplifyRedOrScan space scan_op nes ts kbody = do
+  space' <- Engine.simplify space
+  nes' <- mapM Engine.simplify nes
+  ts' <- mapM Engine.simplify ts
+
+  (scan_op', scan_op_hoisted) <-
+    Engine.localVtable (<>scope_vtable) $
+    Engine.localVtable (\vtable -> vtable { ST.simplifyMemory = True }) $
+    Engine.simplifyLambda scan_op $ replicate (length nes * 2) Nothing
+
+  (kbody', body_hoisted) <- simplifyKernelBody space kbody
+
+  return (space', scan_op', nes', ts', kbody',
+          scan_op_hoisted <> body_hoisted)
+
+  where scope = scopeOfSegSpace space
+        scope_vtable = ST.fromScope scope
+
+simplifySegOp :: (Attributes lore,
+                  Engine.Simplifiable (LetAttr lore),
+                  Engine.Simplifiable (FParamAttr lore),
+                  Engine.Simplifiable (LParamAttr lore),
+                  Engine.Simplifiable (RetType lore),
+                  Engine.Simplifiable (BranchType lore),
+                  Engine.Simplifiable lvl,
+                  CanBeWise (Op lore),
+                  ST.IndexOp (OpWithWisdom (Op lore)), BinderOps (Wise lore),
+                  BodyAttr lore ~ ()) =>
+                 SegOp lvl lore
+              -> Engine.SimpleM lore (SegOp lvl (Wise lore), Stms (Wise lore))
+simplifySegOp (SegMap lvl space ts kbody) = do
+  (lvl', space', ts') <- Engine.simplify (lvl, space, ts)
+  (kbody', body_hoisted) <- simplifyKernelBody space kbody
+  return (SegMap lvl' space' ts' kbody',
+          body_hoisted)
+
+simplifySegOp (SegRed lvl space reds ts kbody) = do
+  (lvl', space', ts') <- Engine.simplify (lvl, space, ts)
+  (reds', reds_hoisted) <- fmap unzip $ forM reds $ \(SegRedOp comm lam nes shape) -> do
+    (lam', hoisted) <-
+      Engine.localVtable (<>scope_vtable) $
+      Engine.localVtable (\vtable -> vtable { ST.simplifyMemory = True }) $
+      Engine.simplifyLambda lam $ replicate (length nes * 2) Nothing
+    shape' <- Engine.simplify shape
+    nes' <- mapM Engine.simplify nes
+    return (SegRedOp comm lam' nes' shape', hoisted)
+
+  (kbody', body_hoisted) <- simplifyKernelBody space kbody
+
+  return (SegRed lvl' space' reds' ts' kbody',
+          mconcat reds_hoisted <> body_hoisted)
+  where scope = scopeOfSegSpace space
+        scope_vtable = ST.fromScope scope
+
+simplifySegOp (SegScan lvl space scan_op nes ts kbody) = do
+  lvl' <- Engine.simplify lvl
+  (space', scan_op', nes', ts', kbody', hoisted) <-
+    simplifyRedOrScan space scan_op nes ts kbody
+
+  return (SegScan lvl' space' scan_op' nes' ts' kbody',
+          hoisted)
+
+simplifySegOp (SegHist lvl space ops ts kbody) = do
+  (lvl', space', ts') <- Engine.simplify (lvl, space, ts)
+
+  (ops', ops_hoisted) <- fmap unzip $ forM ops $
+    \(HistOp w rf arrs nes dims lam) -> do
+      w' <- Engine.simplify w
+      rf' <- Engine.simplify rf
+      arrs' <- Engine.simplify arrs
+      nes' <- Engine.simplify nes
+      dims' <- Engine.simplify dims
+      (lam', op_hoisted) <-
+        Engine.localVtable (<>scope_vtable) $
+        Engine.localVtable (\vtable -> vtable { ST.simplifyMemory = True }) $
+        Engine.simplifyLambda lam $
+        replicate (length nes * 2) Nothing
+      return (HistOp w' rf' arrs' nes' dims' lam',
+              op_hoisted)
+
+  (kbody', body_hoisted) <- simplifyKernelBody space kbody
+
+  return (SegHist lvl' space' ops' ts' kbody',
+          mconcat ops_hoisted <> body_hoisted)
+
+  where scope = scopeOfSegSpace space
+        scope_vtable = ST.fromScope scope
+
+-- | Does this lore contain 'SegOp's in its 'Op's?  A lore must be an
+-- instance of this class for the simplification rules to work.
+class HasSegOp lvl lore | lore -> lvl where
+  asSegOp :: Op lore -> Maybe (SegOp lvl lore)
+  segOp :: SegOp lvl lore -> Op lore
+
+-- | Simplification rules for simplifying 'SegOp's.
+segOpRules :: (HasSegOp lvl lore, BinderOps lore, Bindable lore) =>
+              RuleBook lore
+segOpRules =
+  ruleBook [ RuleOp segOpRuleTopDown ] [ RuleOp segOpRuleBottomUp ]
+
+segOpRuleTopDown :: (HasSegOp lvl lore, BinderOps lore, Bindable lore) =>
+                    TopDownRuleOp lore
+segOpRuleTopDown vtable pat attr op
+  | Just op' <- asSegOp op =
+      topDownSegOp vtable pat attr op'
+  | otherwise =
+      Skip
+
+segOpRuleBottomUp :: (HasSegOp lvl lore, BinderOps lore) =>
+                     BottomUpRuleOp lore
+segOpRuleBottomUp vtable pat attr op
+  | Just op' <- asSegOp op =
+      bottomUpSegOp vtable pat attr op'
+  | otherwise =
+      Skip
+
+topDownSegOp :: (HasSegOp lvl lore, BinderOps lore, Bindable lore) =>
+                ST.SymbolTable lore
+             -> Pattern lore
+             -> StmAux (ExpAttr lore)
+             -> SegOp lvl lore
+             -> Rule lore
+
+-- If a SegOp produces something invariant to the SegOp, turn it
+-- into a replicate.
+topDownSegOp vtable (Pattern [] kpes) attr (SegMap lvl space ts (KernelBody _ kstms kres)) = Simplify $ do
+  (ts', kpes', kres') <-
+    unzip3 <$> filterM checkForInvarianceResult (zip3 ts kpes kres)
+
+  -- Check if we did anything at all.
+  when (kres == kres')
+    cannotSimplify
+
+  kbody <- mkKernelBodyM kstms kres'
+  addStm $ Let (Pattern [] kpes') attr $ Op $ segOp $
+    SegMap lvl space ts' kbody
+
+  where isInvariant Constant{} = True
+        isInvariant (Var v) = isJust $ ST.lookup v vtable
+
+        checkForInvarianceResult (_, pe, Returns rm se)
+          | rm == ResultMaySimplify,
+            isInvariant se = do
+              letBindNames_ [patElemName pe] $
+                BasicOp $ Replicate (Shape $ segSpaceDims space) se
+              return False
+        checkForInvarianceResult _ =
+          return True
+
+-- If a SegRed contains two reduction operations that have the same
+-- vector shape, merge them together.  This saves on communication
+-- overhead, but can in principle lead to more local memory usage.
+topDownSegOp _ (Pattern [] pes) _ (SegRed lvl space ops ts kbody)
+  | length ops > 1,
+    op_groupings <- groupBy sameShape $ zip ops $ chunks (map (length . segRedNeutral) ops) $
+                    zip3 red_pes red_ts red_res,
+    any ((>1) . length) op_groupings = Simplify $ do
+      let (ops', aux) = unzip $ mapMaybe combineOps op_groupings
+          (red_pes', red_ts', red_res') = unzip3 $ concat aux
+          pes' = red_pes' ++ map_pes
+          ts' = red_ts' ++ map_ts
+          kbody' = kbody { kernelBodyResult = red_res' ++ map_res }
+      letBind_ (Pattern [] pes') $ Op $ segOp $ SegRed lvl space ops' ts' kbody'
+  where (red_pes, map_pes) = splitAt (segRedResults ops) pes
+        (red_ts, map_ts) = splitAt (segRedResults ops) ts
+        (red_res, map_res) = splitAt (segRedResults ops) $ kernelBodyResult kbody
+
+        sameShape (op1, _) (op2, _) = segRedShape op1 == segRedShape op2
+
+        combineOps [] = Nothing
+        combineOps (x:xs) = Just $ foldl' combine x xs
+
+        combine (op1, op1_aux) (op2, op2_aux) =
+          let lam1 = segRedLambda op1
+              lam2 = segRedLambda op2
+              (op1_xparams, op1_yparams) =
+                splitAt (length (segRedNeutral op1)) $ lambdaParams lam1
+              (op2_xparams, op2_yparams) =
+                splitAt (length (segRedNeutral op2)) $ lambdaParams lam2
+              lam = Lambda { lambdaParams = op1_xparams ++ op2_xparams ++
+                                            op1_yparams ++ op2_yparams
+                           , lambdaReturnType = lambdaReturnType lam1 ++ lambdaReturnType lam2
+                           , lambdaBody =
+                               mkBody (bodyStms (lambdaBody lam1) <> bodyStms (lambdaBody lam2)) $
+                               bodyResult (lambdaBody lam1) <> bodyResult (lambdaBody lam2)
+                           }
+          in (SegRedOp { segRedComm = segRedComm op1 <> segRedComm op2
+                       , segRedLambda = lam
+                       , segRedNeutral = segRedNeutral op1 ++ segRedNeutral op2
+                       , segRedShape = segRedShape op1 -- Same as shape of op2 due to the grouping.
+                       },
+               op1_aux ++ op2_aux)
+topDownSegOp _ _ _ _ = Skip
+
+bottomUpSegOp :: (HasSegOp lvl lore, BinderOps lore) =>
+                 (ST.SymbolTable lore, UT.UsageTable)
+              -> Pattern lore
+              -> StmAux (ExpAttr lore)
+              -> SegOp lvl lore
+              -> Rule lore
+
+-- Some SegOp results can be moved outside the SegOp, which can
+-- simplify further analysis.
+bottomUpSegOp (vtable, used) (Pattern [] kpes) attr (SegMap lvl space kts (KernelBody _ kstms kres)) = Simplify $ do
+
+  -- Iterate through the bindings.  For each, we check whether it is
+  -- in kres and can be moved outside.  If so, we remove it from kres
+  -- and kpes and make it a binding outside.
+  (kpes', kts', kres', kstms') <- localScope (scopeOfSegSpace space) $
+    foldM distribute (kpes, kts, kres, mempty) kstms
+
+  when (kpes' == kpes)
+    cannotSimplify
+
+  kbody <- localScope (scopeOfSegSpace space) $
+           mkKernelBodyM kstms' kres'
+
+  addStm $ Let (Pattern [] kpes') attr $ Op $ segOp $
+    SegMap lvl space kts' kbody
+  where
+    free_in_kstms = foldMap freeIn kstms
+
+    sliceWithGtidsFixed stm
+      | Let _ _ (BasicOp (Index arr slice)) <- stm,
+        space_slice <- map (DimFix . Var . fst) $ unSegSpace space,
+        space_slice `isPrefixOf` slice,
+        remaining_slice <- drop (length space_slice) slice,
+        all (isJust . flip ST.lookup vtable) $ namesToList $
+          freeIn arr <> freeIn remaining_slice =
+          Just (remaining_slice, arr)
+
+      | otherwise =
+          Nothing
+
+    distribute (kpes', kts', kres', kstms') stm
+      | Let (Pattern [] [pe]) _ _ <- stm,
+        Just (remaining_slice, arr) <- sliceWithGtidsFixed stm,
+        Just (kpe, kpes'', kts'', kres'') <- isResult kpes' kts' kres' pe = do
+          let outer_slice = map (\d -> DimSlice
+                                       (constant (0::Int32))
+                                       d
+                                       (constant (1::Int32))) $
+                            segSpaceDims space
+              index kpe' = letBind_ (Pattern [] [kpe']) $ BasicOp $ Index arr $
+                           outer_slice <> remaining_slice
+          if patElemName kpe `UT.isConsumed` used
+            then do precopy <- newVName $ baseString (patElemName kpe) <> "_precopy"
+                    index kpe { patElemName = precopy }
+                    letBind_ (Pattern [] [kpe]) $ BasicOp $ Copy precopy
+            else index kpe
+          return (kpes'', kts'', kres'',
+                  if patElemName pe `nameIn` free_in_kstms
+                  then kstms' <> oneStm stm
+                  else kstms')
+
+    distribute (kpes', kts', kres', kstms') stm =
+      return (kpes', kts', kres', kstms' <> oneStm stm)
+
+    isResult kpes' kts' kres' pe =
+      case partition matches $ zip3 kpes' kts' kres' of
+        ([(kpe,_,_)], kpes_and_kres)
+          | (kpes'', kts'', kres'') <- unzip3 kpes_and_kres ->
+              Just (kpe, kpes'', kts'', kres'')
+        _ -> Nothing
+      where matches (_, _, Returns _ (Var v)) = v == patElemName pe
+            matches _ = False
+bottomUpSegOp _ _ _ _ = Skip

--- a/src/Futhark/TypeCheck.hs
+++ b/src/Futhark/TypeCheck.hs
@@ -32,7 +32,6 @@ module Futhark.TypeCheck
   , checkType
   , checkExtType
   , matchExtPattern
-  , matchExtReturnType
   , matchExtBranchType
   , argType
   , argAliases
@@ -977,6 +976,15 @@ matchExtReturns rettype res ts = do
       (ctx_ts, val_ts) = splitFromEnd (length rettype) ts
 
   unless (length val_res == length rettype) problem
+
+  let num_exts = length $ S.fromList $
+                 concatMap (mapMaybe isExt . arrayExtDims) rettype
+  unless (num_exts == length ctx_res) $
+    bad $ TypeError $
+    "Number of context results does not match number of existentials in the return type.\n" ++
+    "Type:\n  " ++
+    prettyTuple rettype ++
+    "\ncannot match context parameters:\n  " ++ prettyTuple ctx_res
 
   let ctx_vals = zip ctx_res ctx_ts
       instantiateExt i = case maybeNth i ctx_vals of

--- a/src/Language/Futhark/Traversals.hs
+++ b/src/Language/Futhark/Traversals.hs
@@ -238,20 +238,24 @@ traverseScalarType f g h (TypeVar als u t args) =
   TypeVar <$> h als <*> pure u <*> f t <*> traverse (traverseTypeArg f g) args
 traverseScalarType f g h (Arrow als v t1 t2) =
   Arrow <$> h als <*> pure v <*> traverseType f g h t1 <*> traverseType f g h t2
-traverseScalarType f g h (Sum cs) = Sum <$> (traverse . traverse) (traverseType f g h) cs
+traverseScalarType f g h (Sum cs) =
+  Sum <$> (traverse . traverse) (traverseType f g h) cs
 
 traverseType :: Applicative f =>
                 TypeTraverser f TypeBase dim1 als1 dims als2
 traverseType f g h (Array als u et shape) =
-  Array <$> h als <*> pure u <*> traverseScalarType f g pure et <*> traverse g shape
+  Array <$> h als <*> pure u <*>
+  traverseScalarType f g pure et <*> traverse g shape
 traverseType f g h (Scalar t) =
   Scalar <$> traverseScalarType f g h t
 
 traverseTypeArg :: Applicative f =>
                    (TypeName -> f TypeName) -> (dim1 -> f dim2)
                 -> TypeArg dim1 -> f (TypeArg dim2)
-traverseTypeArg _ g (TypeArgDim d loc) = TypeArgDim <$> g d <*> pure loc
-traverseTypeArg f g (TypeArgType t loc) = TypeArgType <$> traverseType f g pure t <*> pure loc
+traverseTypeArg _ g (TypeArgDim d loc) =
+  TypeArgDim <$> g d <*> pure loc
+traverseTypeArg f g (TypeArgType t loc) =
+  TypeArgType <$> traverseType f g pure t <*> pure loc
 
 instance ASTMappable StructType where
   astMap tv = traverseType f (astMap tv) pure

--- a/tests/issue941.fut
+++ b/tests/issue941.fut
@@ -1,0 +1,11 @@
+type sometype 't = #someval t
+
+let geni32 (maxsize : i32) : sometype i32 = #someval maxsize
+
+let genarr 'elm
+           (genelm: i32 -> sometype elm)
+           (ownsize : i32)
+           : sometype ([ownsize](sometype elm)) =
+  #someval (tabulate ownsize genelm)
+
+let main = genarr geni32 1

--- a/tests/issue942.fut
+++ b/tests/issue942.fut
@@ -1,0 +1,13 @@
+-- ==
+-- input {} output { [0] }
+
+type sometype 't = #someval t
+
+let f (size : i32) (_ : i32) : sometype ([size]i32) =
+  #someval (iota size)
+
+let apply '^a '^b (f: a -> b) (x: a) = f x
+
+let main : [1]i32 =
+  match apply (f 1) 0
+  case #someval x -> x


### PR DESCRIPTION
**You probably don't want to merge this yet.**

This PR introduces a distinct intermediate representation for multicore parallelism.  The change in code generation is not great yet, but it will allow us to add various extra information, and do different transformations, compared to the GPU backend.  The main visible change from your point of view is that parallelism may now be *nested*.  That is, the body of a SegOp may contain other SegOps.  This doesn't work with the current scheduler, which is why I think we should probably wait a bit before merging this.