### PR TITLE
Apply moderate flattening for multicore backend

### DIFF
--- a/futhark.cabal
+++ b/futhark.cabal
@@ -177,6 +177,8 @@ library
       Futhark.Pass.ExtractKernels.Interchange
       Futhark.Pass.ExtractKernels.Intragroup
       Futhark.Pass.ExtractKernels.ISRWIM
+      Futhark.Pass.ExtractKernels.StreamKernel
+      Futhark.Pass.ExtractKernels.ToKernels
       Futhark.Pass.ExtractMulticore
       Futhark.Pass.FirstOrderTransform
       Futhark.Pass.KernelBabysitting

--- a/src/Futhark/CLI/Dev.hs
+++ b/src/Futhark/CLI/Dev.hs
@@ -463,6 +463,8 @@ runPolyPasses config initial_prog = do
         actionProcedure action prog
       (KernelsMem prog, KernelsMemAction action) ->
         actionProcedure action prog
+      (MCMem prog, MCMemAction action) ->
+        actionProcedure action prog
 
       (SOACS soacs_prog, PolyAction acs) ->
         actionProcedure (actionSOACS acs) soacs_prog

--- a/src/Futhark/Pass/ExpandAllocations.hs
+++ b/src/Futhark/Pass/ExpandAllocations.hs
@@ -25,7 +25,8 @@ import Futhark.Representation.KernelsMem
 import qualified Futhark.Representation.Kernels as Kernels
 import Futhark.Representation.Kernels.Simplify as Kernels
 import qualified Futhark.Representation.Mem.IxFun as IxFun
-import Futhark.Pass.ExtractKernels.BlockedKernel (segThread, nonSegRed)
+import Futhark.Pass.ExtractKernels.BlockedKernel (nonSegRed)
+import Futhark.Pass.ExtractKernels.ToKernels (segThread)
 import Futhark.Pass.ExplicitAllocations.Kernels (explicitAllocationsInStms)
 import Futhark.Transform.Rename (renameStm)
 import Futhark.Transform.CopyPropagate (copyPropagateInFun)

--- a/src/Futhark/Pass/ExtractKernels.hs
+++ b/src/Futhark/Pass/ExtractKernels.hs
@@ -180,6 +180,8 @@ import Futhark.Pass.ExtractKernels.DistributeNests
 import Futhark.Pass.ExtractKernels.ISRWIM
 import Futhark.Pass.ExtractKernels.BlockedKernel
 import Futhark.Pass.ExtractKernels.Intragroup
+import Futhark.Pass.ExtractKernels.StreamKernel
+import Futhark.Pass.ExtractKernels.ToKernels
 import Futhark.Util
 import Futhark.Util.Log
 
@@ -231,6 +233,8 @@ transformFunDef scope (FunDef entry name rettype params body) = runDistribM $ do
   body' <- localScope (scope <> scopeOfFParams params) $
            transformBody mempty body
   return $ FunDef entry name rettype params body'
+
+type KernelsStms = Stms Out.Kernels
 
 transformBody :: KernelPath -> Body -> DistribM (Out.Body Out.Kernels)
 transformBody path body = do bnds <- transformStms path $ stmsToList $ bodyStms body
@@ -380,7 +384,8 @@ transformStm path (Let pat (StmAux cs _) (Op (Screma w form arrs)))
           (red_lam', nes', shape) <- determineReduceOp red_lam nes
           let comm' | commutativeLambda red_lam' = Commutative
                     | otherwise = comm
-          return $ SegRedOp comm' red_lam' nes' shape
+              red_lam'' = soacsLambdaToKernels red_lam'
+          return $ SegRedOp comm' red_lam'' nes' shape
         let map_lam_sequential = soacsLambdaToKernels map_lam
         lvl <- segThreadCapped [w] "segred" $ NoRecommendation SegNoVirt
         addStms =<<
@@ -447,7 +452,8 @@ transformStm path (Let pat aux@(StmAux cs _) (Op (Stream w (Parallel o comm red_
               red_pat = Pattern [] red_pat_elems
 
           ((num_threads, red_results), stms) <-
-            streamMap (map (baseString . patElemName) red_pat_elems) concat_pat_elems w
+            streamMap segThreadCapped
+            (map (baseString . patElemName) red_pat_elems) concat_pat_elems w
             Noncommutative fold_fun' nes arrs
 
           reduce_soac <- reduceSOAC [Reduce comm' red_fun nes]
@@ -461,7 +467,8 @@ transformStm path (Let pat aux@(StmAux cs _) (Op (Stream w (Parallel o comm red_
           let red_fun_sequential = soacsLambdaToKernels red_fun
               fold_fun_sequential = soacsLambdaToKernels fold_fun
           fmap (certify cs) <$>
-            streamRed pat w comm' red_fun_sequential fold_fun_sequential nes arrs
+            streamRed segThreadCapped
+            pat w comm' red_fun_sequential fold_fun_sequential nes arrs
 
     outerParallelBody path' =
       renameBody =<<
@@ -519,7 +526,8 @@ transformStm _ (Let orig_pat (StmAux cs _) (Op (Hist w ops bucket_fun imgs))) = 
   -- subhistograms as well.
   runBinder_ $ do
     lvl <- segThreadCapped [w] "seghist" $ NoRecommendation SegNoVirt
-    addStms =<< histKernel lvl orig_pat [] [] cs w ops bfun' imgs
+    addStms =<< histKernel onLambda lvl orig_pat [] [] cs w ops bfun' imgs
+  where onLambda = pure . soacsLambdaToKernels
 
 transformStm _ bnd =
   runBinder_ $ FOT.transformStmRecursively bnd
@@ -571,7 +579,8 @@ worthSequentialising lam = interesting $ lambdaBody lam
         interesting' _ = False
 
 
-onTopLevelStms :: KernelPath -> Stms SOACS -> DistNestT DistribM KernelsStms
+onTopLevelStms :: KernelPath -> Stms SOACS
+               -> DistNestT Out.Kernels DistribM KernelsStms
 onTopLevelStms path stms = do
   scope <- askScope
   lift $ localScope scope $ transformStms path $ stmsToList stms
@@ -588,6 +597,8 @@ onMap path (MapLoop pat cs w lam arrs) = do
                   , distOnInnerMap = onInnerMap path'
                   , distOnTopLevelStms = onTopLevelStms path'
                   , distSegLevel = segThreadCapped
+                  , distOnSOACSStms = pure . oneStm . soacsStmToKernels
+                  , distOnSOACSLambda = pure . soacsLambdaToKernels
                   }
       exploitInnerParallelism path' =
         runDistNestT (env path') $
@@ -599,7 +610,7 @@ onMap path (MapLoop pat cs w lam arrs) = do
     let exploitOuterParallelism path' = do
           let lam' = soacsLambdaToKernels lam
           runDistNestT (env path') $ distribute $
-            addStmsToKernel (bodyStms $ lambdaBody lam') acc
+            addStmsToAcc (bodyStms $ lambdaBody lam') acc
 
     onMap' (newKernel loopnest) path exploitOuterParallelism exploitInnerParallelism pat lam
     where acc = DistAcc { distTargets = singleTarget (pat, bodyResult $ lambdaBody lam)
@@ -667,17 +678,18 @@ onMap' loopnest path mk_seq_stms mk_par_stms pat lam = do
       ((outer_suff_stms<>intra_suff_stms)<>) <$>
         kernelAlternatives pat par_body (seq_alts ++ [(intra_ok, group_par_body)])
 
-onInnerMap :: KernelPath -> MapLoop -> DistAcc -> DistNestT DistribM DistAcc
+onInnerMap :: KernelPath -> MapLoop -> DistAcc Out.Kernels
+           -> DistNestT Out.Kernels DistribM (DistAcc Out.Kernels)
 onInnerMap path maploop@(MapLoop pat cs w lam arrs) acc
   | unbalancedLambda lam, lambdaContainsParallelism lam =
-      addStmToKernel (mapLoopStm maploop) acc
+      addStmToAcc (mapLoopStm maploop) acc
   | not incrementalFlattening =
       distributeMap maploop acc
   | otherwise =
       distributeSingleStm acc (mapLoopStm maploop) >>= \case
       Just (post_kernels, res, nest, acc')
         | Just (perm, _pat_unused) <- permutationAndMissing pat res -> do
-            addKernels post_kernels
+            addPostStms post_kernels
             multiVersion perm nest acc'
       _ -> distributeMap maploop acc
 
@@ -729,5 +741,5 @@ onInnerMap path maploop@(MapLoop pat cs w lam arrs) acc
           exploitInnerParallelism
           outer_pat lam'
 
-      addKernel stms
+      postStm stms
       return acc'

--- a/src/Futhark/Pass/ExtractKernels/BlockedKernel.hs
+++ b/src/Futhark/Pass/ExtractKernels/BlockedKernel.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ConstraintKinds #-}
 module Futhark.Pass.ExtractKernels.BlockedKernel
-       ( MkSegLevel
+       ( DistLore
+       , MkSegLevel
        , ThreadRecommendation(..)
        , segRed
        , nonSegRed
@@ -9,125 +11,49 @@ module Futhark.Pass.ExtractKernels.BlockedKernel
        , segHist
        , segMap
 
-       , streamRed
-       , streamMap
-
        , mapKernel
        , KernelInput(..)
        , readKernelInput
 
-       , soacsLambdaToKernels
-       , soacsStmToKernels
-       , scopeForKernels
-       , scopeForSOACs
-
-       , getSize
-       , segThread
-       , segThreadCapped
        , mkSegSpace
+       , dummyDim
        )
        where
 
 import Control.Monad
 import Control.Monad.Writer
-import Control.Monad.Identity
 import Data.List ()
 
 import Prelude hiding (quot)
 
 import Futhark.Analysis.PrimExp
-import Futhark.Analysis.Rephrase
 import Futhark.Representation.AST
-import Futhark.Representation.SOACS (SOACS)
-import qualified Futhark.Representation.SOACS.SOAC as SOAC
-import Futhark.Representation.Kernels
-       hiding (Prog, Body, Stm, Pattern, PatElem,
-               BasicOp, Exp, Lambda, FunDef, FParam, LParam, RetType)
+import Futhark.Representation.SegOp
 import Futhark.MonadFreshNames
 import Futhark.Tools
 import Futhark.Transform.Rename
 
-getSize :: (MonadBinder m, Op (Lore m) ~ HostOp (Lore m) inner) =>
-           String -> SizeClass -> m SubExp
-getSize desc size_class = do
-  size_key <- nameFromString . pretty <$> newVName desc
-  letSubExp desc $ Op $ SizeOp $ GetSize size_key size_class
-
-numberOfGroups :: (MonadBinder m, Op (Lore m) ~ HostOp (Lore m) inner) =>
-                  String -> SubExp -> SubExp -> m (SubExp, SubExp)
-numberOfGroups desc w64 group_size = do
-  max_num_groups_key <- nameFromString . pretty <$> newVName (desc ++ "_num_groups")
-  num_groups <- letSubExp "num_groups" $
-                Op $ SizeOp $ CalcNumGroups w64 max_num_groups_key group_size
-  num_threads <- letSubExp "num_threads" $ BasicOp $ BinOp (Mul Int32) num_groups group_size
-  return (num_groups, num_threads)
-
-segThread :: (MonadBinder m, Op (Lore m) ~ HostOp (Lore m) inner) =>
-             String -> m SegLevel
-segThread desc =
-  SegThread
-    <$> (Count <$> getSize (desc ++ "_num_groups") SizeNumGroups)
-    <*> (Count <$> getSize (desc ++ "_group_size") SizeGroup)
-    <*> pure SegVirt
+-- | Constraints pertinent to performing distribution/flattening.
+type DistLore lore = (Bindable lore,
+                      HasSegOp lore,
+                      BinderOps lore,
+                      LetAttr lore ~ Type,
+                      ExpAttr lore ~ (),
+                      BodyAttr lore ~ ())
 
 data ThreadRecommendation = ManyThreads | NoRecommendation SegVirt
 
-type MkSegLevel m =
-  [SubExp] -> String -> ThreadRecommendation -> BinderT Kernels m SegLevel
-
--- | Like 'segThread', but cap the thread count to the input size.
--- This is more efficient for small kernels, e.g. summing a small
--- array.
-segThreadCapped :: MonadFreshNames m => MkSegLevel m
-segThreadCapped ws desc r = do
-  w64 <- letSubExp "nest_size" =<<
-         foldBinOp (Mul Int64) (intConst Int64 1) =<<
-         mapM (asIntS Int64) ws
-  group_size <- getSize (desc ++ "_group_size") SizeGroup
-
-  case r of
-    ManyThreads -> do
-      usable_groups <- letSubExp "segmap_usable_groups" .
-                       BasicOp . ConvOp (SExt Int64 Int32) =<<
-                       letSubExp "segmap_usable_groups_64" =<<
-                       eDivRoundingUp Int64 (eSubExp w64)
-                       (eSubExp =<< asIntS Int64 group_size)
-      return $ SegThread (Count usable_groups) (Count group_size) SegNoVirt
-    NoRecommendation v -> do
-      (num_groups, _) <- numberOfGroups desc w64 group_size
-      return $ SegThread (Count num_groups) (Count group_size) v
+type MkSegLevel lore m =
+  [SubExp] -> String -> ThreadRecommendation -> BinderT lore m (SegOpLevel lore)
 
 mkSegSpace :: MonadFreshNames m => [(VName, SubExp)] -> m SegSpace
 mkSegSpace dims = SegSpace <$> newVName "phys_tid" <*> pure dims
 
--- | Given a chunked fold lambda that takes its initial accumulator
--- value as parameters, bind those parameters to the neutral element
--- instead.
-kerneliseLambda :: MonadFreshNames m =>
-                   [SubExp] -> Lambda Kernels -> m (Lambda Kernels)
-kerneliseLambda nes lam = do
-  thread_index <- newVName "thread_index"
-  let thread_index_param = Param thread_index $ Prim int32
-      (fold_chunk_param, fold_acc_params, fold_inp_params) =
-        partitionChunkedFoldParameters (length nes) $ lambdaParams lam
-
-      mkAccInit p (Var v)
-        | not $ primType $ paramType p =
-            mkLet [] [paramIdent p] $ BasicOp $ Copy v
-      mkAccInit p x = mkLet [] [paramIdent p] $ BasicOp $ SubExp x
-      acc_init_bnds = stmsFromList $ zipWith mkAccInit fold_acc_params nes
-  return lam { lambdaBody = insertStms acc_init_bnds $
-                            lambdaBody lam
-             , lambdaParams = thread_index_param :
-                              fold_chunk_param :
-                              fold_inp_params
-             }
-
-prepareRedOrScan :: (MonadBinder m, Lore m ~ Kernels) =>
+prepareRedOrScan :: (MonadBinder m, DistLore (Lore m)) =>
                     SubExp
-                 -> Lambda Kernels
+                 -> Lambda (Lore m)
                  -> [VName] -> [(VName, SubExp)] -> [KernelInput]
-                 -> m (SegSpace, KernelBody Kernels)
+                 -> m (SegSpace, KernelBody (Lore m))
 prepareRedOrScan w map_lam arrs ispace inps = do
   gtid <- newVName "gtid"
   space <- mkSegSpace $ ispace ++ [(gtid, w)]
@@ -142,52 +68,52 @@ prepareRedOrScan w map_lam arrs ispace inps = do
 
   return (space, kbody)
 
-segRed :: (MonadFreshNames m, HasScope Kernels m) =>
-          SegLevel
-       -> Pattern Kernels
+segRed :: (MonadFreshNames m, DistLore lore, HasScope lore m) =>
+          SegOpLevel lore
+       -> Pattern lore
        -> SubExp -- segment size
-       -> [SegRedOp Kernels]
-       -> Lambda Kernels
+       -> [SegRedOp lore]
+       -> Lambda lore
        -> [VName]
        -> [(VName, SubExp)] -- ispace = pair of (gtid, size) for the maps on "top" of this reduction
        -> [KernelInput]     -- inps = inputs that can be looked up by using the gtids from ispace
-       -> m (Stms Kernels)
+       -> m (Stms lore)
 segRed lvl pat w ops map_lam arrs ispace inps = runBinder_ $ do
   (kspace, kbody) <- prepareRedOrScan w map_lam arrs ispace inps
-  letBind_ pat $ Op $ SegOp $
+  letBind_ pat $ Op $ segOp $
     SegRed lvl kspace ops (lambdaReturnType map_lam) kbody
 
-segScan :: (MonadFreshNames m, HasScope Kernels m) =>
-           SegLevel
-        -> Pattern Kernels
+segScan :: (MonadFreshNames m, DistLore lore, HasScope lore m) =>
+           SegOpLevel lore
+        -> Pattern lore
         -> SubExp -- segment size
-        -> Lambda Kernels -> Lambda Kernels
+        -> Lambda lore -> Lambda lore
         -> [SubExp] -> [VName]
         -> [(VName, SubExp)] -- ispace = pair of (gtid, size) for the maps on "top" of this scan
         -> [KernelInput]     -- inps = inputs that can be looked up by using the gtids from ispace
-        -> m (Stms Kernels)
+        -> m (Stms lore)
 segScan lvl pat w scan_lam map_lam nes arrs ispace inps = runBinder_ $ do
   (kspace, kbody) <- prepareRedOrScan w map_lam arrs ispace inps
-  letBind_ pat $ Op $ SegOp $
+  letBind_ pat $ Op $ segOp $
     SegScan lvl kspace scan_lam nes (lambdaReturnType map_lam) kbody
 
-segMap :: (MonadFreshNames m, HasScope Kernels m) =>
-          SegLevel
-       -> Pattern Kernels
+segMap :: (MonadFreshNames m, DistLore lore, HasScope lore m) =>
+          SegOpLevel lore
+       -> Pattern lore
        -> SubExp -- segment size
-       -> Lambda Kernels
+       -> Lambda lore
        -> [VName]
        -> [(VName, SubExp)] -- ispace = pair of (gtid, size) for the maps on "top" of this map
        -> [KernelInput]     -- inps = inputs that can be looked up by using the gtids from ispace
-       -> m (Stms Kernels)
+       -> m (Stms lore)
 segMap lvl pat w map_lam arrs ispace inps = runBinder_ $ do
   (kspace, kbody) <- prepareRedOrScan w map_lam arrs ispace inps
-  letBind_ pat $ Op $ SegOp $
+  letBind_ pat $ Op $ segOp $
     SegMap lvl kspace (lambdaReturnType map_lam) kbody
 
-dummyDim :: (MonadFreshNames m, MonadBinder m) =>
-            Pattern Kernels
-         -> m (Pattern Kernels, [(VName, SubExp)], m ())
+dummyDim :: (MonadFreshNames m, MonadBinder m, DistLore (Lore m)) =>
+            Pattern (Lore m)
+         -> m (Pattern (Lore m), [(VName, SubExp)], m ())
 dummyDim pat = do
   -- We add a unit-size segment on top to ensure that the result
   -- of the SegRed is an array, which we then immediately index.
@@ -206,109 +132,28 @@ dummyDim pat = do
              letBindNames_ [to] $ BasicOp $ Index from $
                fullSlice from_t [DimFix $ intConst Int32 0])
 
-nonSegRed :: (MonadFreshNames m, HasScope Kernels m) =>
-             SegLevel
-          -> Pattern Kernels
+nonSegRed :: (MonadFreshNames m, DistLore lore, HasScope lore m) =>
+             SegOpLevel lore
+          -> Pattern lore
           -> SubExp
-          -> [SegRedOp Kernels]
-          -> Lambda Kernels
+          -> [SegRedOp lore]
+          -> Lambda lore
           -> [VName]
-          -> m (Stms Kernels)
+          -> m (Stms lore)
 nonSegRed lvl pat w ops map_lam arrs = runBinder_ $ do
   (pat', ispace, read_dummy) <- dummyDim pat
   addStms =<< segRed lvl pat' w ops map_lam arrs ispace []
   read_dummy
 
-prepareStream :: (MonadBinder m, Lore m ~ Kernels) =>
-                 KernelSize
-              -> [(VName, SubExp)]
-              -> SubExp
-              -> Commutativity
-              -> Lambda Kernels
-              -> [SubExp]
-              -> [VName]
-              -> m (SubExp, SegSpace, [Type], KernelBody Kernels)
-prepareStream size ispace w comm fold_lam nes arrs = do
-  let (KernelSize elems_per_thread num_threads) = size
-  let (ordering, split_ordering) =
-        case comm of Commutative -> (Disorder, SplitStrided num_threads)
-                     Noncommutative -> (InOrder, SplitContiguous)
-
-  fold_lam' <- kerneliseLambda nes fold_lam
-
-  elems_per_thread_32 <- asIntS Int32 elems_per_thread
-
-  gtid <- newVName "gtid"
-  space <- mkSegSpace $ ispace ++ [(gtid, num_threads)]
-  kbody <- fmap (uncurry (flip (KernelBody ()))) $ runBinder $
-           localScope (scopeOfSegSpace space) $ do
-    (chunk_red_pes, chunk_map_pes) <-
-      blockedPerThread gtid w size ordering fold_lam' (length nes) arrs
-    let concatReturns pe =
-          ConcatReturns split_ordering w elems_per_thread_32 $ patElemName pe
-    return (map (Returns ResultMaySimplify . Var . patElemName) chunk_red_pes ++
-            map concatReturns chunk_map_pes)
-
-  let (redout_ts, mapout_ts) = splitAt (length nes) $ lambdaReturnType fold_lam
-      ts = redout_ts ++ map rowType mapout_ts
-
-  return (num_threads, space, ts, kbody)
-
-streamRed :: (MonadFreshNames m, HasScope Kernels m) =>
-             Pattern Kernels
-          -> SubExp
-          -> Commutativity
-          -> Lambda Kernels -> Lambda Kernels
-          -> [SubExp] -> [VName]
-          -> m (Stms Kernels)
-streamRed pat w comm red_lam fold_lam nes arrs = runBinder_ $ do
-  -- The strategy here is to rephrase the stream reduction as a
-  -- non-segmented SegRed that does explicit chunking within its body.
-  -- First, figure out how many threads to use for this.
-  size <- blockedKernelSize "stream_red" w
-
-  let (redout_pes, mapout_pes) = splitAt (length nes) $ patternElements pat
-  (redout_pat, ispace, read_dummy) <- dummyDim $ Pattern [] redout_pes
-  let pat' = Pattern [] $ patternElements redout_pat ++ mapout_pes
-
-  (_, kspace, ts, kbody) <- prepareStream size ispace w comm fold_lam nes arrs
-
-  lvl <- segThreadCapped [w] "stream_red" $ NoRecommendation SegNoVirt
-  letBind_ pat' $ Op $ SegOp $ SegRed lvl kspace
-    [SegRedOp comm red_lam nes mempty] ts kbody
-
-  read_dummy
-
--- Similar to streamRed, but without the last reduction.
-streamMap :: (MonadFreshNames m, HasScope Kernels m) =>
-              [String] -> [PatElem Kernels] -> SubExp
-           -> Commutativity -> Lambda Kernels -> [SubExp] -> [VName]
-           -> m ((SubExp, [VName]), Stms Kernels)
-streamMap out_desc mapout_pes w comm fold_lam nes arrs = runBinder $ do
-  size <- blockedKernelSize "stream_map" w
-
-  (threads, kspace, ts, kbody) <- prepareStream size [] w comm fold_lam nes arrs
-
-  let redout_ts = take (length nes) ts
-
-  redout_pes <- forM (zip out_desc redout_ts) $ \(desc, t) ->
-    PatElem <$> newVName desc <*> pure (t `arrayOfRow` threads)
-
-  let pat = Pattern [] $ redout_pes ++ mapout_pes
-  lvl <- segThreadCapped [w] "stream_map" $ NoRecommendation SegNoVirt
-  letBind_ pat $ Op $ SegOp $ SegMap lvl kspace ts kbody
-
-  return (threads, map patElemName redout_pes)
-
-segHist :: (MonadFreshNames m, HasScope Kernels m) =>
-             SegLevel
-          -> Pattern Kernels
-          -> SubExp
-          -> [(VName,SubExp)] -- ^ Segment indexes and sizes.
-          -> [KernelInput]
-          -> [HistOp Kernels]
-          -> Lambda Kernels -> [VName]
-          -> m (Stms Kernels)
+segHist :: (DistLore lore, MonadFreshNames m, HasScope lore m) =>
+           SegOpLevel lore
+        -> Pattern lore
+        -> SubExp
+        -> [(VName,SubExp)] -- ^ Segment indexes and sizes.
+        -> [KernelInput]
+        -> [HistOp lore]
+        -> Lambda lore -> [VName]
+        -> m (Stms lore)
 segHist lvl pat arr_w ispace inps ops lam arrs = runBinder_ $ do
   gtid <- newVName "gtid"
   space <- mkSegSpace $ ispace ++ [(gtid, arr_w)]
@@ -322,103 +167,22 @@ segHist lvl pat arr_w ispace inps ops lam arrs = runBinder_ $ do
         BasicOp $ Index arr $ fullSlice arr_t [DimFix $ Var gtid]
     map (Returns ResultMaySimplify) <$> bodyBind (lambdaBody lam)
 
-  letBind_ pat $ Op $ SegOp $ SegHist lvl space ops (lambdaReturnType lam) kbody
+  letBind_ pat $ Op $ segOp $ SegHist lvl space ops (lambdaReturnType lam) kbody
 
-blockedPerThread :: (MonadBinder m, Lore m ~ Kernels) =>
-                    VName -> SubExp -> KernelSize -> StreamOrd -> Lambda Kernels
-                 -> Int -> [VName]
-                 -> m ([PatElem Kernels], [PatElem Kernels])
-blockedPerThread thread_gtid w kernel_size ordering lam num_nonconcat arrs = do
-  let (_, chunk_size, [], arr_params) =
-        partitionChunkedKernelFoldParameters 0 $ lambdaParams lam
-
-      ordering' =
-        case ordering of InOrder -> SplitContiguous
-                         Disorder -> SplitStrided $ kernelNumThreads kernel_size
-      red_ts = take num_nonconcat $ lambdaReturnType lam
-      map_ts = map rowType $ drop num_nonconcat $ lambdaReturnType lam
-
-  per_thread <- asIntS Int32 $ kernelElementsPerThread kernel_size
-  splitArrays (paramName chunk_size) (map paramName arr_params) ordering' w
-    (Var thread_gtid) per_thread arrs
-
-  chunk_red_pes <- forM red_ts $ \red_t -> do
-    pe_name <- newVName "chunk_fold_red"
-    return $ PatElem pe_name red_t
-  chunk_map_pes <- forM map_ts $ \map_t -> do
-    pe_name <- newVName "chunk_fold_map"
-    return $ PatElem pe_name $ map_t `arrayOfRow` Var (paramName chunk_size)
-
-  let (chunk_red_ses, chunk_map_ses) =
-        splitAt num_nonconcat $ bodyResult $ lambdaBody lam
-
-  addStms $
-    bodyStms (lambdaBody lam) <>
-    stmsFromList
-    [ Let (Pattern [] [pe]) (defAux ()) $ BasicOp $ SubExp se
-    | (pe,se) <- zip chunk_red_pes chunk_red_ses ] <>
-    stmsFromList
-    [ Let (Pattern [] [pe]) (defAux ()) $ BasicOp $ SubExp se
-    | (pe,se) <- zip chunk_map_pes chunk_map_ses ]
-
-  return (chunk_red_pes, chunk_map_pes)
-
-splitArrays :: (MonadBinder m, Lore m ~ Kernels) =>
-               VName -> [VName]
-            -> SplitOrdering -> SubExp -> SubExp -> SubExp -> [VName]
-            -> m ()
-splitArrays chunk_size split_bound ordering w i elems_per_i arrs = do
-  letBindNames_ [chunk_size] $ Op $ SizeOp $ SplitSpace ordering w i elems_per_i
-  case ordering of
-    SplitContiguous     -> do
-      offset <- letSubExp "slice_offset" $ BasicOp $ BinOp (Mul Int32) i elems_per_i
-      zipWithM_ (contiguousSlice offset) split_bound arrs
-    SplitStrided stride -> zipWithM_ (stridedSlice stride) split_bound arrs
-  where contiguousSlice offset slice_name arr = do
-          arr_t <- lookupType arr
-          let slice = fullSlice arr_t [DimSlice offset (Var chunk_size) (constant (1::Int32))]
-          letBindNames_ [slice_name] $ BasicOp $ Index arr slice
-
-        stridedSlice stride slice_name arr = do
-          arr_t <- lookupType arr
-          let slice = fullSlice arr_t [DimSlice i (Var chunk_size) stride]
-          letBindNames_ [slice_name] $ BasicOp $ Index arr slice
-
-data KernelSize = KernelSize { kernelElementsPerThread :: SubExp
-                               -- ^ Int64
-                             , kernelNumThreads :: SubExp
-                               -- ^ Int32
-                             }
-                deriving (Eq, Ord, Show)
-
-blockedKernelSize :: (MonadBinder m, Lore m ~ Kernels) =>
-                     String -> SubExp -> m KernelSize
-blockedKernelSize desc w = do
-  group_size <- getSize (desc ++ "_group_size") SizeGroup
-
-  w64 <- letSubExp "w64" $ BasicOp $ ConvOp (SExt Int32 Int64) w
-  (_, num_threads) <- numberOfGroups desc w64 group_size
-
-  per_thread_elements <-
-    letSubExp "per_thread_elements" =<<
-    eDivRoundingUp Int64 (eSubExp w64) (toExp =<< asIntS Int64 num_threads)
-
-  return $ KernelSize per_thread_elements num_threads
-
-mapKernelSkeleton :: (HasScope Kernels m, MonadFreshNames m) =>
+mapKernelSkeleton :: (DistLore lore, HasScope lore m, MonadFreshNames m) =>
                      [(VName, SubExp)] -> [KernelInput]
-                  -> m (SegSpace, Stms Kernels)
+                  -> m (SegSpace, Stms lore)
 mapKernelSkeleton ispace inputs = do
   read_input_bnds <- runBinder_ $ mapM readKernelInput inputs
 
   space <- mkSegSpace ispace
   return (space, read_input_bnds)
 
-mapKernel :: (HasScope Kernels m, MonadFreshNames m) =>
-             MkSegLevel m
+mapKernel :: (DistLore lore, HasScope lore m, MonadFreshNames m) =>
+             MkSegLevel lore m
           -> [(VName, SubExp)] -> [KernelInput]
-          -> [Type] -> KernelBody Kernels
-          -> m (SegOp SegLevel Kernels, Stms Kernels)
+          -> [Type] -> KernelBody lore
+          -> m (SegOp (SegOpLevel lore) lore, Stms lore)
 mapKernel mk_lvl ispace inputs rts (KernelBody () kstms krets) = runBinderT' $ do
   (space, read_input_stms) <- mapKernelSkeleton ispace inputs
 
@@ -442,7 +206,7 @@ data KernelInput = KernelInput { kernelInputName :: VName
                                }
                  deriving (Show)
 
-readKernelInput :: (MonadBinder m, Lore m ~ Kernels) =>
+readKernelInput :: (DistLore (Lore m), MonadBinder m) =>
                    KernelInput -> m ()
 readKernelInput inp = do
   let pe = PatElem (kernelInputName inp) $ kernelInputType inp
@@ -450,38 +214,3 @@ readKernelInput inp = do
   letBind_ (Pattern [] [pe]) $
     BasicOp $ Index (kernelInputArray inp) $
     fullSlice arr_t $ map DimFix $ kernelInputIndices inp
-
-injectSOACS :: (Monad m,
-                SameScope from to,
-                ExpAttr from ~ ExpAttr to,
-                BodyAttr from ~ BodyAttr to,
-                RetType from ~ RetType to,
-                BranchType from ~ BranchType to,
-                Op from ~ SOAC from) =>
-               (SOAC to -> Op to) -> Rephraser m from to
-injectSOACS f = Rephraser { rephraseExpLore = return
-                          , rephraseBodyLore = return
-                          , rephraseLetBoundLore = return
-                          , rephraseFParamLore = return
-                          , rephraseLParamLore = return
-                          , rephraseOp = fmap f . onSOAC
-                          , rephraseRetType = return
-                          , rephraseBranchType = return
-                          }
-  where onSOAC = SOAC.mapSOACM mapper
-        mapper = SOAC.SOACMapper { SOAC.mapOnSOACSubExp = return
-                                 , SOAC.mapOnSOACVName = return
-                                 , SOAC.mapOnSOACLambda = rephraseLambda $ injectSOACS f
-                                 }
-
-soacsStmToKernels :: Stm SOACS -> Stm Kernels
-soacsStmToKernels = runIdentity . rephraseStm (injectSOACS OtherOp)
-
-soacsLambdaToKernels :: Lambda SOACS -> Lambda Kernels
-soacsLambdaToKernels = runIdentity . rephraseLambda (injectSOACS OtherOp)
-
-scopeForSOACs :: Scope Kernels -> Scope SOACS
-scopeForSOACs = castScope
-
-scopeForKernels :: Scope SOACS -> Scope Kernels
-scopeForKernels = castScope

--- a/src/Futhark/Pass/ExtractKernels/Distribution.hs
+++ b/src/Futhark/Pass/ExtractKernels/Distribution.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ConstraintKinds #-}
 module Futhark.Pass.ExtractKernels.Distribution
        (
          Target
@@ -18,6 +19,7 @@ module Futhark.Pass.ExtractKernels.Distribution
 
        , LoopNesting (..)
        , ppLoopNesting
+       , scopeOfLoopNesting
 
        , Nesting (..)
        , Nestings
@@ -50,16 +52,17 @@ import Data.Foldable
 import Data.Maybe
 import Data.List (elemIndex, sortOn)
 
-import Futhark.Representation.Kernels
+import Futhark.Representation.AST
+import Futhark.Representation.SegOp
 import Futhark.MonadFreshNames
 import Futhark.Tools
 import Futhark.Util
 import Futhark.Transform.Rename
 import Futhark.Util.Log
 import Futhark.Pass.ExtractKernels.BlockedKernel
-  (mapKernel, KernelInput(..), readKernelInput, MkSegLevel)
+  (DistLore, mapKernel, KernelInput(..), readKernelInput, MkSegLevel)
 
-type Target = (Pattern Kernels, Result)
+type Target = (PatternT Type, Result)
 
 -- | First pair element is the very innermost ("current") target.  In
 -- the list, the outermost target comes first.  Invariant: Every
@@ -104,21 +107,21 @@ popInnerTarget (Targets t ts) =
     x:xs -> Just (t, Targets x $ reverse xs)
     []   -> Nothing
 
-targetScope :: Target -> Scope Kernels
+targetScope :: DistLore lore => Target -> Scope lore
 targetScope = scopeOfPattern . fst
 
-targetsScope :: Targets -> Scope Kernels
+targetsScope :: DistLore lore => Targets -> Scope lore
 targetsScope (Targets t ts) = mconcat $ map targetScope $ t : ts
 
-data LoopNesting = MapNesting { loopNestingPattern :: Pattern Kernels
+data LoopNesting = MapNesting { loopNestingPattern :: PatternT Type
                               , loopNestingCertificates :: Certificates
                               , loopNestingWidth :: SubExp
                               , loopNestingParamsAndArrs :: [(Param Type, VName)]
                               }
                  deriving (Show)
 
-instance Scoped Kernels LoopNesting where
-  scopeOf = scopeOfLParams . map fst . loopNestingParamsAndArrs
+scopeOfLoopNesting :: DistLore lore => LoopNesting -> Scope lore
+scopeOfLoopNesting = scopeOfLParams . map fst . loopNestingParamsAndArrs
 
 ppLoopNesting :: LoopNesting -> String
 ppLoopNesting (MapNesting _ _ _ params_and_arrs) =
@@ -126,7 +129,7 @@ ppLoopNesting (MapNesting _ _ _ params_and_arrs) =
   " <- " ++
   pretty (map snd params_and_arrs)
 
-loopNestingParams :: LoopNesting -> [LParam Kernels]
+loopNestingParams :: LoopNesting -> [Param Type]
 loopNestingParams  = map fst . loopNestingParamsAndArrs
 
 instance FreeIn LoopNesting where
@@ -199,7 +202,7 @@ pushInnerKernelNesting target newnest (nest, nests) =
           []  -> nest
           n:_ -> n
 
-fixNestingPatternOrder :: LoopNesting -> Target -> Pattern Kernels -> LoopNesting
+fixNestingPatternOrder :: LoopNesting -> Target -> PatternT Type -> LoopNesting
 fixNestingPatternOrder nest (_,res) inner_pat =
   nest { loopNestingPattern = basicPattern [] pat' }
   where pat = loopNestingPattern nest
@@ -226,9 +229,9 @@ boundInKernelNests = map (namesFromList .
 kernelNestWidths :: KernelNest -> [SubExp]
 kernelNestWidths = map loopNestingWidth . kernelNestLoops
 
-constructKernel :: (MonadFreshNames m, LocalScope Kernels m) =>
-                   MkSegLevel m -> KernelNest -> Body Kernels
-                -> m (Stm Kernels, Stms Kernels)
+constructKernel :: (DistLore lore, MonadFreshNames m, LocalScope lore m) =>
+                   MkSegLevel lore m -> KernelNest -> Body lore
+                -> m (Stm lore, Stms lore)
 constructKernel mk_lvl kernel_nest inner_body = runBinderT' $ do
   (ispace, inps) <- flatKernel kernel_nest
   let cs = loopNestingCertificates first_nest
@@ -245,7 +248,7 @@ constructKernel mk_lvl kernel_nest inner_body = runBinderT' $ do
 
   addStms aux_stms
 
-  return $ Let pat (StmAux cs ()) $ Op $ SegOp segop
+  return $ Let pat (StmAux cs ()) $ Op $ segOp segop
   where
     first_nest = fst kernel_nest
     inputIsUsed input = kernelInputName input `nameIn` freeIn inner_body
@@ -293,7 +296,7 @@ data DistributionBody = DistributionBody {
     -- ^ Also related to avoiding identity mapping.
   }
 
-distributionInnerPattern :: DistributionBody -> Pattern Kernels
+distributionInnerPattern :: DistributionBody -> PatternT Type
 distributionInnerPattern = fst . innerTarget . distributionTarget
 
 distributionBodyFromStms :: Attributes lore =>
@@ -337,7 +340,7 @@ createKernelNest (inner_nest, nests) distrib_body = do
 
         distributeAtNesting :: (HasScope t m, MonadFreshNames m) =>
                                Nesting
-                            -> Pattern Kernels
+                            -> PatternT Type
                             -> (LoopNesting -> KernelNest, Names)
                             -> M.Map VName Ident
                             -> [Ident]
@@ -446,8 +449,8 @@ removeUnusedNestingParts used (MapNesting pat cs w params_and_arrs) =
           filter ((`nameIn` used) . paramName . fst) $
           zip params arrs
 
-removeIdentityMappingGeneral :: Names -> Pattern Kernels -> Result
-                             -> (Pattern Kernels,
+removeIdentityMappingGeneral :: Names -> PatternT Type -> Result
+                             -> (PatternT Type,
                                  Result,
                                  M.Map VName Ident,
                                  Target -> Target)
@@ -469,8 +472,8 @@ removeIdentityMappingGeneral bound pat res =
           | not (v `nameIn` bound) = Left (patElem, v)
         isIdentity x               = Right x
 
-removeIdentityMappingFromNesting :: Names -> Pattern Kernels -> Result
-                                 -> (Pattern Kernels,
+removeIdentityMappingFromNesting :: Names -> PatternT Type -> Result
+                                 -> (PatternT Type,
                                      Result,
                                      M.Map VName Ident,
                                      Target -> Target)
@@ -479,9 +482,10 @@ removeIdentityMappingFromNesting bound_in_nesting pat res =
         removeIdentityMappingGeneral bound_in_nesting pat res
   in (pat', res', identity_map, expand_target)
 
-tryDistribute :: (MonadFreshNames m, LocalScope Kernels m, MonadLogger m) =>
-                 MkSegLevel m -> Nestings -> Targets -> Stms Kernels
-              -> m (Maybe (Targets, Stms Kernels))
+tryDistribute :: (DistLore lore, MonadFreshNames m,
+                  LocalScope lore m, MonadLogger m) =>
+                 MkSegLevel lore m -> Nestings -> Targets -> Stms lore
+              -> m (Maybe (Targets, Stms lore))
 tryDistribute _ _ targets stms | null stms =
   -- No point in distributing an empty kernel.
   return $ Just (targets, mempty)

--- a/src/Futhark/Pass/ExtractKernels/Intragroup.hs
+++ b/src/Futhark/Pass/ExtractKernels/Intragroup.hs
@@ -24,6 +24,7 @@ import Futhark.Tools
 import Futhark.Pass.ExtractKernels.DistributeNests
 import Futhark.Pass.ExtractKernels.Distribution
 import Futhark.Pass.ExtractKernels.BlockedKernel
+import Futhark.Pass.ExtractKernels.ToKernels
 import Futhark.Util (chunks)
 import Futhark.Util.Log
 
@@ -180,6 +181,10 @@ intraGroupStm lvl stm@(Let pat aux e) = do
                         , distSegLevel = \minw _ _ -> do
                             lift $ parallelMin minw
                             return lvl
+                        , distOnSOACSStms =
+                            pure . oneStm . soacsStmToKernels
+                        , distOnSOACSLambda =
+                            pure . soacsLambdaToKernels
                         }
           acc = DistAcc { distTargets = singleTarget (pat, bodyResult $ lambdaBody lam)
                         , distStms = mempty
@@ -209,7 +214,8 @@ intraGroupStm lvl stm@(Let pat aux e) = do
     Op (Hist w ops bucket_fun arrs) -> do
       ops' <- forM ops $ \(HistOp num_bins rf dests nes op) -> do
         (op', nes', shape) <- determineReduceOp op nes
-        return $ Out.HistOp num_bins rf dests nes' shape op'
+        let op'' = soacsLambdaToKernels op'
+        return $ Out.HistOp num_bins rf dests nes' shape op''
 
       let bucket_fun' = soacsLambdaToKernels bucket_fun
       certifying (stmAuxCerts aux) $

--- a/src/Futhark/Pass/ExtractKernels/StreamKernel.hs
+++ b/src/Futhark/Pass/ExtractKernels/StreamKernel.hs
@@ -1,0 +1,244 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ConstraintKinds #-}
+module Futhark.Pass.ExtractKernels.StreamKernel
+  ( segThreadCapped
+  , streamRed
+  , streamMap
+  )
+  where
+
+import Control.Monad
+import Control.Monad.Writer
+import Data.List ()
+
+import Prelude hiding (quot)
+
+import Futhark.Analysis.PrimExp
+import Futhark.Representation.AST
+import Futhark.Representation.Kernels
+       hiding (Prog, Body, Stm, Pattern, PatElem,
+               BasicOp, Exp, Lambda, FunDef, FParam, LParam, RetType)
+import Futhark.Pass.ExtractKernels.BlockedKernel
+import Futhark.Pass.ExtractKernels.ToKernels
+import Futhark.MonadFreshNames
+import Futhark.Tools
+
+data KernelSize = KernelSize { kernelElementsPerThread :: SubExp
+                               -- ^ Int64
+                             , kernelNumThreads :: SubExp
+                               -- ^ Int32
+                             }
+                deriving (Eq, Ord, Show)
+
+numberOfGroups :: (MonadBinder m, Op (Lore m) ~ HostOp (Lore m) inner) =>
+                  String -> SubExp -> SubExp -> m (SubExp, SubExp)
+numberOfGroups desc w64 group_size = do
+  max_num_groups_key <- nameFromString . pretty <$> newVName (desc ++ "_num_groups")
+  num_groups <- letSubExp "num_groups" $
+                Op $ SizeOp $ CalcNumGroups w64 max_num_groups_key group_size
+  num_threads <- letSubExp "num_threads" $ BasicOp $ BinOp (Mul Int32) num_groups group_size
+  return (num_groups, num_threads)
+
+blockedKernelSize :: (MonadBinder m, Lore m ~ Kernels) =>
+                     String -> SubExp -> m KernelSize
+blockedKernelSize desc w = do
+  group_size <- getSize (desc ++ "_group_size") SizeGroup
+
+  w64 <- letSubExp "w64" $ BasicOp $ ConvOp (SExt Int32 Int64) w
+  (_, num_threads) <- numberOfGroups desc w64 group_size
+
+  per_thread_elements <-
+    letSubExp "per_thread_elements" =<<
+    eDivRoundingUp Int64 (eSubExp w64) (toExp =<< asIntS Int64 num_threads)
+
+  return $ KernelSize per_thread_elements num_threads
+
+splitArrays :: (MonadBinder m, Lore m ~ Kernels) =>
+               VName -> [VName]
+            -> SplitOrdering -> SubExp -> SubExp -> SubExp -> [VName]
+            -> m ()
+splitArrays chunk_size split_bound ordering w i elems_per_i arrs = do
+  letBindNames_ [chunk_size] $ Op $ SizeOp $ SplitSpace ordering w i elems_per_i
+  case ordering of
+    SplitContiguous     -> do
+      offset <- letSubExp "slice_offset" $ BasicOp $ BinOp (Mul Int32) i elems_per_i
+      zipWithM_ (contiguousSlice offset) split_bound arrs
+    SplitStrided stride -> zipWithM_ (stridedSlice stride) split_bound arrs
+  where contiguousSlice offset slice_name arr = do
+          arr_t <- lookupType arr
+          let slice = fullSlice arr_t [DimSlice offset (Var chunk_size) (constant (1::Int32))]
+          letBindNames_ [slice_name] $ BasicOp $ Index arr slice
+
+        stridedSlice stride slice_name arr = do
+          arr_t <- lookupType arr
+          let slice = fullSlice arr_t [DimSlice i (Var chunk_size) stride]
+          letBindNames_ [slice_name] $ BasicOp $ Index arr slice
+
+
+blockedPerThread :: (MonadBinder m, Lore m ~ Kernels) =>
+                    VName -> SubExp -> KernelSize -> StreamOrd -> Lambda (Lore m)
+                 -> Int -> [VName]
+                 -> m ([PatElemT Type], [PatElemT Type])
+blockedPerThread thread_gtid w kernel_size ordering lam num_nonconcat arrs = do
+  let (_, chunk_size, [], arr_params) =
+        partitionChunkedKernelFoldParameters 0 $ lambdaParams lam
+
+      ordering' =
+        case ordering of InOrder -> SplitContiguous
+                         Disorder -> SplitStrided $ kernelNumThreads kernel_size
+      red_ts = take num_nonconcat $ lambdaReturnType lam
+      map_ts = map rowType $ drop num_nonconcat $ lambdaReturnType lam
+
+  per_thread <- asIntS Int32 $ kernelElementsPerThread kernel_size
+  splitArrays (paramName chunk_size) (map paramName arr_params) ordering' w
+    (Var thread_gtid) per_thread arrs
+
+  chunk_red_pes <- forM red_ts $ \red_t -> do
+    pe_name <- newVName "chunk_fold_red"
+    return $ PatElem pe_name red_t
+  chunk_map_pes <- forM map_ts $ \map_t -> do
+    pe_name <- newVName "chunk_fold_map"
+    return $ PatElem pe_name $ map_t `arrayOfRow` Var (paramName chunk_size)
+
+  let (chunk_red_ses, chunk_map_ses) =
+        splitAt num_nonconcat $ bodyResult $ lambdaBody lam
+
+  addStms $
+    bodyStms (lambdaBody lam) <>
+    stmsFromList
+    [ Let (Pattern [] [pe]) (defAux ()) $ BasicOp $ SubExp se
+    | (pe,se) <- zip chunk_red_pes chunk_red_ses ] <>
+    stmsFromList
+    [ Let (Pattern [] [pe]) (defAux ()) $ BasicOp $ SubExp se
+    | (pe,se) <- zip chunk_map_pes chunk_map_ses ]
+
+  return (chunk_red_pes, chunk_map_pes)
+
+-- | Given a chunked fold lambda that takes its initial accumulator
+-- value as parameters, bind those parameters to the neutral element
+-- instead.
+kerneliseLambda :: MonadFreshNames m =>
+                   [SubExp] -> Lambda Kernels -> m (Lambda Kernels)
+kerneliseLambda nes lam = do
+  thread_index <- newVName "thread_index"
+  let thread_index_param = Param thread_index $ Prim int32
+      (fold_chunk_param, fold_acc_params, fold_inp_params) =
+        partitionChunkedFoldParameters (length nes) $ lambdaParams lam
+
+      mkAccInit p (Var v)
+        | not $ primType $ paramType p =
+            mkLet [] [paramIdent p] $ BasicOp $ Copy v
+      mkAccInit p x = mkLet [] [paramIdent p] $ BasicOp $ SubExp x
+      acc_init_bnds = stmsFromList $ zipWith mkAccInit fold_acc_params nes
+  return lam { lambdaBody = insertStms acc_init_bnds $
+                            lambdaBody lam
+             , lambdaParams = thread_index_param :
+                              fold_chunk_param :
+                              fold_inp_params
+             }
+
+prepareStream :: (MonadBinder m, Lore m ~ Kernels) =>
+                 KernelSize
+              -> [(VName, SubExp)]
+              -> SubExp
+              -> Commutativity
+              -> Lambda Kernels
+              -> [SubExp]
+              -> [VName]
+              -> m (SubExp, SegSpace, [Type], KernelBody Kernels)
+prepareStream size ispace w comm fold_lam nes arrs = do
+  let (KernelSize elems_per_thread num_threads) = size
+  let (ordering, split_ordering) =
+        case comm of Commutative -> (Disorder, SplitStrided num_threads)
+                     Noncommutative -> (InOrder, SplitContiguous)
+
+  fold_lam' <- kerneliseLambda nes fold_lam
+
+  elems_per_thread_32 <- asIntS Int32 elems_per_thread
+
+  gtid <- newVName "gtid"
+  space <- mkSegSpace $ ispace ++ [(gtid, num_threads)]
+  kbody <- fmap (uncurry (flip (KernelBody ()))) $ runBinder $
+           localScope (scopeOfSegSpace space) $ do
+    (chunk_red_pes, chunk_map_pes) <-
+      blockedPerThread gtid w size ordering fold_lam' (length nes) arrs
+    let concatReturns pe =
+          ConcatReturns split_ordering w elems_per_thread_32 $ patElemName pe
+    return (map (Returns ResultMaySimplify . Var . patElemName) chunk_red_pes ++
+            map concatReturns chunk_map_pes)
+
+  let (redout_ts, mapout_ts) = splitAt (length nes) $ lambdaReturnType fold_lam
+      ts = redout_ts ++ map rowType mapout_ts
+
+  return (num_threads, space, ts, kbody)
+
+streamRed :: (MonadFreshNames m, HasScope Kernels m) =>
+             MkSegLevel Kernels m
+          -> Pattern Kernels
+          -> SubExp
+          -> Commutativity
+          -> Lambda Kernels -> Lambda Kernels
+          -> [SubExp] -> [VName]
+          -> m (Stms Kernels)
+streamRed mk_lvl pat w comm red_lam fold_lam nes arrs = runBinderT'_ $ do
+  -- The strategy here is to rephrase the stream reduction as a
+  -- non-segmented SegRed that does explicit chunking within its body.
+  -- First, figure out how many threads to use for this.
+  size <- blockedKernelSize "stream_red" w
+
+  let (redout_pes, mapout_pes) = splitAt (length nes) $ patternElements pat
+  (redout_pat, ispace, read_dummy) <- dummyDim $ Pattern [] redout_pes
+  let pat' = Pattern [] $ patternElements redout_pat ++ mapout_pes
+
+  (_, kspace, ts, kbody) <- prepareStream size ispace w comm fold_lam nes arrs
+
+  lvl <- mk_lvl [w] "stream_red" $ NoRecommendation SegNoVirt
+  letBind_ pat' $ Op $ SegOp $ SegRed lvl kspace
+    [SegRedOp comm red_lam nes mempty] ts kbody
+
+  read_dummy
+
+-- Similar to streamRed, but without the last reduction.
+streamMap :: (MonadFreshNames m, HasScope Kernels m) =>
+              MkSegLevel Kernels m
+          -> [String] -> [PatElem Kernels] -> SubExp
+           -> Commutativity -> Lambda Kernels -> [SubExp] -> [VName]
+           -> m ((SubExp, [VName]), Stms Kernels)
+streamMap mk_lvl out_desc mapout_pes w comm fold_lam nes arrs = runBinderT' $ do
+  size <- blockedKernelSize "stream_map" w
+
+  (threads, kspace, ts, kbody) <- prepareStream size [] w comm fold_lam nes arrs
+
+  let redout_ts = take (length nes) ts
+
+  redout_pes <- forM (zip out_desc redout_ts) $ \(desc, t) ->
+    PatElem <$> newVName desc <*> pure (t `arrayOfRow` threads)
+
+  let pat = Pattern [] $ redout_pes ++ mapout_pes
+  lvl <- mk_lvl [w] "stream_map" $ NoRecommendation SegNoVirt
+  letBind_ pat $ Op $ SegOp $ SegMap lvl kspace ts kbody
+
+  return (threads, map patElemName redout_pes)
+
+-- | Like 'segThread', but cap the thread count to the input size.
+-- This is more efficient for small kernels, e.g. summing a small
+-- array.
+segThreadCapped :: MonadFreshNames m => MkSegLevel Kernels m
+segThreadCapped ws desc r = do
+  w64 <- letSubExp "nest_size" =<<
+         foldBinOp (Mul Int64) (intConst Int64 1) =<<
+         mapM (asIntS Int64) ws
+  group_size <- getSize (desc ++ "_group_size") SizeGroup
+
+  case r of
+    ManyThreads -> do
+      usable_groups <- letSubExp "segmap_usable_groups" .
+                       BasicOp . ConvOp (SExt Int64 Int32) =<<
+                       letSubExp "segmap_usable_groups_64" =<<
+                       eDivRoundingUp Int64 (eSubExp w64)
+                       (eSubExp =<< asIntS Int64 group_size)
+      return $ SegThread (Count usable_groups) (Count group_size) SegNoVirt
+    NoRecommendation v -> do
+      (num_groups, _) <- numberOfGroups desc w64 group_size
+      return $ SegThread (Count num_groups) (Count group_size) v

--- a/src/Futhark/Pass/ExtractKernels/ToKernels.hs
+++ b/src/Futhark/Pass/ExtractKernels/ToKernels.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ConstraintKinds #-}
+module Futhark.Pass.ExtractKernels.ToKernels
+       ( getSize
+       , segThread
+
+       , soacsLambdaToKernels
+       , soacsStmToKernels
+       , scopeForKernels
+       , scopeForSOACs
+       )
+       where
+
+import Control.Monad.Identity
+import Data.List ()
+
+import Futhark.Analysis.Rephrase
+import Futhark.Representation.AST
+import Futhark.Representation.SOACS (SOACS)
+import qualified Futhark.Representation.SOACS.SOAC as SOAC
+import Futhark.Representation.Kernels
+import Futhark.Tools
+
+getSize :: (MonadBinder m, Op (Lore m) ~ HostOp (Lore m) inner) =>
+           String -> SizeClass -> m SubExp
+getSize desc size_class = do
+  size_key <- nameFromString . pretty <$> newVName desc
+  letSubExp desc $ Op $ SizeOp $ GetSize size_key size_class
+
+segThread :: (MonadBinder m, Op (Lore m) ~ HostOp (Lore m) inner) =>
+             String -> m SegLevel
+segThread desc =
+  SegThread
+    <$> (Count <$> getSize (desc ++ "_num_groups") SizeNumGroups)
+    <*> (Count <$> getSize (desc ++ "_group_size") SizeGroup)
+    <*> pure SegVirt
+
+injectSOACS :: (Monad m,
+                SameScope from to,
+                ExpAttr from ~ ExpAttr to,
+                BodyAttr from ~ BodyAttr to,
+                RetType from ~ RetType to,
+                BranchType from ~ BranchType to,
+                Op from ~ SOAC from) =>
+               (SOAC to -> Op to) -> Rephraser m from to
+injectSOACS f = Rephraser { rephraseExpLore = return
+                          , rephraseBodyLore = return
+                          , rephraseLetBoundLore = return
+                          , rephraseFParamLore = return
+                          , rephraseLParamLore = return
+                          , rephraseOp = fmap f . onSOAC
+                          , rephraseRetType = return
+                          , rephraseBranchType = return
+                          }
+  where onSOAC = SOAC.mapSOACM mapper
+        mapper = SOAC.SOACMapper { SOAC.mapOnSOACSubExp = return
+                                 , SOAC.mapOnSOACVName = return
+                                 , SOAC.mapOnSOACLambda = rephraseLambda $ injectSOACS f
+                                 }
+
+soacsStmToKernels :: Stm SOACS -> Stm Kernels
+soacsStmToKernels = runIdentity . rephraseStm (injectSOACS OtherOp)
+
+soacsLambdaToKernels :: Lambda SOACS -> Lambda Kernels
+soacsLambdaToKernels = runIdentity . rephraseLambda (injectSOACS OtherOp)
+
+scopeForSOACs :: Scope Kernels -> Scope SOACS
+scopeForSOACs = castScope
+
+scopeForKernels :: Scope SOACS -> Scope Kernels
+scopeForKernels = castScope

--- a/src/Futhark/Representation/Kernels.hs
+++ b/src/Futhark/Representation/Kernels.hs
@@ -26,10 +26,6 @@ import Futhark.Binder
 import Futhark.Construct
 import qualified Futhark.TypeCheck as TypeCheck
 
--- This module could be written much nicer if Haskell had functors
--- like Standard ML.  Instead, we have to abuse the namespace/module
--- system.
-
 data Kernels
 
 instance Annotations Kernels where
@@ -56,3 +52,9 @@ instance BinderOps Kernels where
   mkLetNamesB = bindableMkLetNamesB
 
 instance PrettyLore Kernels where
+
+instance HasSegOp Kernels where
+  type SegOpLevel Kernels = SegLevel
+  asSegOp (SegOp op) = Just op
+  asSegOp _ = Nothing
+  segOp = SegOp

--- a/src/Futhark/Representation/Kernels/Simplify.hs
+++ b/src/Futhark/Representation/Kernels/Simplify.hs
@@ -73,7 +73,8 @@ instance BinderOps (Wise Kernels) where
   mkBodyB = bindableMkBodyB
   mkLetNamesB = bindableMkLetNamesB
 
-instance HasSegOp SegLevel (Wise Kernels) where
+instance HasSegOp (Wise Kernels) where
+  type SegOpLevel (Wise Kernels) = SegLevel
   asSegOp (SegOp op) = Just op
   asSegOp _ = Nothing
   segOp = SegOp

--- a/src/Futhark/Representation/MC.hs
+++ b/src/Futhark/Representation/MC.hs
@@ -72,10 +72,12 @@ simplifyProg = Simplify.simplifyProg simpleMC rules blockers
   where blockers = Engine.noExtraHoistBlockers
         rules = standardRules <> segOpRules
 
-instance HasSegOp () MC where
+instance HasSegOp MC where
+  type SegOpLevel MC = ()
   asSegOp = Just
   segOp = id
 
-instance HasSegOp () (Engine.Wise MC) where
+instance HasSegOp (Engine.Wise MC) where
+  type SegOpLevel (Engine.Wise MC) = ()
   asSegOp = Just
   segOp = id


### PR DESCRIPTION
This PR re-introduces a significant degree of flattening to the multicore backend.  In practice, nested SegOps will only occur in cases of irregular parallelism.

We will probably need to experiment with the right way to flatten for the multicore backend.  It is definitely worth flattening simple `map`s, and probably also doing `loop` interchange, but it may not be worth it to produce e.g. actual multi-dimensional `SegRed`s in most cases.