### PR TITLE
Multicore vector scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+  * Faster index calculations for very tight GPU kernels (such as the
+    ones corresponding to 2D tiling).
+
+  * `scan` with vectorised operators (e.g. `map2 (+)`) is now faster
+    in some cases.
+
 ### Removed
 
 ### Changed
 
 ### Fixed
+
+  * Fixed some cases of missing fusion (#953).
 
 ## [0.15.6]
 

--- a/src/Futhark/CodeGen/ImpGen/Kernels.hs
+++ b/src/Futhark/CodeGen/ImpGen/Kernels.hs
@@ -124,8 +124,8 @@ segOpCompiler pat (SegMap lvl space _ kbody) =
   compileSegMap pat lvl space kbody
 segOpCompiler pat (SegRed lvl@SegThread{} space reds _ kbody) =
   compileSegRed pat lvl space reds kbody
-segOpCompiler pat (SegScan lvl@SegThread{} space scan_op nes _ kbody) =
-  compileSegScan pat lvl space scan_op nes kbody
+segOpCompiler pat (SegScan lvl@SegThread{} space scans _ kbody) =
+  compileSegScan pat lvl space scans kbody
 segOpCompiler pat (SegHist (SegThread num_groups group_size _) space ops _ kbody) =
   compileSegHist pat num_groups group_size space ops kbody
 segOpCompiler pat segop =

--- a/src/Futhark/CodeGen/ImpGen/Kernels/SegHist.hs
+++ b/src/Futhark/CodeGen/ImpGen/Kernels/SegHist.hs
@@ -974,7 +974,7 @@ compileSegHist (Pattern _ pes) num_groups group_size space ops kbody = do
               zip vector_ids (shapeDims $ histShape op) ++
               [(subhistogram_id, Var num_histos)]
 
-        let segred_op = SegRedOp Commutative (histOp op) (histNeutral op) mempty
+        let segred_op = SegBinOp Commutative (histOp op) (histNeutral op) mempty
         compileSegRed' (Pattern [] red_pes) lvl segred_space [segred_op] $ \red_cont ->
           red_cont $ flip map subhistos $ \subhisto ->
             (Var subhisto, map Imp.vi32 $

--- a/src/Futhark/CodeGen/ImpGen/Kernels/SegScan.hs
+++ b/src/Futhark/CodeGen/ImpGen/Kernels/SegScan.hs
@@ -5,8 +5,9 @@ module Futhark.CodeGen.ImpGen.Kernels.SegScan
   where
 
 import Control.Monad.Except
+import Control.Monad.State
 import Data.Maybe
-import Data.List ()
+import Data.List (delete, find, foldl', zip4)
 
 import Prelude hiding (quot, rem)
 
@@ -17,22 +18,53 @@ import Futhark.CodeGen.ImpGen
 import Futhark.CodeGen.ImpGen.Kernels.Base
 import qualified Futhark.Representation.Mem.IxFun as IxFun
 import Futhark.Util.IntegralExp (quotRoundingUp, quot, rem)
+import Futhark.Util (takeLast)
 
-makeLocalArrays :: Count GroupSize SubExp -> SubExp -> [SubExp] -> Lambda KernelsMem
-                -> InKernelGen [VName]
-makeLocalArrays (Count group_size) num_threads nes scan_op = do
-  let (scan_x_params, _scan_y_params) =
-        splitAt (length nes) $ lambdaParams scan_op
-  forM scan_x_params $ \p ->
-    case paramAttr p of
-      MemArray pt shape _ (ArrayIn mem _) -> do
-        let shape' = Shape [num_threads] <> shape
-        sArray "scan_arr" pt shape' $
-          ArrayIn mem $ IxFun.iota $ map (primExpFromSubExp int32) $ shapeDims shape'
-      _ -> do
-        let pt = elemType $ paramType p
-            shape = Shape [group_size]
-        sAllocArray "scan_arr" pt shape $ Space "local"
+-- Aggressively try to reuse memory for different SegBinOps, because
+-- we will run them sequentially after another.
+makeLocalArrays :: Count GroupSize SubExp -> SubExp -> [SegBinOp KernelsMem]
+                -> InKernelGen [[VName]]
+makeLocalArrays (Count group_size) num_threads scans = do
+  (arrs, mems_and_sizes) <- runStateT (mapM onScan scans) mempty
+  let maxSize sizes =
+        Imp.bytes $ foldl' (Imp.BinOpExp (SMax Int32)) 1 $
+        map Imp.unCount sizes
+  forM_ mems_and_sizes $ \(sizes, mem) ->
+    sAlloc_ mem (maxSize sizes) (Space "local")
+  return arrs
+
+  where onScan (SegBinOp _ scan_op nes _) = do
+          let (scan_x_params, _scan_y_params) =
+                splitAt (length nes) $ lambdaParams scan_op
+          (arrs, used_mems) <- fmap unzip $ forM scan_x_params $ \p ->
+            case paramAttr p of
+              MemArray pt shape _ (ArrayIn mem _) -> do
+                let shape' = Shape [num_threads] <> shape
+                arr <- lift $ sArray "scan_arr" pt shape' $
+                  ArrayIn mem $ IxFun.iota $ map (primExpFromSubExp int32) $ shapeDims shape'
+                return (arr, [])
+              _ -> do
+                let pt = elemType $ paramType p
+                    shape = Shape [group_size]
+                (sizes, mem') <- getMem pt shape
+                arr <- lift $ sArrayInMem "scan_arr" pt shape mem'
+                return (arr, [(sizes, mem')])
+          modify (<>concat used_mems)
+          return arrs
+
+        getMem pt shape = do
+          let size = typeSize $ Array pt shape NoUniqueness
+          mems <- get
+          case (find ((size `elem`) . fst) mems, mems) of
+            (Just mem, _) -> do
+              modify $ delete mem
+              return mem
+            (Nothing, (size', mem) : mems') -> do
+              put mems'
+              return (size : size', mem)
+            (Nothing, []) -> do
+              mem <- lift $ sDeclareMem "scan_arr_mem" $ Space "local"
+              return ([size], mem)
 
 type CrossesSegment = Maybe (Imp.Exp -> Imp.Exp -> Imp.Exp)
 
@@ -48,28 +80,68 @@ barrierFor scan_op = (array_scan, fence, sOp $ Imp.Barrier fence)
         fence | array_scan = Imp.FenceGlobal
               | otherwise = Imp.FenceLocal
 
+xParams, yParams :: SegBinOp KernelsMem -> [LParam KernelsMem]
+xParams scan =
+  take (length (segBinOpNeutral scan)) (lambdaParams (segBinOpLambda scan))
+yParams scan =
+  drop (length (segBinOpNeutral scan)) (lambdaParams (segBinOpLambda scan))
+
+writeToScanValues :: [VName]
+                  -> ([PatElem KernelsMem], SegBinOp KernelsMem, [KernelResult])
+                  -> InKernelGen ()
+writeToScanValues gtids (pes, scan, scan_res)
+  | shapeRank (segBinOpShape scan) > 0 =
+      forM_ (zip pes scan_res) $ \(pe, res) ->
+      copyDWIMFix (patElemName pe) (map Imp.vi32 gtids)
+      (kernelResultSubExp res) []
+  | otherwise =
+      forM_ (zip (yParams scan) scan_res) $ \(p, res) ->
+      copyDWIMFix (paramName p) [] (kernelResultSubExp res) []
+
+readToScanValues :: [Imp.Exp] -> [PatElem KernelsMem] -> SegBinOp KernelsMem
+                 -> InKernelGen ()
+readToScanValues is pes scan
+  | shapeRank (segBinOpShape scan) > 0 =
+      forM_ (zip (yParams scan) pes) $ \(p, pe) ->
+      copyDWIMFix (paramName p) [] (Var (patElemName pe)) is
+  | otherwise =
+      return ()
+
+readCarries :: Imp.Exp -> [Imp.Exp] -> [Imp.Exp]
+            -> [PatElem KernelsMem]
+            -> SegBinOp KernelsMem
+            -> InKernelGen ()
+readCarries chunk_offset dims' vec_is pes scan
+  | shapeRank (segBinOpShape scan) > 0 = do
+      ltid <- kernelLocalThreadId . kernelConstants <$> askEnv
+      -- We may have to reload the carries from the output of the
+      -- previous chunk.
+      sIf (chunk_offset .>. 0 .&&. ltid .==. 0)
+        (do let is = unflattenIndex dims' $ chunk_offset - 1
+            forM_ (zip (xParams scan) pes) $ \(p, pe) ->
+              copyDWIMFix (paramName p) [] (Var (patElemName pe)) (is++vec_is))
+        (forM_ (zip (xParams scan) (segBinOpNeutral scan)) $ \(p, ne) ->
+            copyDWIMFix (paramName p) [] ne [])
+  | otherwise =
+      return ()
+
 -- | Produce partially scanned intervals; one per workgroup.
 scanStage1 :: Pattern KernelsMem
            -> Count NumGroups SubExp -> Count GroupSize SubExp -> SegSpace
-           -> Lambda KernelsMem -> [SubExp]
+           -> [SegBinOp KernelsMem]
            -> KernelBody KernelsMem
            -> CallKernelGen (VName, Imp.Exp, CrossesSegment)
-scanStage1 (Pattern _ pes) num_groups group_size space scan_op nes kbody = do
+scanStage1 (Pattern _ all_pes) num_groups group_size space scans kbody = do
   num_groups' <- traverse toExp num_groups
   group_size' <- traverse toExp group_size
   num_threads <- dPrimV "num_threads" $
                  unCount num_groups' * unCount group_size'
 
   let (gtids, dims) = unzip $ unSegSpace space
-      rets = lambdaReturnType scan_op
   dims' <- mapM toExp dims
   let num_elements = product dims'
       elems_per_thread = num_elements `quotRoundingUp` Imp.vi32 num_threads
       elems_per_group = unCount group_size' * elems_per_thread
-
-  -- Squirrel away a copy of the operator with unique names that we
-  -- can pass to groupScan.
-  scan_op_renamed <- renameLambda scan_op
 
   let crossesSegment =
         case reverse dims' of
@@ -79,16 +151,14 @@ scanStage1 (Pattern _ pes) num_groups group_size space scan_op nes kbody = do
 
   sKernelThread "scan_stage1" num_groups' group_size' (segFlat space) $ do
     constants <- kernelConstants <$> askEnv
-    local_arrs <- makeLocalArrays group_size (Var num_threads) nes scan_op
+    all_local_arrs <- makeLocalArrays group_size (Var num_threads) scans
 
     -- The variables from scan_op will be used for the carry and such
     -- in the big chunking loop.
-    dScope Nothing $ scopeOfLParams $ lambdaParams scan_op
-    let (scan_x_params, scan_y_params) =
-          splitAt (length nes) $ lambdaParams scan_op
-
-    forM_ (zip scan_x_params nes) $ \(p, ne) ->
-      copyDWIMFix (paramName p) [] ne []
+    forM_ scans $ \scan -> do
+      dScope Nothing $ scopeOfLParams $ lambdaParams $ segBinOpLambda scan
+      forM_ (zip (xParams scan) (segBinOpNeutral scan)) $ \(p, ne) ->
+        copyDWIMFix (paramName p) [] ne []
 
     sFor "j" elems_per_thread $ \j -> do
       chunk_offset <- dPrimV "chunk_offset" $
@@ -97,92 +167,112 @@ scanStage1 (Pattern _ pes) num_groups group_size space scan_op nes kbody = do
       flat_idx <- dPrimV "flat_idx" $
                   Imp.var chunk_offset int32 + kernelLocalThreadId constants
       -- Construct segment indices.
-      zipWithM_ dPrimV_ gtids $ unflattenIndex dims' $ Imp.var flat_idx int32
+      zipWithM_ dPrimV_ gtids $ unflattenIndex dims' $ Imp.vi32 flat_idx
 
-      let in_bounds =
-            foldl1 (.&&.) $ zipWith (.<.) (map (`Imp.var` int32) gtids) dims'
+      let per_scan_pes = segBinOpChunks scans all_pes
+
+          in_bounds =
+            foldl1 (.&&.) $ zipWith (.<.) (map Imp.vi32 gtids) dims'
+
           when_in_bounds = compileStms mempty (kernelBodyStms kbody) $ do
-            let (scan_res, map_res) = splitAt (length nes) $ kernelBodyResult kbody
+            let (all_scan_res, map_res) =
+                  splitAt (segBinOpResults scans) $ kernelBodyResult kbody
+                per_scan_res =
+                  segBinOpChunks scans all_scan_res
+
             sComment "write to-scan values to parameters" $
-              forM_ (zip scan_y_params scan_res) $ \(p, se) ->
-              copyDWIMFix (paramName p) [] (kernelResultSubExp se) []
+              mapM_ (writeToScanValues gtids) $
+              zip3 per_scan_pes scans per_scan_res
+
             sComment "write mapped values results to global memory" $
-              forM_ (zip (drop (length nes) pes) map_res) $ \(pe, se) ->
-              copyDWIMFix (patElemName pe) (map (`Imp.var` int32) gtids)
+              forM_ (zip (takeLast (length map_res) all_pes) map_res) $ \(pe, se) ->
+              copyDWIMFix (patElemName pe) (map Imp.vi32 gtids)
               (kernelResultSubExp se) []
-          when_out_of_bounds = forM_ (zip scan_y_params nes) $ \(p, ne) ->
-            copyDWIMFix (paramName p) [] ne []
 
-      sComment "threads in bounds read input; others get neutral element" $
-        sIf in_bounds when_in_bounds when_out_of_bounds
+      sComment "threads in bounds read input" $
+        sWhen in_bounds when_in_bounds
 
-      sComment "combine with carry and write to local memory" $
-        compileStms mempty (bodyStms $ lambdaBody scan_op) $
-        forM_ (zip3 rets local_arrs (bodyResult $ lambdaBody scan_op)) $ \(t, arr, se) ->
-        copyDWIMFix arr [localArrayIndex constants t] se []
+      forM_ (zip3 per_scan_pes scans all_local_arrs) $
+        \(pes, scan@(SegBinOp _ scan_op nes vec_shape), local_arrs) ->
+        sComment "do one intra-group scan operation" $ do
+        let rets = lambdaReturnType scan_op
+            scan_x_params = xParams scan
+            (array_scan, fence, barrier) = barrierFor scan_op
+        sLoopNest vec_shape $ \vec_is -> do
+          sComment "maybe restore some to-scan values to parameters, or read neutral" $
+            sIf in_bounds
+            (do readToScanValues (map Imp.vi32 gtids++vec_is) pes scan
+                readCarries (Imp.vi32 chunk_offset) dims' vec_is pes scan)
+            (forM_ (zip (yParams scan) (segBinOpNeutral scan)) $ \(p, ne) ->
+                copyDWIMFix (paramName p) [] ne [])
 
-      let crossesSegment' = do
-            f <- crossesSegment
-            Just $ \from to ->
-              let from' = from + Imp.var chunk_offset int32
-                  to' = to + Imp.var chunk_offset int32
-              in f from' to'
+          sComment "combine with carry and write to local memory" $
+            compileStms mempty (bodyStms $ lambdaBody scan_op) $
+            forM_ (zip3 rets local_arrs (bodyResult $ lambdaBody scan_op)) $
+            \(t, arr, se) -> copyDWIMFix arr [localArrayIndex constants t] se []
 
-      sOp $ Imp.ErrorSync fence
+          let crossesSegment' = do
+                f <- crossesSegment
+                Just $ \from to ->
+                  let from' = from + Imp.var chunk_offset int32
+                      to' = to + Imp.var chunk_offset int32
+                  in f from' to'
 
-      groupScan crossesSegment'
-        (Imp.vi32 num_threads)
-        (kernelGroupSize constants) scan_op_renamed local_arrs
+          sOp $ Imp.ErrorSync fence
 
-      sComment "threads in bounds write partial scan result" $
-        sWhen in_bounds $ forM_ (zip3 rets pes local_arrs) $ \(t, pe, arr) ->
-        copyDWIMFix (patElemName pe) (map (`Imp.var` int32) gtids)
-        (Var arr) [localArrayIndex constants t]
+          -- We need to avoid parameter name clashes.
+          scan_op_renamed <- renameLambda scan_op
+          groupScan crossesSegment'
+            (Imp.vi32 num_threads)
+            (kernelGroupSize constants) scan_op_renamed local_arrs
 
-      barrier
+          sComment "threads in bounds write partial scan result" $
+            sWhen in_bounds $ forM_ (zip3 rets pes local_arrs) $ \(t, pe, arr) ->
+            copyDWIMFix (patElemName pe) (map Imp.vi32 gtids++vec_is)
+            (Var arr) [localArrayIndex constants t]
 
-      let load_carry =
-            forM_ (zip local_arrs scan_x_params) $ \(arr, p) ->
-            copyDWIMFix (paramName p) [] (Var arr)
-            [if primType $ paramType p
-             then kernelGroupSize constants - 1
-             else (kernelGroupId constants+1) * kernelGroupSize constants - 1]
-          load_neutral =
-            forM_ (zip nes scan_x_params) $ \(ne, p) ->
-            copyDWIMFix (paramName p) [] ne []
+          barrier
 
-      sComment "first thread reads last element as carry-in for next iteration" $ do
-        crosses_segment <- dPrimVE "crosses_segment" $
-          case crossesSegment of
-            Nothing -> false
-            Just f -> f (Imp.var chunk_offset int32 +
-                         kernelGroupSize constants-1)
-                        (Imp.var chunk_offset int32 +
-                         kernelGroupSize constants)
-        should_load_carry <- dPrimVE "should_load_carry" $
-          kernelLocalThreadId constants .==. 0 .&&. UnOpExp Not crosses_segment
-        sWhen should_load_carry load_carry
-        when array_scan barrier
-        sUnless should_load_carry load_neutral
+          let load_carry =
+                forM_ (zip local_arrs scan_x_params) $ \(arr, p) ->
+                copyDWIMFix (paramName p) [] (Var arr)
+                [if primType $ paramType p
+                 then kernelGroupSize constants - 1
+                 else (kernelGroupId constants+1) * kernelGroupSize constants - 1]
+              load_neutral =
+                forM_ (zip nes scan_x_params) $ \(ne, p) ->
+                copyDWIMFix (paramName p) [] ne []
 
-      barrier
+          sComment "first thread reads last element as carry-in for next iteration" $ do
+            crosses_segment <- dPrimVE "crosses_segment" $
+              case crossesSegment of
+                Nothing -> false
+                Just f -> f (Imp.var chunk_offset int32 +
+                             kernelGroupSize constants-1)
+                            (Imp.var chunk_offset int32 +
+                             kernelGroupSize constants)
+            should_load_carry <- dPrimVE "should_load_carry" $
+              kernelLocalThreadId constants .==. 0 .&&. UnOpExp Not crosses_segment
+            sWhen should_load_carry load_carry
+            when array_scan barrier
+            sUnless should_load_carry load_neutral
+
+          barrier
 
   return (num_threads, elems_per_group, crossesSegment)
 
-  where (array_scan, fence, barrier) = barrierFor scan_op
-
 scanStage2 :: Pattern KernelsMem
            -> VName -> Imp.Exp -> Count NumGroups SubExp -> CrossesSegment -> SegSpace
-           -> Lambda KernelsMem -> [SubExp]
+           -> [SegBinOp KernelsMem]
            -> CallKernelGen ()
-scanStage2 (Pattern _ pes) stage1_num_threads elems_per_group num_groups crossesSegment space scan_op nes = do
+scanStage2 (Pattern _ all_pes) stage1_num_threads elems_per_group num_groups crossesSegment space scans = do
+  let (gtids, dims) = unzip $ unSegSpace space
+  dims' <- mapM toExp dims
+
   -- Our group size is the number of groups for the stage 1 kernel.
   let group_size = Count $ unCount num_groups
   group_size' <- traverse toExp group_size
 
-  let (gtids, dims) = unzip $ unSegSpace space
-      rets = lambdaReturnType scan_op
-  dims' <- mapM toExp dims
   let crossesSegment' = do
         f <- crossesSegment
         Just $ \from to ->
@@ -190,42 +280,51 @@ scanStage2 (Pattern _ pes) stage1_num_threads elems_per_group num_groups crosses
 
   sKernelThread  "scan_stage2" 1 group_size' (segFlat space) $ do
     constants <- kernelConstants <$> askEnv
-    local_arrs <- makeLocalArrays group_size (Var stage1_num_threads) nes scan_op
+    per_scan_local_arrs <- makeLocalArrays group_size (Var stage1_num_threads) scans
+    let per_scan_rets = map (lambdaReturnType . segBinOpLambda) scans
+        per_scan_pes = segBinOpChunks scans all_pes
 
     flat_idx <- dPrimV "flat_idx" $
       (kernelLocalThreadId constants + 1) * elems_per_group - 1
     -- Construct segment indices.
     zipWithM_ dPrimV_ gtids $ unflattenIndex dims' $ Imp.var flat_idx int32
 
-    let in_bounds =
-          foldl1 (.&&.) $ zipWith (.<.) (map (`Imp.var` int32) gtids) dims'
-        when_in_bounds = forM_ (zip3 rets local_arrs pes) $ \(t, arr, pe) ->
-          copyDWIMFix arr [localArrayIndex constants t]
-          (Var $ patElemName pe) $ map (`Imp.var` int32) gtids
-        when_out_of_bounds = forM_ (zip3 rets local_arrs nes) $ \(t, arr, ne) ->
-          copyDWIMFix arr [localArrayIndex constants t] ne []
+    forM_ (zip4 scans per_scan_local_arrs per_scan_rets per_scan_pes) $
+      \(SegBinOp _ scan_op nes vec_shape, local_arrs, rets, pes) ->
+        sLoopNest vec_shape $ \vec_is -> do
+        let glob_is = map Imp.vi32 gtids ++ vec_is
 
-    sComment "threads in bound read carries; others get neutral element" $
-      sIf in_bounds when_in_bounds when_out_of_bounds
+            in_bounds =
+              foldl1 (.&&.) $ zipWith (.<.) (map Imp.vi32 gtids) dims'
 
-    barrier
+            when_in_bounds = forM_ (zip3 rets local_arrs pes) $ \(t, arr, pe) ->
+              copyDWIMFix arr [localArrayIndex constants t]
+              (Var $ patElemName pe) glob_is
 
-    groupScan crossesSegment'
-      (Imp.vi32 stage1_num_threads) (kernelGroupSize constants) scan_op local_arrs
+            when_out_of_bounds = forM_ (zip3 rets local_arrs nes) $ \(t, arr, ne) ->
+              copyDWIMFix arr [localArrayIndex constants t] ne []
+            (_, _, barrier) =
+              barrierFor scan_op
 
-    sComment "threads in bounds write scanned carries" $
-      sWhen in_bounds $ forM_ (zip3 rets pes local_arrs) $ \(t, pe, arr) ->
-      copyDWIMFix (patElemName pe) (map (`Imp.var` int32) gtids)
-      (Var arr) [localArrayIndex constants t]
+        sComment "threads in bound read carries; others get neutral element" $
+          sIf in_bounds when_in_bounds when_out_of_bounds
 
-  where (_, _, barrier) = barrierFor scan_op
+        barrier
+
+        groupScan crossesSegment'
+          (Imp.vi32 stage1_num_threads) (kernelGroupSize constants) scan_op local_arrs
+
+        sComment "threads in bounds write scanned carries" $
+          sWhen in_bounds $ forM_ (zip3 rets pes local_arrs) $ \(t, pe, arr) ->
+          copyDWIMFix (patElemName pe) glob_is
+          (Var arr) [localArrayIndex constants t]
 
 scanStage3 :: Pattern KernelsMem
            -> Count NumGroups SubExp -> Count GroupSize SubExp
            -> Imp.Exp -> CrossesSegment -> SegSpace
-           -> Lambda KernelsMem -> [SubExp]
+           -> [SegBinOp KernelsMem]
            -> CallKernelGen ()
-scanStage3 (Pattern _ pes) num_groups group_size elems_per_group crossesSegment space scan_op nes = do
+scanStage3 (Pattern _ all_pes) num_groups group_size elems_per_group crossesSegment space scans = do
   num_groups' <- traverse toExp num_groups
   group_size' <- traverse toExp group_size
   let (gtids, dims) = unzip $ unSegSpace space
@@ -256,7 +355,7 @@ scanStage3 (Pattern _ pes) num_groups group_size elems_per_group crossesSegment 
     -- then the carry was updated in stage 2), and we are not crossing
     -- a segment boundary.
     let in_bounds =
-          foldl1 (.&&.) $ zipWith (.<.) (map (`Imp.var` int32) gtids) dims'
+          foldl1 (.&&.) $ zipWith (.<.) (map Imp.vi32 gtids) dims'
         crosses_segment = fromMaybe false $
           crossesSegment <*>
             pure (Imp.var carry_in_flat_idx int32) <*>
@@ -265,32 +364,43 @@ scanStage3 (Pattern _ pes) num_groups group_size elems_per_group crossesSegment 
                      (Imp.var orig_group int32 + 1) * elems_per_group - 1
         no_carry_in = Imp.var orig_group int32 .==. 0 .||. is_a_carry .||. crosses_segment
 
-    sWhen in_bounds $ sUnless no_carry_in $ do
-      dScope Nothing $ scopeOfLParams $ lambdaParams scan_op
-      let (scan_x_params, scan_y_params) =
-            splitAt (length nes) $ lambdaParams scan_op
-      forM_ (zip scan_x_params pes) $ \(p, pe) ->
-        copyDWIMFix (paramName p) [] (Var $ patElemName pe) carry_in_idx
-      forM_ (zip scan_y_params pes) $ \(p, pe) ->
-        copyDWIMFix (paramName p) [] (Var $ patElemName pe) $ map (`Imp.var` int32) gtids
-      compileBody' scan_x_params $ lambdaBody scan_op
-      forM_ (zip scan_x_params pes) $ \(p, pe) ->
-        copyDWIMFix (patElemName pe) (map (`Imp.var` int32) gtids) (Var $ paramName p) []
+    let per_scan_pes = segBinOpChunks scans all_pes
+    sWhen in_bounds $ sUnless no_carry_in $
+      forM_ (zip per_scan_pes scans) $
+      \(pes, SegBinOp _ scan_op nes vec_shape) -> do
+        dScope Nothing $ scopeOfLParams $ lambdaParams scan_op
+        let (scan_x_params, scan_y_params) =
+              splitAt (length nes) $ lambdaParams scan_op
+
+        sLoopNest vec_shape $ \vec_is -> do
+          forM_ (zip scan_x_params pes) $ \(p, pe) ->
+            copyDWIMFix (paramName p) []
+            (Var $ patElemName pe) (carry_in_idx++vec_is)
+
+          forM_ (zip scan_y_params pes) $ \(p, pe) ->
+            copyDWIMFix (paramName p) []
+            (Var $ patElemName pe) (map Imp.vi32 gtids++vec_is)
+
+          compileBody' scan_x_params $ lambdaBody scan_op
+
+          forM_ (zip scan_x_params pes) $ \(p, pe) ->
+            copyDWIMFix (patElemName pe) (map Imp.vi32 gtids++vec_is)
+            (Var $ paramName p) []
 
 -- | Compile 'SegScan' instance to host-level code with calls to
 -- various kernels.
 compileSegScan :: Pattern KernelsMem
                -> SegLevel -> SegSpace
-               -> Lambda KernelsMem -> [SubExp]
+               -> [SegBinOp KernelsMem]
                -> KernelBody KernelsMem
                -> CallKernelGen ()
-compileSegScan pat lvl space scan_op nes kbody = do
+compileSegScan pat lvl space scans kbody = do
   emit $ Imp.DebugPrint "\n# SegScan" Nothing
 
   (stage1_num_threads, elems_per_group, crossesSegment) <-
-    scanStage1 pat (segNumGroups lvl) (segGroupSize lvl) space scan_op nes kbody
+    scanStage1 pat (segNumGroups lvl) (segGroupSize lvl) space scans kbody
 
   emit $ Imp.DebugPrint "elems_per_group" $ Just elems_per_group
 
-  scanStage2 pat stage1_num_threads elems_per_group (segNumGroups lvl) crossesSegment space scan_op nes
-  scanStage3 pat (segNumGroups lvl) (segGroupSize lvl) elems_per_group crossesSegment space scan_op nes
+  scanStage2 pat stage1_num_threads elems_per_group (segNumGroups lvl) crossesSegment space scans
+  scanStage3 pat (segNumGroups lvl) (segGroupSize lvl) elems_per_group crossesSegment space scans

--- a/src/Futhark/CodeGen/ImpGen/Multicore.hs
+++ b/src/Futhark/CodeGen/ImpGen/Multicore.hs
@@ -30,8 +30,8 @@ compileSegOp :: Pattern MCMem -> SegOp () MCMem
 compileSegOp pat  (SegHist _ space histops _ kbody) =
   compileSegHist pat space histops kbody
 
-compileSegOp pat (SegScan _ space op nes _ kbody) =
-  compileSegScan pat space op nes kbody
+compileSegOp pat (SegScan _ space scans _ kbody) =
+  compileSegScan pat space scans kbody
 
 compileSegOp pat (SegRed _ space reds _ kbody) =
   compileSegRed pat space reds kbody

--- a/src/Futhark/CodeGen/ImpGen/Multicore/SegHist.hs
+++ b/src/Futhark/CodeGen/ImpGen/Multicore/SegHist.hs
@@ -316,7 +316,7 @@ smallDestHistogram pat space histops num_threads kbody = do
             [(bucket_id, num_buckets)] ++
             [(subhistogram_id, Var num_histos)]
 
-      let segred_op = SegRedOp Commutative (histOp op) (histNeutral op) (histShape op)
+      let segred_op = SegBinOp Commutative (histOp op) (histNeutral op) (histShape op)
       compileSegRed' (Pattern [] red_pes) segred_space [segred_op] $ \red_cont -> do
         red_cont $ flip map hists $ \subhisto ->
               (Var subhisto, map Imp.vi32 $

--- a/src/Futhark/CodeGen/ImpGen/Multicore/SegRed.hs
+++ b/src/Futhark/CodeGen/ImpGen/Multicore/SegRed.hs
@@ -19,16 +19,16 @@ type DoSegBody = (([(SubExp, [Imp.Exp])] -> MulticoreGen ()) -> MulticoreGen ())
 -- Compile a SegRed construct
 compileSegRed :: Pattern MCMem
                  -> SegSpace
-                 -> [SegRedOp MCMem]
+                 -> [SegBinOp MCMem]
                  -> KernelBody MCMem
                  -> MulticoreGen ()
 compileSegRed pat space reds kbody =
   compileSegRed' pat space reds $ \red_cont ->
     compileStms mempty (kernelBodyStms kbody) $ do
-    let (red_res, map_res) = splitAt (segRedResults reds) $ kernelBodyResult kbody
+    let (red_res, map_res) = splitAt (segBinOpResults reds) $ kernelBodyResult kbody
 
     sComment "save map-out results" $ do
-      let map_arrs = drop (segRedResults reds) $ patternElements pat
+      let map_arrs = drop (segBinOpResults reds) $ patternElements pat
       zipWithM_ (compileThreadResult space) map_arrs map_res
 
     red_cont $ zip (map kernelResultSubExp red_res) $ repeat []
@@ -36,7 +36,7 @@ compileSegRed pat space reds kbody =
 -- | Like 'compileSegRed', but where the body is a monadic action.
 compileSegRed' :: Pattern MCMem
                -> SegSpace
-               -> [SegRedOp MCMem]
+               -> [SegBinOp MCMem]
                -> DoSegBody
                -> MulticoreGen ()
 compileSegRed' pat space reds kbody
@@ -53,59 +53,59 @@ compileSegRed' pat space reds kbody
 -- first-stage reduction, if necessary.  When actually storing group
 -- results, the first index is set to 0.
 groupResultArrays :: SubExp
-                  -> [SegRedOp MCMem]
+                  -> [SegBinOp MCMem]
                   -> MulticoreGen [[VName]]
 groupResultArrays num_threads reds =
-  forM reds $ \(SegRedOp _ lam _ shape) ->
+  forM reds $ \(SegBinOp _ lam _ shape) ->
     forM (lambdaReturnType lam) $ \t -> do
     let pt = elemType t
         full_shape = Shape [num_threads] <> shape <> arrayShape t
     sAllocArray "group_res_arr" pt full_shape DefaultSpace
 
 
--- | A SegRedOp with auxiliary information.
-data SegRedOpSlug =
-  SegRedOpSlug
-  { slugOp :: SegRedOp MCMem
+-- | A SegBinOp with auxiliary information.
+data SegBinOpSlug =
+  SegBinOpSlug
+  { slugOp :: SegBinOp MCMem
   , slugAccs :: [(VName, [Imp.Exp])]
     -- ^ Places to store accumulator in stage 1 reduction.
   }
 
 
-slugBody :: SegRedOpSlug -> Body MCMem
-slugBody = lambdaBody . segRedLambda . slugOp
+slugBody :: SegBinOpSlug -> Body MCMem
+slugBody = lambdaBody . segBinOpLambda . slugOp
 
-slugParams :: SegRedOpSlug -> [LParam MCMem]
-slugParams = lambdaParams . segRedLambda . slugOp
+slugParams :: SegBinOpSlug -> [LParam MCMem]
+slugParams = lambdaParams . segBinOpLambda . slugOp
 
-slugNeutral :: SegRedOpSlug -> [SubExp]
-slugNeutral = segRedNeutral . slugOp
+slugNeutral :: SegBinOpSlug -> [SubExp]
+slugNeutral = segBinOpNeutral . slugOp
 
-slugShape :: SegRedOpSlug -> Shape
-slugShape = segRedShape . slugOp
+slugShape :: SegBinOpSlug -> Shape
+slugShape = segBinOpShape . slugOp
 
-accParams, nextParams :: SegRedOpSlug -> [LParam MCMem]
+accParams, nextParams :: SegBinOpSlug -> [LParam MCMem]
 accParams slug = take (length (slugNeutral slug)) $ slugParams slug
 nextParams slug = drop (length (slugNeutral slug)) $ slugParams slug
 
-slugsComm :: [SegRedOpSlug] -> Commutativity
-slugsComm = mconcat . map (segRedComm . slugOp)
+slugsComm :: [SegBinOpSlug] -> Commutativity
+slugsComm = mconcat . map (segBinOpComm . slugOp)
 
 
-segRedOpSlug :: Imp.Exp
-             -> (SegRedOp MCMem, [VName])
-             -> MulticoreGen SegRedOpSlug
-segRedOpSlug local_tid (op, param_arrs) =
-  SegRedOpSlug op <$> mapM (\param_arr -> return (param_arr, [local_tid])) param_arrs
+segBinOpOpSlug :: Imp.Exp
+             -> (SegBinOp MCMem, [VName])
+             -> MulticoreGen SegBinOpSlug
+segBinOpOpSlug local_tid (op, param_arrs) =
+  SegBinOpSlug op <$> mapM (\param_arr -> return (param_arr, [local_tid])) param_arrs
 
 
 nonsegmentedReduction :: Pattern MCMem
                       -> SegSpace
-                      -> [SegRedOp MCMem]
+                      -> [SegBinOp MCMem]
                       -> DoSegBody
                       -> MulticoreGen ()
 nonsegmentedReduction pat space reds kbody = do
-  emit $ Imp.DebugPrint "nonsegmented segRed " Nothing
+  emit $ Imp.DebugPrint "nonsegmented segBinOp " Nothing
   sUnpauseProfiling
 
   let (is, ns) = unzip $ unSegSpace space
@@ -119,7 +119,7 @@ nonsegmentedReduction pat space reds kbody = do
   tid <- dPrim "tid" $ IntType Int32
   tid' <- toExp $ Var tid
 
-  slugs <- mapM (segRedOpSlug tid') $ zip reds stage_one_red_arrs
+  slugs <- mapM (segBinOpOpSlug tid') $ zip reds stage_one_red_arrs
 
   -- TODO: Need to declare this for reduce6.fut
   -- reduce6.fut still doesn't work though
@@ -173,7 +173,7 @@ nonsegmentedReduction pat space reds kbody = do
   -- Reduce over intermediate results
   dScope Nothing $ scopeOfLParams $ concatMap slugParams slugs
   sFor "i" ntasks' $ \i' -> do
-    emit $ Imp.DebugPrint "nonsegmented segRed stage 2" Nothing
+    emit $ Imp.DebugPrint "nonsegmented segBinOp stage 2" Nothing
     tid <-- i'
     sComment "Apply main thread reduction" $
       forM_ slugs $ \slug ->
@@ -196,11 +196,11 @@ nonsegmentedReduction pat space reds kbody = do
 -- based on n_segments and dimensions etc.
 segmentedReduction :: Pattern MCMem
                    -> SegSpace
-                   -> [SegRedOp MCMem]
+                   -> [SegBinOp MCMem]
                    -> DoSegBody
                    -> MulticoreGen ()
 segmentedReduction pat space reds kbody = do
-  emit $ Imp.DebugPrint "segmented segRed " Nothing
+  emit $ Imp.DebugPrint "segmented segBinOp " Nothing
   sUnpauseProfiling
 
   let (is, ns) = unzip $ unSegSpace space
@@ -213,37 +213,37 @@ segmentedReduction pat space reds kbody = do
 
   -- Perform sequential reduce on inner most dimension
   fbody <- collect $ do
-    emit $ Imp.DebugPrint "segmented segRed stage 1" Nothing
+    emit $ Imp.DebugPrint "segmented segBinOp stage 1" Nothing
     sComment "neutral-initialise the accumulators" $
       forM_ reds $ \red->
-        forM_ (zip (patternElements pat) (segRedNeutral red)) $ \(pe, ne) ->
-          sLoopNest (segRedShape red) $ \vec_is ->
+        forM_ (zip (patternElements pat) (segBinOpNeutral red)) $ \(pe, ne) ->
+          sLoopNest (segBinOpShape red) $ \vec_is ->
             copyDWIMFix (patElemName pe) (n_segments' : vec_is) ne []
 
 
     sComment "function main body" $ do
       let inner_bound = last ns'
-      dScope Nothing $ scopeOfLParams $ concatMap (lambdaParams . segRedLambda) reds
+      dScope Nothing $ scopeOfLParams $ concatMap (lambdaParams . segBinOpLambda) reds
       sFor "i" inner_bound $ \i -> do
         dPrimV_ (segFlat space) (n_segments' * inner_bound + i)
         zipWithM_ dPrimV_ is $ unflattenIndex ns' $ Imp.vi32 $ segFlat space
         kbody $ \all_red_res -> do
-          let red_res' = chunks (map (length . segRedNeutral) reds) all_red_res
+          let red_res' = chunks (map (length . segBinOpNeutral) reds) all_red_res
           forM_ (zip reds red_res') $ \(red, res') ->
-            sLoopNest (segRedShape red) $ \vec_is -> do
+            sLoopNest (segBinOpShape red) $ \vec_is -> do
 
             sComment "load acuum " $ do
-              let acc_params = take (length (segRedNeutral red)) $ (lambdaParams . segRedLambda) red
+              let acc_params = take (length (segBinOpNeutral red)) $ (lambdaParams . segBinOpLambda) red
               forM_ (zip acc_params (patternElements pat)) $ \(p, pe) ->
                 copyDWIMFix (paramName p) [] (Var $ patElemName pe) (n_segments' : vec_is)
 
             sComment "load new val" $ do
-              let next_params = drop (length (segRedNeutral red)) $ (lambdaParams . segRedLambda) red
+              let next_params = drop (length (segBinOpNeutral red)) $ (lambdaParams . segBinOpLambda) red
               forM_ (zip next_params res') $ \(p, (res, res_is)) ->
                 copyDWIMFix (paramName p) [] res (res_is ++ vec_is)
 
             sComment "apply reduction" $ do
-              let lbody = (lambdaBody . segRedLambda) red
+              let lbody = (lambdaBody . segBinOpLambda) red
               compileStms mempty (bodyStms lbody) $
                 sComment "write back to res" $
                 forM_ (zip (patternElements pat) (bodyResult lbody)) $

--- a/src/Futhark/CodeGen/ImpGen/Multicore/SegScan.hs
+++ b/src/Futhark/CodeGen/ImpGen/Multicore/SegScan.hs
@@ -35,25 +35,23 @@ createTemporaryArrays num_threads nes scan_op = do
 
 compileSegScan :: Pattern MCMem
                 -> SegSpace
-                -> Lambda MCMem
-                -> [SubExp]
+                -> [SegBinOp MCMem]
                 -> KernelBody MCMem
                 -> MulticoreGen ()
-compileSegScan pat space scan_op nes kbody
+compileSegScan pat space scans kbody
   | segment_depth <- unSegSpace space,
     length segment_depth == 1 =
-      nonsegmentedScan pat space scan_op nes kbody
+      nonsegmentedScan pat space scans kbody
   | otherwise =
-      segmentedScan pat space scan_op nes kbody
+      segmentedScan pat space scans kbody
 
 
 segmentedScan :: Pattern MCMem
-                -> SegSpace
-                -> Lambda MCMem
-                -> [SubExp]
-                -> KernelBody MCMem
-                -> MulticoreGen ()
-segmentedScan pat space scan_op nes kbody = do
+              -> SegSpace
+              -> [SegBinOp MCMem]
+              -> KernelBody MCMem
+              -> MulticoreGen ()
+segmentedScan pat space [SegBinOp _ scan_op nes _] kbody = do
   emit $ Imp.DebugPrint "segmented segScan" Nothing
   sUnpauseProfiling
 
@@ -134,11 +132,10 @@ segScanOpSlug local_tid op param_arrs =
 
 nonsegmentedScan :: Pattern MCMem
                  -> SegSpace
-                 -> Lambda MCMem
-                 -> [SubExp]
+                 -> [SegBinOp MCMem]
                  -> KernelBody MCMem
                  -> MulticoreGen ()
-nonsegmentedScan pat space scan_op nes kbody = do
+nonsegmentedScan pat space [SegBinOp _ scan_op nes _] kbody = do
   emit $ Imp.DebugPrint "nonsegmented segScan " Nothing
   sUnpauseProfiling
 

--- a/src/Futhark/Pass/ExplicitAllocations/Kernels.hs
+++ b/src/Futhark/Pass/ExplicitAllocations/Kernels.hs
@@ -77,7 +77,7 @@ kernelExpHints (Op (Inner (SegOp (SegMap lvl@SegThread{} space ts body)))) =
 
 kernelExpHints (Op (Inner (SegOp (SegRed lvl@SegThread{} space reds ts body)))) =
   (map (const NoHint) red_res <>) <$> zipWithM (mapResultHint lvl space) (drop num_reds ts) map_res
-  where num_reds = segRedResults reds
+  where num_reds = segBinOpResults reds
         (red_res, map_res) = splitAt num_reds $ kernelBodyResult body
 
 kernelExpHints e =

--- a/src/Futhark/Pass/ExtractKernels/BlockedKernel.hs
+++ b/src/Futhark/Pass/ExtractKernels/BlockedKernel.hs
@@ -72,7 +72,7 @@ segRed :: (MonadFreshNames m, DistLore lore, HasScope lore m) =>
           SegOpLevel lore
        -> Pattern lore
        -> SubExp -- segment size
-       -> [SegRedOp lore]
+       -> [SegBinOp lore]
        -> Lambda lore
        -> [VName]
        -> [(VName, SubExp)] -- ispace = pair of (gtid, size) for the maps on "top" of this reduction
@@ -87,15 +87,15 @@ segScan :: (MonadFreshNames m, DistLore lore, HasScope lore m) =>
            SegOpLevel lore
         -> Pattern lore
         -> SubExp -- segment size
-        -> Lambda lore -> [SubExp]
-        -> Lambda lore -> [VName]
+        -> [SegBinOp lore] -> Lambda lore
+        -> [VName]
         -> [(VName, SubExp)] -- ispace = pair of (gtid, size) for the maps on "top" of this scan
         -> [KernelInput]     -- inps = inputs that can be looked up by using the gtids from ispace
         -> m (Stms lore)
-segScan lvl pat w scan_lam nes map_lam arrs ispace inps = runBinder_ $ do
+segScan lvl pat w ops map_lam arrs ispace inps = runBinder_ $ do
   (kspace, kbody) <- prepareRedOrScan w map_lam arrs ispace inps
   letBind_ pat $ Op $ segOp $
-    SegScan lvl kspace scan_lam nes (lambdaReturnType map_lam) kbody
+    SegScan lvl kspace ops (lambdaReturnType map_lam) kbody
 
 segMap :: (MonadFreshNames m, DistLore lore, HasScope lore m) =>
           SegOpLevel lore
@@ -136,7 +136,7 @@ nonSegRed :: (MonadFreshNames m, DistLore lore, HasScope lore m) =>
              SegOpLevel lore
           -> Pattern lore
           -> SubExp
-          -> [SegRedOp lore]
+          -> [SegBinOp lore]
           -> Lambda lore
           -> [VName]
           -> m (Stms lore)

--- a/src/Futhark/Pass/ExtractKernels/DistributeNests.hs
+++ b/src/Futhark/Pass/ExtractKernels/DistributeNests.hs
@@ -826,9 +826,10 @@ segmentedScanomapKernel nest perm segment_size lam map_lam nes arrs = do
   mk_lvl <- asks distSegLevel
   isSegmentedOp nest perm segment_size (freeIn lam) (freeIn map_lam) nes arrs $
     \pat ispace inps nes' _ _ -> do
+    let scan_op = SegBinOp Noncommutative lam nes' mempty
     lvl <- mk_lvl (segment_size : map snd ispace) "segscan" $ NoRecommendation SegNoVirt
     addStms =<< traverse renameStm =<<
-      segScan lvl pat segment_size lam nes' map_lam arrs ispace inps
+      segScan lvl pat segment_size [scan_op] map_lam arrs ispace inps
 
 regularSegmentedRedomapKernel :: (MonadFreshNames m, DistLore lore) =>
                                  KernelNest
@@ -841,7 +842,7 @@ regularSegmentedRedomapKernel nest perm segment_size comm lam map_lam nes arrs =
   mk_lvl <- asks distSegLevel
   isSegmentedOp nest perm segment_size (freeIn lam) (freeIn map_lam) nes arrs $
     \pat ispace inps nes' _ _ -> do
-      let red_op = SegRedOp comm lam nes' mempty
+      let red_op = SegBinOp comm lam nes' mempty
       lvl <- mk_lvl (segment_size : map snd ispace) "segred" $ NoRecommendation SegNoVirt
       addStms =<< traverse renameStm =<<
         segRed lvl pat segment_size [red_op] map_lam arrs ispace inps

--- a/src/Futhark/Pass/ExtractKernels/Intragroup.hs
+++ b/src/Futhark/Pass/ExtractKernels/Intragroup.hs
@@ -199,7 +199,7 @@ intraGroupStm lvl stm@(Let pat aux e) = do
       let scanfun' = soacsLambdaToKernels scanfun
           mapfun' = soacsLambdaToKernels mapfun
       certifying (stmAuxCerts aux) $
-        addStms =<< segScan lvl' pat w scanfun' nes mapfun' arrs [] []
+        addStms =<< segScan lvl' pat w [SegBinOp Noncommutative scanfun' nes mempty] mapfun' arrs [] []
       parallelMin [w]
 
     Op (Screma w form arrs)
@@ -208,7 +208,7 @@ intraGroupStm lvl stm@(Let pat aux e) = do
       let red_lam' = soacsLambdaToKernels red_lam
           map_lam' = soacsLambdaToKernels map_lam
       certifying (stmAuxCerts aux) $
-        addStms =<< segRed lvl' pat w [SegRedOp comm red_lam' nes mempty] map_lam' arrs [] []
+        addStms =<< segRed lvl' pat w [SegBinOp comm red_lam' nes mempty] map_lam' arrs [] []
       parallelMin [w]
 
 

--- a/src/Futhark/Pass/ExtractKernels/StreamKernel.hs
+++ b/src/Futhark/Pass/ExtractKernels/StreamKernel.hs
@@ -195,7 +195,7 @@ streamRed mk_lvl pat w comm red_lam fold_lam nes arrs = runBinderT'_ $ do
 
   lvl <- mk_lvl [w] "stream_red" $ NoRecommendation SegNoVirt
   letBind_ pat' $ Op $ SegOp $ SegRed lvl kspace
-    [SegRedOp comm red_lam nes mempty] ts kbody
+    [SegBinOp comm red_lam nes mempty] ts kbody
 
   read_dummy
 

--- a/tests/soacs/reduce7.fut
+++ b/tests/soacs/reduce7.fut
@@ -1,0 +1,6 @@
+-- A funky reduce with vectorised operator (and not interchangeable).
+-- ==
+-- compiled random input { [100][100]i32 } auto output
+
+let main [n][m] (xss: [n][m]i32) =
+  reduce (map2 (+)) (replicate m 0) (map (scan (+) 0) xss)

--- a/tests/soacs/scan5.fut
+++ b/tests/soacs/scan5.fut
@@ -1,0 +1,8 @@
+-- A funky scan with vectorised operator (and not interchangeable).
+-- ==
+-- compiled random input { [1][100]i32 } auto output
+-- compiled random input { [100][1]i32 } auto output
+-- compiled random input { [100][100]i32 } auto output
+
+let main [n][m] (xss: [n][m]i32) =
+  scan (map2 (+)) (replicate m 0) (map (scan (+) 0) xss)


### PR DESCRIPTION
SegScan now has about the same design as SegReds.  I have not changed the code generation much, so OptionPricing will now crash the compiler.  However, the scan and reduce operators will no longer have memory operands!