### PR TITLE
Warn on out-of-bounds literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+  * Warnings for overflowing literals, such as `1000 : u8`.
+
 ### Removed
 
 ### Changed

--- a/src/Language/Futhark/TypeChecker/Terms.hs
+++ b/src/Language/Futhark/TypeChecker/Terms.hs
@@ -2449,8 +2449,8 @@ literalOverflowCheck = (() <$) . check
         check e@(FloatLit x ty loc) = e <$ case ty of
           Info (Scalar (Prim (FloatType t))) -> warnBounds (inBoundsF x t) x t loc
           _ -> error "Inferred type of float literal is not a float"
-        check e@(Negate (IntLit x ty _) loc) = e <$ case ty of
-          Info (Scalar (Prim t)) -> warnBounds (inBoundsI (-x) t) (-x) t loc
+        check e@(Negate (IntLit x ty loc1) loc2) = e <$ case ty of
+          Info (Scalar (Prim t)) -> warnBounds (inBoundsI (-x) t) (-x) t (loc1 <> loc2)
           _ -> error "Inferred type of int literal is not a number"
         check e = astMap identityMapper{mapOnExp = check} e
         bitWidth :: IntType -> Int

--- a/src/Language/Futhark/TypeChecker/Terms.hs
+++ b/src/Language/Futhark/TypeChecker/Terms.hs
@@ -2336,6 +2336,7 @@ checkOneExp e = fmap fst . runTermTypeM $ do
   e'' <- updateTypes e'
   checkUnmatched e''
   causalityCheck e''
+  literalOverflowCheck e''
   return (tparams, e'')
 
 -- Verify that all sum type constructors and empty array literals have
@@ -2436,6 +2437,38 @@ causalityCheck binding_body = do
           align (textwrap "Bind the expression producing" <+> pquote (pprName d) <+>
                  "with 'let' beforehand.")
 
+-- | Traverse the expression, emitting warnings if any of the literals overflow
+-- their inferred types
+--
+-- Note: currently unable to detect float underflow (such as 1e-400 -> 0)
+literalOverflowCheck :: Exp -> TermTypeM ()
+literalOverflowCheck = (() <$) . check
+  where check e@(IntLit x ty loc) = e <$ case ty of
+          Info (Scalar (Prim t)) -> warnBounds (inBoundsI x t) x t loc
+          _ -> error "Inferred type of int literal is not a number"
+        check e@(FloatLit x ty loc) = e <$ case ty of
+          Info (Scalar (Prim (FloatType t))) -> warnBounds (inBoundsF x t) x t loc
+          _ -> error "Inferred type of float literal is not a float"
+        check e@(Negate (IntLit x ty _) loc) = e <$ case ty of
+          Info (Scalar (Prim t)) -> warnBounds (inBoundsI (-x) t) (-x) t loc
+          _ -> error "Inferred type of int literal is not a number"
+        check e = astMap identityMapper{mapOnExp = check} e
+        bitWidth :: IntType -> Int
+        bitWidth Int8 = 8
+        bitWidth Int16 = 16
+        bitWidth Int32 = 32
+        bitWidth Int64 = 64
+        inBoundsI x (Signed t) = x >= -2^(bitWidth t - 1) && x < 2^(bitWidth t - 1)
+        inBoundsI x (Unsigned t) = x >= 0 && x < 2^bitWidth t
+        inBoundsI x (FloatType Float32) = not $ isInfinite (fromIntegral x :: Float)
+        inBoundsI x (FloatType Float64) = not $ isInfinite (fromIntegral x :: Double)
+        inBoundsI _ Bool = error "Inferred type of int literal is not a number"
+        inBoundsF x Float32 = not $ isInfinite (realToFrac x :: Float)
+        inBoundsF x Float64 = not $ isInfinite x
+        warnBounds inBounds x ty loc = if inBounds
+          then pure ()
+          else warn loc $ "Literal " <> show x <> " out of bounds for inferred type " <> pretty ty
+
 -- | Type-check a top-level (or module-level) function definition.
 -- Despite the name, this is also used for checking constant
 -- definitions, by treating them as 0-ary functions.
@@ -2465,6 +2498,8 @@ checkFunDef (fname, maybe_retdecl, tparams, params, body, loc) =
 
   -- Check if the function body can actually be evaluated.
   causalityCheck body''
+
+  literalOverflowCheck body''
 
   bindSpaced [(Term, fname)] $ do
     fname' <- checkName Term fname loc

--- a/tests/overflowing_lits.fut
+++ b/tests/overflowing_lits.fut
@@ -1,0 +1,6 @@
+-- Warn on overflowing literals
+--
+-- ==
+-- warning: (out of bounds.*){3}
+
+entry main : (i8, u8, f32) = (128, -4, -1e40)

--- a/tests/overflowing_lits.fut
+++ b/tests/overflowing_lits.fut
@@ -1,6 +1,0 @@
--- Warn on overflowing literals
---
--- ==
--- warning: (out of bounds.*){3}
-
-entry main : (i8, u8, f32) = (128, -4, -1e40)

--- a/tests/overflowing_lits0.fut
+++ b/tests/overflowing_lits0.fut
@@ -1,0 +1,7 @@
+-- Warn on overflowing literals
+--
+-- ==
+-- warning: (out of bounds.*){5}
+
+entry main : (i16, i32, u16, u32, f32)
+  = (-10000000, 1000000000000, 100000, -4, 9.7e42)

--- a/tests/overflowing_lits1.fut
+++ b/tests/overflowing_lits1.fut
@@ -1,0 +1,7 @@
+-- Warn on overflowing literals – edge cases that should produce warnings
+--
+-- ==
+-- warning: (out of bounds.*){6}
+
+entry main : (i8, i8, u8, u8, f32, f64)
+  = (-129, 128, -4, 256, -1e40, 1.8e308)

--- a/tests/overflowing_lits2.fut
+++ b/tests/overflowing_lits2.fut
@@ -1,0 +1,6 @@
+-- Some edge cases of literals that don't overflow, but are close
+--
+-- ==
+-- warning: ^$
+
+entry main : (i8, i8, u16, f64) = (-128, 127, 65535, 1.79e308)


### PR DESCRIPTION
Resolves #979 

Areas where this PR falls short:
 * It adds an extra traversal.
 * I would have liked to include a test that it didn't warn for e.g. `-128 : i8` (interesting since the sub-expression of +128 is out of bounds).  I don't think this is possible with the current test setup.
 * For the program `let main : f64 = 1e400`, it warns `Literal Infinity out of bounds`.  This isn't fixable without changes to the AST/parser.
 * It doesn't warn for type-postfixed literals like `100000u8`, since these are truncated by the parser.  This isn't fixable without changes to the AST/parser.