### PR TITLE
Fix the memory confusion.

### DIFF
--- a/src/Futhark/CodeGen/ImpCode/Multicore.hs
+++ b/src/Futhark/CodeGen/ImpCode/Multicore.hs
@@ -8,7 +8,6 @@ module Futhark.CodeGen.ImpCode.Multicore
        , MulticoreFunc(..)
        , SequentialFunc(..)
        , Scheduling(..)
-       , ValueType(..)
        , module Futhark.CodeGen.ImpCode
        )
        where
@@ -38,8 +37,6 @@ data Multicore = ParLoop [Param] Imp.Exp Code Code VName [Param]
                | SeqCode VName Code Code
 
 type Granularity = Int32
-
-data ValueType = Prim | MemBlock | Other
 
 -- | Whether the Scheduler can/should schedule the tasks as Dynamic
 -- or it is restainted to Static


### PR DESCRIPTION
The only difference between "cached memory" and ordinary memory is whether or not we look at the `.mem` field when we write it into the struct.  We also no longer propagate cached memory into parallel loops - these are just turned into memory blocks with NULL reference count (in principle we can do a little better than this, but I'm not sure it's worth it).