### PR TITLE
Existentialize loop returns in order to eliminate some unnecessary copies

### DIFF
--- a/src/Futhark/Analysis/PrimExp/Generalize.hs
+++ b/src/Futhark/Analysis/PrimExp/Generalize.hs
@@ -4,7 +4,6 @@ module Futhark.Analysis.PrimExp.Generalize
     leastGeneralGeneralization
   ) where
 
-import           Control.Monad
 import           Data.List (elemIndex)
 
 
@@ -13,54 +12,55 @@ import           Futhark.IR.Syntax.Core (Ext(..))
 
 -- | Generalize two 'PrimExp's of the the same type.
 leastGeneralGeneralization :: (Eq v) => [(PrimExp v, PrimExp v)] -> PrimExp v -> PrimExp v ->
-                              Maybe (PrimExp (Ext v), [(PrimExp v, PrimExp v)])
+                              (PrimExp (Ext v), [(PrimExp v, PrimExp v)])
 leastGeneralGeneralization m exp1@(LeafExp v1 t1) exp2@(LeafExp v2 _) =
   if v1 == v2 then
-    Just (LeafExp (Free v1) t1, m)
+    (LeafExp (Free v1) t1, m)
   else
-    Just $ generalize m exp1 exp2
+    generalize m exp1 exp2
 leastGeneralGeneralization m exp1@(ValueExp v1) exp2@(ValueExp v2) =
   if v1 == v2 then
-    Just (ValueExp v1, m)
+    (ValueExp v1, m)
   else
-    Just $ generalize m exp1 exp2
+    generalize m exp1 exp2
 leastGeneralGeneralization m exp1@(BinOpExp op1 e11 e12) exp2@(BinOpExp op2 e21 e22) =
-  if op1 == op2 then do
-    (e1, m1) <- leastGeneralGeneralization m e11 e21
-    (e2, m2) <- leastGeneralGeneralization m1 e12 e22
-    return (BinOpExp op1 e1 e2, m2)
+  if op1 == op2 then
+    let (e1, m1) = leastGeneralGeneralization m e11 e21
+        (e2, m2) = leastGeneralGeneralization m1 e12 e22
+    in (BinOpExp op1 e1 e2, m2)
   else
-    Just $ generalize m exp1 exp2
+    generalize m exp1 exp2
 leastGeneralGeneralization m exp1@(CmpOpExp op1 e11 e12) exp2@(CmpOpExp op2 e21 e22) =
-  if op1 == op2 then do
-    (e1, m1) <- leastGeneralGeneralization m e11 e21
-    (e2, m2) <- leastGeneralGeneralization m1 e12 e22
-    return (CmpOpExp op1 e1 e2, m2)
+  if op1 == op2 then
+    let (e1, m1) = leastGeneralGeneralization m e11 e21
+        (e2, m2) = leastGeneralGeneralization m1 e12 e22
+    in (CmpOpExp op1 e1 e2, m2)
   else
-    Just $ generalize m exp1 exp2
+    generalize m exp1 exp2
 leastGeneralGeneralization m exp1@(UnOpExp op1 e1) exp2@(UnOpExp op2 e2) =
-  if op1 == op2 then do
-    (e, m1) <- leastGeneralGeneralization m e1 e2
-    return (UnOpExp op1 e, m1)
+  if op1 == op2 then
+    let (e, m1) = leastGeneralGeneralization m e1 e2
+    in (UnOpExp op1 e, m1)
   else
-    Just $ generalize m exp1 exp2
+    generalize m exp1 exp2
 leastGeneralGeneralization m exp1@(ConvOpExp op1 e1) exp2@(ConvOpExp op2 e2) =
-  if op1 == op2 then do
-    (e, m1) <- leastGeneralGeneralization m e1 e2
-    return (ConvOpExp op1 e, m1)
+  if op1 == op2 then
+    let (e, m1) = leastGeneralGeneralization m e1 e2
+    in (ConvOpExp op1 e, m1)
   else
-    Just $ generalize m exp1 exp2
+    generalize m exp1 exp2
 leastGeneralGeneralization m exp1@(FunExp s1 args1 t1) exp2@(FunExp s2 args2 _) =
-  if s1 == s2 && length args1 == length args2 then do
-    (args, m') <- foldM (\(arg_acc, m_acc) (a1, a2) -> do
-                            (a, m'') <- leastGeneralGeneralization m_acc a1 a2
-                            return (a : arg_acc, m'')
-                        ) ([], m) (zip args1 args2)
-    return (FunExp s1 (reverse args) t1, m')
+  if s1 == s2 && length args1 == length args2 then
+    let (args, m') =
+          foldl (\(arg_acc, m_acc) (a1, a2) ->
+                    let (a, m'') = leastGeneralGeneralization m_acc a1 a2
+                    in  (a : arg_acc, m'')
+                ) ([], m) (zip args1 args2)
+    in (FunExp s1 (reverse args) t1, m')
   else
-    Just $ generalize m exp1 exp2
+    generalize m exp1 exp2
 leastGeneralGeneralization m exp1 exp2 =
-  Just $ generalize m exp1 exp2
+  generalize m exp1 exp2
 
 generalize :: Eq v => [(PrimExp v, PrimExp v)] -> PrimExp v -> PrimExp v -> (PrimExp (Ext v), [(PrimExp v, PrimExp v)])
 generalize m exp1 exp2 =

--- a/src/Futhark/Analysis/PrimExp/Generalize.hs
+++ b/src/Futhark/Analysis/PrimExp/Generalize.hs
@@ -2,10 +2,11 @@
 module Futhark.Analysis.PrimExp.Generalize
   (
     leastGeneralGeneralization
+  , existentialize
   ) where
 
 import           Data.List (elemIndex)
-
+import           Control.Monad.State
 
 import           Futhark.Analysis.PrimExp
 import           Futhark.IR.Syntax.Core (Ext(..))
@@ -68,3 +69,10 @@ generalize m exp1 exp2 =
   in case elemIndex (exp1, exp2) m of
        Just i -> (LeafExp (Ext i) t, m)
        Nothing -> (LeafExp (Ext $ length m) t, m ++ [(exp1, exp2)])
+
+existentialize :: PrimExp v -> State [PrimExp v] (PrimExp (Ext v))
+existentialize e = do
+  i <- gets length
+  modify (++ [e])
+  let t = primExpType e
+  return $ LeafExp (Ext i) t

--- a/src/Futhark/CodeGen/Backends/GenericC.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC.hs
@@ -645,7 +645,15 @@ setMem dest src space = do
                        return 1;
                      }|]
     else case space of
-           ScalarSpace{} -> stm [C.cstm|$exp:dest[0] = $exp:src[0];|]
+           ScalarSpace ds _ -> do
+             i' <- newVName "i"
+             let i = C.toIdent i'
+                 it = primTypeToCType $ IntType Int32
+                 ds' = map (`C.toExp` noLoc) ds
+                 bound = cproduct ds'
+             stm [C.cstm|for ($ty:it $id:i = 0; $id:i < $exp:bound; $id:i++) {
+                            $exp:dest[$id:i] = $exp:src[$id:i];
+                  }|]
            _ -> stm [C.cstm|$exp:dest = $exp:src;|]
 
 unRefMem :: C.ToExp a => a -> Space -> CompilerM op s ()

--- a/src/Futhark/CodeGen/Backends/GenericC.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC.hs
@@ -644,7 +644,9 @@ setMem dest src space = do
                                                $string:src_s) != 0) {
                        return 1;
                      }|]
-    else stm [C.cstm|$exp:dest = $exp:src;|]
+    else case space of
+           ScalarSpace{} -> stm [C.cstm|$exp:dest[0] = $exp:src[0];|]
+           _ -> stm [C.cstm|$exp:dest = $exp:src;|]
 
 unRefMem :: C.ToExp a => a -> Space -> CompilerM op s ()
 unRefMem mem space = do

--- a/src/Futhark/IR/Mem.hs
+++ b/src/Futhark/IR/Mem.hs
@@ -623,10 +623,7 @@ matchReturnType rettype res ts = do
             "\nixfun of return type: ", pretty x_ixfun,
             "\nand context elements: ", pretty ctx_res]
         case x_mem_type of
-          MemMem y_space -> do
-            unless (x_mem == Var y_mem) $
-              throwError $ unwords ["Expected memory", pretty x_ext, "=>", pretty x_mem,
-                                    "but got", pretty y_mem]
+          MemMem y_space ->
             unless (x_space == y_space) $
               throwError $ unwords ["Expected memory", pretty y_mem, "in space", pretty x_space,
                                     "but actually in space", pretty y_space]
@@ -682,20 +679,20 @@ matchPatternToExp pat e = do
         matches ctxids ctxexts (MemArray x_pt x_shape _ x_ret) (MemArray y_pt y_shape _ y_ret) =
           x_pt == y_pt && x_shape == y_shape &&
           case (x_ret, y_ret) of
-            (ReturnsInBlock x_mem x_ixfun, Just (ReturnsInBlock y_mem y_ixfun)) ->
+            (ReturnsInBlock _ x_ixfun, Just (ReturnsInBlock _ y_ixfun)) ->
               let x_ixfun' = IxFun.substituteInIxFun ctxids  x_ixfun
                   y_ixfun' = IxFun.substituteInIxFun ctxexts y_ixfun
-              in  x_mem == y_mem && x_ixfun' == y_ixfun'
+              in  IxFun.closeEnough x_ixfun' y_ixfun'
             (ReturnsInBlock _ x_ixfun,
              Just (ReturnsNewBlock _ _ y_ixfun)) ->
               let x_ixfun' = IxFun.substituteInIxFun ctxids  x_ixfun
                   y_ixfun' = IxFun.substituteInIxFun ctxexts y_ixfun
-              in  x_ixfun' == y_ixfun'
-            (ReturnsNewBlock x_space x_i x_ixfun,
-             Just (ReturnsNewBlock y_space y_i y_ixfun)) ->
+              in  IxFun.closeEnough x_ixfun' y_ixfun'
+            (ReturnsNewBlock _ x_i x_ixfun,
+             Just (ReturnsNewBlock _ y_i y_ixfun)) ->
               let x_ixfun' = IxFun.substituteInIxFun  ctxids x_ixfun
                   y_ixfun' = IxFun.substituteInIxFun ctxexts y_ixfun
-              in  x_space == y_space && x_i == y_i && IxFun.closeEnough x_ixfun' y_ixfun'
+              in  x_i == y_i && IxFun.closeEnough x_ixfun' y_ixfun'
             (_, Nothing) -> True
             _ -> False
         matches _ _ _ _ = False

--- a/src/Futhark/IR/Mem/IxFun.hs
+++ b/src/Futhark/IR/Mem/IxFun.hs
@@ -744,7 +744,7 @@ leastGeneralGeneralization (IxFun (lmad1 :| []) oshp1 ctg1) (IxFun (lmad2 :| [])
   (oshp, m2) <- generalize m1 oshp1 oshp2
   (dstd, m3) <- generalize m2 (lmadDSrd lmad1) (lmadDSrd lmad2)
   (drot, m4) <- generalize m3 (lmadDRot lmad1) (lmadDRot lmad2)
-  (offt, m5) <- PEG.leastGeneralGeneralization m4 (lmadOffset lmad1) (lmadOffset lmad2)
+  let (offt, m5) = PEG.leastGeneralGeneralization m4 (lmadOffset lmad1) (lmadOffset lmad2)
   let lmad_dims = map (\(a,b,c,d,e) -> LMADDim a b c d e) $
         zip5 dstd drot dshp dperm dmon
       lmad = LMAD offt lmad_dims
@@ -755,7 +755,7 @@ leastGeneralGeneralization (IxFun (lmad1 :| []) oshp1 ctg1) (IxFun (lmad2 :| [])
         lmadDRot = map ldRotate . lmadDims
         generalize m l1 l2 =
           foldM (\(l_acc, m') (pe1,pe2) -> do
-                    (e, m'') <- PEG.leastGeneralGeneralization m' pe1 pe2
+                    let (e, m'') = PEG.leastGeneralGeneralization m' pe1 pe2
                     return (l_acc++[e], m'')
                 ) ([], m) (zip l1 l2)
 leastGeneralGeneralization _ _ = Nothing

--- a/src/Futhark/IR/Mem/IxFun.hs
+++ b/src/Futhark/IR/Mem/IxFun.hs
@@ -811,7 +811,6 @@ existentialize _ = return Nothing
 closeEnough :: IxFun num -> IxFun num -> Bool
 closeEnough ixf1 ixf2 =
   (length (base ixf1) == length (base ixf2)) &&
-  (ixfunContig ixf1 == ixfunContig ixf2) &&
   (NE.length (ixfunLMADs ixf1) == NE.length (ixfunLMADs ixf2)) &&
   all closeEnoughLMADs (NE.zip (ixfunLMADs ixf1) (ixfunLMADs ixf2))
   where

--- a/src/Futhark/Pass/ExplicitAllocations.hs
+++ b/src/Futhark/Pass/ExplicitAllocations.hs
@@ -390,24 +390,25 @@ lookupMemSpace v = do
 
 directIxFun :: PrimType -> Shape -> u -> VName -> Type -> MemBound u
 directIxFun bt shape u mem t =
-  MemArray bt shape u $ ArrayIn mem $
-  IxFun.iota $ map (primExpFromSubExp int32) $ arrayDims t
+  let ixf = IxFun.iota $ map (primExpFromSubExp int32) $ arrayDims t
+  in MemArray bt shape u $ ArrayIn mem ixf
+
 
 allocInFParams :: (Allocable fromlore tolore) =>
                   [(FParam fromlore, Space)] ->
                   ([FParam tolore] -> AllocM fromlore tolore a)
                -> AllocM fromlore tolore a
 allocInFParams params m = do
-  (valparams, memparams) <-
+  (valparams, (ctxparams, memparams)) <-
     runWriterT $ mapM (uncurry allocInFParam) params
-  let params' = memparams <> valparams
+  let params' = ctxparams <> memparams <> valparams
       summary = scopeOfFParams params'
   localScope summary $ m params'
 
 allocInFParam :: (Allocable fromlore tolore) =>
                  FParam fromlore
               -> Space
-              -> WriterT [FParam tolore]
+              -> WriterT ([FParam tolore], [FParam tolore])
                  (AllocM fromlore tolore) (FParam tolore)
 allocInFParam param pspace =
   case paramDeclType param of
@@ -415,7 +416,7 @@ allocInFParam param pspace =
       let memname = baseString (paramName param) <> "_mem"
           ixfun = IxFun.iota $ map (primExpFromSubExp int32) $ shapeDims shape
       mem <- lift $ newVName memname
-      tell [Param mem $ MemMem pspace]
+      tell ([], [Param mem $ MemMem pspace])
       return param { paramDec =  MemArray bt shape u $ ArrayIn mem ixfun }
     Prim bt ->
       return param { paramDec = MemPrim bt }
@@ -424,65 +425,103 @@ allocInFParam param pspace =
 
 allocInMergeParams :: (Allocable fromlore tolore,
                        Allocator tolore (AllocM fromlore tolore)) =>
-                      [VName]
-                   -> [(FParam fromlore,SubExp)]
+                      [(FParam fromlore,SubExp)]
                    -> ([FParam tolore]
                        -> [FParam tolore]
                        -> ([SubExp] -> AllocM fromlore tolore ([SubExp], [SubExp]))
                        -> AllocM fromlore tolore a)
                    -> AllocM fromlore tolore a
-allocInMergeParams variant merge m = do
-  ((valparams, handle_loop_subexps), mem_params) <-
+allocInMergeParams merge m = do
+  ((valparams, handle_loop_subexps), (ctx_params, mem_params)) <-
     runWriterT $ unzip <$> mapM allocInMergeParam merge
-  let mergeparams' = mem_params <> valparams
+  let mergeparams' = ctx_params <> mem_params <> valparams
       summary = scopeOfFParams mergeparams'
 
       mk_loop_res ses = do
-        (valargs, memargs) <-
+        (valargs, (ctxargs, memargs)) <-
           runWriterT $ zipWithM ($) handle_loop_subexps ses
-        return (memargs, valargs)
+        return (ctxargs <> memargs, valargs)
 
-  localScope summary $ m mem_params valparams mk_loop_res
-  where allocInMergeParam (mergeparam, Var v)
-          | Array bt shape u <- paramDeclType mergeparam = do
-              (mem, ixfun) <- lift $ lookupArraySummary v
-              space <- lift $ lookupMemSpace mem
-              reuse <- asks aggressiveReuse
-              if space /= Space "local" &&
-                 reuse &&
-                 u == Unique &&
-                 loopInvariantShape mergeparam
-                then return (mergeparam { paramDec = MemArray bt shape Unique $ ArrayIn mem ixfun },
-                             lift . ensureArrayIn (paramType mergeparam) mem ixfun)
-                else do def_space <- asks allocSpace
-                        doDefault mergeparam def_space
+  localScope summary $ m (ctx_params <> mem_params) valparams mk_loop_res
+  where
+    allocInMergeParam :: (Allocable fromlore tolore, Allocator tolore (AllocM fromlore tolore)) =>
+                         (Param DeclType, SubExp) ->
+                         WriterT
+                         ([FParam tolore], [FParam tolore])
+                         (AllocM fromlore tolore)
+                         (FParam tolore, SubExp -> WriterT ([SubExp], [SubExp]) (AllocM fromlore tolore) SubExp)
+    allocInMergeParam (mergeparam, Var v)
+      | Array bt shape u <- paramDeclType mergeparam = do
+          (mem', _) <- lift $ lookupArraySummary v
+          mem_space <- lift $ lookupMemSpace mem'
 
-        allocInMergeParam (mergeparam, _) = doDefault mergeparam =<< lift askDefaultSpace
+          (_, ext_ixfun, substs, _) <- lift $ existentializeArray mem_space v
 
-        doDefault mergeparam space = do
-          mergeparam' <- allocInFParam mergeparam space
-          return (mergeparam', linearFuncallArg (paramType mergeparam) space)
+          (ctx_params, param_ixfun_substs) <-
+            unzip <$>
+            mapM (\primExp -> do
+                     let pt = primExpType primExp
+                     vname <- lift $ newVName "ctx_param_ext"
+                     return (Param vname $ MemPrim pt,
+                             fmap Free $ primExpFromSubExp int32 $ Var vname))
+            substs
 
-        variant_names = variant ++ map (paramName . fst) merge
-        loopInvariantShape =
-          not . any (`elem` variant_names) . subExpVars . arrayDims . paramType
+          tell (ctx_params, [])
+
+          param_ixfun <- instantiateIxFun $
+                         IxFun.substituteInIxFun (M.fromList $ zip (fmap Ext [0..]) param_ixfun_substs)
+                         ext_ixfun
+
+          mem_name <- newVName "mem_param"
+          tell ([], [Param mem_name $ MemMem mem_space])
+
+          return (mergeparam { paramDec = MemArray bt shape u $ ArrayIn mem_name param_ixfun },
+                  ensureArrayIn mem_space)
+
+    allocInMergeParam (mergeparam, _) = doDefault mergeparam =<< lift askDefaultSpace
+
+    doDefault mergeparam space = do
+      mergeparam' <- allocInFParam mergeparam space
+      return (mergeparam', linearFuncallArg (paramType mergeparam) space)
+
+
+-- Returns the existentialized index function, the list of substituted values and the memory location.
+existentializeArray :: (Allocable fromlore tolore, Allocator tolore (AllocM fromlore tolore)) =>
+                       Space -> VName -> AllocM fromlore tolore (SubExp, ExtIxFun, [PrimExp VName], VName)
+existentializeArray space v = do
+  (mem', ixfun) <- lookupArraySummary v
+  sp <- lookupMemSpace mem'
+
+  let (ext_ixfun', substs') = runState (IxFun.existentialize ixfun) []
+
+  case (ext_ixfun', sp == space) of
+    (Just x, True) -> return (Var v, x, substs', mem')
+    _ -> do
+      (mem, subexp) <- allocLinearArray space (baseString v) v
+      ixfun' <- fromJust <$> subExpIxFun subexp
+      let (ext_ixfun, substs) = runState (IxFun.existentialize ixfun') []
+      return (subexp, fromJust ext_ixfun, substs, mem)
+
+
 
 ensureArrayIn :: (Allocable fromlore tolore,
                   Allocator tolore (AllocM fromlore tolore)) =>
-                 Type -> VName -> IxFun -> SubExp
-              -> AllocM fromlore tolore SubExp
-ensureArrayIn _ _ _ (Constant v) =
+                 Space -> SubExp
+              -> WriterT ([SubExp], [SubExp]) (AllocM fromlore tolore) SubExp
+ensureArrayIn _ (Constant v) =
   error $ "ensureArrayIn: " ++ pretty v ++ " cannot be an array."
-ensureArrayIn t mem ixfun (Var v) = do
-  (src_mem, src_ixfun) <- lookupArraySummary v
-  if src_mem == mem && src_ixfun == ixfun
-    then return $ Var v
-    else do copy <- newIdent (baseString v ++ "_ensure_copy") t
-            let summary = MemArray (elemType t) (arrayShape t) NoUniqueness $
-                          ArrayIn mem ixfun
-                pat = Pattern [] [PatElem (identName copy) summary]
-            letBind pat $ BasicOp $ Copy v
-            return $ Var $ identName copy
+ensureArrayIn space (Var v) = do
+  (sub_exp, _, substs, mem) <- lift $ existentializeArray space v
+  (ctx_vals, _) <-
+    unzip <$>
+    mapM (\s -> do
+             vname <- lift $ letExp "ctx_val" =<< toExp s
+             return (Var vname, fmap Free $ primExpFromSubExp int32 $ Var vname))
+    substs
+
+  tell (ctx_vals, [Var mem])
+
+  return sub_exp
 
 ensureDirectArray :: (Allocable fromlore tolore,
                       Allocator tolore (AllocM fromlore tolore)) =>
@@ -506,9 +545,8 @@ allocLinearArray space s v = do
   t <- lookupType v
   mem <- allocForArray t space
   v' <- newIdent (s ++ "_linear") t
-  let pat = Pattern [] [PatElem (identName v') $
-                        directIxFun (elemType t) (arrayShape t)
-                        NoUniqueness mem t]
+  let ixfun = directIxFun (elemType t) (arrayShape t) NoUniqueness mem t
+  let pat = Pattern [] [PatElem (identName v') ixfun]
   addStm $ Let pat (defAux ()) $ BasicOp $ Copy v
   return (mem, Var $ identName v')
 
@@ -516,20 +554,20 @@ funcallArgs :: (Allocable fromlore tolore,
                 Allocator tolore (AllocM fromlore tolore)) =>
                [(SubExp,Diet)] -> AllocM fromlore tolore [(SubExp,Diet)]
 funcallArgs args = do
-  (valargs, mem_and_size_args) <- runWriterT $ forM args $ \(arg,d) -> do
+  (valargs, (ctx_args, mem_and_size_args)) <- runWriterT $ forM args $ \(arg,d) -> do
     t <- lift $ subExpType arg
     space <- lift askDefaultSpace
     arg' <- linearFuncallArg t space arg
     return (arg', d)
-  return $ map (,Observe) mem_and_size_args <> valargs
+  return $ map (,Observe) (ctx_args <> mem_and_size_args) <> valargs
 
 linearFuncallArg :: (Allocable fromlore tolore,
                      Allocator tolore (AllocM fromlore tolore)) =>
                     Type -> Space -> SubExp
-                 -> WriterT [SubExp] (AllocM fromlore tolore) SubExp
+                 -> WriterT ([SubExp], [SubExp]) (AllocM fromlore tolore) SubExp
 linearFuncallArg Array{} space (Var v) = do
   (mem, arg') <- lift $ ensureDirectArray (Just space) v
-  tell [Var mem]
+  tell ([], [Var mem])
   return arg'
 linearFuncallArg _ _ arg =
   return arg
@@ -640,8 +678,8 @@ allocInStm (Let (Pattern sizeElems valElems) _ e) = do
 allocInExp :: (Allocable fromlore tolore, Allocator tolore (AllocM fromlore tolore)) =>
               Exp fromlore -> AllocM fromlore tolore (Exp tolore)
 allocInExp (DoLoop ctx val form (Body () bodybnds bodyres)) =
-  allocInMergeParams mempty ctx $ \_ ctxparams' _ ->
-  allocInMergeParams (map paramName ctxparams') val $
+  allocInMergeParams ctx $ \_ ctxparams' _ ->
+  allocInMergeParams val $
   \new_ctx_params valparams' mk_loop_val -> do
   form' <- allocInLoopForm form
   localScope (scopeOf form') $ do
@@ -690,9 +728,9 @@ allocInExp (If cond tbranch0 fbranch0 (IfDec rets ifsort)) = do
         fbranch'' = fbranch' { bodyResult = r_else_ext ++ drop size_ext res_else }
         res_if_expr = If cond tbranch'' fbranch'' $ IfDec rets'' ifsort
     return res_if_expr
-      where generalize :: (Maybe Space, Maybe MemBind) -> (Maybe Space, Maybe MemBind)
+      where generalize :: (Maybe Space, Maybe IxFun) -> (Maybe Space, Maybe IxFun)
                        -> (Maybe Space, Maybe (ExtIxFun, [(PrimExp VName, PrimExp VName)]))
-            generalize (Just sp1, Just (ArrayIn _ ixf1)) (Just sp2, Just (ArrayIn _ ixf2)) =
+            generalize (Just sp1, Just ixf1) (Just sp2, Just ixf2) =
               if sp1 /= sp2 then (Just sp1, Nothing)
               else case IxFun.leastGeneralGeneralization ixf1 ixf2 of
                 Just (ixf, m) -> (Just sp1, Just (ixf, m))
@@ -708,19 +746,12 @@ allocInExp (If cond tbranch0 fbranch0 (IfDec rets ifsort)) = do
             -- does not unify (e.g., does not ensures direct); implementation
             -- extends `allocInBodyNoDirect`, but also return `MemBind`
             allocInIfBody :: (Allocable fromlore tolore, Allocator tolore (AllocM fromlore tolore)) =>
-                             Int -> Body fromlore -> AllocM fromlore tolore (Body tolore, [Maybe MemBind])
+                             Int -> Body fromlore -> AllocM fromlore tolore (Body tolore, [Maybe IxFun])
             allocInIfBody num_vals (Body _ bnds res) =
               allocInStms bnds $ \bnds' -> do
                 let (_, val_res) = splitFromEnd num_vals res
-                mem_ixfs <- mapM bodyReturnMIxf val_res
+                mem_ixfs <- mapM subExpIxFun val_res
                 return (Body () bnds' res, mem_ixfs)
-                  where
-                    bodyReturnMIxf Constant{} = return Nothing
-                    bodyReturnMIxf (Var v) = do
-                      info <- lookupMemInfo v
-                      case info of
-                        MemArray _ptp _shp _u mem_ixf -> return $ Just mem_ixf
-                        _ -> return Nothing
 allocInExp e = mapExpM alloc e
   where alloc =
           identityMapper { mapOnBody = error "Unhandled Body in ExplicitAllocations"
@@ -731,6 +762,18 @@ allocInExp e = mapExpM alloc e
                          , mapOnOp = \op -> do handle <- asks allocInOp
                                                handle op
                          }
+
+
+
+subExpIxFun :: (Allocable fromlore tolore, Allocator tolore (AllocM fromlore tolore)) =>
+                  SubExp -> AllocM fromlore tolore (Maybe IxFun)
+subExpIxFun Constant{} = return Nothing
+subExpIxFun (Var v) = do
+  info <- lookupMemInfo v
+  case info of
+    MemArray _ptp _shp _u (ArrayIn _ ixf) -> return $ Just ixf
+    _ -> return Nothing
+
 
 addResCtxInIfBody :: (Allocable fromlore tolore, Allocator tolore (AllocM fromlore tolore)) =>
                      [ExtType] -> Body tolore -> [Maybe Space] ->

--- a/tests/existential-loop/rotate.fut
+++ b/tests/existential-loop/rotate.fut
@@ -1,0 +1,9 @@
+-- Permutations of the index functions require a copy
+-- ==
+-- input { [2, 1000, 42, 1001, 50000] }
+-- output { [42, 1001, 50000, 2, 1000] }
+-- structure gpu { Copy 2 }
+
+let main [n] (a: [n]i32): []i32 =
+  loop xs = a for i < a[0] do
+    rotate 1 xs

--- a/tests/existential-loop/slice.fut
+++ b/tests/existential-loop/slice.fut
@@ -1,0 +1,10 @@
+-- A simple test for index-function generalization across a for loop
+-- ==
+-- input { [0, 1000, 42, 1001, 50000] }
+-- output { 52043i32 }
+-- structure gpu { Copy 0 }
+
+let main [n] (a: [n]i32): i32 =
+  let b = loop xs = a[1:] for i < n / 2 - 2 do
+          xs[i:]                 -- This will result in a copy, but it needn't
+  in reduce (+) 0 b


### PR DESCRIPTION
The approach here is to always existentialize or generalize as much of the array
type and index function as possible. Therefore, the technique is a bit different
from the technique used to avoid copies in `if` branches, where we explicitly
try to do the least amount of generalization possible. The approach taken here
is simpler, but leads to more existentials. We therefore rely on the simplifier
to remove some of the invariant loop returns.

For this to work, we need to relax the type checker a bit. We also fixed a bug
in the imperative code generator that didn't handle ScalarSpace correctly.

Here's the resulting benchmark differences from master:

```

futhark-benchmarks/accelerate/canny/canny.fut
  data/lena512.in:                                                      0.99x
  data/lena256.in:                                                      0.96x

futhark-benchmarks/accelerate/crystal/crystal.fut
  #0 ("200i32 30.0f32 5i32 1i32 1.0f32"):                               0.98x
  #4 ("2000i32 30.0f32 50i32 1i32 1.0f32"):                             1.00x
  #5 ("4000i32 30.0f32 50i32 1i32 1.0f32"):                             1.00x

futhark-benchmarks/accelerate/fft/fft.fut
  data/64x256.in:                                                       0.93x
  data/128x512.in:                                                      0.97x
  data/1024x1024.in:                                                    0.96x
  data/512x512.in:                                                      0.97x
  data/256x256.in:                                                      0.98x
  data/128x128.in:                                                      0.95x

futhark-benchmarks/accelerate/fluid/fluid.fut
  benchmarking/medium.in:                                               0.99x

futhark-benchmarks/accelerate/hashcat/hashcat.fut
  rockyou.dataset:                                                      1.00x

futhark-benchmarks/accelerate/kmeans/kmeans.fut
  data/k5_n50000.in:                                                    1.00x
  data/trivial.in:                                                      1.01x
  data/k5_n200000.in:                                                   1.00x

futhark-benchmarks/accelerate/mandelbrot/mandelbrot.fut
  #1 ("1000i32 1000i32 -0.7f32 0.0f32 3.067f32 100i32 16...."):         1.01x
  #3 ("4000i32 4000i32 -0.7f32 0.0f32 3.067f32 100i32 16...."):         1.00x
  #2 ("2000i32 2000i32 -0.7f32 0.0f32 3.067f32 100i32 16...."):         1.00x
  #0 ("800i32 600i32 -0.7f32 0.0f32 3.067f32 100i32 16.0f..."):         1.00x
  #4 ("8000i32 8000i32 -0.7f32 0.0f32 3.067f32 100i32 16...."):         1.00x

futhark-benchmarks/accelerate/nbody/nbody-bh.fut
  data/10000-bodies.in:                                                 1.06x
  data/100000-bodies.in:                                                0.96x
  data/1000-bodies.in:                                                  0.97x

futhark-benchmarks/accelerate/nbody/nbody.fut
  data/10000-bodies.in:                                                 0.83x
  data/100000-bodies.in:                                                0.96x
  data/1000-bodies.in:                                                  0.47x

futhark-benchmarks/accelerate/pagerank/pagerank.fut
  data/small.in:                                                        0.95x
  data/random_medium.in:                                                0.99x

futhark-benchmarks/accelerate/ray/trace.fut
  #0 ("800i32 600i32 100i32 50.0f32 -100.0f32 -700.0f32 1..."):         1.00x

futhark-benchmarks/accelerate/smoothlife/smoothlife.fut
  #1 ("256i32"):                                                        0.93x
  #2 ("512i32"):                                                        1.00x
  #3 ("1024i32"):                                                       0.95x
  #0 ("128i32"):                                                        0.93x

futhark-benchmarks/accelerate/tunnel/tunnel.fut
  #1 ("10.0f32 1000i32 1000i32"):                                       1.00x
  #4 ("10.0f32 8000i32 8000i32"):                                       0.96x
  #0 ("10.0f32 800i32 600i32"):                                         0.99x
  #2 ("10.0f32 2000i32 2000i32"):                                       1.00x
  #3 ("10.0f32 4000i32 4000i32"):                                       1.00x

futhark-benchmarks/finpar/LocVolCalib.fut
  LocVolCalib-data/small.in:                                            1.03x
  LocVolCalib-data/medium.in:                                           1.00x
  LocVolCalib-data/large.in:                                            1.00x

futhark-benchmarks/finpar/OptionPricing.fut
  OptionPricing-data/medium.in:                                         1.00x
  OptionPricing-data/small.in:                                          1.01x
  OptionPricing-data/large.in:                                          1.00x

futhark-benchmarks/jgf/crypt/crypt.fut
  crypt-data/medium.in:                                                 0.98x

futhark-benchmarks/jgf/crypt/keys.fut
  crypt-data/userkey0.txt:                                              0.96x

futhark-benchmarks/jgf/series/series.fut
  data/1000000.in:                                                      1.00x
  data/10000.in:                                                        1.00x
  data/100000.in:                                                       1.00x

futhark-benchmarks/misc/bfast/bfast-cloudy.fut
  data/peru.in:                                                         1.08x
  data/sahara-cloudy.in:                                                1.08x

futhark-benchmarks/misc/bfast/bfast.fut
  data/sahara.in:                                                       1.07x

futhark-benchmarks/misc/heston/heston32.fut
  data/1062_quotes.in:                                                  1.02x
  data/10000_quotes.in:                                                 1.01x
  data/100000_quotes.in:                                                1.00x

futhark-benchmarks/misc/heston/heston64.fut
  data/1062_quotes.in:                                                  1.03x
  data/10000_quotes.in:                                                 1.00x
  data/100000_quotes.in:                                                1.00x

futhark-benchmarks/misc/knn-by-kdtree/buildKDtree.fut
  valid-data/kdtree-ppl-32-m-2097152.in:                                1.02x

futhark-benchmarks/misc/radix_sort/radix_sort_blelloch_benchmark.fut
  data/radix_sort_100K.in:                                              0.99x
  data/radix_sort_10K.in:                                               1.00x
  data/radix_sort_1M.in:                                                0.99x

futhark-benchmarks/misc/radix_sort/radix_sort_large.fut
  data/radix_sort_100K.in:                                              1.44x
  data/radix_sort_10K.in:                                               1.02x
  data/radix_sort_1M.in:                                                0.99x

futhark-benchmarks/parboil/histo/histo.fut
  data/default.in:                                                      1.00x
  data/large.in:                                                        1.01x

futhark-benchmarks/parboil/mri-q/mri-q.fut
  data/large.in:                                                        1.00x
  data/small.in:                                                        1.00x

futhark-benchmarks/parboil/sgemm/sgemm.fut
  data/tiny.in:                                                         0.97x
  data/small.in:                                                        1.02x
  data/medium.in:                                                       1.00x

futhark-benchmarks/parboil/stencil/stencil.fut
  data/default.in:                                                      1.00x
  data/small.in:                                                        1.00x

futhark-benchmarks/parboil/tpacf/tpacf.fut
  data/large.in:                                                        1.00x
  data/small.in:                                                        1.00x
  data/medium.in:                                                       1.00x

futhark-benchmarks/pbbs/ray/ray.fut
  data/angel.in:                                                        0.99x
  data/dragon.in:                                                       1.00x
  data/happy.in:                                                        1.00x

futhark-benchmarks/rodinia/backprop/backprop.fut
  data/small.in:                                                        0.97x
  data/medium.in:                                                       1.00x

futhark-benchmarks/rodinia/bfs/bfs_asympt_ok_but_slow.fut
  data/64kn_32e-var-1-256-skew.in:                                      1.00x
  data/512nodes_high_edge_variance.in:                                  0.98x
  data/graph1MW_6.in:                                                   1.05x
  data/4096nodes.in:                                                    0.99x

futhark-benchmarks/rodinia/bfs/bfs_filt_padded_fused.fut
  data/64kn_32e-var-1-256-skew.in:                                      0.94x
  data/512nodes_high_edge_variance.in:                                  0.97x
  data/graph1MW_6.in:                                                   1.02x
  data/4096nodes.in:                                                    0.89x

futhark-benchmarks/rodinia/bfs/bfs_heuristic.fut
  data/64kn_32e-var-1-256-skew.in:                                      1.00x
  data/512nodes_high_edge_variance.in:                                  0.96x
  data/graph1MW_6.in:                                                   0.99x
  data/4096nodes.in:                                                    0.95x

futhark-benchmarks/rodinia/bfs/bfs_iter_work_ok.fut
  data/64kn_32e-var-1-256-skew.in:                                      1.06x
  data/512nodes_high_edge_variance.in:                                  1.29x
  data/graph1MW_6.in:                                                   1.22x
  data/4096nodes.in:                                                    1.35x

futhark-benchmarks/rodinia/cfd/cfd.fut
  data/fvcorr.domn.193K.toa:                                            1.01x
  data/fvcorr.domn.097K.toa:                                            0.90x

futhark-benchmarks/rodinia/hotspot/hotspot.fut
  data/512.in:                                                          0.49x
  data/1024.in:                                                         0.99x
  data/64.in:                                                           0.98x

futhark-benchmarks/rodinia/kmeans/kmeans.fut
  data/kdd_cup.in:                                                      1.01x
  data/100.in:                                                          0.98x
  data/204800.in:                                                       0.97x

futhark-benchmarks/rodinia/lavaMD/lavaMD.fut
  data/3_boxes.in:                                                      0.99x
  data/10_boxes.in:                                                     1.02x

futhark-benchmarks/rodinia/lud/lud.fut
  data/512.in:                                                          1.02x
  data/64.in:                                                           1.01x
  data/256.in:                                                          0.97x
  data/16by16.in:                                                       0.99x
  data/2048.in:                                                         0.98x

futhark-benchmarks/rodinia/myocyte/myocyte.fut
  data/small.in:                                                        1.02x
  data/medium.in:                                                       0.99x

futhark-benchmarks/rodinia/nn/nn.fut
  data/medium.in:                                                       0.99x

futhark-benchmarks/rodinia/nw/nw.fut
  data/large.in:                                                        1.00x

futhark-benchmarks/rodinia/particlefilter/particlefilter.fut
  data/128_128_10_image_400000_particles.in:                            1.00x
  data/128_128_10_image_10000_particles.in:                             0.98x

futhark-benchmarks/rodinia/pathfinder/pathfinder.fut
  data/medium.in:                                                       0.39x

futhark-benchmarks/rodinia/srad/srad.fut
  data/image.in:                                                        0.96x
```

You'll note that some benchmarks are slower (most notably nbody, pathfinder and hotspot), while some are faster (radix_sort_large and bfs_iter_work). The slower ones are slower because some of end-of-function copies, which are made redundant, but not removed by the simplifier. The hope is that a future pass (using registry allocation techniques) will be able to remove the unnecessary allocations and copies.