### PR TITLE
Let the allocator use memory blocks with right size but wrong tag.

### DIFF
--- a/rts/c/cuda.h
+++ b/rts/c/cuda.h
@@ -527,7 +527,7 @@ static CUresult cuda_alloc(struct cuda_context *ctx, size_t min_size,
   }
 
   size_t size;
-  if (free_list_find(&ctx->free_list, tag, &size, mem_out) == 0) {
+  if (free_list_find(&ctx->free_list, tag, min_size, &size, mem_out) == 0) {
     if (size >= min_size) {
       return CUDA_SUCCESS;
     } else {
@@ -561,7 +561,7 @@ static CUresult cuda_free(struct cuda_context *ctx, CUdeviceptr mem,
   CUdeviceptr existing_mem;
 
   // If there is already a block with this tag, then remove it.
-  if (free_list_find(&ctx->free_list, tag, &size, &existing_mem) == 0) {
+  if (free_list_find(&ctx->free_list, tag, -1, &size, &existing_mem) == 0) {
     CUresult res = cuMemFree(existing_mem);
     if (res != CUDA_SUCCESS) {
       return res;

--- a/rts/c/opencl.h
+++ b/rts/c/opencl.h
@@ -833,7 +833,7 @@ static int opencl_alloc(struct opencl_context *ctx, size_t min_size, const char 
 
   size_t size;
 
-  if (free_list_find(&ctx->free_list, tag, &size, mem_out) == 0) {
+  if (free_list_find(&ctx->free_list, tag, min_size, &size, mem_out) == 0) {
     // Successfully found a free block.  Is it big enough?
     //
     // FIXME: we might also want to check whether the block is *too
@@ -892,7 +892,7 @@ static int opencl_free(struct opencl_context *ctx, cl_mem mem, const char *tag) 
   cl_mem existing_mem;
 
   // If there is already a block with this tag, then remove it.
-  if (free_list_find(&ctx->free_list, tag, &size, &existing_mem) == 0) {
+  if (free_list_find(&ctx->free_list, tag, -1, &size, &existing_mem) == 0) {
     int error = clReleaseMemObject(existing_mem);
     if (error != CL_SUCCESS) {
       return error;


### PR DESCRIPTION
Worst case, this means we push a fresh allocation to later rather than
now, so it should not have any negative consequences.

That said, our free list logic is still fairly crude, and there is
likely room for further refinement.

With this change, the performance impact of #1003 drops to just the extra copies.