### PR TITLE
Perform incremental flattening by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+  * Incremental flattening is now performed by default.  Use
+    attributes to constrain and direct the flattening if you have
+    exotic needs.  This will likely need further iteration and
+    refinement.
+
 ### Fixed
 
   * Fix bug in slice simplification (#992).

--- a/tests/attributes/sequential_outer1.fut
+++ b/tests/attributes/sequential_outer1.fut
@@ -1,6 +1,12 @@
 -- Slightly odd result due to interchange.
 -- ==
 -- random input { [10][10][10]i32 } auto output
--- structure distributed { /DoLoop 1 /DoLoop/SegRed 1 /DoLoop/SegMap 1 }
+-- structure distributed {
+--   /DoLoop 1
+--   /DoLoop/SegRed 1
+--   /DoLoop/SegMap 1
+-- }
 
-let main = map (\xss -> #[sequential_outer] map i32.sum xss)
+let main xsss =
+  #[incremental_flattening_only_inner]
+  map (\xss -> #[sequential_outer] map i32.sum xss) xsss

--- a/tests/distribution/distribution0.fut
+++ b/tests/distribution/distribution0.fut
@@ -9,6 +9,7 @@
 -- structure distributed { SegMap 1 DoLoop 2 }
 
 let fftmp (num_paths: i32) (md_c: [][]f64) (zi: []f64): [num_paths]f64 =
+  #[incremental_flattening_only_outer]
     map (\(j: i32): f64  ->
             let x = map2 (*) (take(j+1) zi) (take (j+1) md_c[j])
             in  reduce (+) (0.0) x
@@ -16,8 +17,10 @@ let fftmp (num_paths: i32) (md_c: [][]f64) (zi: []f64): [num_paths]f64 =
        )
 
 let correlateDeltas [n] (num_paths: i32) (md_c: [n][]f64) (zds: [][]f64): [n][num_paths]f64 =
+  #[incremental_flattening_only_inner]
     map (fftmp num_paths md_c) zds
 
 let main (num_paths: i32) (md_c: [][]f64) (bb_mat: [][][]f64): [][][]f64 =
+  #[incremental_flattening_only_inner]
   map (\bb_arr -> correlateDeltas num_paths md_c bb_arr)
       bb_mat

--- a/tests/distribution/distribution1.fut
+++ b/tests/distribution/distribution1.fut
@@ -32,6 +32,8 @@ let main(md_vols: [][]f64,
          md_drifts: [][]f64,
          md_starts: []f64,
          noises_mat: [][][]f64): [][][]f64 =
+  #[incremental_flattening_only_inner]
   map  (\(noises: [][]f64) ->
+          #[incremental_flattening_only_inner]
          mkPrices(md_starts, md_vols, md_drifts, noises)) (
        noises_mat)

--- a/tests/distribution/distribution10.fut
+++ b/tests/distribution/distribution10.fut
@@ -15,7 +15,7 @@ let max8 (max_v: u8) (v: u8): u8 =
 let main [h][w] (frame : [h][w]i32) : [h][w]u8 =
   map (\row: [w]u8 ->
          let rs = map u8.i32 row
-         let m = reduce max8 0u8 rs
+         let m = #[sequential] reduce max8 0u8 rs
          let rs' = map (max8 m) rs
          in rs')
    frame

--- a/tests/distribution/distribution12.fut
+++ b/tests/distribution/distribution12.fut
@@ -1,0 +1,5 @@
+-- A triply nested map should not cause any multi-versioning.
+-- ==
+-- structure distributed { SegMap 1 }
+
+let main (xsss: [][][]i32) = map (map (map (+1))) xsss

--- a/tests/distribution/distribution2.fut
+++ b/tests/distribution/distribution2.fut
@@ -3,8 +3,8 @@
 --
 -- ==
 -- structure distributed {
---   SegMap 1
---   DoLoop 2
+--   SegMap 6
+--   DoLoop 10
 -- }
 
 

--- a/tests/distribution/distribution3.fut
+++ b/tests/distribution/distribution3.fut
@@ -1,16 +1,7 @@
--- Expected distributed structure:
---
--- map
---   map
---     scan
--- map
---   map
---     scan
---
 -- ==
 -- compiled random input { [10][16][16]i32 } auto output
 -- compiled random input { [10][8][32]i32 } auto output
--- structure distributed { SegScan 2 }
+-- structure distributed { SegScan 4 }
 
 let main [k][n][m] (a: [k][n][m]i32): [][][]i32 =
   map (\(a_row: [][]i32): [m][n]i32  ->

--- a/tests/distribution/distribution4.fut
+++ b/tests/distribution/distribution4.fut
@@ -6,7 +6,7 @@
 --   map
 --
 -- ==
--- structure distributed { SegMap 2 }
+-- structure distributed { SegMap 5 }
 
 let main [n][an] [bn] (a: [n][an]i32, b: [n][bn]i32): ([][]i32,[][]i32) =
   unzip(map2 (\(a_row: []i32) (b_row: []i32): ([an]i32,[bn]i32)  ->

--- a/tests/distribution/distribution5.fut
+++ b/tests/distribution/distribution5.fut
@@ -16,9 +16,13 @@
 -- }
 
 let main [k][n][an][bn] (a: [n][an][k]i32) (b: [n][bn]i32): ([][]i32,[][]i32) =
-  unzip(map2 (\(a_row: [][]i32) (b_row: []i32): ([bn]i32,[an]i32)  ->
-                  (map (\x -> x-1) (b_row),
-                   map (\(a_row_row: []i32): i32  ->
-                         let x = map (+1) (a_row_row) in
-                         reduce (+) 0 (concat x x)
-                      ) a_row)) a b)
+  #[incremental_flattening_only_inner]
+  unzip(
+    #[incremental_flattening_only_inner]
+    map2 (\(a_row: [][]i32) (b_row: []i32): ([bn]i32,[an]i32)  ->
+            #[incremental_flattening_only_inner]
+            (map (\x -> x-1) (b_row),
+             map (\(a_row_row: []i32): i32  ->
+                    let x = map (+1) (a_row_row) in
+                    reduce (+) 0 (concat x x)
+                 ) a_row)) a b)

--- a/tests/distribution/distribution8.fut
+++ b/tests/distribution/distribution8.fut
@@ -25,9 +25,9 @@ let mkPrices [num_und][num_dates]
   let e_rows = map (\(x: []f64)  ->
                       map f64.exp x
                   ) (map combineVs (zip3 noises (md_vols) (md_drifts)))
-  in  scan (\(x: []f64) (y: []f64)  ->
-              map2 (*) x y)
-              md_starts e_rows
+  in scan (\(x: []f64) (y: []f64)  ->
+             map2 (*) x y)
+     md_starts e_rows
 
 let main(n: i32,
                     md_vols: [][]f64,
@@ -35,6 +35,8 @@ let main(n: i32,
                     md_starts: []f64,
                     noises_mat: [][][]f64): [][][]f64 =
   loop (noises_mat) for i < n do
+    #[incremental_flattening_only_inner]
     map  (\(noises: [][]f64) ->
+            #[incremental_flattening_only_inner]
            mkPrices(md_starts, md_vols, md_drifts, noises)) (
          noises_mat)

--- a/tests/distribution/icfp16-example.fut
+++ b/tests/distribution/icfp16-example.fut
@@ -28,13 +28,16 @@
 
 let main [n][m] (pss: [n][m]i32): ([n][m][m]i32, [n][m]i32) =
   let (asss, bss) =
+    #[incremental_flattening_only_inner]
     unzip(map (\(ps: []i32): ([m][m]i32, [m]i32)  ->
+                #[incremental_flattening_only_inner]
                 let ass = map (\(p: i32): [m]i32  ->
                                 let cs = scan (+) 0 (0..1..<p)
                                 let f = reduce (+) 0 cs
                                 let as = map (+f) ps
                                 in as) ps
                 let bs' = loop bs=ps for i < n do
+                  #[incremental_flattening_only_inner]
                   let bs' = map (\(as: []i32, b: i32): i32  ->
                                   let d = reduce (+) 0 as
                                   let e = d + b

--- a/tests/distribution/irregular0.fut
+++ b/tests/distribution/irregular0.fut
@@ -9,5 +9,6 @@
 -- }
 
 let main(a: []i32): []i32 =
+  #[incremental_flattening_only_inner]
   map (\(i: i32): i32  ->
         reduce (+) 0 (map (+1) (0..<i))) a

--- a/tests/distribution/loop6.fut
+++ b/tests/distribution/loop6.fut
@@ -3,6 +3,7 @@
 -- structure distributed { /SegMap 0 /DoLoop 1 /DoLoop/SegMap 1 }
 
 let main [m] [n] (xss: *[m][n]i32) =
+  #[incremental_flattening_only_inner]
   map (\xs ->
        (loop (xs,out) = (xs, replicate n 0f32) for i < n do
          (let xs = map (+1) xs

--- a/tests/distribution/redomap0.fut
+++ b/tests/distribution/redomap0.fut
@@ -1,19 +1,6 @@
 -- Distribute a redomap inside of a map.
---
--- One possible structure:
---
--- map
---   map
--- map
---   reduce
---
--- Currently expected structure:
---
--- map
---   loop
 -- ==
---
--- structure distributed { SegMap 1 }
+-- structure distributed { SegRed 1 }
 
 let main(a: [][]i32): []i32 =
   map (\(a_r: []i32): i32  ->

--- a/tests/streamRed_interchange.fut
+++ b/tests/streamRed_interchange.fut
@@ -111,7 +111,7 @@
 -- -0.000443f32, 0.000283f32, -0.000084f32, 0.000129f32, 0.000419f32,
 -- -0.000178f32, -0.001124f32, -0.001211f32, 0.000297f32, 0.000291f32,
 -- 0.001163f32, 0.001455f32]]}
--- structure distributed { SegRed 1 SegMap 2 }
+-- structure distributed { SegRed 1 SegMap 4 }
 
 
 let main (nfeatures: i32) (npoints: i32) (nclusters: i32): [nclusters][nfeatures]f32 =
@@ -120,7 +120,8 @@ let main (nfeatures: i32) (npoints: i32) (nclusters: i32): [nclusters][nfeatures
   -- Just generate some random-seeming points.
   let points = map (\(i: i32): [nfeatures]f32  ->
                      map (*100f32) (map f32.sin (map r32 (map (^i) (iota(nfeatures)))))
-                  ) (iota(npoints)) in
+                   ) (iota(npoints)) in
+  #[sequential_inner]
   reduce_stream (\acc elem -> map2 (\x y -> map2 (+) x y) acc elem)
              (\chunk (inp: [chunk]([nfeatures]f32,i32)) ->
                  loop acc = replicate nclusters (replicate nfeatures 0.0f32) for i < chunk do

--- a/tests/tiling/seqloop_1d.fut
+++ b/tests/tiling/seqloop_1d.fut
@@ -5,4 +5,7 @@
 -- structure distributed { SegMap/DoLoop/DoLoop/SegMap 2 }
 
 let main (ns: []i32) (xs: [][]i32) (ys: []i32) =
-  map (\n -> map (\y -> loop y for i < n do i32.sum (map (+y) (#[unsafe] xs[i]))) ys) ns
+  map (\n -> map (\y -> loop y for i < n do
+                          #[sequential] i32.sum (map (+y) (#[unsafe] xs[i])))
+                 ys)
+      ns

--- a/tests/tiling/seqloop_2d.fut
+++ b/tests/tiling/seqloop_2d.fut
@@ -5,7 +5,8 @@
 -- structure distributed { SegMap/DoLoop/DoLoop/SegMap 2 }
 
 let main [k] (ns: []i32) (xss: [][k]i32) (yss: [][k]i32) =
-  map (\n -> map (\xs' -> map (\ys' -> loop z = 0 for _p < n do i32.sum (map (+z) (map2 (*) xs' ys')))
+  map (\n -> map (\xs' -> map (\ys' -> loop z = 0 for _p < n do
+                                         #[sequential] i32.sum (map (+z) (map2 (*) xs' ys')))
                               yss)
                  xss)
        ns

--- a/tests/tiling/tiling_1d_complex.fut
+++ b/tests/tiling/tiling_1d_complex.fut
@@ -23,4 +23,5 @@ let find_nearest_point [k] (pts: [k]point) (pt: point): i32 =
 let main [n] (xs: [n]f32) (ys: [n]f32) =
   let points = zip xs ys
   let cluster_centres = take 10 points
-  in map (find_nearest_point cluster_centres) points
+  in #[sequential_inner]
+     map (find_nearest_point cluster_centres) points


### PR DESCRIPTION
Moderate flattening is completely gone - instead, you can use
attributes to control parallelisation, if needed.

I expect this will have problems and require lots of tweaking, but it
is time we address it directly.

Compile times are harmed, of course.  I hope that is offset by the
significant improvements we've made to compile times recently (and
besides, most of the time is currently spent before kernel extraction,
during inlining, which this change does not affect).

This commit also makes minor changes to the heuristics we use to prune
the multi-versioning tree.  Nothing major, but I expect it will also
require more tuning.