### PR TITLE
Disregard tags when finding free allocs

### DIFF
--- a/rts/c/cuda.h
+++ b/rts/c/cuda.h
@@ -527,7 +527,7 @@ static CUresult cuda_alloc(struct cuda_context *ctx, size_t min_size,
   }
 
   size_t size;
-  if (free_list_find(&ctx->free_list, tag, min_size, &size, mem_out) == 0) {
+  if (free_list_find(&ctx->free_list, min_size, &size, mem_out) == 0) {
     if (size >= min_size) {
       return CUDA_SUCCESS;
     } else {
@@ -561,7 +561,7 @@ static CUresult cuda_free(struct cuda_context *ctx, CUdeviceptr mem,
   CUdeviceptr existing_mem;
 
   // If there is already a block with this tag, then remove it.
-  if (free_list_find(&ctx->free_list, tag, -1, &size, &existing_mem) == 0) {
+  if (free_list_find(&ctx->free_list, -1, &size, &existing_mem) == 0) {
     CUresult res = cuMemFree(existing_mem);
     if (res != CUDA_SUCCESS) {
       return res;

--- a/rts/c/free_list.h
+++ b/rts/c/free_list.h
@@ -85,28 +85,24 @@ static void free_list_insert(struct free_list *l, size_t size, fl_mem_t mem, con
 // Find and remove a memory block of the indicated tag, or if that
 // does not exist, another memory block with exactly the desired size.
 // Returns 0 on success.
-static int free_list_find(struct free_list *l, const char *tag, size_t size,
+static int free_list_find(struct free_list *l, size_t size,
                           size_t *size_out, fl_mem_t *mem_out) {
   int size_match = -1;
   int i;
   for (i = 0; i < l->capacity; i++) {
-    if (l->entries[i].valid) {
-      if (l->entries[i].tag == tag) {
-        break;
-      } else if (size == l->entries[i].size) {
-        size_match = i;
-      }
+    if (l->entries[i].valid &&
+        size <= l->entries[i].size &&
+        (size_match < 0 || l->entries[i].size < l->entries[size_match].size)) {
+      // If this entry is valid, has sufficient size, and is smaller than the
+      // best entry found so far, use this entry.
+      size_match = i;
     }
   }
 
-  if (i == l->capacity && size_match >= 0) {
-    i = size_match;
-  }
-
-  if (i != l->capacity) {
-    l->entries[i].valid = 0;
-    *size_out = l->entries[i].size;
-    *mem_out = l->entries[i].mem;
+  if (size_match >= 0) {
+    l->entries[size_match].valid = 0;
+    *size_out = l->entries[size_match].size;
+    *mem_out = l->entries[size_match].mem;
     l->used--;
     return 0;
   } else {

--- a/rts/c/opencl.h
+++ b/rts/c/opencl.h
@@ -833,7 +833,7 @@ static int opencl_alloc(struct opencl_context *ctx, size_t min_size, const char 
 
   size_t size;
 
-  if (free_list_find(&ctx->free_list, tag, min_size, &size, mem_out) == 0) {
+  if (free_list_find(&ctx->free_list, min_size, &size, mem_out) == 0) {
     // Successfully found a free block.  Is it big enough?
     //
     // FIXME: we might also want to check whether the block is *too
@@ -892,7 +892,7 @@ static int opencl_free(struct opencl_context *ctx, cl_mem mem, const char *tag) 
   cl_mem existing_mem;
 
   // If there is already a block with this tag, then remove it.
-  if (free_list_find(&ctx->free_list, tag, -1, &size, &existing_mem) == 0) {
+  if (free_list_find(&ctx->free_list, -1, &size, &existing_mem) == 0) {
     int error = clReleaseMemObject(existing_mem);
     if (error != CL_SUCCESS) {
       return error;


### PR DESCRIPTION
Instead, let's try to find the already allocated block that has the best fit.

Here's a benchmark run comparing to the current master:

```
/home/jxk588/src/futhark $ ./tools/cmp-bench-json.py bench-master.json bench-just-size.json

futhark-benchmarks/accelerate/canny/canny.fut
  data/lena512.in:                                                      1.16x
  data/lena256.in:                                                      1.13x

futhark-benchmarks/accelerate/crystal/crystal.fut
  #0 ("200i32 30.0f32 5i32 1i32 1.0f32"):                               0.97x
  #4 ("2000i32 30.0f32 50i32 1i32 1.0f32"):                             1.00x
  #5 ("4000i32 30.0f32 50i32 1i32 1.0f32"):                             1.00x

futhark-benchmarks/accelerate/fft/fft.fut
  data/64x256.in:                                                       1.01x
  data/128x512.in:                                                      1.15x
  data/1024x1024.in:                                                    1.01x
  data/512x512.in:                                                      1.05x
  data/256x256.in:                                                      1.03x
  data/128x128.in:                                                      1.04x

futhark-benchmarks/accelerate/fluid/fluid.fut
  benchmarking/medium.in:                                               1.07x

futhark-benchmarks/accelerate/hashcat/hashcat.fut
  rockyou.dataset:                                                      0.98x

futhark-benchmarks/accelerate/kmeans/kmeans.fut
  data/k5_n50000.in:                                                    1.00x
  data/trivial.in:                                                      1.08x
  data/k5_n200000.in:                                                   1.10x

futhark-benchmarks/accelerate/mandelbrot/mandelbrot.fut
  #1 ("1000i32 1000i32 -0.7f32 0.0f32 3.067f32 100i32 16...."):         1.01x
  #3 ("4000i32 4000i32 -0.7f32 0.0f32 3.067f32 100i32 16...."):         1.00x
  #2 ("2000i32 2000i32 -0.7f32 0.0f32 3.067f32 100i32 16...."):         1.00x
  #0 ("800i32 600i32 -0.7f32 0.0f32 3.067f32 100i32 16.0f..."):         0.99x
  #4 ("8000i32 8000i32 -0.7f32 0.0f32 3.067f32 100i32 16...."):         1.00x

futhark-benchmarks/accelerate/nbody/nbody-bh.fut
  data/10000-bodies.in:                                                 1.13x
  data/100000-bodies.in:                                                1.06x
  data/1000-bodies.in:                                                  1.07x

futhark-benchmarks/accelerate/nbody/nbody.fut
  data/10000-bodies.in:                                                 1.32x
  data/100000-bodies.in:                                                1.00x
  data/1000-bodies.in:                                                  3.15x

futhark-benchmarks/accelerate/pagerank/pagerank.fut
  data/small.in:                                                        1.04x
  data/random_medium.in:                                                1.13x

futhark-benchmarks/accelerate/ray/trace.fut
  #0 ("800i32 600i32 100i32 50.0f32 -100.0f32 -700.0f32 1..."):         1.00x

futhark-benchmarks/accelerate/smoothlife/smoothlife.fut
  #1 ("256i32"):                                                        1.00x
  #2 ("512i32"):                                                        0.99x
  #3 ("1024i32"):                                                       1.00x
  #0 ("128i32"):                                                        1.01x

futhark-benchmarks/accelerate/tunnel/tunnel.fut
  #1 ("10.0f32 1000i32 1000i32"):                                       1.00x
  #4 ("10.0f32 8000i32 8000i32"):                                       1.00x
  #0 ("10.0f32 800i32 600i32"):                                         1.00x
  #2 ("10.0f32 2000i32 2000i32"):                                       1.00x
  #3 ("10.0f32 4000i32 4000i32"):                                       1.00x

futhark-benchmarks/finpar/LocVolCalib.fut
  LocVolCalib-data/small.in:                                            0.99x
  LocVolCalib-data/medium.in:                                           1.00x
  LocVolCalib-data/large.in:                                            1.00x

futhark-benchmarks/finpar/OptionPricing.fut
  OptionPricing-data/medium.in:                                         1.04x
  OptionPricing-data/small.in:                                          1.05x
  OptionPricing-data/large.in:                                          1.00x

futhark-benchmarks/jgf/crypt/crypt.fut
  crypt-data/medium.in:                                                 2.51x

futhark-benchmarks/jgf/crypt/keys.fut
  crypt-data/userkey0.txt:                                              1.05x

futhark-benchmarks/jgf/series/series.fut
  data/1000000.in:                                                      1.00x
  data/10000.in:                                                        0.99x
  data/100000.in:                                                       1.00x

futhark-benchmarks/misc/bfast/bfast-cloudy.fut
  data/peru.in:                                                         0.94x
  data/sahara-cloudy.in:                                                0.94x

futhark-benchmarks/misc/bfast/bfast.fut
  data/sahara.in:                                                       1.03x

futhark-benchmarks/misc/heston/heston32.fut
  data/1062_quotes.in:                                                  0.97x
  data/10000_quotes.in:                                                 1.03x
  data/100000_quotes.in:                                                0.99x

futhark-benchmarks/misc/heston/heston64.fut
  data/1062_quotes.in:                                                  1.00x
  data/10000_quotes.in:                                                 1.00x
  data/100000_quotes.in:                                                1.00x

futhark-benchmarks/misc/knn-by-kdtree/buildKDtree.fut
  valid-data/kdtree-ppl-32-m-2097152.in:                                1.01x

futhark-benchmarks/misc/radix_sort/radix_sort_blelloch_benchmark.fut
  data/radix_sort_100K.in:                                              0.84x
  data/radix_sort_10K.in:                                               1.11x
  data/radix_sort_1M.in:                                                1.09x

futhark-benchmarks/misc/radix_sort/radix_sort_large.fut
  data/radix_sort_100K.in:                                              1.01x
  data/radix_sort_10K.in:                                               0.86x
  data/radix_sort_1M.in:                                                1.02x

futhark-benchmarks/parboil/histo/histo.fut
  data/default.in:                                                      1.35x
  data/large.in:                                                        1.33x

futhark-benchmarks/parboil/mri-q/mri-q.fut
  data/large.in:                                                        1.04x
  data/small.in:                                                        1.03x

futhark-benchmarks/parboil/sgemm/sgemm.fut
  data/tiny.in:                                                         1.94x
  data/small.in:                                                        1.54x
  data/medium.in:                                                       1.11x

futhark-benchmarks/parboil/stencil/stencil.fut
  data/default.in:                                                      1.00x
  data/small.in:                                                        1.00x

futhark-benchmarks/parboil/tpacf/tpacf.fut
  data/large.in:                                                        1.00x
  data/small.in:                                                        1.00x
  data/medium.in:                                                       1.00x

futhark-benchmarks/pbbs/ray/ray.fut
  data/angel.in:                                                        0.99x
  data/dragon.in:                                                       1.05x
  data/happy.in:                                                        1.02x

futhark-benchmarks/rodinia/backprop/backprop.fut
  data/small.in:                                                        1.22x
  data/medium.in:                                                       1.16x

futhark-benchmarks/rodinia/bfs/bfs_asympt_ok_but_slow.fut
  data/64kn_32e-var-1-256-skew.in:                                      1.05x
  data/512nodes_high_edge_variance.in:                                  1.03x
  data/graph1MW_6.in:                                                   1.02x
  data/4096nodes.in:                                                    0.99x

futhark-benchmarks/rodinia/bfs/bfs_filt_padded_fused.fut
  data/64kn_32e-var-1-256-skew.in:                                      0.97x
  data/512nodes_high_edge_variance.in:                                  1.08x
  data/graph1MW_6.in:                                                   1.12x
  data/4096nodes.in:                                                    0.93x

futhark-benchmarks/rodinia/bfs/bfs_heuristic.fut
  data/64kn_32e-var-1-256-skew.in:                                      1.03x
  data/512nodes_high_edge_variance.in:                                  1.05x
  data/graph1MW_6.in:                                                   1.07x
  data/4096nodes.in:                                                    1.21x

futhark-benchmarks/rodinia/bfs/bfs_iter_work_ok.fut
  data/64kn_32e-var-1-256-skew.in:                                      1.06x
  data/512nodes_high_edge_variance.in:                                  1.24x
  data/graph1MW_6.in:                                                   1.05x
  data/4096nodes.in:                                                    1.15x

futhark-benchmarks/rodinia/cfd/cfd.fut
  data/fvcorr.domn.193K.toa:                                            1.00x
  data/fvcorr.domn.097K.toa:                                            1.00x

futhark-benchmarks/rodinia/hotspot/hotspot.fut
  data/512.in:                                                          1.04x
  data/1024.in:                                                         1.02x
  data/64.in:                                                           1.04x

futhark-benchmarks/rodinia/kmeans/kmeans.fut
  data/kdd_cup.in:                                                      0.98x
  data/100.in:                                                          1.02x
  data/204800.in:                                                       1.00x

futhark-benchmarks/rodinia/lavaMD/lavaMD.fut
  data/3_boxes.in:                                                      1.40x
  data/10_boxes.in:                                                     1.13x

futhark-benchmarks/rodinia/lud/lud.fut
  data/512.in:                                                          1.01x
  data/64.in:                                                           0.99x
  data/256.in:                                                          1.11x
  data/16by16.in:                                                       1.01x
  data/2048.in:                                                         1.01x

futhark-benchmarks/rodinia/myocyte/myocyte.fut
  data/small.in:                                                        0.99x
  data/medium.in:                                                       1.00x

futhark-benchmarks/rodinia/nn/nn.fut
  data/medium.in:                                                       1.03x

futhark-benchmarks/rodinia/nw/nw.fut
  data/large.in:                                                        1.00x

futhark-benchmarks/rodinia/particlefilter/particlefilter.fut
  data/128_128_10_image_400000_particles.in:                            0.99x
  data/128_128_10_image_10000_particles.in:                             1.01x

futhark-benchmarks/rodinia/pathfinder/pathfinder.fut
  data/medium.in:                                                       0.96x

futhark-benchmarks/rodinia/srad/srad.fut
  data/image.in:                                                        1.02x
```