### PR TITLE
Add safe variants of division operators.

### DIFF
--- a/rts/python/scalar.py
+++ b/rts/python/scalar.py
@@ -30,23 +30,44 @@ def shlN(x,y):
 def ashrN(x,y):
   return x >> y
 
+# Python is so slow that we just make all the unsafe operations safe,
+# always.
+
 def sdivN(x,y):
-  return x // y
+  if y == 0:
+    return x-x
+  else:
+    return x // y
 
 def smodN(x,y):
-  return x % y
+  if y == 0:
+    return x-x
+  else:
+    return x % y
 
 def udivN(x,y):
-  return signed(unsigned(x) // unsigned(y))
+  if y == 0:
+    return x-x
+  else:
+    return signed(unsigned(x) // unsigned(y))
 
 def umodN(x,y):
-  return signed(unsigned(x) % unsigned(y))
+  if y == 0:
+    return x-x
+  else:
+    return signed(unsigned(x) % unsigned(y))
 
 def squotN(x,y):
-  return np.floor_divide(np.abs(x), np.abs(y)) * np.sign(x) * np.sign(y)
+  if y == 0:
+    return x-x
+  else:
+    return np.floor_divide(np.abs(x), np.abs(y)) * np.sign(x) * np.sign(y)
 
 def sremN(x,y):
-  return np.remainder(np.abs(x), np.abs(y)) * np.sign(x)
+  if y == 0:
+    return x-x
+  else:
+    return np.remainder(np.abs(x), np.abs(y)) * np.sign(x)
 
 def sminN(x,y):
   return min(x,y)
@@ -171,14 +192,21 @@ def zext_i64_i32(x):
 def zext_i64_i64(x):
   return np.int64(np.uint64(x))
 
+sdiv8 = sdiv16 = sdiv32 = sdiv64 = sdivN
+sdiv_safe8 = sdiv1_safe6 = sdiv_safe32 = sdiv_safe64 = sdivN
+smod8 = smod16 = smod32 = smod64 = smodN
+smod_safe8 = smod_safe16 = smod_safe32 = smod_safe64 = smodN
+udiv8 = udiv16 = udiv32 = udiv64 = udivN
+udiv_safe8 = udiv_safe16 = udiv_safe32 = udiv_safe64 = udivN
+umod8 = umod16 = umod32 = umod64 = umodN
+umod_safe8 = umod_safe16 = umod_safe32 = umod_safe64 = umodN
+squot8 = squot16 = squot32 = squot64 = squotN
+squot_safe8 = squot_safe16 = squot_safe32 = squot_safe64 = squotN
+srem8 = srem16 = srem32 = srem64 = sremN
+srem_safe8 = srem_safe16 = srem_safe32 = srem_safe64 = sremN
+
 shl8 = shl16 = shl32 = shl64 = shlN
 ashr8 = ashr16 = ashr32 = ashr64 = ashrN
-sdiv8 = sdiv16 = sdiv32 = sdiv64 = sdivN
-smod8 = smod16 = smod32 = smod64 = smodN
-udiv8 = udiv16 = udiv32 = udiv64 = udivN
-umod8 = umod16 = umod32 = umod64 = umodN
-squot8 = squot16 = squot32 = squot64 = squotN
-srem8 = srem16 = srem32 = srem64 = sremN
 smax8 = smax16 = smax32 = smax64 = smaxN
 smin8 = smin16 = smin32 = smin64 = sminN
 umax8 = umax16 = umax32 = umax64 = umaxN

--- a/src/Futhark/Analysis/PrimExp.hs
+++ b/src/Futhark/Analysis/PrimExp.hs
@@ -184,17 +184,19 @@ instance Pretty v => Fractional (PrimExp v) where
   fromRational = ValueExp . FloatValue . Float64Value . fromRational
 
 instance Pretty v => IntegralExp (PrimExp v) where
-  x `div` y | Just z <- msum [asIntOp SDiv x y, asFloatOp FDiv x y] = constFoldPrimExp z
+  x `div` y | Just z <- msum [asIntOp (`SDiv` Unsafe) x y,
+                              asFloatOp FDiv x y] =
+                constFoldPrimExp z
             | otherwise = numBad "div" (x,y)
 
-  x `mod` y | Just z <- msum [asIntOp SMod x y] = z
+  x `mod` y | Just z <- msum [asIntOp (`SMod` Unsafe) x y] = z
             | otherwise = numBad "mod" (x,y)
 
   x `quot` y | oneIshExp y = x
-             | Just z <- msum [asIntOp SQuot x y] = constFoldPrimExp z
+             | Just z <- msum [asIntOp (`SQuot` Unsafe) x y] = constFoldPrimExp z
              | otherwise = numBad "quot" (x,y)
 
-  x `rem` y | Just z <- msum [asIntOp SRem x y] = constFoldPrimExp z
+  x `rem` y | Just z <- msum [asIntOp (`SRem` Unsafe) x y] = constFoldPrimExp z
             | otherwise = numBad "rem" (x,y)
 
   sgn (ValueExp (IntValue i)) = Just $ signum $ valueIntegral i

--- a/src/Futhark/CodeGen/Backends/CCUDA/Boilerplate.hs
+++ b/src/Futhark/CodeGen/Backends/CCUDA/Boilerplate.hs
@@ -45,7 +45,7 @@ profilingEnclosure name =
 
 -- | Called after most code has been generated to generate the bulk of
 -- the boilerplate.
-generateBoilerplate :: String -> String -> [Name] -> M.Map KernelName Safety
+generateBoilerplate :: String -> String -> [Name] -> M.Map KernelName KernelSafety
                     -> M.Map Name SizeClass
                     -> [FailureMsg]
                     -> GC.CompilerM OpenCL () ()
@@ -263,7 +263,7 @@ generateConfigFuns sizes = do
                        }|])
   return cfg
 
-generateContextFuns :: String -> [Name] -> M.Map KernelName Safety
+generateContextFuns :: String -> [Name] -> M.Map KernelName KernelSafety
                     -> M.Map Name SizeClass
                     -> [FailureMsg]
                     -> GC.CompilerM OpenCL () ()

--- a/src/Futhark/CodeGen/Backends/PyOpenCL.hs
+++ b/src/Futhark/CodeGen/Backends/PyOpenCL.hs
@@ -160,7 +160,7 @@ callKernel (Imp.LaunchKernel safety name args num_workgroups workgroup_size) = d
 
   where mult_exp = BinOp "*"
 
-launchKernel :: Imp.KernelName -> Imp.Safety -> [PyExp] -> [PyExp] -> [Imp.KernelArg]
+launchKernel :: Imp.KernelName -> Imp.KernelSafety -> [PyExp] -> [PyExp] -> [Imp.KernelArg]
              -> Py.CompilerM op s ()
 launchKernel kernel_name safety kernel_dims workgroup_dims args = do
   let kernel_dims' = Tuple kernel_dims

--- a/src/Futhark/CodeGen/Backends/SimpleRep.hs
+++ b/src/Futhark/CodeGen/Backends/SimpleRep.hs
@@ -77,9 +77,9 @@ cIntOps :: [C.Definition]
 cIntOps = concatMap (`map` [minBound..maxBound]) ops
           ++ cIntPrimFuns
   where ops = [mkAdd, mkSub, mkMul,
-               mkUDiv, mkUMod,
-               mkSDiv, mkSMod,
-               mkSQuot, mkSRem,
+               mkUDiv, mkUMod, mkUDivSafe, mkUModSafe,
+               mkSDiv, mkSMod, mkSDivSafe, mkSModSafe,
+               mkSQuot, mkSRem, mkSQuotSafe, mkSRemSafe,
                mkSMin, mkUMin,
                mkSMax, mkUMax,
                mkShl, mkLShr, mkAShr,
@@ -103,6 +103,8 @@ cIntOps = concatMap (`map` [minBound..maxBound]) ops
         mkMul = simpleUintOp "mul" [C.cexp|x * y|]
         mkUDiv = simpleUintOp "udiv" [C.cexp|x / y|]
         mkUMod = simpleUintOp "umod" [C.cexp|x % y|]
+        mkUDivSafe = simpleUintOp "udiv_safe" [C.cexp|y == 0 ? 0 : x / y|]
+        mkUModSafe = simpleUintOp "umod_safe" [C.cexp|y == 0 ? 0 : x % y|]
         mkUMax = simpleUintOp "umax" [C.cexp|x < y ? y : x|]
         mkUMin = simpleUintOp "umin" [C.cexp|x < y ? x : y|]
 
@@ -121,9 +123,15 @@ cIntOps = concatMap (`map` [minBound..maxBound]) ops
                          return r +
                            ((r == 0 || (x > 0 && y > 0) || (x < 0 && y < 0)) ? 0 : y);
               }|]
+        mkSDivSafe t =
+          simpleIntOp "sdiv_safe" [C.cexp|y == 0 ? 0 : $id:(taggedI "sdiv" t)(x,y)|] t
+        mkSModSafe t =
+          simpleIntOp "smod_safe" [C.cexp|y == 0 ? 0 : $id:(taggedI "smod" t)(x,y)|] t
 
         mkSQuot = simpleIntOp "squot" [C.cexp|x / y|]
         mkSRem = simpleIntOp "srem" [C.cexp|x % y|]
+        mkSQuotSafe = simpleIntOp "squot_safe" [C.cexp|y == 0 ? 0 : x / y|]
+        mkSRemSafe = simpleIntOp "srem_safe" [C.cexp|y == 0 ? 0 : x % y|]
         mkSMax = simpleIntOp "smax" [C.cexp|x < y ? y : x|]
         mkSMin = simpleIntOp "smin" [C.cexp|x < y ? x : y|]
         mkShl = simpleUintOp "shl" [C.cexp|x << y|]

--- a/src/Futhark/CodeGen/ImpCode/OpenCL.hs
+++ b/src/Futhark/CodeGen/ImpCode/OpenCL.hs
@@ -14,7 +14,7 @@ module Futhark.CodeGen.ImpCode.OpenCL
        , KernelName
        , KernelArg (..)
        , OpenCL (..)
-       , Safety(..)
+       , KernelSafety(..)
        , numFailureParams
        , KernelTarget (..)
        , FailureMsg(..)
@@ -35,7 +35,7 @@ import Futhark.Util.Pretty
 data Program = Program { openClProgram :: String
                        , openClPrelude :: String
                          -- ^ Must be prepended to the program.
-                       , openClKernelNames :: M.Map KernelName Safety
+                       , openClKernelNames :: M.Map KernelName KernelSafety
                        , openClUsedTypes :: [PrimType]
                          -- ^ So we can detect whether the device is capable.
                        , openClSizes :: M.Map Name SizeClass
@@ -76,7 +76,7 @@ data MayFail = MayFail | CannotFail
 
 -- | Information about bounds checks and how sensitive it is to
 -- errors.  Ordered by least demanding to most.
-data Safety
+data KernelSafety
   = SafetyNone
     -- ^ Does not need to know if we are in a failing state, and also
     -- cannot fail.
@@ -89,13 +89,13 @@ data Safety
 
 -- | How many leading failure arguments we must pass when launching a
 -- kernel with these safety characteristics.
-numFailureParams :: Safety -> Int
+numFailureParams :: KernelSafety -> Int
 numFailureParams SafetyNone = 0
 numFailureParams SafetyCheap = 1
 numFailureParams SafetyFull = 3
 
 -- | Host-level OpenCL operation.
-data OpenCL = LaunchKernel Safety KernelName [KernelArg] [Exp] [Exp]
+data OpenCL = LaunchKernel KernelSafety KernelName [KernelArg] [Exp] [Exp]
             | GetSize VName Name
             | CmpSizeLe VName Name Exp
             | GetSizeMax VName SizeClass

--- a/src/Futhark/CodeGen/ImpGen/Kernels/ToOpenCL.hs
+++ b/src/Futhark/CodeGen/ImpGen/Kernels/ToOpenCL.hs
@@ -102,7 +102,7 @@ newKernelState failures = KernelState mempty failures 0 False False
 errorLabel :: KernelState -> String
 errorLabel = ("error_"++) . show . kernelNextSync
 
-data ToOpenCL = ToOpenCL { clKernels :: M.Map KernelName (Safety, C.Func)
+data ToOpenCL = ToOpenCL { clKernels :: M.Map KernelName (KernelSafety, C.Func)
                          , clUsedTypes :: S.Set PrimType
                          , clSizes :: M.Map Name SizeClass
                          , clFailures :: [FailureMsg]

--- a/src/Futhark/Construct.hs
+++ b/src/Futhark/Construct.hs
@@ -271,14 +271,15 @@ eLambda lam args = do zipWithM_ bindParam (lambdaParams lam) args
 eDivRoundingUp :: MonadBinder m =>
                   IntType -> m (Exp (Lore m)) -> m (Exp (Lore m)) -> m (Exp (Lore m))
 eDivRoundingUp t x y =
-  eBinOp (SQuot t) (eBinOp (Add t OverflowWrap) x (eBinOp (Sub t OverflowWrap) y (eSubExp one))) y
+  eBinOp (SQuot t Unsafe)
+  (eBinOp (Add t OverflowWrap) x (eBinOp (Sub t OverflowWrap) y (eSubExp one))) y
   where one = intConst t 1
 
 eRoundToMultipleOf :: MonadBinder m =>
                       IntType -> m (Exp (Lore m)) -> m (Exp (Lore m)) -> m (Exp (Lore m))
 eRoundToMultipleOf t x d =
   ePlus x (eMod (eMinus d (eMod x d)) d)
-  where eMod = eBinOp (SMod t)
+  where eMod = eBinOp (SMod t Unsafe)
         eMinus = eBinOp (Sub t OverflowWrap)
         ePlus = eBinOp (Add t OverflowWrap)
 

--- a/src/Futhark/IR/Primitive.hs
+++ b/src/Futhark/IR/Primitive.hs
@@ -24,6 +24,7 @@ module Futhark.IR.Primitive
 
          -- * Operations
        , Overflow (..)
+       , Safety(..)
        , UnOp (..), allUnOps
        , BinOp (..), allBinOps
        , ConvOp (..), allConvOps
@@ -296,6 +297,24 @@ instance Eq Overflow where
 instance Ord Overflow where
   _ `compare` _ = EQ
 
+-- | Whether something is safe or unsafe (mostly function calls, and
+-- in the context of whether operations are dynamically checked).
+-- When we inline an 'Unsafe' function, we remove all safety checks in
+-- its body.  The 'Ord' instance picks 'Unsafe' as being less than
+-- 'Safe'.
+--
+-- For operations like integer division, a safe division will not
+-- explode the computer in case of division by zero, but instead
+-- return some unspecified value.  This always involves a run-time
+-- check, so generally the unsafe variant is what the compiler will
+-- insert, but guarded by an explicit assertion elsewhere.  Safe
+-- operations are useful when the optimiser wants to move e.g. a
+-- division to a location where the divisor may be zero, but where the
+-- result will only be used when it is non-zero (so it doesn't matter
+-- what result is provided with a zero divisor, as long as the program
+-- keeps running).
+data Safety = Unsafe | Safe deriving (Eq, Ord, Show)
+
 -- | Binary operators.  These correspond closely to the binary operators in
 -- LLVM.  Most are parametrised by their expected input and output
 -- types.
@@ -308,26 +327,26 @@ data BinOp = Add IntType Overflow -- ^ Integer addition.
            | Mul IntType Overflow -- ^ Integer multiplication.
            | FMul FloatType -- ^ Floating-point multiplication.
 
-           | UDiv IntType
+           | UDiv IntType Safety
              -- ^ Unsigned integer division.  Rounds towards
              -- negativity infinity.  Note: this is different
              -- from LLVM.
-           | SDiv IntType
+           | SDiv IntType Safety
              -- ^ Signed integer division.  Rounds towards
              -- negativity infinity.  Note: this is different
              -- from LLVM.
            | FDiv FloatType -- ^ Floating-point division.
            | FMod FloatType -- ^ Floating-point modulus.
 
-           | UMod IntType
+           | UMod IntType Safety
              -- ^ Unsigned integer modulus; the countepart to 'UDiv'.
-           | SMod IntType
+           | SMod IntType Safety
              -- ^ Signed integer modulus; the countepart to 'SDiv'.
 
-           | SQuot IntType
+           | SQuot IntType Safety
              -- ^ Signed integer division.  Rounds towards zero.
              -- This corresponds to the @sdiv@ instruction in LLVM.
-           | SRem IntType
+           | SRem IntType Safety
              -- ^ Signed integer division.  Rounds towards zero.
              -- This corresponds to the @srem@ instruction in LLVM.
 
@@ -427,14 +446,14 @@ allBinOps = concat [ map (`Add` OverflowWrap) allIntTypes
                    , map FSub allFloatTypes
                    , map (`Mul` OverflowWrap) allIntTypes
                    , map FMul allFloatTypes
-                   , map UDiv allIntTypes
-                   , map SDiv allIntTypes
+                   , map (`UDiv` Unsafe) allIntTypes
+                   , map (`SDiv` Unsafe) allIntTypes
                    , map FDiv allFloatTypes
                    , map FMod allFloatTypes
-                   , map UMod allIntTypes
-                   , map SMod allIntTypes
-                   , map SQuot allIntTypes
-                   , map SRem allIntTypes
+                   , map (`UMod` Unsafe) allIntTypes
+                   , map (`SMod` Unsafe) allIntTypes
+                   , map (`SQuot` Unsafe) allIntTypes
+                   , map (`SRem` Unsafe) allIntTypes
                    , map SMin allIntTypes
                    , map UMin allIntTypes
                    , map FMin allFloatTypes
@@ -796,12 +815,12 @@ binOpType :: BinOp -> PrimType
 binOpType (Add t _) = IntType t
 binOpType (Sub t _) = IntType t
 binOpType (Mul t _) = IntType t
-binOpType (SDiv t)  = IntType t
-binOpType (SMod t)  = IntType t
-binOpType (SQuot t) = IntType t
-binOpType (SRem t)  = IntType t
-binOpType (UDiv t)  = IntType t
-binOpType (UMod t)  = IntType t
+binOpType (SDiv t _)  = IntType t
+binOpType (SMod t _)  = IntType t
+binOpType (SQuot t _) = IntType t
+binOpType (SRem t _)  = IntType t
+binOpType (UDiv t _)  = IntType t
+binOpType (UMod t _)  = IntType t
 binOpType (SMin t)  = IntType t
 binOpType (UMin t)  = IntType t
 binOpType (FMin t)  = FloatType t
@@ -1176,12 +1195,18 @@ instance Pretty BinOp where
   ppr (FAdd t)  = taggedF "fadd" t
   ppr (FSub t)  = taggedF "fsub" t
   ppr (FMul t)  = taggedF "fmul" t
-  ppr (UDiv t)  = taggedI "udiv" t
-  ppr (UMod t)  = taggedI "umod" t
-  ppr (SDiv t)  = taggedI "sdiv" t
-  ppr (SMod t)  = taggedI "smod" t
-  ppr (SQuot t) = taggedI "squot" t
-  ppr (SRem t)  = taggedI "srem" t
+  ppr (UDiv t Safe)    = taggedI "udiv_safe" t
+  ppr (UDiv t Unsafe)  = taggedI "udiv" t
+  ppr (UMod t Safe)    = taggedI "umod_safe" t
+  ppr (UMod t Unsafe)  = taggedI "umod" t
+  ppr (SDiv t Safe)    = taggedI "sdiv_safe" t
+  ppr (SDiv t Unsafe)  = taggedI "sdiv" t
+  ppr (SMod t Safe)    = taggedI "smod_safe" t
+  ppr (SMod t Unsafe)  = taggedI "smod" t
+  ppr (SQuot t Safe)   = taggedI "squot_safe" t
+  ppr (SQuot t Unsafe) = taggedI "squot" t
+  ppr (SRem t Safe)    = taggedI "srem_safe" t
+  ppr (SRem t Unsafe)  = taggedI "srem" t
   ppr (FDiv t)  = taggedF "fdiv" t
   ppr (FMod t)  = taggedF "fmod" t
   ppr (SMin t)  = taggedI "smin" t

--- a/src/Futhark/IR/Prop.hs
+++ b/src/Futhark/IR/Prop.hs
@@ -76,7 +76,14 @@ asBasicOp _            = Nothing
 -- bounds.  On the other hand, adding two numbers cannot fail.
 safeExp :: IsOp (Op lore) => Exp lore -> Bool
 safeExp (BasicOp op) = safeBasicOp op
-  where safeBasicOp (BinOp SDiv{} _ (Constant y)) = not $ zeroIsh y
+  where safeBasicOp (BinOp (SDiv _ Safe) _ _) = True
+        safeBasicOp (BinOp (SQuot _ Safe) _ _) = True
+        safeBasicOp (BinOp (UDiv _ Safe) _ _) = True
+        safeBasicOp (BinOp (SMod _ Safe) _ _) = True
+        safeBasicOp (BinOp (SRem _ Safe) _ _) = True
+        safeBasicOp (BinOp (UMod _ Safe) _ _) = True
+
+        safeBasicOp (BinOp SDiv{} _ (Constant y)) = not $ zeroIsh y
         safeBasicOp (BinOp SDiv{} _ _) = False
         safeBasicOp (BinOp UDiv{} _ (Constant y)) = not $ zeroIsh y
         safeBasicOp (BinOp UDiv{} _ _) = False

--- a/src/Futhark/IR/Syntax.hs
+++ b/src/Futhark/IR/Syntax.hs
@@ -419,13 +419,6 @@ deriving instance Decorations lore => Eq (ExpT lore)
 deriving instance Decorations lore => Show (ExpT lore)
 deriving instance Decorations lore => Ord (ExpT lore)
 
--- | Whether something is safe or unsafe (mostly function calls, and
--- in the context of whether operations are dynamically checked).
--- When we inline an 'Unsafe' function, we remove all safety checks in
--- its body.  The 'Ord' instance picks 'Unsafe' as being less than
--- 'Safe'.
-data Safety = Unsafe | Safe deriving (Eq, Ord, Show)
-
 -- | For-loop or while-loop?
 data LoopForm lore = ForLoop VName IntType SubExp [(LParam lore,VName)]
                    | WhileLoop VName

--- a/src/Futhark/Internalise.hs
+++ b/src/Futhark/Internalise.hs
@@ -993,8 +993,9 @@ internaliseDimIndex w (E.DimSlice i j s) = do
   -- Something like a division-rounding-up, but accomodating negative
   -- operands.
   let divRounding x y =
-        eBinOp (SQuot Int32) (eBinOp (Add Int32 I.OverflowWrap) x
-                              (eBinOp (Sub Int32 I.OverflowWrap) y (eSignum $ toExp s'))) y
+        eBinOp (SQuot Int32 Unsafe)
+        (eBinOp (Add Int32 I.OverflowWrap) x
+         (eBinOp (Sub Int32 I.OverflowWrap) y (eSignum $ toExp s'))) y
   n <- letSubExp "n" =<< divRounding (toExp j_m_i) (toExp s')
 
   -- Bounds checks depend on whether we are slicing forwards or
@@ -1260,10 +1261,10 @@ internaliseBinOp _ desc E.Times x y (E.FloatType t) _ =
   simpleBinOp desc (I.FMul t) x y
 internaliseBinOp loc desc E.Divide x y (E.Signed t) _ =
   certifyingNonzero loc t y $
-  simpleBinOp desc (I.SDiv t) x y
+  simpleBinOp desc (I.SDiv t I.Unsafe) x y
 internaliseBinOp loc desc E.Divide x y (E.Unsigned t) _ =
   certifyingNonzero loc t y $
-  simpleBinOp desc (I.UDiv t) x y
+  simpleBinOp desc (I.UDiv t I.Unsafe) x y
 internaliseBinOp _ desc E.Divide x y (E.FloatType t) _ =
   simpleBinOp desc (I.FDiv t) x y
 internaliseBinOp _ desc E.Pow x y (E.FloatType t) _ =
@@ -1275,24 +1276,24 @@ internaliseBinOp _ desc E.Pow x y (E.Unsigned t) _ =
   simpleBinOp desc (I.Pow t) x y
 internaliseBinOp loc desc E.Mod x y (E.Signed t) _ =
   certifyingNonzero loc t y $
-  simpleBinOp desc (I.SMod t) x y
+  simpleBinOp desc (I.SMod t I.Unsafe) x y
 internaliseBinOp loc desc E.Mod x y (E.Unsigned t) _ =
   certifyingNonzero loc t y $
-  simpleBinOp desc (I.UMod t) x y
+  simpleBinOp desc (I.UMod t I.Unsafe) x y
 internaliseBinOp _ desc E.Mod x y (E.FloatType t) _ =
   simpleBinOp desc (I.FMod t) x y
 internaliseBinOp loc desc E.Quot x y (E.Signed t) _ =
   certifyingNonzero loc t y $
-  simpleBinOp desc (I.SQuot t) x y
+  simpleBinOp desc (I.SQuot t I.Unsafe) x y
 internaliseBinOp loc desc E.Quot x y (E.Unsigned t) _ =
   certifyingNonzero loc t y $
-  simpleBinOp desc (I.UDiv t) x y
+  simpleBinOp desc (I.UDiv t I.Unsafe) x y
 internaliseBinOp loc desc E.Rem x y (E.Signed t) _ =
   certifyingNonzero loc t y $
-  simpleBinOp desc (I.SRem t) x y
+  simpleBinOp desc (I.SRem t I.Unsafe) x y
 internaliseBinOp loc desc E.Rem x y (E.Unsigned t) _ =
   certifyingNonzero loc t y $
-  simpleBinOp desc (I.UMod t) x y
+  simpleBinOp desc (I.UMod t I.Unsafe) x y
 internaliseBinOp _ desc E.ShiftR x y (E.Signed t) _ =
   simpleBinOp desc (I.AShr t) x y
 internaliseBinOp _ desc E.ShiftR x y (E.Unsigned t) _ =

--- a/src/Futhark/Optimise/Simplify/Rules.hs
+++ b/src/Futhark/Optimise/Simplify/Rules.hs
@@ -430,7 +430,7 @@ simplifyBinOp _ _ (BinOp FMul{} e1 e2)
   | isCt1 e1 = subExpRes e2
   | isCt1 e2 = subExpRes e1
 
-simplifyBinOp look _ (BinOp (SMod t) e1 e2)
+simplifyBinOp look _ (BinOp (SMod t _) e1 e2)
   | isCt1 e2 = constRes $ IntValue $ intValue t (0 :: Int)
   | e1 == e2 = constRes $ IntValue $ intValue t (0 :: Int)
   | Var v1 <- e1,
@@ -447,7 +447,7 @@ simplifyBinOp _ _ (BinOp FDiv{} e1 e2)
   | isCt1 e2 = subExpRes e1
   | isCt0 e2 = Nothing
 
-simplifyBinOp _ _ (BinOp (SRem t) e1 e2)
+simplifyBinOp _ _ (BinOp (SRem t _) e1 e2)
   | isCt1 e2 = constRes $ IntValue $ intValue t (0 :: Int)
   | e1 == e2 = constRes $ IntValue $ intValue t (1 :: Int)
 
@@ -661,7 +661,7 @@ simplifyIndexing vtable seType idd inds consuming =
       dims <- arrayDims <$> lookupType a
       let adjustI i o d = do
             i_p_o <- letSubExp "i_p_o" $ BasicOp $ BinOp (Add Int32 OverflowWrap) i o
-            letSubExp "rot_i" (BasicOp $ BinOp (SMod Int32) i_p_o d)
+            letSubExp "rot_i" (BasicOp $ BinOp (SMod Int32 Unsafe) i_p_o d)
           adjust (DimFix i, o, d) =
             DimFix <$> adjustI i o d
           adjust (DimSlice i n s, o, d) =

--- a/src/Futhark/Optimise/TileLoops.hs
+++ b/src/Futhark/Optimise/TileLoops.hs
@@ -622,7 +622,7 @@ processResidualTile1D
   -- The number of residual elements that are not covered by
   -- the whole tiles.
   residual_input <- letSubExp "residual_input" $
-    BasicOp $ BinOp (SRem Int32) w tile_size
+    BasicOp $ BinOp (SRem Int32 Unsafe) w tile_size
 
   letTupExp "acc_after_residual" =<<
     eIf (toExp $ primExpFromSubExp int32 residual_input .==. 0)
@@ -670,7 +670,8 @@ tiling1d dims_on_top initial_lvl gtid kdim w = do
   let tile_size = unCount $ segGroupSize lvl
 
   -- Number of whole tiles that fit in the input.
-  num_whole_tiles <- letSubExp "num_whole_tiles" $ BasicOp $ BinOp (SQuot Int32) w tile_size
+  num_whole_tiles <- letSubExp "num_whole_tiles" $
+                     BasicOp $ BinOp (SQuot Int32 Unsafe) w tile_size
   return Tiling
     { tilingSegMap = \desc lvl' manifest f -> segMap1D desc lvl' manifest $ \ltid -> do
         letBindNames [gtid] =<<
@@ -836,7 +837,7 @@ processResidualTile2D
   -- The number of residual elements that are not covered by
   -- the whole tiles.
   residual_input <- letSubExp "residual_input" $
-    BasicOp $ BinOp (SRem Int32) w tile_size
+    BasicOp $ BinOp (SRem Int32 Unsafe) w tile_size
 
   letTupExp "acc_after_residual" =<<
     eIf (toExp $ primExpFromSubExp int32 residual_input .==. 0)
@@ -887,7 +888,7 @@ tiling2d dims_on_top _initial_lvl (gtid_x, gtid_y) (kdim_x, kdim_y) w = do
 
   -- Number of whole tiles that fit in the input.
   num_whole_tiles <- letSubExp "num_whole_tiles" $
-    BasicOp $ BinOp (SQuot Int32) w tile_size
+    BasicOp $ BinOp (SQuot Int32 Unsafe) w tile_size
   return Tiling
     { tilingSegMap = \desc lvl' manifest f ->
         segMap2D desc lvl' manifest (tile_size, tile_size) $ \(ltid_x, ltid_y) -> do

--- a/src/Futhark/Pass/KernelBabysitting.hs
+++ b/src/Futhark/Pass/KernelBabysitting.hs
@@ -386,7 +386,8 @@ rearrangeSlice d w num_chunks arr = do
 
   (w_padded, padding) <- paddedScanReduceInput w num_chunks'
 
-  per_chunk <- letSubExp "per_chunk" $ BasicOp $ BinOp (SQuot Int32) w_padded num_chunks'
+  per_chunk <- letSubExp "per_chunk" $
+               BasicOp $ BinOp (SQuot Int32 Unsafe) w_padded num_chunks'
   arr_t <- lookupType arr
   arr_padded <- padArray w_padded padding arr_t
   rearrange num_chunks' w_padded per_chunk (baseString arr) arr_padded arr_t

--- a/src/Language/Futhark/Interpreter.hs
+++ b/src/Language/Futhark/Interpreter.hs
@@ -1237,10 +1237,20 @@ initialCtx =
     def "-" = arithOp (`P.Sub` P.OverflowWrap) P.FSub
     def "*" = arithOp (`P.Mul` P.OverflowWrap) P.FMul
     def "**" = arithOp P.Pow P.FPow
-    def "/" = Just $ bopDef $ sintOp P.SDiv ++ uintOp P.UDiv ++ floatOp P.FDiv
-    def "%" = Just $ bopDef $ sintOp P.SMod ++ uintOp P.UMod ++ floatOp P.FMod
-    def "//" = Just $ bopDef $ sintOp P.SQuot ++ uintOp P.UDiv
-    def "%%" = Just $ bopDef $ sintOp P.SRem ++ uintOp P.UMod
+    def "/" = Just $ bopDef $
+              sintOp (`P.SDiv` P.Unsafe) ++
+              uintOp (`P.UDiv` P.Unsafe) ++
+              floatOp P.FDiv
+    def "%" = Just $ bopDef $
+              sintOp (`P.SMod` P.Unsafe) ++
+              uintOp (`P.UMod` P.Unsafe) ++
+              floatOp P.FMod
+    def "//" = Just $ bopDef $
+               sintOp (`P.SQuot` P.Unsafe) ++
+               uintOp (`P.UDiv` P.Unsafe)
+    def "%%" = Just $ bopDef $
+               sintOp (`P.SRem` P.Unsafe) ++
+               uintOp (`P.UMod` P.Unsafe)
     def "^" = Just $ bopDef $ intOp P.Xor
     def "&" = Just $ bopDef $ intOp P.And
     def "|" = Just $ bopDef $ intOp P.Or

--- a/tests/hoist-unsafe2.fut
+++ b/tests/hoist-unsafe2.fut
@@ -3,7 +3,7 @@
 -- ==
 -- input { 4 [1,2,3] } output { 6 }
 -- input { 0 empty([0]i32) } output { 0 }
--- structure { /If/True/BinOp 1 }
+-- structure { /DoLoop/BinOp 2 }
 
 let main [n] (a: i32) (xs: [n]i32) =
   loop acc = 0 for x in xs do acc + x*(a/n)


### PR DESCRIPTION
Used when hoisting them out of loops.

Closes #1009.