### PR TITLE
Set default threshold size to 2000000000 when autotuning

### DIFF
--- a/src/Futhark/CLI/Autotune.hs
+++ b/src/Futhark/CLI/Autotune.hs
@@ -33,11 +33,12 @@ data AutotuneOptions = AutotuneOptions
                     , optExtraOptions :: [String]
                     , optVerbose :: Int
                     , optTimeout :: Int
+                    , optDefaultThreshold :: Int
                     }
 
 initialAutotuneOptions :: AutotuneOptions
 initialAutotuneOptions =
-  AutotuneOptions "opencl" Nothing 10 (Just "tuning") [] 0 60
+  AutotuneOptions "opencl" Nothing 10 (Just "tuning") [] 0 60 thresholdMax
 
 compileOptions :: AutotuneOptions -> IO CompileOptions
 compileOptions opts = do
@@ -51,7 +52,11 @@ runOptions :: Path -> Int -> AutotuneOptions -> RunOptions
 runOptions path timeout_s opts =
   RunOptions { runRunner = ""
              , runRuns = optRuns opts
-             , runExtraOptions = "-L" : map opt path ++ optExtraOptions opts
+             , runExtraOptions = "--default-threshold" :
+                                 show (optDefaultThreshold opts) :
+                                 "-L" :
+                                 map opt path ++
+                                 optExtraOptions opts
              , runTimeout = timeout_s
              , runVerbose = optVerbose opts
              , runResultAction = Nothing


### PR DESCRIPTION
For incremental flattening, Futhark uses a default threshold in OpenCL GPU
programs of 32768. Some programs and benchmarks (bfast in partcular) have higher
degrees of parallelism for some combinations of threshold and dataset. To
correctly tune threshold parameters, the autotuner assumes that any unset
thresholds will always block execution of the guarded code version, but if the
default threshold is not high enough, that's not always the case. This commit
fixes that, by explicitly setting the default threshold parameter to
2000000000, which is `thresholdMax` in the tuner.

This commit should fix the autotuning problems we've been having with the bfast
benchmark.