### PR TITLE
Use 64-bit arithmetic for computing array offsets.

### DIFF
--- a/src/Futhark/Analysis/PrimExp.hs
+++ b/src/Futhark/Analysis/PrimExp.hs
@@ -25,6 +25,7 @@ module Futhark.Analysis.PrimExp
   , bNot
   , sMax32, sMin32, sMax64, sMin64
   , sExt32, sExt64
+  , zExt32, zExt64
   , fMin64, fMax64
   ) where
 
@@ -474,6 +475,14 @@ sExt32 = isInt32 . sExt Int32 . untyped
 -- | Sign-extend to 64 bit integer.
 sExt64 :: IntExp t => TPrimExp t v -> TPrimExp Int64 v
 sExt64 = isInt64 . sExt Int64 . untyped
+
+-- | Zero-extend to 32 bit integer.
+zExt32 :: IntExp t => TPrimExp t v -> TPrimExp Int32 v
+zExt32 = isInt32 . zExt Int32 . untyped
+
+-- | Zero-extend to 64 bit integer.
+zExt64 :: IntExp t => TPrimExp t v -> TPrimExp Int64 v
+zExt64 = isInt64 . zExt Int64 . untyped
 
 -- | 64-bit float minimum.
 fMin64 :: TPrimExp Double v -> TPrimExp Double v -> TPrimExp Double v

--- a/src/Futhark/CodeGen/Backends/COpenCL.hs
+++ b/src/Futhark/CodeGen/Backends/COpenCL.hs
@@ -339,13 +339,14 @@ launchKernel kernel_name num_workgroups workgroup_dims local_bytes = do
       }
     }|]
   where kernel_rank = length kernel_dims
-        kernel_dims = zipWith multExp num_workgroups workgroup_dims
+        kernel_dims = zipWith multExp (map toSize num_workgroups) (map toSize workgroup_dims)
         kernel_dims' = map toInit kernel_dims
         workgroup_dims' = map toInit workgroup_dims
         total_elements = foldl multExp [C.cexp|1|] kernel_dims
 
         toInit e = [C.cinit|$exp:e|]
         multExp x y = [C.cexp|$exp:x * $exp:y|]
+        toSize e = [C.cexp|(size_t)$exp:e|]
 
         printKernelSize :: VName -> [C.Stm]
         printKernelSize work_size =

--- a/src/Futhark/CodeGen/Backends/GenericC.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC.hs
@@ -1873,7 +1873,7 @@ compileExp = compilePrimExp compileLeaf
           return [C.cexp|$id:src[$exp:iexp']|]
 
         compileLeaf (SizeOf t) =
-          return [C.cexp|(typename int32_t)sizeof($ty:t')|]
+          return [C.cexp|(typename int64_t)sizeof($ty:t')|]
           where t' = primTypeToCType t
 
 -- | Tell me how to compile a @v@, and I'll Compile any @PrimExp v@ for you.

--- a/src/Futhark/CodeGen/ImpCode.hs
+++ b/src/Futhark/CodeGen/ImpCode.hs
@@ -206,13 +206,13 @@ data Code a = Skip
               -- all memory blocks will be freed with this statement.
               -- Backends are free to ignore it entirely.
             | Copy
-              VName (Count Bytes (TExp Int32)) Space
-              VName (Count Bytes (TExp Int32)) Space
+              VName (Count Bytes (TExp Int64)) Space
+              VName (Count Bytes (TExp Int64)) Space
               (Count Bytes (TExp Int64))
               -- ^ Destination, offset in destination, destination
               -- space, source, offset in source, offset space, number
               -- of bytes.
-            | Write VName (Count Elements (TExp Int32)) PrimType Space Volatility Exp
+            | Write VName (Count Elements (TExp Int64)) PrimType Space Volatility Exp
               -- ^ @Write mem i t space vol v@ writes the value @v@ to
               -- @mem@ offset by @i@ elements of type @t@.  The
               -- 'Space' argument is the memory space of @mem@
@@ -310,7 +310,7 @@ data ExpLeaf = ScalarVar VName
                -- 'LeafExp' constructor itself.
              | SizeOf PrimType
                -- ^ The size of a primitive type.
-             | Index VName (Count Elements (TExp Int32)) PrimType Space Volatility
+             | Index VName (Count Elements (TExp Int64)) PrimType Space Volatility
                -- ^ Reading a value from memory.  The arguments have
                -- the same meaning as with 'Write'.
            deriving (Eq, Show)
@@ -356,7 +356,7 @@ vi32 :: VName -> TExp Int32
 vi32 = TPrimExp . flip var (IntType Int32)
 
 -- | Concise wrapper for using 'Index'.
-index :: VName -> Count Elements (TExp Int32) -> PrimType -> Space -> Volatility -> Exp
+index :: VName -> Count Elements (TExp Int64) -> PrimType -> Space -> Volatility -> Exp
 index arr i t s vol = LeafExp (Index arr i t s vol) t
 
 -- Prettyprinting definitions.

--- a/src/Futhark/CodeGen/ImpCode.hs
+++ b/src/Futhark/CodeGen/ImpCode.hs
@@ -33,7 +33,7 @@ module Futhark.CodeGen.ImpCode
   , Volatility (..)
   , Arg (..)
   , var
-  , vi32
+  , vi32, vi64
   , index
   , ErrorMsg(..)
   , ErrorMsgPart(..)
@@ -354,6 +354,10 @@ var = LeafExp . ScalarVar
 -- | Turn a 'VName' into a v'Int32' 'Imp.ScalarVar'.
 vi32 :: VName -> TExp Int32
 vi32 = TPrimExp . flip var (IntType Int32)
+
+-- | Turn a 'VName' into a v'Int64' 'Imp.ScalarVar'.
+vi64 :: VName -> TExp Int64
+vi64 = TPrimExp . flip var (IntType Int64)
 
 -- | Concise wrapper for using 'Index'.
 index :: VName -> Count Elements (TExp Int64) -> PrimType -> Space -> Volatility -> Exp

--- a/src/Futhark/CodeGen/ImpGen.hs
+++ b/src/Futhark/CodeGen/ImpGen.hs
@@ -1055,13 +1055,13 @@ destinationFromPattern pat =
               return $ ScalarDestination name
 
 fullyIndexArray :: VName -> [Imp.TExp Int32]
-                -> ImpM lore r op (VName, Imp.Space, Count Elements (Imp.TExp Int32))
+                -> ImpM lore r op (VName, Imp.Space, Count Elements (Imp.TExp Int64))
 fullyIndexArray name indices = do
   arr <- lookupArray name
   fullyIndexArray' (entryArrayLocation arr) indices
 
 fullyIndexArray' :: MemLocation -> [Imp.TExp Int32]
-                 -> ImpM lore r op (VName, Imp.Space, Count Elements (Imp.TExp Int32))
+                 -> ImpM lore r op (VName, Imp.Space, Count Elements (Imp.TExp Int64))
 fullyIndexArray' (MemLocation mem _ ixfun) indices = do
   space <- entryMemSpace <$> lookupMemory mem
   let indices' = case space of
@@ -1069,8 +1069,10 @@ fullyIndexArray' (MemLocation mem _ ixfun) indices = do
                      let (zero_is, is) = splitFromEnd (length ds) indices
                      in map (const 0) zero_is ++ is
                    _ -> indices
+      ixfun64 = fmap sExt64 ixfun
+      indices64 = fmap sExt64 indices'
   return (mem, space,
-          elements $ IxFun.index ixfun indices')
+          elements $ IxFun.index ixfun64 indices64)
 
 -- More complicated read/write operations that use index functions.
 
@@ -1083,9 +1085,9 @@ copy bt dest destslice src srcslice = do
 defaultCopy :: CopyCompiler lore r op
 defaultCopy bt dest destslice src srcslice
   | Just destoffset <-
-      IxFun.linearWithOffset (IxFun.slice destIxFun destslice) bt_size,
+      IxFun.linearWithOffset (IxFun.slice dest_ixfun64 destslice64) bt_size,
     Just srcoffset  <-
-      IxFun.linearWithOffset (IxFun.slice srcIxFun srcslice) bt_size = do
+      IxFun.linearWithOffset (IxFun.slice src_ixfun64 srcslice64) bt_size = do
         srcspace <- entryMemSpace <$> lookupMemory srcmem
         destspace <- entryMemSpace <$> lookupMemory destmem
         if isScalarSpace srcspace || isScalarSpace destspace
@@ -1098,8 +1100,15 @@ defaultCopy bt dest destslice src srcslice
       copyElementWise bt dest destslice src srcslice
   where bt_size = primByteSize bt
         num_elems = Imp.elements $ product $ sliceDims srcslice
-        MemLocation destmem _ destIxFun = dest
-        MemLocation srcmem _ srcIxFun = src
+
+        MemLocation destmem _ dest_ixfun = dest
+        MemLocation srcmem _ src_ixfun = src
+
+        dest_ixfun64 = fmap sExt64 dest_ixfun
+        destslice64 = map (fmap sExt64) destslice
+        src_ixfun64 = fmap sExt64 src_ixfun
+        srcslice64 = map (fmap sExt64) srcslice
+
         isScalarSpace ScalarSpace{} = True
         isScalarSpace _ = False
 
@@ -1292,8 +1301,8 @@ compileAlloc pat _ _ =
 typeSize :: Type -> Count Bytes (Imp.TExp Int64)
 typeSize t =
   Imp.bytes $
-  isInt64 (sExt Int64 (Imp.LeafExp (Imp.SizeOf $ elemType t) int32)) *
-  product (map (isInt64 . sExt Int64 . toExp' int32) (arrayDims t))
+  isInt64 (Imp.LeafExp (Imp.SizeOf $ elemType t) int64) *
+  product (map (sExt64 . toInt32Exp) (arrayDims t))
 
 --- Building blocks for constructing code.
 

--- a/src/Futhark/CodeGen/ImpGen.hs
+++ b/src/Futhark/CodeGen/ImpGen.hs
@@ -1069,8 +1069,15 @@ fullyIndexArray' (MemLocation mem _ ixfun) indices = do
                      let (zero_is, is) = splitFromEnd (length ds) indices
                      in map (const 0) zero_is ++ is
                    _ -> indices
+      -- We zero-extend the indexes because they cannot be negative
+      -- anyway, and it apparently helps the downstream kernel code
+      -- generator produce better code (presumably because it will
+      -- know that the values are non-negative).
+      --
+      -- We sign-extend the index functions, because negative strides
+      -- are allowed.
       ixfun64 = fmap sExt64 ixfun
-      indices64 = fmap sExt64 indices'
+      indices64 = fmap zExt64 indices'
   return (mem, space,
           elements $ IxFun.index ixfun64 indices64)
 

--- a/src/Futhark/CodeGen/ImpGen/Kernels.hs
+++ b/src/Futhark/CodeGen/ImpGen/Kernels.hs
@@ -228,8 +228,8 @@ callKernelCopy bt
         srcspace <- entryMemSpace <$> lookupMemory srcmem
         destspace <- entryMemSpace <$> lookupMemory destmem
         emit $ Imp.Copy
-          destmem (bytes destoffset) destspace
-          srcmem (bytes srcoffset) srcspace $
+          destmem (bytes $ sExt64 destoffset) destspace
+          srcmem (bytes $ sExt64 srcoffset) srcspace $
           num_elems `Imp.withElemType` bt
 
   | otherwise = sCopy bt destloc destslice srcloc srcslice
@@ -322,8 +322,8 @@ mapTransposeFunction bt =
                 sExt64 $
                 Imp.vi32 x * Imp.vi32 y * isInt32 (Imp.LeafExp (Imp.SizeOf bt) (IntType Int32))
           in Imp.Copy
-               destmem (Imp.Count $ Imp.vi32 destoffset) space
-               srcmem (Imp.Count $ Imp.vi32 srcoffset) space
+               destmem (Imp.Count $ sExt64 $ Imp.vi32 destoffset) space
+               srcmem (Imp.Count $ sExt64 $ Imp.vi32 srcoffset) space
                (Imp.Count num_bytes)
 
         callTransposeKernel =

--- a/src/Futhark/CodeGen/ImpGen/Kernels/Base.hs
+++ b/src/Futhark/CodeGen/ImpGen/Kernels/Base.hs
@@ -1101,17 +1101,17 @@ inBlockScan constants seg_flag arrs_full_size lockstep_width block_size active a
           | otherwise =
               copyDWIM (paramName y) [] (Var $ paramName x) []
 
-computeMapKernelGroups :: Imp.TExp Int32 -> CallKernelGen (Imp.TExp Int32, Imp.TExp Int32)
+computeMapKernelGroups :: Imp.TExp Int64 -> CallKernelGen (Imp.TExp Int64, Imp.TExp Int32)
 computeMapKernelGroups kernel_size = do
   group_size <- dPrim "group_size" int32
   fname <- askFunction
   let group_size_var = Imp.vi32 group_size
       group_size_key = keyWithEntryPoint fname $ nameFromString $ pretty group_size
   sOp $ Imp.GetSize group_size group_size_key Imp.SizeGroup
-  num_groups <- dPrimV "num_groups" $ kernel_size `divUp` group_size_var
-  return (Imp.vi32 num_groups, Imp.vi32 group_size)
+  num_groups <- dPrimV "num_groups" $ kernel_size `divUp` sExt64 group_size_var
+  return (Imp.vi64 num_groups, Imp.vi32 group_size)
 
-simpleKernelConstants :: Imp.TExp Int32 -> String
+simpleKernelConstants :: Imp.TExp Int64 -> String
                       -> CallKernelGen (KernelConstants, InKernelGen ())
 simpleKernelConstants kernel_size desc = do
   thread_gtid <- newVName $ desc ++ "_gtid"
@@ -1130,8 +1130,8 @@ simpleKernelConstants kernel_size desc = do
   return (KernelConstants
           (Imp.vi32 thread_gtid) (Imp.vi32 thread_ltid) (Imp.vi32 group_id)
           thread_gtid thread_ltid group_id
-          num_groups group_size (group_size*num_groups) 0
-          (Imp.vi32 thread_gtid .<. kernel_size)
+          (sExt32 num_groups) group_size (group_size*sExt32 num_groups) 0
+          (Imp.vi64 thread_gtid .<. kernel_size)
           mempty,
 
           set_constants)
@@ -1262,7 +1262,7 @@ sReplicateKernel arr se = do
 
   let dims = map toInt32Exp $ ds ++ arrayDims t
   (constants, set_constants) <-
-    simpleKernelConstants (product dims) "replicate"
+    simpleKernelConstants (product $ map sExt64 dims) "replicate"
 
   fname <- askFunction
   let name = keyWithEntryPoint fname $ nameFromString $
@@ -1324,7 +1324,7 @@ sReplicate arr se = do
     Nothing -> sReplicateKernel arr se
 
 -- | Perform an Iota with a kernel.
-sIotaKernel :: VName -> Imp.TExp Int32 -> Imp.Exp -> Imp.Exp -> IntType
+sIotaKernel :: VName -> Imp.TExp Int64 -> Imp.Exp -> Imp.Exp -> IntType
             -> CallKernelGen ()
 sIotaKernel arr n x s et = do
   destloc <- entryArrayLocation <$> lookupArray arr
@@ -1372,7 +1372,7 @@ iotaForType bt = do
     function fname [] params $ do
       arr <- sArray "arr" (IntType bt) shape $ ArrayIn mem $ IxFun.iota $
              map pe32 $ shapeDims shape
-      sIotaKernel arr n' x' s' bt
+      sIotaKernel arr (sExt64 n') x' s' bt
 
   return fname
 
@@ -1385,7 +1385,7 @@ sIota arr n x s et = do
     fname <- iotaForType et
     emit $ Imp.Call [] fname
       [Imp.MemArg arr_mem, Imp.ExpArg $ untyped n, Imp.ExpArg x, Imp.ExpArg s]
-    else sIotaKernel arr n x s et
+    else sIotaKernel arr (sExt64 n) x s et
 
 sCopy :: CopyCompiler KernelsMem HostEnv Imp.HostOp
 sCopy bt
@@ -1395,7 +1395,7 @@ sCopy bt
   -- Note that the shape of the destination and the source are
   -- necessarily the same.
   let shape = sliceDims srcslice
-      kernel_size = product shape
+      kernel_size = product $ map sExt64 shape
 
   (constants, set_constants) <- simpleKernelConstants kernel_size "copy"
 
@@ -1415,7 +1415,7 @@ sCopy bt
     (_, srcspace, srcidx) <-
       fullyIndexArray' srcloc $ fixSlice srcslice src_is
 
-    sWhen (gtid .<. kernel_size) $ emit $
+    sWhen (gtid .<. sExt32 kernel_size) $ emit $
       Imp.Write destmem destidx bt destspace Imp.Nonvolatile $
       Imp.index srcmem srcidx bt srcspace Imp.Nonvolatile
 

--- a/src/Futhark/CodeGen/ImpGen/Kernels/SegRed.hs
+++ b/src/Futhark/CodeGen/ImpGen/Kernels/SegRed.hs
@@ -637,8 +637,8 @@ reductionStageTwo constants segred_pes
     sOp $ Imp.MemFence Imp.FenceGlobal
     -- Increment the counter, thus stating that our result is
     -- available.
-    sOp $ Imp.Atomic DefaultSpace $ Imp.AtomicAdd Int32 old_counter counter_mem counter_offset $
-      untyped (1::Imp.TExp Int32)
+    sOp $ Imp.Atomic DefaultSpace $ Imp.AtomicAdd Int32 old_counter counter_mem
+      (sExt32 <$> counter_offset) $ untyped (1::Imp.TExp Int32)
     -- Now check if we were the last group to write our result.  If
     -- so, it is our responsibility to produce the final result.
     sWrite sync_arr [0] $ untyped $ Imp.vi32 old_counter .==. groups_per_segment - 1
@@ -656,7 +656,7 @@ reductionStageTwo constants segred_pes
     -- races in oclgrind.
     sWhen (local_tid .==. 0) $
       sOp $ Imp.Atomic DefaultSpace $
-      Imp.AtomicAdd Int32 old_counter counter_mem counter_offset $
+      Imp.AtomicAdd Int32 old_counter counter_mem (sExt32 <$> counter_offset) $
       untyped $ negate groups_per_segment
 
     sLoopNest (slugShape slug) $ \vec_is -> do

--- a/src/Futhark/CodeGen/ImpGen/Kernels/Transpose.hs
+++ b/src/Futhark/CodeGen/ImpGen/Kernels/Transpose.hs
@@ -52,8 +52,8 @@ mapTranspose block_dim args t kind =
       , dec index_out $ vi32 x_index * height + vi32 y_index
 
       , when (vi32 get_global_id_0 .<. width * height * num_arrays)
-        (Write odata (elements $ vi32 odata_offset + vi32 index_out) t (Space "global") Nonvolatile $
-         index idata (elements $ vi32 idata_offset + vi32 index_in) t (Space "global") Nonvolatile)
+        (Write odata (elements $ sExt64 $ vi32 odata_offset + vi32 index_out) t (Space "global") Nonvolatile $
+         index idata (elements $ sExt64 $ vi32 idata_offset + vi32 index_in) t (Space "global") Nonvolatile)
       ]
 
     TransposeLowWidth ->
@@ -83,10 +83,11 @@ mapTranspose block_dim args t kind =
         let i = vi32 j * (tile_dim `quot` elemsPerThread)
         in mconcat [ dec index_in $ (vi32 y_index + i) * width + vi32 x_index
                    , when (vi32 y_index + i .<. height) $
-                     Write block (elements $ (vi32 get_local_id_1 + i) * (tile_dim+1)
-                                             + vi32 get_local_id_0)
+                     Write block (elements $ sExt64 $
+                                  (vi32 get_local_id_1 + i) * (tile_dim+1)
+                                  + vi32 get_local_id_0)
                      t (Space "local") Nonvolatile $
-                     index idata (elements $ vi32 idata_offset + vi32 index_in)
+                     index idata (elements $ sExt64 $ vi32 idata_offset + vi32 index_in)
                      t (Space "global") Nonvolatile]
       , Op $ Barrier FenceLocal
       , SetScalar x_index $ untyped $ vi32 get_group_id_1 * tile_dim + vi32 get_local_id_0
@@ -96,10 +97,10 @@ mapTranspose block_dim args t kind =
         let i = vi32 j * (tile_dim `quot` elemsPerThread)
         in mconcat [ dec index_out $ (vi32 y_index + i) * height + vi32 x_index
                    , when (vi32 y_index + i .<. width) $
-                     Write odata (elements $ vi32 odata_offset + vi32 index_out)
+                     Write odata (elements $ sExt64 $ vi32 odata_offset + vi32 index_out)
                      t (Space "global") Nonvolatile $
-                     index block (elements $ vi32 get_local_id_0 * (tile_dim+1)
-                                             + vi32 get_local_id_1+i)
+                     index block (elements $ sExt64 $
+                                  vi32 get_local_id_0 * (tile_dim+1) + vi32 get_local_id_1+i)
                      t (Space "local") Nonvolatile
                    ]
       ]
@@ -166,18 +167,18 @@ mapTranspose block_dim args t kind =
           , dec y_index y_in_index
           , dec index_in $ vi32 y_index * width + vi32 x_index
           , when (vi32 x_index .<. width .&&. vi32 y_index .<. height) $
-            Write block (elements $ vi32 get_local_id_1 * (block_dim+1) + vi32 get_local_id_0)
+            Write block (elements $ sExt64 $ vi32 get_local_id_1 * (block_dim+1) + vi32 get_local_id_0)
             t (Space "local") Nonvolatile $
-            index idata (elements $ vi32 idata_offset + vi32 index_in)
+            index idata (elements $ sExt64 $ vi32 idata_offset + vi32 index_in)
             t (Space "global") Nonvolatile
           , Op $ Barrier FenceLocal
           , SetScalar x_index $ untyped x_out_index
           , SetScalar y_index $ untyped y_out_index
           , dec index_out $ vi32 y_index * height + vi32 x_index
           , when (vi32 x_index .<. height .&&. vi32 y_index .<. width) $
-            Write odata (elements $ vi32 odata_offset + vi32 index_out)
+            Write odata (elements $ sExt64 (vi32 odata_offset + vi32 index_out))
             t (Space "global") Nonvolatile $
-            index block (elements $ vi32 get_local_id_0 * (block_dim+1) + vi32 get_local_id_1)
+            index block (elements $ sExt64 $ vi32 get_local_id_0 * (block_dim+1) + vi32 get_local_id_1)
             t (Space "local") Nonvolatile
           ]
 

--- a/tests/big.fut
+++ b/tests/big.fut
@@ -1,9 +1,10 @@
 -- Testing big arrays.
 -- ==
--- no_opencl compiled input { 2 1100000000 1 1073741823 } output { 255u8 }
--- no_opencl compiled input { 3 1073741824 2 1073741823 } output { 255u8 }
--- structure { Replicate 1 Iota 1 }
+-- tags { no_python }
+-- no_opencl compiled input { 2 1100000000 1 1073741823 } output { -2i8 }
+-- no_opencl compiled input { 3 1073741824 2 1073741823 } output { -3i8 }
+-- structure gpu { SegMap 1  }
 
 let main (n: i32) (m: i32) (i: i32) (j: i32) =
   -- The opaque is just to force manifestation.
-  (opaque (replicate n (tabulate m (\i -> u8.i32 i))))[i,j]
+  (opaque (tabulate_2d n m (\i j -> i8.i32 (i ^ j))))[i,j]

--- a/tests/big.fut
+++ b/tests/big.fut
@@ -1,8 +1,8 @@
 -- Testing big arrays.
 -- ==
 -- tags { no_python }
--- no_opencl compiled input { 2 1100000000 1 1073741823 } output { -2i8 }
--- no_opencl compiled input { 3 1073741824 2 1073741823 } output { -3i8 }
+-- no_python no_opencl compiled input { 2 1100000000 1 1073741823 } output { -2i8 }
+-- no_python no_opencl compiled input { 3 1073741824 2 1073741823 } output { -3i8 }
 -- structure gpu { SegMap 1  }
 
 let main (n: i32) (m: i32) (i: i32) (j: i32) =

--- a/tests/big.fut
+++ b/tests/big.fut
@@ -1,0 +1,9 @@
+-- Testing big arrays.
+-- ==
+-- no_opencl compiled input { 2 1100000000 1 1073741823 } output { 255u8 }
+-- no_opencl compiled input { 3 1073741824 2 1073741823 } output { 255u8 }
+-- structure { Replicate 1 Iota 1 }
+
+let main (n: i32) (m: i32) (i: i32) (j: i32) =
+  -- The opaque is just to force manifestation.
+  (opaque (replicate n (tabulate m (\i -> u8.i32 i))))[i,j]

--- a/tests/intragroup/big0.fut
+++ b/tests/intragroup/big0.fut
@@ -1,0 +1,7 @@
+-- This needs more than 2**31 threads, but its input isn't that big.
+-- ==
+-- tags { no_python }
+-- compiled random input { [10000000]f32 } auto output
+
+let main (xs: []f32) =
+  map (\x -> iota 256 |> map r32 |> map (+x) |> scan (+) 0 |> f32.sum) xs


### PR DESCRIPTION
This is not a complete solution to #134, because individual array
dimensions must still fit in a signed 32-bit integer.  However, it
does allow the product of dimensions to be large.