### PR TITLE
Use inner parallelism when for intra-group threshold comparisons.

### DIFF
--- a/src/Futhark/CodeGen/Backends/CCUDA.hs
+++ b/src/Futhark/CodeGen/Backends/CCUDA.hs
@@ -204,7 +204,7 @@ callKernel (GetSizeMax v size_class) =
   let field = "max_" ++ cudaSizeClass size_class
   in GC.stm [C.cstm|$id:v = ctx->cuda.$id:field;|]
   where
-    cudaSizeClass (SizeThreshold _) = "threshold"
+    cudaSizeClass SizeThreshold{} = "threshold"
     cudaSizeClass SizeGroup = "block_size"
     cudaSizeClass SizeNumGroups = "grid_size"
     cudaSizeClass SizeTile = "tile_size"

--- a/src/Futhark/CodeGen/Backends/CCUDA/Boilerplate.hs
+++ b/src/Futhark/CodeGen/Backends/CCUDA/Boilerplate.hs
@@ -20,6 +20,7 @@ import Futhark.CodeGen.Backends.COpenCL.Boilerplate
 import Futhark.Util (chunk, zEncodeString)
 
 import qualified Data.Map as M
+import Data.Maybe
 import Data.FileEmbed (embedStringFile)
 
 errorMsgNumArgs :: ErrorMsg a -> Int
@@ -117,8 +118,7 @@ generateConfigFuns sizes = do
 
   let size_value_inits = zipWith sizeInit [0..M.size sizes-1] (M.elems sizes)
       sizeInit i size = [C.cstm|cfg->sizes[$int:i] = $int:val;|]
-         where val = case size of SizeBespoke _ x -> x
-                                  _               -> 0
+         where val = fromMaybe 0 $ sizeDefault size
   GC.publicDef_ "context_config_new" GC.InitDecl $ \s ->
     ([C.cedecl|struct $id:cfg* $id:s(void);|],
      [C.cedecl|struct $id:cfg* $id:s(void) {

--- a/src/Futhark/CodeGen/Backends/COpenCL/Boilerplate.hs
+++ b/src/Futhark/CodeGen/Backends/COpenCL/Boilerplate.hs
@@ -17,6 +17,7 @@ module Futhark.CodeGen.Backends.COpenCL.Boilerplate
 import Control.Monad.State
 import Data.FileEmbed
 import qualified Data.Map as M
+import Data.Maybe
 import qualified Language.C.Syntax as C
 import qualified Language.C.Quote.OpenCL as C
 
@@ -113,8 +114,7 @@ generateBoilerplate opencl_code opencl_prelude cost_centres kernels types sizes 
 
   let size_value_inits = zipWith sizeInit [0..M.size sizes-1] (M.elems sizes)
       sizeInit i size = [C.cstm|cfg->sizes[$int:i] = $int:val;|]
-         where val = case size of SizeBespoke _ x -> x
-                                  _               -> 0
+         where val = fromMaybe 0 $ sizeDefault size
   GC.publicDef_ "context_config_new" GC.InitDecl $ \s ->
     ([C.cedecl|struct $id:cfg* $id:s(void);|],
      [C.cedecl|struct $id:cfg* $id:s(void) {

--- a/src/Futhark/CodeGen/Backends/PyOpenCL/Boilerplate.hs
+++ b/src/Futhark/CodeGen/Backends/PyOpenCL/Boilerplate.hs
@@ -9,12 +9,13 @@ module Futhark.CodeGen.Backends.PyOpenCL.Boilerplate
 
 import Control.Monad.Identity
 import Data.FileEmbed
-import qualified Data.Map as M
+import Data.Maybe
 import qualified Data.Text as T
+import qualified Data.Map as M
 import NeatInterpolation (text)
 
 import Futhark.CodeGen.ImpCode.OpenCL
-  (PrimType(..), SizeClass(..),
+  (PrimType(..), SizeClass(..), sizeDefault,
    FailureMsg(..), ErrorMsg(..), ErrorMsgPart(..), errorMsgArgTypes)
 import Futhark.CodeGen.OpenCL.Heuristics
 import Futhark.CodeGen.Backends.GenericPython.AST
@@ -75,9 +76,8 @@ sizeClassesToPython = Dict . map f . M.toList
   where f (size_name, size_class) =
           (String $ pretty size_name,
            Dict [(String "class", String $ pretty size_class),
-                 (String "value", defValue size_class)])
-        defValue (SizeBespoke _ x) = Integer $ toInteger x
-        defValue _ = None
+                 (String "value", Integer $ fromIntegral $ fromMaybe 0 $
+                                  sizeDefault size_class)])
 
 sizeHeuristicsToPython :: [SizeHeuristic] -> PyExp
 sizeHeuristicsToPython = List . map f

--- a/src/Futhark/CodeGen/ImpGen/Kernels.hs
+++ b/src/Futhark/CodeGen/ImpGen/Kernels.hs
@@ -120,8 +120,8 @@ opCompiler pat e =
   pretty pat ++ "\nfor expression\n  " ++ pretty e
 
 sizeClassWithEntryPoint :: Maybe Name -> Imp.SizeClass -> Imp.SizeClass
-sizeClassWithEntryPoint fname (Imp.SizeThreshold path) =
-  Imp.SizeThreshold $ map f path
+sizeClassWithEntryPoint fname (Imp.SizeThreshold path def) =
+  Imp.SizeThreshold (map f path) def
   where f (name, x) = (keyWithEntryPoint fname name, x)
 sizeClassWithEntryPoint _ size_class = size_class
 

--- a/src/Futhark/CodeGen/ImpGen/Kernels/ToOpenCL.hs
+++ b/src/Futhark/CodeGen/ImpGen/Kernels/ToOpenCL.hs
@@ -78,8 +78,8 @@ translateKernels target prog =
 cleanSizes :: M.Map Name SizeClass -> M.Map Name SizeClass
 cleanSizes m = M.map clean m
   where known = M.keys m
-        clean (SizeThreshold path) =
-          SizeThreshold $ filter ((`elem` known) . fst) path
+        clean (SizeThreshold path def) =
+          SizeThreshold (filter ((`elem` known) . fst) path) def
         clean s = s
 
 pointerQuals ::  Monad m => String -> m [C.TypeQual]


### PR DESCRIPTION
Makes the default threshold generated for intra-group much smaller (32).

This is based on the principle that intra-group is always worth using
(at least by default), as long as the groups are not too tiny.