### PR TITLE
Revert "Stricter type checking."

### DIFF
--- a/src/Futhark/TypeCheck.hs
+++ b/src/Futhark/TypeCheck.hs
@@ -507,18 +507,9 @@ funParamsToNameInfos = map nameTypeAndLore
 
 checkFunParams :: Checkable lore =>
                   [FParam lore] -> TypeM lore ()
-checkFunParams params = foldM_ check mempty params
-  where param_bound = namesFromList $ map paramName params
-        check prev param =
-          context ("In function parameter " ++ pretty param) $ do
-            checkFParamLore (paramName param) (paramDec param)
-            case namesToList $
-                 (freeIn param `namesIntersection` param_bound)
-                 `namesSubtract` prev of
-              [] -> return ()
-              v:_ ->
-                bad $ TypeError $ pretty v ++ " bound in a later parameter."
-            return $ oneName (paramName param) <> prev
+checkFunParams = mapM_ $ \param ->
+  context ("In function parameter " ++ pretty param) $
+    checkFParamLore (paramName param) (paramDec param)
 
 checkLambdaParams :: Checkable lore =>
                      [LParam lore] -> TypeM lore ()


### PR DESCRIPTION
This reverts commit 0abf01a3e0c623351b25f9b4d18d4d2aa01584b1.

This was to work around limitations in inlining, but I don't think
this is the right way to go about it.  And in fact, the problem goes
away if you apply copy propagation after inlining, which we do now.