### PR TITLE
Add sexp-based representation for Futhark IR

### DIFF
--- a/futhark.cabal
+++ b/futhark.cabal
@@ -286,6 +286,7 @@ library
     , process >=1.4.3.0
     , process-extras >=0.7.2
     , regex-tdfa >=1.2
+    , sexp-grammar >= 2.2.1
     , srcloc >=0.4
     , template-haskell >=2.11.1
     , temporary
@@ -342,6 +343,7 @@ test-suite unit
     , megaparsec
     , mtl
     , parser-combinators
+    , sexp-grammar
     , tasty
     , tasty-hunit
     , tasty-quickcheck

--- a/futhark.nix
+++ b/futhark.nix
@@ -3,11 +3,11 @@
 , directory-tree, dlist, file-embed, filepath, free, gitrev, happy
 , haskeline, language-c-quote, mainland-pretty, megaparsec, mtl
 , neat-interpolation, parallel, parser-combinators, pcg-random
-, process, process-extras, QuickCheck, regex-tdfa, srcloc, stdenv
-, tasty, tasty-hunit, tasty-quickcheck, template-haskell, temporary
-, terminal-size, text, time, transformers, unordered-containers
-, utf8-string, vector, vector-binary-instances, versions
-, zip-archive, zlib
+, process, process-extras, QuickCheck, regex-tdfa, sexp-grammar_2_2_1
+, srcloc, stdenv, tasty, tasty-hunit, tasty-quickcheck
+, template-haskell, temporary, terminal-size, text, time
+, transformers, unordered-containers, utf8-string, vector
+, vector-binary-instances, versions, zip-archive, zlib
 }:
 mkDerivation {
   pname = "futhark";
@@ -20,16 +20,16 @@ mkDerivation {
     cmark-gfm containers directory directory-tree dlist file-embed
     filepath free gitrev haskeline language-c-quote mainland-pretty
     megaparsec mtl neat-interpolation parallel pcg-random process
-    process-extras regex-tdfa srcloc template-haskell temporary
-    terminal-size text time transformers unordered-containers
+    process-extras regex-tdfa sexp-grammar_2_2_1 srcloc template-haskell
+    temporary terminal-size text time transformers unordered-containers
     utf8-string vector vector-binary-instances versions zip-archive
     zlib
   ];
   libraryToolDepends = [ alex happy ];
   executableHaskellDepends = [ base text ];
   testHaskellDepends = [
-    base containers megaparsec mtl parser-combinators QuickCheck tasty
-    tasty-hunit tasty-quickcheck text
+    base containers megaparsec mtl parser-combinators QuickCheck
+    sexp-grammar_2_2_1 tasty tasty-hunit tasty-quickcheck text
   ];
   homepage = "https://futhark-lang.org";
   description = "An optimising compiler for a functional, array-oriented language";

--- a/src/Futhark/Actions.hs
+++ b/src/Futhark/Actions.hs
@@ -9,14 +9,17 @@ module Futhark.Actions
   , compileCAction
   , compileOpenCLAction
   , compileCUDAAction
+  , sexpAction
   )
 where
 
+import Language.SexpGrammar as Sexp
 import Control.Monad
 import Control.Monad.IO.Class
 import System.Exit
 import System.FilePath
 import qualified System.Info
+import qualified Data.ByteString.Lazy.Char8 as ByteString
 
 import Futhark.Compiler.CLI
 import Futhark.Analysis.Alias
@@ -63,6 +66,26 @@ kernelImpCodeGenAction =
          , actionDescription = "Translate program into imperative IL with kernels and write it on standard output."
          , actionProcedure = liftIO . putStrLn . pretty . snd <=< ImpGenKernels.compileProgOpenCL
          }
+
+-- | Print metrics about AST node counts to stdout.
+sexpAction :: ASTLore lore => Action lore
+sexpAction =
+  Action { actionName = "Print sexps"
+         , actionDescription = "Print sexps on the final IR."
+         , actionProcedure = liftIO . helper
+         }
+  where
+    helper :: ASTLore lore => Prog lore -> IO ()
+    helper prog =
+      case encodePretty prog of
+        Right prog' -> do
+          ByteString.putStrLn prog'
+          let prog'' = decode prog'
+          unless (prog'' == Right prog) $
+            error $ "S-exp not isomorph!\n" ++
+            either show pretty prog''
+        Left s ->
+          error $ "Couldn't encode program: " ++ s
 
 -- | The @futhark c@ action.
 compileCAction :: FutharkConfig -> CompilerMode -> FilePath -> Action SeqMem

--- a/src/Futhark/CLI/Dev.hs
+++ b/src/Futhark/CLI/Dev.hs
@@ -1,13 +1,16 @@
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeApplications #-}
 -- | Futhark Compiler Driver
 module Futhark.CLI.Dev (main) where
 
+import qualified Data.ByteString.Lazy as ByteString
 import Data.Maybe
 import Data.List (intersperse)
 import Control.Category (id)
 import Control.Monad
 import Control.Monad.State
 import qualified Data.Text.IO as T
+import qualified Language.SexpGrammar as Sexp
 import System.IO
 import System.Exit
 import System.Console.GetOpt
@@ -341,6 +344,11 @@ commandLineOptions =
     (NoArg $ Right $ \opts ->
         opts { futharkAction = PolyAction $ AllActions metricsAction metricsAction metricsAction metricsAction metricsAction })
     "Print AST metrics of the resulting internal representation on standard output."
+  , Option [] ["sexp"]
+    (NoArg $ Right $ \opts ->
+        opts { futharkAction = PolyAction $ AllActions sexpAction sexpAction sexpAction sexpAction sexpAction
+             })
+    "Print the resulting IR as S-expressions to standard output."
   , Option [] ["defunctorise"]
     (NoArg $ Right $ \opts -> opts { futharkPipeline = Defunctorise })
     "Partially evaluate all module constructs and print the residual program."
@@ -445,9 +453,31 @@ main = mainWithOptions newConfig commandLineOptions "options... program" compile
                 Defunctorise.transformProg imports
                 >>= Monomorphise.transformProg
                 >>= Defunctionalise.transformProg
-            Pipeline{} -> do
-              prog <- runPipelineOnProgram (futharkConfig config) id file
-              runPolyPasses config (file `replaceExtension` "") (SOACS prog)
+            Pipeline{} ->
+              case splitExtensions file of
+                (base, ".fut") -> do
+                  prog <- runPipelineOnProgram (futharkConfig config) id file
+                  runPolyPasses config base (SOACS prog)
+                (base, ".sexp") -> do
+                  input <- liftIO $ ByteString.readFile file
+                  prog <- case Sexp.decode @(Prog SOACS.SOACS) input of
+                        Right prog' -> return $ SOACS prog'
+                        Left _ ->
+                          case Sexp.decode @(Prog Kernels.Kernels) input of
+                            Right prog' -> return $ Kernels prog'
+                            Left _ ->
+                              case Sexp.decode @(Prog Seq.Seq) input of
+                                Right prog' -> return $ Seq prog'
+                                Left _ ->
+                                  case Sexp.decode @(Prog KernelsMem.KernelsMem) input of
+                                    Right prog' -> return $ KernelsMem prog'
+                                    Left _ ->
+                                      case Sexp.decode @(Prog SeqMem.SeqMem) input of
+                                        Right prog' -> return $ SeqMem prog'
+                                        Left e -> externalErrorS $ "Couldn't parse sexp input: " ++ show e
+                  runPolyPasses config base prog
+                (_, ext) ->
+                  externalErrorS $ unwords ["Unsupported extension", show ext, ". Supported extensions: sexp, fut"]
 
 runPolyPasses :: Config -> FilePath -> UntypedPassState -> FutharkM ()
 runPolyPasses config base initial_prog = do

--- a/src/Futhark/IR/Aliases.hs
+++ b/src/Futhark/IR/Aliases.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -38,6 +40,9 @@ module Futhark.IR.Aliases
        )
 where
 
+import GHC.Generics
+import Language.SexpGrammar as Sexp
+import Language.SexpGrammar.Generic
 import Control.Monad.Identity
 import Control.Monad.Reader
 import Data.Maybe
@@ -60,7 +65,10 @@ data Aliases lore
 -- | A wrapper around 'AliasDec to get around the fact that we need an
 -- 'Ord' instance, which 'AliasDec does not have.
 newtype AliasDec = AliasDec { unAliases :: Names }
-               deriving (Show)
+               deriving (Show, Generic)
+
+instance SexpIso AliasDec where
+  sexpIso = with $ \vname -> sexpIso >>> vname
 
 instance Semigroup AliasDec where
   x <> y = AliasDec $ unAliases x <> unAliases y

--- a/src/Futhark/IR/Decorations.hs
+++ b/src/Futhark/IR/Decorations.hs
@@ -9,6 +9,7 @@ module Futhark.IR.Decorations
 
 import qualified Data.Kind
 
+import Language.SexpGrammar (SexpIso)
 import Futhark.IR.Syntax.Core
 import Futhark.IR.RetType
 import Futhark.IR.Prop.Types
@@ -21,7 +22,8 @@ class (Show (LetDec l), Show (ExpDec l), Show (BodyDec l), Show (FParamInfo l), 
        Ord (LetDec l), Ord (ExpDec l), Ord (BodyDec l), Ord (FParamInfo l), Ord (LParamInfo l), Ord (RetType l), Ord (BranchType l), Ord (Op l),
        IsRetType (RetType l), IsBodyType (BranchType l),
        Typed (FParamInfo l), Typed (LParamInfo l), Typed (LetDec l),
-       DeclTyped (FParamInfo l))
+       DeclTyped (FParamInfo l),
+       SexpIso (LetDec l), SexpIso (ExpDec l), SexpIso (BodyDec l), SexpIso (FParamInfo l), SexpIso (LParamInfo l), SexpIso (RetType l), SexpIso (BranchType l), SexpIso (Op l))
       => Decorations l where
   -- | Decoration for every let-pattern element.
   type LetDec l :: Data.Kind.Type

--- a/src/Futhark/IR/Prop.hs
+++ b/src/Futhark/IR/Prop.hs
@@ -43,6 +43,7 @@ module Futhark.IR.Prop
   )
   where
 
+import Language.SexpGrammar as Sexp
 import Data.List (find)
 import Data.Maybe (mapMaybe, isJust)
 import qualified Data.Map.Strict as M
@@ -200,7 +201,7 @@ certify cs1 (Let pat (StmAux cs2 attrs dec) e) =
 -- | A handy shorthand for properties that we usually want to things
 -- we stuff into ASTs.
 type ASTConstraints a =
-  (Eq a, Ord a, Show a, Rename a, Substitute a, FreeIn a, Pretty a)
+  (Eq a, Ord a, Show a, Rename a, Substitute a, FreeIn a, Pretty a, SexpIso a)
 
 -- | A type class for operations.
 class (ASTConstraints op, TypedOp op) => IsOp op where

--- a/src/Futhark/IR/Prop/Names.hs
+++ b/src/Futhark/IR/Prop/Names.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleInstances, FlexibleContexts, UndecidableInstances #-}
+{-# LANGUAGE FlexibleInstances, FlexibleContexts, UndecidableInstances, DeriveGeneric, Safe #-}
 -- | Facilities for determining which names are used in some syntactic
 -- construct.  The most important interface is the 'FreeIn' class and
 -- its instances, but for reasons related to the Haskell type system,
@@ -34,6 +34,11 @@ module Futhark.IR.Prop.Names
        )
        where
 
+import Prelude hiding ((.), id)
+import Control.Category
+import GHC.Generics
+import Language.SexpGrammar as Sexp
+import Language.SexpGrammar.Generic
 import Control.Monad.State.Strict
 import qualified Data.IntMap.Strict as IM
 import qualified Data.Map.Strict as M
@@ -48,7 +53,12 @@ import Futhark.Util.Pretty
 -- | A set of names.  Note that the 'Ord' instance is a dummy that
 -- treats everything as 'EQ' if '==', and otherwise 'LT'.
 newtype Names = Names (IM.IntMap VName)
-              deriving (Eq, Show)
+              deriving (Eq, Show, Generic)
+
+instance SexpIso Names where
+  sexpIso = with $ \names ->
+    (iso IM.fromList IM.toList . sexpIso) >>> names
+
 
 -- | Retrieve the data structure underlying the names representation.
 namesIntMap :: Names -> IM.IntMap VName

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,6 +3,8 @@ packages:
 - .
 
 extra-deps:
+  - sexp-grammar-2.2.1@sha256:a05a86f83e7d1d9767fbc1b0cba7859455a10c6365173b72c10f5b0e93140a50,2473
+  - invertible-grammar-0.1.3@sha256:aeae40093db800e1130b8f58ae47f4474b131c22d830913d1051d1ab083f6f13,1651
 
 flags: {}
 


### PR DESCRIPTION
The purpose of this PR is to allow users to inspect and modify the IR of a program using `futhark dev`. 

We introduce a number of new features to `futhark dev`:

 - Writing the output result as an sexp using the `--sexp` flag.
 - When reading files, `futhark dev` will distinguish between files ending in `.fut` and files ending in `.sexp`. If a file ends in `.sexp`, `futhark dev` will use the sexp based decoder to decode the IR in the file.
 - Added `--compile-opencl` and `--compile-c` flags, to allow users to compile modified IR using the sexp based notation.

There is plenty of room for improvement in the representation that I've made, and sexp-grammar should allow for a much nicer language than what we have now, but I wanted to get this merged so I can actually start using it in my interference tests.

There also isn't a whole lot of testing in place to actually make sure the IR representation is actually bidirectional. However, `futhark dev --sexp` will make sure that any encoded program is also decodeable, and that the decoded program is identical to the original program.