### PR TITLE
Fix build warning on MacOS

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -14,4 +14,4 @@ nix:
 # By default, stack doesn't compile multiple modules in parallel.
 # This makes it do so.
 ghc-options:
-  $locals: -j
+  $locals: -j -optP-Wno-nonportable-include-path


### PR DESCRIPTION
When building from source on Mac with Stack there is a build warning.

```~/CS/forks/futhark/src$ stack build
futhark-0.17.0: unregistering (local file changes: src/futhark.hs)
futhark> configure (lib + exe)
Configuring futhark-0.17.0...
futhark> build (lib + exe)
Preprocessing library for futhark-0.17.0..
Building library for futhark-0.17.0..
Preprocessing executable 'futhark' for futhark-0.17.0..
Building executable 'futhark' for futhark-0.17.0..

/Users/philiplassen/CS/forks/futhark/<built-in>:15:10: error:
     warning: non-portable path to file '".stack-work/dist/x86_64-osx/Cabal-3.0.1.0/build/Futhark/autogen/cabal_macros.h"'; specified path differs in case from file name on disk [-Wnonportable-include-path]
#include ".stack-work/dist/x86_64-osx/Cabal-3.0.1.0/build/futhark/autogen/cabal_macros.h"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         ".stack-work/dist/x86_64-osx/Cabal-3.0.1.0/build/Futhark/autogen/cabal_macros.h"
1 warning generated.
[2 of 2] Compiling Main

/Users/philiplassen/CS/forks/futhark/<built-in>:15:10: error:
     warning: non-portable path to file '".stack-work/dist/x86_64-osx/Cabal-3.0.1.0/build/Futhark/autogen/cabal_macros.h"'; specified path differs in case from file name on disk [-Wnonportable-include-path]
#include ".stack-work/dist/x86_64-osx/Cabal-3.0.1.0/build/futhark/autogen/cabal_macros.h"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         ".stack-work/dist/x86_64-osx/Cabal-3.0.1.0/build/Futhark/autogen/cabal_macros.h"
1 warning generated.
Linking .stack-work/dist/x86_64-osx/Cabal-3.0.1.0/build/futhark/futhark ...
futhark> copy/register
Installing library in /Users/philiplassen/CS/forks/futhark/.stack-work/install/x86_64-osx/49dd8236ee2bb8f60c628223f1957502b33126e47a5714e822e79f59545c8d8e/8.8.3/lib/x86_64-osx-ghc-8.8.3/futhark-0.17.0-CsLhTrlSOIU6XYF8t8rP2x
Installing executable futhark in /Users/philiplassen/CS/forks/futhark/.stack-work/install/x86_64-osx/49dd8236ee2bb8f60c628223f1957502b33126e47a5714e822e79f59545c8d8e/8.8.3/bin
Registering library for futhark-0.17.0..
```

This seems to be a known problem with building with GHC on Mac due to its  case-insensitive file system (https://github.com/haskell/cabal/issues/4739). Specifically src/futhark.hs and the src/Futhark/ folder create the warning.  I added the flag ```-optP-Wno-nonportable-include-path``` to the ```ghc-options``` in ```stack.yml``` that the comments in the issue discussion suggested to solve the problem. With the addition of the new flag there are no warnings when building with stack on Mac. Example when building with new flag added below.

```
stack build
futhark-0.17.0: unregistering (local file changes: src/futhark.hs)
futhark> configure (lib + exe)
Configuring futhark-0.17.0...
futhark> build (lib + exe)
Preprocessing library for futhark-0.17.0..
Building library for futhark-0.17.0..
Preprocessing executable 'futhark' for futhark-0.17.0..
Building executable 'futhark' for futhark-0.17.0..
[2 of 2] Compiling Main
Linking .stack-work/dist/x86_64-osx/Cabal-3.0.1.0/build/futhark/futhark ...
futhark> copy/register
Installing library in /Users/philiplassen/CS/forks/futhark/.stack-work/install/x86_64-osx/49dd8236ee2bb8f60c628223f1957502b33126e47a5714e822e79f59545c8d8e/8.8.3/lib/x86_64-osx-ghc-8.8.3/futhark-0.17.0-CsLhTrlSOIU6XYF8t8rP2x
Installing executable futhark in /Users/philiplassen/CS/forks/futhark/.stack-work/install/x86_64-osx/49dd8236ee2bb8f60c628223f1957502b33126e47a5714e822e79f59545c8d8e/8.8.3/bin
Registering library for futhark-0.17.0..
```