### PR TITLE
Update nix scripts

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -13,12 +13,7 @@ let
   futhark =
     pkgs.haskell.lib.overrideCabal
       (pkgs.haskell.lib.addBuildTools
-        (pkgs.haskell.packages.${compiler}.callCabal2nix "futhark"
-          ( pkgs.lib.cleanSourceWith { filter = name: type:
-                                         baseNameOf (toString name) != "default.nix";
-                                       src = pkgs.lib.cleanSource ./.;
-                                     })
-          { })
+        (pkgs.haskell.packages.${compiler}.callPackage ./futhark.nix { })
         [ pkgs.python37Packages.sphinx ])
     ( _drv: {
       isLibrary = false;

--- a/futhark.nix
+++ b/futhark.nix
@@ -1,0 +1,37 @@
+{ mkDerivation, aeson, alex, ansi-terminal, array, base, binary
+, blaze-html, bytestring, cmark-gfm, containers, directory
+, directory-tree, dlist, file-embed, filepath, free, gitrev, happy
+, haskeline, language-c-quote, mainland-pretty, megaparsec, mtl
+, neat-interpolation, parallel, parser-combinators, pcg-random
+, process, process-extras, QuickCheck, regex-tdfa, srcloc, stdenv
+, tasty, tasty-hunit, tasty-quickcheck, template-haskell, temporary
+, terminal-size, text, time, transformers, unordered-containers
+, utf8-string, vector, vector-binary-instances, versions
+, zip-archive, zlib
+}:
+mkDerivation {
+  pname = "futhark";
+  version = "0.17.0";
+  src = ./.;
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    aeson ansi-terminal array base binary blaze-html bytestring
+    cmark-gfm containers directory directory-tree dlist file-embed
+    filepath free gitrev haskeline language-c-quote mainland-pretty
+    megaparsec mtl neat-interpolation parallel pcg-random process
+    process-extras regex-tdfa srcloc template-haskell temporary
+    terminal-size text time transformers unordered-containers
+    utf8-string vector vector-binary-instances versions zip-archive
+    zlib
+  ];
+  libraryToolDepends = [ alex happy ];
+  executableHaskellDepends = [ base text ];
+  testHaskellDepends = [
+    base containers megaparsec mtl parser-combinators QuickCheck tasty
+    tasty-hunit tasty-quickcheck text
+  ];
+  homepage = "https://futhark-lang.org";
+  description = "An optimising compiler for a functional, array-oriented language";
+  license = stdenv.lib.licenses.isc;
+}

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "f73bf8d584148677b01859677a63191c31911eae",
-        "sha256": "0jlmrx633jvqrqlyhlzpvdrnim128gc81q5psz2lpp2af8p8q9qs",
+        "rev": "89ae775e9dfc2571f912156dd2f8627e14d4d507",
+        "sha256": "0ssw6byyn79fpyzswi28s5b85x66xh4xsfhmcfl5mkdxxpmyy0ns",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/f73bf8d584148677b01859677a63191c31911eae.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/89ae775e9dfc2571f912156dd2f8627e14d4d507.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -17,10 +17,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs-channels",
-        "rev": "1357624fa9edff4add4c535c0606eb673f29966f",
-        "sha256": "0pgzh7xw9gp50akh7yzvyai68ph22jaf1lq4a5pvhq3g15pxga0m",
+        "rev": "13209156c191524437d5556bd8b24a132c4a899a",
+        "sha256": "06g21xf0nd0r2nziw72qk3vp8cd3vdy39snd44fir6j3fyjx1p98",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs-channels/archive/1357624fa9edff4add4c535c0606eb673f29966f.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs-channels/archive/13209156c191524437d5556bd8b24a132c4a899a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -12,36 +12,29 @@ let
     else
       pkgs.fetchurl { inherit (spec) url sha256; };
 
-  fetch_tarball = pkgs: spec:
-    if spec.builtin or true then
-      builtins_fetchTarball { inherit (spec) url sha256; }
-    else
-      pkgs.fetchzip { inherit (spec) url sha256; };
+  fetch_tarball = pkgs: name: spec:
+    let
+      ok = str: ! builtins.isNull (builtins.match "[a-zA-Z0-9+-._?=]" str);
+      # sanitize the name, though nix will still fail if name starts with period
+      name' = stringAsChars (x: if ! ok x then "-" else x) "${name}-src";
+    in
+      if spec.builtin or true then
+        builtins_fetchTarball { name = name'; inherit (spec) url sha256; }
+      else
+        pkgs.fetchzip { name = name'; inherit (spec) url sha256; };
 
   fetch_git = spec:
     builtins.fetchGit { url = spec.repo; inherit (spec) rev ref; };
 
-  fetch_builtin-tarball = spec:
-    builtins.trace
-      ''
-        WARNING:
-          The niv type "builtin-tarball" will soon be deprecated. You should
-          instead use `builtin = true`.
+  fetch_local = spec: spec.path;
 
-          $ niv modify <package> -a type=tarball -a builtin=true
-      ''
-      builtins_fetchTarball { inherit (spec) url sha256; };
+  fetch_builtin-tarball = name: throw
+    ''[${name}] The niv type "builtin-tarball" is deprecated. You should instead use `builtin = true`.
+        $ niv modify ${name} -a type=tarball -a builtin=true'';
 
-  fetch_builtin-url = spec:
-    builtins.trace
-      ''
-        WARNING:
-          The niv type "builtin-url" will soon be deprecated. You should
-          instead use `builtin = true`.
-
-          $ niv modify <package> -a type=file -a builtin=true
-      ''
-      (builtins_fetchurl { inherit (spec) url sha256; });
+  fetch_builtin-url = name: throw
+    ''[${name}] The niv type "builtin-url" will soon be deprecated. You should instead use `builtin = true`.
+        $ niv modify ${name} -a type=file -a builtin=true'';
 
   #
   # Various helpers
@@ -72,12 +65,22 @@ let
     if ! builtins.hasAttr "type" spec then
       abort "ERROR: niv spec ${name} does not have a 'type' attribute"
     else if spec.type == "file" then fetch_file pkgs spec
-    else if spec.type == "tarball" then fetch_tarball pkgs spec
+    else if spec.type == "tarball" then fetch_tarball pkgs name spec
     else if spec.type == "git" then fetch_git spec
-    else if spec.type == "builtin-tarball" then fetch_builtin-tarball spec
-    else if spec.type == "builtin-url" then fetch_builtin-url spec
+    else if spec.type == "local" then fetch_local spec
+    else if spec.type == "builtin-tarball" then fetch_builtin-tarball name
+    else if spec.type == "builtin-url" then fetch_builtin-url name
     else
       abort "ERROR: niv spec ${name} has unknown type ${builtins.toJSON spec.type}";
+
+  # If the environment variable NIV_OVERRIDE_${name} is set, then use
+  # the path directly as opposed to the fetched source.
+  replace = name: drv:
+    let
+      saneName = stringAsChars (c: if isNull (builtins.match "[a-zA-Z0-9]" c) then "_" else c) name;
+      ersatz = builtins.getEnv "NIV_OVERRIDE_${saneName}";
+    in
+      if ersatz == "" then drv else ersatz;
 
   # Ports of functions for older nix versions
 
@@ -87,13 +90,23 @@ let
     listToAttrs (map (attr: { name = attr; value = f attr set.${attr}; }) (attrNames set))
   );
 
+  # https://github.com/NixOS/nixpkgs/blob/0258808f5744ca980b9a1f24fe0b1e6f0fecee9c/lib/lists.nix#L295
+  range = first: last: if first > last then [] else builtins.genList (n: first + n) (last - first + 1);
+
+  # https://github.com/NixOS/nixpkgs/blob/0258808f5744ca980b9a1f24fe0b1e6f0fecee9c/lib/strings.nix#L257
+  stringToCharacters = s: map (p: builtins.substring p 1 s) (range 0 (builtins.stringLength s - 1));
+
+  # https://github.com/NixOS/nixpkgs/blob/0258808f5744ca980b9a1f24fe0b1e6f0fecee9c/lib/strings.nix#L269
+  stringAsChars = f: s: concatStrings (map f (stringToCharacters s));
+  concatStrings = builtins.concatStringsSep "";
+
   # fetchTarball version that is compatible between all the versions of Nix
-  builtins_fetchTarball = { url, sha256 }@attrs:
+  builtins_fetchTarball = { url, name, sha256 }@attrs:
     let
       inherit (builtins) lessThan nixVersion fetchTarball;
     in
       if lessThan nixVersion "1.12" then
-        fetchTarball { inherit url; }
+        fetchTarball { inherit name url; }
       else
         fetchTarball attrs;
 
@@ -115,13 +128,13 @@ let
         then abort
           "The values in sources.json should not have an 'outPath' attribute"
         else
-          spec // { outPath = fetch config.pkgs name spec; }
+          spec // { outPath = replace name (fetch config.pkgs name spec); }
     ) config.sources;
 
   # The "config" used by the fetchers
   mkConfig =
-    { sourcesFile ? ./sources.json
-    , sources ? builtins.fromJSON (builtins.readFile sourcesFile)
+    { sourcesFile ? if builtins.pathExists ./sources.json then ./sources.json else null
+    , sources ? if isNull sourcesFile then {} else builtins.fromJSON (builtins.readFile sourcesFile)
     , pkgs ? mkPkgs sources
     }: rec {
       # The sources, i.e. the attribute set of spec name to spec
@@ -130,5 +143,6 @@ let
       # The "pkgs" (evaluated nixpkgs) to use for e.g. non-builtin fetchers
       inherit pkgs;
     };
+
 in
 mkSources (mkConfig {}) // { __functor = _: settings: mkSources (mkConfig settings); }

--- a/shell.nix
+++ b/shell.nix
@@ -17,5 +17,6 @@ pkgs.stdenv.mkDerivation {
     pkgs.pkgconfig
     pkgs.zlib
     pkgs.zlib.out
+    pkgs.cabal2nix
   ];
 }

--- a/src/Language/Futhark/Interpreter.hs
+++ b/src/Language/Futhark/Interpreter.hs
@@ -1354,7 +1354,7 @@ initialCtx =
         _ ->
           error $ "Invalid arguments to map intrinsic:\n" ++
           unlines [pretty t, pretty v]
-      where typeRowShape = traverse id . structTypeShape mempty . stripArray 1
+      where typeRowShape = sequenceA . structTypeShape mempty . stripArray 1
 
     def s | "reduce" `isPrefixOf` s = Just $ fun3t $ \f ne xs ->
       foldM (apply2 noLoc mempty f) ne $ snd $ fromArray xs


### PR DESCRIPTION
Update sources, niv script, and use manually generated futhark.nix file instead of relying on callCabal2Nix. Needed for #1078.