### PR TITLE
Add ghcid to shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -18,5 +18,6 @@ pkgs.stdenv.mkDerivation {
     pkgs.zlib
     pkgs.zlib.out
     pkgs.cabal2nix
+    pkgs.ghcid
   ];
 }


### PR DESCRIPTION
ghcid is an alternative to a full IDE environment. When running, it
incrementally builds futhark every time you make a change.