### PR TITLE
Use cache-oblivious transpose on CPU.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
   * Obscure loop optimisation (#1110).
 
+  * Faster matrix transposition in C backend.
+
 ### Removed
 
 ### Changed

--- a/futhark.cabal
+++ b/futhark.cabal
@@ -118,6 +118,7 @@ library
       Futhark.CodeGen.ImpGen.Kernels.Transpose
       Futhark.CodeGen.ImpGen.OpenCL
       Futhark.CodeGen.ImpGen.Sequential
+      Futhark.CodeGen.ImpGen.Transpose
       Futhark.CodeGen.OpenCL.Heuristics
       Futhark.CodeGen.SetDefaultSpace
       Futhark.Compiler

--- a/src/Futhark/CodeGen/ImpGen.hs
+++ b/src/Futhark/CodeGen/ImpGen.hs
@@ -71,6 +71,7 @@ module Futhark.CodeGen.ImpGen
     copyDWIMFix,
     copyElementWise,
     typeSize,
+    isMapTransposeCopy,
 
     -- * Constructing code.
     dLParams,
@@ -129,11 +130,11 @@ import Futhark.CodeGen.ImpCode
     withElemType,
   )
 import qualified Futhark.CodeGen.ImpCode as Imp
-import Futhark.Construct (fullSliceNum)
+import Futhark.CodeGen.ImpGen.Transpose
+import Futhark.Construct hiding (ToExp (..))
 import Futhark.IR.Mem
 import qualified Futhark.IR.Mem.IxFun as IxFun
 import Futhark.IR.SOACS (SOACS)
-import Futhark.MonadFreshNames
 import Futhark.Util
 import Futhark.Util.Loc (noLoc)
 import Language.Futhark.Warnings
@@ -1211,17 +1212,105 @@ copy bt dest destslice src srcslice = do
   cc <- asks envCopyCompiler
   cc bt dest destslice src srcslice
 
+-- | Is this copy really a mapping with transpose?
+isMapTransposeCopy ::
+  PrimType ->
+  MemLocation ->
+  Slice (Imp.TExp Int32) ->
+  MemLocation ->
+  Slice (Imp.TExp Int32) ->
+  Maybe
+    ( Imp.TExp Int32,
+      Imp.TExp Int32,
+      Imp.TExp Int32,
+      Imp.TExp Int32,
+      Imp.TExp Int32
+    )
+isMapTransposeCopy
+  bt
+  (MemLocation _ _ destIxFun)
+  destslice
+  (MemLocation _ _ srcIxFun)
+  srcslice
+    | Just (dest_offset, perm_and_destshape) <- IxFun.rearrangeWithOffset destIxFun' bt_size,
+      (perm, destshape) <- unzip perm_and_destshape,
+      Just src_offset <- IxFun.linearWithOffset srcIxFun' bt_size,
+      Just (r1, r2, _) <- isMapTranspose perm =
+      isOk destshape swap r1 r2 dest_offset src_offset
+    | Just dest_offset <- IxFun.linearWithOffset destIxFun' bt_size,
+      Just (src_offset, perm_and_srcshape) <- IxFun.rearrangeWithOffset srcIxFun' bt_size,
+      (perm, srcshape) <- unzip perm_and_srcshape,
+      Just (r1, r2, _) <- isMapTranspose perm =
+      isOk srcshape id r1 r2 dest_offset src_offset
+    | otherwise =
+      Nothing
+    where
+      bt_size = primByteSize bt
+      swap (x, y) = (y, x)
+
+      destIxFun' = IxFun.slice destIxFun destslice
+      srcIxFun' = IxFun.slice srcIxFun srcslice
+
+      isOk shape f r1 r2 dest_offset src_offset = do
+        let (num_arrays, size_x, size_y) = getSizes shape f r1 r2
+        return
+          ( dest_offset,
+            src_offset,
+            num_arrays,
+            size_x,
+            size_y
+          )
+
+      getSizes shape f r1 r2 =
+        let (mapped, notmapped) = splitAt r1 shape
+            (pretrans, posttrans) = f $ splitAt r2 notmapped
+         in (product mapped, product pretrans, product posttrans)
+
+mapTransposeName :: PrimType -> String
+mapTransposeName bt = "map_transpose_" ++ pretty bt
+
+mapTransposeForType :: PrimType -> ImpM lore r op Name
+mapTransposeForType bt = do
+  let fname = nameFromString $ "builtin#" <> mapTransposeName bt
+
+  exists <- hasFunction fname
+  unless exists $ emitFunction fname $ mapTransposeFunction fname bt
+
+  return fname
+
 -- | Use an 'Imp.Copy' if possible, otherwise 'copyElementWise'.
 defaultCopy :: CopyCompiler lore r op
-defaultCopy bt dest destslice src srcslice
+defaultCopy pt dest destslice src srcslice
+  | Just
+      ( destoffset,
+        srcoffset,
+        num_arrays,
+        size_x,
+        size_y
+        ) <-
+      isMapTransposeCopy pt dest destslice src srcslice = do
+    fname <- mapTransposeForType pt
+    emit $
+      Imp.Call
+        []
+        fname
+        $ transposeArgs
+          pt
+          destmem
+          (bytes $ sExt64 destoffset)
+          srcmem
+          (bytes $ sExt64 srcoffset)
+          (sExt64 num_arrays)
+          (sExt64 size_x)
+          (sExt64 size_y)
   | Just destoffset <-
-      IxFun.linearWithOffset (IxFun.slice dest_ixfun64 destslice64) bt_size,
+      IxFun.linearWithOffset (IxFun.slice dest_ixfun64 destslice64) pt_size,
     Just srcoffset <-
-      IxFun.linearWithOffset (IxFun.slice src_ixfun64 srcslice64) bt_size = do
+      IxFun.linearWithOffset (IxFun.slice src_ixfun64 srcslice64) pt_size = do
     srcspace <- entryMemSpace <$> lookupMemory srcmem
     destspace <- entryMemSpace <$> lookupMemory destmem
     if isScalarSpace srcspace || isScalarSpace destspace
-      then copyElementWise bt dest destslice src srcslice
+      then copyElementWise pt dest destslice src srcslice
       else
         emit $
           Imp.Copy
@@ -1231,11 +1320,11 @@ defaultCopy bt dest destslice src srcslice
             srcmem
             (bytes srcoffset)
             srcspace
-            $ num_elems `withElemType` bt
+            $ num_elems `withElemType` pt
   | otherwise =
-    copyElementWise bt dest destslice src srcslice
+    copyElementWise pt dest destslice src srcslice
   where
-    bt_size = primByteSize bt
+    pt_size = primByteSize pt
     num_elems = Imp.elements $ product $ sliceDims srcslice
 
     MemLocation destmem _ dest_ixfun = dest

--- a/src/Futhark/CodeGen/ImpGen/Kernels.hs
+++ b/src/Futhark/CodeGen/ImpGen/Kernels.hs
@@ -224,7 +224,7 @@ callKernelCopy
           size_x,
           size_y
           ) <-
-        isMapTransposeKernel bt destloc destslice srcloc srcslice = do
+        isMapTransposeCopy bt destloc destslice srcloc srcslice = do
       fname <- mapTransposeForType bt
       emit $
         Imp.Call
@@ -267,7 +267,7 @@ mapTransposeForType bt = do
   return fname
 
 mapTransposeName :: PrimType -> String
-mapTransposeName bt = "map_transpose_" ++ pretty bt
+mapTransposeName bt = "gpu_map_transpose_" ++ pretty bt
 
 mapTransposeFunction :: PrimType -> Imp.Function
 mapTransposeFunction bt =
@@ -387,56 +387,3 @@ mapTransposeFunction bt =
             block
           )
           bt
-
-isMapTransposeKernel ::
-  PrimType ->
-  MemLocation ->
-  Slice (Imp.TExp Int32) ->
-  MemLocation ->
-  Slice (Imp.TExp Int32) ->
-  Maybe
-    ( Imp.TExp Int32,
-      Imp.TExp Int32,
-      Imp.TExp Int32,
-      Imp.TExp Int32,
-      Imp.TExp Int32
-    )
-isMapTransposeKernel
-  bt
-  (MemLocation _ _ destIxFun)
-  destslice
-  (MemLocation _ _ srcIxFun)
-  srcslice
-    | Just (dest_offset, perm_and_destshape) <- IxFun.rearrangeWithOffset destIxFun' bt_size,
-      (perm, destshape) <- unzip perm_and_destshape,
-      Just src_offset <- IxFun.linearWithOffset srcIxFun' bt_size,
-      Just (r1, r2, _) <- isMapTranspose perm =
-      isOk destshape swap r1 r2 dest_offset src_offset
-    | Just dest_offset <- IxFun.linearWithOffset destIxFun' bt_size,
-      Just (src_offset, perm_and_srcshape) <- IxFun.rearrangeWithOffset srcIxFun' bt_size,
-      (perm, srcshape) <- unzip perm_and_srcshape,
-      Just (r1, r2, _) <- isMapTranspose perm =
-      isOk srcshape id r1 r2 dest_offset src_offset
-    | otherwise =
-      Nothing
-    where
-      bt_size = primByteSize bt
-      swap (x, y) = (y, x)
-
-      destIxFun' = IxFun.slice destIxFun destslice
-      srcIxFun' = IxFun.slice srcIxFun srcslice
-
-      isOk shape f r1 r2 dest_offset src_offset = do
-        let (num_arrays, size_x, size_y) = getSizes shape f r1 r2
-        return
-          ( dest_offset,
-            src_offset,
-            num_arrays,
-            size_x,
-            size_y
-          )
-
-      getSizes shape f r1 r2 =
-        let (mapped, notmapped) = splitAt r1 shape
-            (pretrans, posttrans) = f $ splitAt r2 notmapped
-         in (product mapped, product pretrans, product posttrans)

--- a/src/Futhark/CodeGen/ImpGen/Transpose.hs
+++ b/src/Futhark/CodeGen/ImpGen/Transpose.hs
@@ -1,0 +1,214 @@
+-- | A cache-oblivious sequential transposition for CPU execution.
+-- Generates a recursive function.
+module Futhark.CodeGen.ImpGen.Transpose
+  ( mapTransposeFunction,
+    transposeArgs,
+  )
+where
+
+import Futhark.CodeGen.ImpCode
+import Futhark.IR.Prop.Types
+import Futhark.Util.IntegralExp
+import Prelude hiding (quot)
+
+-- | Take well-typed arguments to the transpose function and produce
+-- the actual argument list.
+transposeArgs ::
+  PrimType ->
+  VName ->
+  Count Bytes (TExp Int64) ->
+  VName ->
+  Count Bytes (TExp Int64) ->
+  TExp Int64 ->
+  TExp Int64 ->
+  TExp Int64 ->
+  [Arg]
+transposeArgs pt destmem destoffset srcmem srcoffset num_arrays m n =
+  [ MemArg destmem,
+    ExpArg $ untyped $ unCount destoffset `quot` primByteSize pt,
+    MemArg srcmem,
+    ExpArg $ untyped $ unCount srcoffset `quot` primByteSize pt,
+    ExpArg $ untyped num_arrays,
+    ExpArg $ untyped m,
+    ExpArg $ untyped n,
+    ExpArg $ untyped (0 :: TExp Int64),
+    ExpArg $ untyped m,
+    ExpArg $ untyped (0 :: TExp Int64),
+    ExpArg $ untyped n
+  ]
+
+-- | We need to know the name of the function we are generating, as
+-- this function is recursive.
+mapTransposeFunction :: Name -> PrimType -> Function op
+mapTransposeFunction fname pt =
+  Function
+    False
+    []
+    params
+    ( mconcat
+        [ dec r $ vi64 re - vi64 rb,
+          dec c $ vi64 ce - vi64 cb,
+          If (vi64 num_arrays .==. 1) doTranspose doMapTranspose
+        ]
+    )
+    []
+    []
+  where
+    params =
+      [ memparam destmem,
+        intparam destoffset,
+        memparam srcmem,
+        intparam srcoffset,
+        intparam num_arrays,
+        intparam m,
+        intparam n,
+        intparam cb,
+        intparam ce,
+        intparam rb,
+        intparam re
+      ]
+
+    memparam v = MemParam v DefaultSpace
+    intparam v = ScalarParam v int64
+
+    [ destmem,
+      destoffset,
+      srcmem,
+      srcoffset,
+      num_arrays,
+      n,
+      m,
+      rb,
+      re,
+      cb,
+      ce,
+      r,
+      c,
+      i,
+      j
+      ] =
+        zipWith
+          (VName . nameFromString)
+          [ "destmem",
+            "destoffset",
+            "srcmem",
+            "srcoffset",
+            "num_arrays",
+            "n",
+            "m",
+            "rb",
+            "re",
+            "cb",
+            "ce",
+            "r",
+            "c",
+            "i",
+            "j" -- local
+          ]
+          [0 ..]
+
+    dec v e = DeclareScalar v Nonvolatile int32 <> SetScalar v (untyped e)
+
+    naiveTranspose =
+      For j (untyped $ vi64 c) $
+        For i (untyped $ vi64 r) $
+          let i' = vi64 i + vi64 rb
+              j' = vi64 j + vi64 cb
+           in Write
+                destmem
+                (elements $ vi64 destoffset + j' * vi64 n + i')
+                pt
+                DefaultSpace
+                Nonvolatile
+                $ index
+                  srcmem
+                  (elements $ vi64 srcoffset + i' * vi64 m + j')
+                  pt
+                  DefaultSpace
+                  Nonvolatile
+
+    recArgs (cb', ce', rb', re') =
+      [ MemArg destmem,
+        ExpArg $ untyped $ vi64 destoffset,
+        MemArg srcmem,
+        ExpArg $ untyped $ vi64 srcoffset,
+        ExpArg $ untyped $ vi64 num_arrays,
+        ExpArg $ untyped $ vi64 m,
+        ExpArg $ untyped $ vi64 n,
+        ExpArg $ untyped cb',
+        ExpArg $ untyped ce',
+        ExpArg $ untyped rb',
+        ExpArg $ untyped re'
+      ]
+
+    cutoff = 64 -- arbitrary
+    doTranspose =
+      mconcat
+        [ If
+            (vi64 r .<=. cutoff .&&. vi64 c .<=. cutoff)
+            naiveTranspose
+            $ If
+              (vi64 r .>=. vi64 c)
+              ( Call
+                  []
+                  fname
+                  ( recArgs
+                      ( vi64 cb,
+                        vi64 ce,
+                        vi64 rb,
+                        vi64 rb + (vi64 r `quot` 2)
+                      )
+                  )
+                  <> Call
+                    []
+                    fname
+                    ( recArgs
+                        ( vi64 cb,
+                          vi64 ce,
+                          vi64 rb + vi64 r `quot` 2,
+                          vi64 re
+                        )
+                    )
+              )
+              ( Call
+                  []
+                  fname
+                  ( recArgs
+                      ( vi64 cb,
+                        vi64 cb + (vi64 c `quot` 2),
+                        vi64 rb,
+                        vi64 re
+                      )
+                  )
+                  <> Call
+                    []
+                    fname
+                    ( recArgs
+                        ( vi64 cb + vi64 c `quot` 2,
+                          vi64 ce,
+                          vi64 rb,
+                          vi64 re
+                        )
+                    )
+              )
+        ]
+
+    doMapTranspose =
+      -- In the map-transpose case, we assume that cb==rb==0, ce==m,
+      -- re==n.
+      For i (untyped $ vi64 num_arrays) $
+        Call
+          []
+          fname
+          [ MemArg destmem,
+            ExpArg $ untyped $ vi64 destoffset + vi64 i * vi64 m * vi64 n,
+            MemArg srcmem,
+            ExpArg $ untyped $ vi64 srcoffset + vi64 i * vi64 m * vi64 n,
+            ExpArg $ untyped (1 :: TExp Int64),
+            ExpArg $ untyped $ vi64 m,
+            ExpArg $ untyped $ vi64 n,
+            ExpArg $ untyped $ vi64 cb,
+            ExpArg $ untyped $ vi64 ce,
+            ExpArg $ untyped $ vi64 rb,
+            ExpArg $ untyped $ vi64 re
+          ]


### PR DESCRIPTION
This is a good bit faster in many cases, but a bit slower for small
arrays.  Maybe we can special case those later.