### PR TITLE
delete gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.x linguist-language=Lex


### PR DESCRIPTION
I made a PR in Linguist that fixes the Logos misclassification of Lex files https://github.com/github/linguist/pull/4952. Version 7.11 was released a few days ago, so its functionality has now taken effect. 

So we no longer need the `.gitattributes` file

