### PR TITLE
Permit array indexing with any integer type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
   * Array creation C API functions now accept `const` pointers.
 
+  * Arrays can now be indexed with any signed integer type (#1122).
+
 ### Removed
 
 ### Changed

--- a/src/Language/Futhark/TypeChecker/Terms.hs
+++ b/src/Language/Futhark/TypeChecker/Terms.hs
@@ -2276,13 +2276,13 @@ checkIdent (Ident name _ loc) = do
 
 checkDimIndex :: DimIndexBase NoInfo Name -> TermTypeM DimIndex
 checkDimIndex (DimFix i) =
-  DimFix <$> (unifies "use as index" (Scalar $ Prim $ Signed Int32) =<< checkExp i)
+  DimFix <$> (require "use as index" anySignedType =<< checkExp i)
 checkDimIndex (DimSlice i j s) =
   DimSlice <$> check i <*> check j <*> check s
   where
     check =
       maybe (return Nothing) $
-        fmap Just . unifies "use as index" (Scalar $ Prim $ Signed Int32) <=< checkExp
+        fmap Just . require "use as index" anySignedType <=< checkExp
 
 sequentially :: TermTypeM a -> (a -> Occurences -> TermTypeM b) -> TermTypeM b
 sequentially m1 m2 = do
@@ -2520,7 +2520,7 @@ checkOneExp e = fmap fst . runTermTypeM $ do
   let t = toStruct $ typeOf e'
   (tparams, _, _, _) <-
     letGeneralise (nameFromString "<exp>") (srclocOf e) [] [] t
-  fixOverloadedTypes
+  fixOverloadedTypes $ typeVars t
   e'' <- updateTypes e'
   checkUnmatched e''
   causalityCheck e''
@@ -2708,7 +2708,8 @@ checkFunDef (fname, maybe_retdecl, tparams, params, body, loc) =
 
       -- Since this is a top-level function, we also resolve overloaded
       -- types, using either defaults or complaining about ambiguities.
-      fixOverloadedTypes
+      fixOverloadedTypes $
+        typeVars rettype' <> foldMap (typeVars . patternType) params'
 
       -- Then replace all inferred types in the body and parameters.
       body'' <- updateTypes body'
@@ -2735,18 +2736,21 @@ checkFunDef (fname, maybe_retdecl, tparams, params, body, loc) =
 
 -- | This is "fixing" as in "setting them", not "correcting them".  We
 -- only make very conservative fixing.
-fixOverloadedTypes :: TermTypeM ()
-fixOverloadedTypes = getConstraints >>= mapM_ fixOverloaded . M.toList . M.map snd
+fixOverloadedTypes :: Names -> TermTypeM ()
+fixOverloadedTypes tyvars_at_toplevel =
+  getConstraints >>= mapM_ fixOverloaded . M.toList . M.map snd
   where
     fixOverloaded (v, Overloaded ots usage)
       | Signed Int32 `elem` ots = do
         unify usage (Scalar (TypeVar () Nonunique (typeName v) [])) $
           Scalar $ Prim $ Signed Int32
-        warn usage "Defaulting ambiguous type to i32."
+        when (v `S.member` tyvars_at_toplevel) $
+          warn usage "Defaulting ambiguous type to i32."
       | FloatType Float64 `elem` ots = do
         unify usage (Scalar (TypeVar () Nonunique (typeName v) [])) $
           Scalar $ Prim $ FloatType Float64
-        warn usage "Defaulting ambiguous type to f64."
+        when (v `S.member` tyvars_at_toplevel) $
+          warn usage "Defaulting ambiguous type to f64."
       | otherwise =
         typeError usage mempty $
           "Type is ambiguous (could be one of" <+> commasep (map ppr ots) <> ")."


### PR DESCRIPTION
Also changes the rules for warning about type defaulting, so that only
types that propagate to the top-level binding are warned about.
Otherwise we would get an ambiguity warning for every instance of
`x[0]`.

Closes #1122.