### PR TITLE
Add error handling for bad file paths

### DIFF
--- a/src/Futhark/CLI/Datacmp.hs
+++ b/src/Futhark/CLI/Datacmp.hs
@@ -3,19 +3,31 @@
 -- | @futhark datacmp@
 module Futhark.CLI.Datacmp (main) where
 
+import Control.Exception
 import qualified Data.ByteString.Lazy.Char8 as BS
+import qualified Data.Text.IO as T
 import Futhark.Test.Values
 import Futhark.Util.Options
-import System.Directory
 import System.Exit
+import System.IO.Error
+
+doesFileExistSafely :: String -> IO Bool
+doesFileExistSafely filepath =
+  (T.readFile filepath >> return True) `catch` couldNotRead
+  where
+    couldNotRead e
+      | isDoesNotExistError e =
+        return False
+      | otherwise =
+        return True
 
 -- | Run @futhark datacmp@
 main :: String -> [String] -> IO ()
 main = mainWithOptions () [] "<file> <file>" f
   where
     f [file_a, file_b] () = Just $ do
-      aExists <- doesFileExist file_a
-      bExists <- doesFileExist file_b
+      aExists <- doesFileExistSafely file_a
+      bExists <- doesFileExistSafely file_b
       case (aExists, bExists) of
         (False, _) ->
           putStrLn $ "No such file : " ++ file_a

--- a/src/Futhark/CLI/Datacmp.hs
+++ b/src/Futhark/CLI/Datacmp.hs
@@ -5,37 +5,40 @@ module Futhark.CLI.Datacmp (main) where
 
 import Control.Exception
 import qualified Data.ByteString.Lazy.Char8 as BS
-import qualified Data.Text.IO as T
 import Futhark.Test.Values
 import Futhark.Util.Options
 import System.Exit
 import System.IO.Error
 
-doesFileExistSafely :: String -> IO Bool
-doesFileExistSafely filepath =
-  (T.readFile filepath >> return True) `catch` couldNotRead
+readFileSafely :: String -> IO (Maybe (Either String BS.ByteString))
+readFileSafely filepath =
+  (Just . Right <$> BS.readFile filepath) `catch` couldNotRead
   where
     couldNotRead e
       | isDoesNotExistError e =
-        return False
+        return Nothing
       | otherwise =
-        return True
+        return $ Just $ Left $ show e
 
 -- | Run @futhark datacmp@
 main :: String -> [String] -> IO ()
 main = mainWithOptions () [] "<file> <file>" f
   where
     f [file_a, file_b] () = Just $ do
-      aExists <- doesFileExistSafely file_a
-      bExists <- doesFileExistSafely file_b
-      case (aExists, bExists) of
-        (False, _) ->
+      file_contents_a_maybe <- readFileSafely file_a
+      file_contents_b_maybe <- readFileSafely file_b
+      case (file_contents_a_maybe, file_contents_b_maybe) of
+        (Nothing, _) ->
           putStrLn $ "No such file : " ++ file_a
-        (_, False) ->
+        (_, Nothing) ->
           putStrLn $ "No such file : " ++ file_b
-        (True, True) -> do
-          vs_a_maybe <- readValues <$> BS.readFile file_a
-          vs_b_maybe <- readValues <$> BS.readFile file_b
+        (Just (Left err_msg), _) ->
+          error $ err_msg ++ " when reading " ++ file_a
+        (_, Just (Left err_msg)) ->
+          error $ err_msg ++ " when reading " ++ file_b
+        (Just (Right contents_a), Just (Right contents_b)) -> do
+          let vs_a_maybe = readValues contents_a
+          let vs_b_maybe = readValues contents_b
           case (vs_a_maybe, vs_b_maybe) of
             (Nothing, _) ->
               error $ "Error reading values from " ++ file_a

--- a/src/Futhark/CLI/Datacmp.hs
+++ b/src/Futhark/CLI/Datacmp.hs
@@ -6,6 +6,7 @@ module Futhark.CLI.Datacmp (main) where
 import qualified Data.ByteString.Lazy.Char8 as BS
 import Futhark.Test.Values
 import Futhark.Util.Options
+import System.Directory
 import System.Exit
 
 -- | Run @futhark datacmp@
@@ -13,18 +14,26 @@ main :: String -> [String] -> IO ()
 main = mainWithOptions () [] "<file> <file>" f
   where
     f [file_a, file_b] () = Just $ do
-      vs_a_maybe <- readValues <$> BS.readFile file_a
-      vs_b_maybe <- readValues <$> BS.readFile file_b
-      case (vs_a_maybe, vs_b_maybe) of
-        (Nothing, _) ->
-          error $ "Error reading values from " ++ file_a
-        (_, Nothing) ->
-          error $ "Error reading values from " ++ file_b
-        (Just vs_a, Just vs_b) ->
-          case compareValues vs_a vs_b of
-            [] -> return ()
-            es -> do
-              mapM_ print es
-              exitWith $ ExitFailure 2
+      aExists <- doesFileExist file_a
+      bExists <- doesFileExist file_b
+      case (aExists, bExists) of
+        (False, _) ->
+          putStrLn $ "No such file : " ++ file_a
+        (_, False) ->
+          putStrLn $ "No such file : " ++ file_b
+        (True, True) -> do
+          vs_a_maybe <- readValues <$> BS.readFile file_a
+          vs_b_maybe <- readValues <$> BS.readFile file_b
+          case (vs_a_maybe, vs_b_maybe) of
+            (Nothing, _) ->
+              error $ "Error reading values from " ++ file_a
+            (_, Nothing) ->
+              error $ "Error reading values from " ++ file_b
+            (Just vs_a, Just vs_b) ->
+              case compareValues vs_a vs_b of
+                [] -> return ()
+                es -> do
+                  mapM_ print es
+                  exitWith $ ExitFailure 2
     f _ _ =
       Nothing


### PR DESCRIPTION
Added some error checking for the case where bad files are provided. The previous error message when a non-existent file path was provided was 
```
futhark datacmp test.data nonexistant.data
```
gives
```
Internal compiler error (unhandled IO exception).
Please report this at https://github.com/diku-dk/futhark/issues
nonexistant.data: openBinaryFile: does not exist (No such file or directory)
```
With the changes the same input gives the following message. 
```
futhark datacmp test.data nonexistant.data          
```
```
No such file : nonexistant.data
```
This omits the whole internal compiler error / please report thing