### PR TITLE
Change ctzl to ctzll

### DIFF
--- a/src/Futhark/CodeGen/Backends/SimpleRep.hs
+++ b/src/Futhark/CodeGen/Backends/SimpleRep.hs
@@ -588,7 +588,7 @@ $esc:("#else")
      return x == 0 ? 32 :  __builtin_ctz(x);
    }
    static typename int32_t $id:(funName' "ctz64") (typename int64_t x) {
-     return x == 0 ? 64 : __builtin_ctzl(x);
+     return x == 0 ? 64 : __builtin_ctzll(x);
    }
 $esc:("#endif")
                 |]


### PR DESCRIPTION
long long is guaranteed to at least be 64 bit. In Emscripten long is only 32 bit. This might also be useful in the case of other archaic platforms. 