### PR TITLE
I propose to merge the basic functionnal map into the mpi branch.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -228,7 +228,7 @@ jobs:
 
     - run: |
         futhark test -c --backend=c tests examples --no-tuning
-        make -C libtests/c
+        make -C libtests/c -j
 
   test-multicore:
     runs-on: ubuntu-20.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
   * Fixed local memory capacity check for intra-group-parallel GPU kernels.
 
+  * Fixed compiler bug on segmented rotates where the rotation amount
+    is variant to the nest (#1192).
+
+  * `futhark repl` no longer crashes on type errors in given file (#1193).
+
+  * Fixed a simplification error for certain arithmetic expressions
+    (#1194).
+
+  * Fixed a small uniqueness-related bug in the compilation of
+    operator section.
+
 ## [0.18.3]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+### Removed
+
+### Changed
+
+### Fixed
+
+## [0.18.4]
+
+### Added
+
   * When compiling to binaries in the C-based backends, the compiler
     now respects the ``CFLAGS`` and ``CC`` environment variables.
 
@@ -18,10 +28,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   * The `cuda` backend now uses a much faster single-pass `scan`
     implementation, although only for nonsegmented scans where the
     operator operates on scalars.
-
-### Removed
-
-### Changed
 
 ### Fixed
 
@@ -40,6 +46,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
   * Fixed a small uniqueness-related bug in the compilation of
     operator section.
+
+  * Sizes of opaque entry point arguments are now properly checked
+    (related to #1198).
 
 ## [0.18.3]
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src="assets/logo.svg" height="50px"/> The Futhark Programming Language
 ==========
 
-[![Join the chat at https://gitter.im/futhark-lang/Lobby](https://badges.gitter.im/futhark-lang/Lobby.svg)](https://gitter.im/futhark-lang/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)[![CI](https://github.com/diku-dk/futhark/workflows/CI/badge.svg)](https://github.com/diku-dk/futhark/actions)
+[![Join the chat at https://gitter.im/futhark-lang/Lobby](https://badges.gitter.im/futhark-lang/Lobby.svg)](https://gitter.im/futhark-lang/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)[![CI](https://github.com/diku-dk/futhark/workflows/CI/badge.svg)](https://github.com/diku-dk/futhark/actions)[![DOI](https://zenodo.org/badge/7960131.svg)](https://zenodo.org/badge/latestdoi/7960131)
 
 Futhark is a purely functional data-parallel programming language in
 the ML family.  It can be compiled to typically very efficient

--- a/futhark.cabal
+++ b/futhark.cabal
@@ -126,6 +126,8 @@ library
       Futhark.CodeGen.ImpGen.Kernels.ToOpenCL
       Futhark.CodeGen.ImpGen.Kernels.Transpose
       Futhark.CodeGen.ImpGen.MPI
+      Futhark.CodeGen.ImpGen.MPI.Base
+      Futhark.CodeGen.ImpGen.MPI.SegMap
       Futhark.CodeGen.ImpGen.Multicore
       Futhark.CodeGen.ImpGen.Multicore.Base
       Futhark.CodeGen.ImpGen.Multicore.SegHist

--- a/libtests/c/Makefile
+++ b/libtests/c/Makefile
@@ -16,13 +16,10 @@ endif
 
 .PHONY: test clean
 
-test: test_a test_b test_c test_d test_e test_f
-	./test_a
-	./test_b
-	./test_c
-	./test_d
-	./test_e
-	./test_f
+test: do_test_a do_test_b do_test_c do_test_d do_test_e do_test_f do_test_g
+
+do_test_%: test_%
+	./test_$*
 
 test_%: test_%.c %.o
 	gcc -o $@ $^ -Wall -Wextra -pedantic -std=c99 $(LDFLAGS) -lpthread

--- a/libtests/c/g.fut
+++ b/libtests/c/g.fut
@@ -1,0 +1,7 @@
+-- Test that size constraints on opaque types are respected.
+
+type vec [n] = {vec: [n]i64}
+
+entry mk_vec (n: i64) : vec [n] = {vec=iota n}
+
+entry use_vec [n] (x: vec [n]) (y: vec [n]) = i64.sum (map2 (+) x.vec y.vec)

--- a/libtests/c/test_g.c
+++ b/libtests/c/test_g.c
@@ -1,0 +1,43 @@
+#include "g.h"
+#include <stdlib.h>
+#include <assert.h>
+#include <stdio.h>
+
+int main() {
+  struct futhark_context_config *cfg = futhark_context_config_new();
+  struct futhark_context *ctx = futhark_context_new(cfg);
+
+  int err;
+
+  int64_t n = 1;
+  int64_t m = 1000;
+
+  struct futhark_opaque_vec *vec_n, *vec_m;
+
+  err = futhark_entry_mk_vec(ctx, &vec_n, n);
+  assert(err == 0);
+
+  err = futhark_entry_mk_vec(ctx, &vec_m, m);
+  assert(err == 0);
+
+  int64_t out = 42;
+  err = futhark_entry_use_vec(ctx, &out, vec_n, vec_n);
+  assert(err == 0);
+  assert(out == 0);
+
+  err = futhark_entry_use_vec(ctx, &out, vec_n, vec_m);
+  assert(err != 0);
+
+  char *err_s = futhark_context_get_error(ctx);
+  assert(err_s != NULL);
+  free(err_s);
+
+  err = futhark_free_opaque_vec(ctx, vec_n);
+  assert(err == 0);
+
+  err = futhark_free_opaque_vec(ctx, vec_m);
+  assert(err == 0);
+
+  futhark_context_free(ctx);
+  futhark_context_config_free(cfg);
+}

--- a/libtests/python/Makefile
+++ b/libtests/python/Makefile
@@ -2,8 +2,10 @@ FUTHARK_BACKEND ?= python
 
 .PHONY: test clean
 
-test: a.py
-	./test_a
+test: do_test_a do_test_g
+
+do_test_%: test_% %.py
+	./test_$*
 
 test_%: %.py
 

--- a/libtests/python/g.fut
+++ b/libtests/python/g.fut
@@ -1,0 +1,7 @@
+-- Test that size constraints on opaque types are respected.
+
+type vec [n] = {vec: [n]i64}
+
+entry mk_vec (n: i64) : vec [n] = {vec=iota n}
+
+entry use_vec [n] (x: vec [n]) (y: vec [n]) = i64.sum (map2 (+) x.vec y.vec)

--- a/libtests/python/test_g
+++ b/libtests/python/test_g
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+import g
+import numpy as np
+
+obj = g.g()
+
+n = 1
+m = 1000
+
+vec_n = obj.mk_vec(n)
+vec_m = obj.mk_vec(m)
+
+assert(obj.use_vec(vec_n, vec_n) == 0)
+
+try:
+    obj.use_vec(vec_n, vec_m) # Should fail.
+    assert(False)
+except Exception as e:
+    assert('size' in str(e))

--- a/rts/c/values.h
+++ b/rts/c/values.h
@@ -679,30 +679,30 @@ static int write_str_array(FILE *out,
     }
 
     if (len*slice_size == 0) {
-      printf("empty(");
+      fprintf(out, "empty(");
       for (int64_t i = 0; i < rank; i++) {
-        printf("[%"PRIi64"]", shape[i]);
+        fprintf(out, "[%"PRIi64"]", shape[i]);
       }
-      printf("%s", elem_type->type_name);
-      printf(")");
+      fprintf(out, "%s", elem_type->type_name);
+      fprintf(out, ")");
     } else if (rank==1) {
-      putchar('[');
+      fputc('[', out);
       for (int64_t i = 0; i < len; i++) {
         elem_type->write_str(out, (void*) (data + i * elem_size));
         if (i != len-1) {
-          printf(", ");
+          fprintf(out, ", ");
         }
       }
-      putchar(']');
+      fputc(']', out);
     } else {
-      putchar('[');
+      fputc('[', out);
       for (int64_t i = 0; i < len; i++) {
         write_str_array(out, elem_type, data + i * slice_size * elem_size, shape+1, rank-1);
         if (i != len-1) {
-          printf(", ");
+          fprintf(out, ", ");
         }
       }
-      putchar(']');
+      fputc(']', out);
     }
   }
   return 0;
@@ -721,7 +721,7 @@ static int write_bin_array(FILE *out,
   fputc('b', out);
   fputc((char)BINARY_FORMAT_VERSION, out);
   fwrite(&rank, sizeof(int8_t), 1, out);
-  fputs(elem_type->binname, out);
+  fwrite(elem_type->binname, 4, 1, out);
   if (shape != NULL) {
     fwrite(shape, sizeof(int64_t), (size_t)rank, out);
   }

--- a/rts/c/values.h
+++ b/rts/c/values.h
@@ -15,14 +15,14 @@ struct array_reader {
   str_reader elem_reader;
 };
 
-static void skipspaces() {
+static void skipspaces(FILE *f) {
   int c;
   do {
-    c = getchar();
+    c = getc(f);
   } while (isspace(c));
 
   if (c != EOF) {
-    ungetc(c, stdin);
+    ungetc(c, f);
   }
 }
 
@@ -31,13 +31,13 @@ static int constituent(char c) {
 }
 
 // Produces an empty token only on EOF.
-static void next_token(char *buf, int bufsize) {
+static void next_token(FILE *f, char *buf, int bufsize) {
  start:
-  skipspaces();
+  skipspaces(f);
 
   int i = 0;
   while (i < bufsize) {
-    int c = getchar();
+    int c = getc(f);
     buf[i] = (char)c;
 
     if (c == EOF) {
@@ -45,7 +45,7 @@ static void next_token(char *buf, int bufsize) {
       return;
     } else if (c == '-' && i == 1 && buf[0] == '-') {
       // Line comment, so skip to end of line and start over.
-      for (; c != '\n' && c != EOF; c = getchar());
+      for (; c != '\n' && c != EOF; c = getc(f));
       goto start;
     } else if (!constituent((char)c)) {
       if (i == 0) {
@@ -55,7 +55,7 @@ static void next_token(char *buf, int bufsize) {
         buf[i+1] = 0;
         return;
       } else {
-        ungetc(c, stdin);
+        ungetc(c, f);
         buf[i] = 0;
         return;
       }
@@ -67,8 +67,8 @@ static void next_token(char *buf, int bufsize) {
   buf[bufsize-1] = 0;
 }
 
-static int next_token_is(char *buf, int bufsize, const char* expected) {
-  next_token(buf, bufsize);
+static int next_token_is(FILE *f, char *buf, int bufsize, const char* expected) {
+  next_token(f, buf, bufsize);
   return strcmp(buf, expected) == 0;
 }
 
@@ -101,7 +101,8 @@ static int read_str_elem(char *buf, struct array_reader *reader) {
   return ret;
 }
 
-static int read_str_array_elems(char *buf, int bufsize,
+static int read_str_array_elems(FILE *f,
+                                char *buf, int bufsize,
                                 struct array_reader *reader, int64_t dims) {
   int ret;
   int first = 1;
@@ -110,7 +111,7 @@ static int read_str_array_elems(char *buf, int bufsize,
   int64_t *elems_read_in_dim = (int64_t*) calloc((size_t)dims, sizeof(int64_t));
 
   while (1) {
-    next_token(buf, bufsize);
+    next_token(f, buf, bufsize);
 
     if (strcmp(buf, "]") == 0) {
       if (knows_dimsize[cur_dim]) {
@@ -130,7 +131,7 @@ static int read_str_array_elems(char *buf, int bufsize,
         elems_read_in_dim[cur_dim]++;
       }
     } else if (strcmp(buf, ",") == 0) {
-      next_token(buf, bufsize);
+      next_token(f, buf, bufsize);
       if (strcmp(buf, "[") == 0) {
         if (cur_dim == dims - 1) {
           ret = 1;
@@ -180,7 +181,7 @@ static int read_str_array_elems(char *buf, int bufsize,
   return ret;
 }
 
-static int read_str_empty_array(char *buf, int bufsize,
+static int read_str_empty_array(FILE *f, char *buf, int bufsize,
                                 const char *type_name, int64_t *shape, int64_t dims) {
   if (strlen(buf) == 0) {
     // EOF
@@ -191,32 +192,32 @@ static int read_str_empty_array(char *buf, int bufsize,
     return 1;
   }
 
-  if (!next_token_is(buf, bufsize, "(")) {
+  if (!next_token_is(f, buf, bufsize, "(")) {
     return 1;
   }
 
   for (int i = 0; i < dims; i++) {
-    if (!next_token_is(buf, bufsize, "[")) {
+    if (!next_token_is(f, buf, bufsize, "[")) {
       return 1;
     }
 
-    next_token(buf, bufsize);
+    next_token(f, buf, bufsize);
 
     if (sscanf(buf, "%"SCNu64, (uint64_t*)&shape[i]) != 1) {
       return 1;
     }
 
-    if (!next_token_is(buf, bufsize, "]")) {
+    if (!next_token_is(f, buf, bufsize, "]")) {
       return 1;
     }
   }
 
-  if (!next_token_is(buf, bufsize, type_name)) {
+  if (!next_token_is(f, buf, bufsize, type_name)) {
     return 1;
   }
 
 
-  if (!next_token_is(buf, bufsize, ")")) {
+  if (!next_token_is(f, buf, bufsize, ")")) {
     return 1;
   }
 
@@ -231,7 +232,8 @@ static int read_str_empty_array(char *buf, int bufsize,
   return 1;
 }
 
-static int read_str_array(int64_t elem_size, str_reader elem_reader,
+static int read_str_array(FILE *f,
+                          int64_t elem_size, str_reader elem_reader,
                           const char *type_name,
                           void **data, int64_t *shape, int64_t dims) {
   int ret;
@@ -240,13 +242,13 @@ static int read_str_array(int64_t elem_size, str_reader elem_reader,
 
   int dims_seen;
   for (dims_seen = 0; dims_seen < dims; dims_seen++) {
-    if (!next_token_is(buf, sizeof(buf), "[")) {
+    if (!next_token_is(f, buf, sizeof(buf), "[")) {
       break;
     }
   }
 
   if (dims_seen == 0) {
-    return read_str_empty_array(buf, sizeof(buf), type_name, shape, dims);
+    return read_str_empty_array(f, buf, sizeof(buf), type_name, shape, dims);
   }
 
   if (dims_seen != dims) {
@@ -260,7 +262,7 @@ static int read_str_array(int64_t elem_size, str_reader elem_reader,
   reader.elems = (char*) realloc(*data, (size_t)(elem_size*reader.n_elems_space));
   reader.elem_reader = elem_reader;
 
-  ret = read_str_array_elems(buf, sizeof(buf), &reader, dims);
+  ret = read_str_array_elems(f, buf, sizeof(buf), &reader, dims);
 
   *data = reader.elems;
 
@@ -469,8 +471,8 @@ static void set_binary_mode(FILE *f) {
 }
 #endif
 
-static int read_byte(void* dest) {
-  int num_elems_read = fread(dest, 1, 1, stdin);
+static int read_byte(FILE *f, void* dest) {
+  int num_elems_read = fread(dest, 1, 1, f);
   return num_elems_read == 1 ? 0 : 1;
 }
 
@@ -529,12 +531,12 @@ static const struct primtype_info_t* primtypes[] = {
 // General value interface.  All endian business taken care of at
 // lower layers.
 
-static int read_is_binary() {
-  skipspaces();
-  int c = getchar();
+static int read_is_binary(FILE *f) {
+  skipspaces(f);
+  int c = getc(f);
   if (c == 'b') {
     int8_t bin_version;
-    int ret = read_byte(&bin_version);
+    int ret = read_byte(f, &bin_version);
 
     if (ret != 0) { futhark_panic(1, "binary-input: could not read version.\n"); }
 
@@ -545,7 +547,7 @@ static int read_is_binary() {
 
     return 1;
   }
-  ungetc(c, stdin);
+  ungetc(c, f);
   return 0;
 }
 
@@ -568,9 +570,9 @@ static const struct primtype_info_t* read_bin_read_type_enum() {
   return NULL;
 }
 
-static void read_bin_ensure_scalar(const struct primtype_info_t *expected_type) {
+static void read_bin_ensure_scalar(FILE *f, const struct primtype_info_t *expected_type) {
   int8_t bin_dims;
-  int ret = read_byte(&bin_dims);
+  int ret = read_byte(f, &bin_dims);
   if (ret != 0) { futhark_panic(1, "binary-input: Couldn't get dims.\n"); }
 
   if (bin_dims != 0) {
@@ -588,11 +590,12 @@ static void read_bin_ensure_scalar(const struct primtype_info_t *expected_type) 
 
 //// High-level interface
 
-static int read_bin_array(const struct primtype_info_t *expected_type, void **data, int64_t *shape, int64_t dims) {
+static int read_bin_array(FILE *f,
+                            const struct primtype_info_t *expected_type, void **data, int64_t *shape, int64_t dims) {
   int ret;
 
   int8_t bin_dims;
-  ret = read_byte(&bin_dims);
+  ret = read_byte(f, &bin_dims);
   if (ret != 0) { futhark_panic(1, "binary-input: Couldn't get dims.\n"); }
 
   if (bin_dims != dims) {
@@ -609,7 +612,7 @@ static int read_bin_array(const struct primtype_info_t *expected_type, void **da
   int64_t elem_count = 1;
   for (int i=0; i<dims; i++) {
     int64_t bin_shape;
-    ret = fread(&bin_shape, sizeof(bin_shape), 1, stdin);
+    ret = fread(&bin_shape, sizeof(bin_shape), 1, f);
     if (ret != 1) {
       futhark_panic(1, "binary-input: Couldn't read size for dimension %i of array.\n", i);
     }
@@ -628,7 +631,7 @@ static int read_bin_array(const struct primtype_info_t *expected_type, void **da
   }
   *data = tmp;
 
-  int64_t num_elems_read = (int64_t)fread(*data, (size_t)elem_size, (size_t)elem_count, stdin);
+  int64_t num_elems_read = (int64_t)fread(*data, (size_t)elem_size, (size_t)elem_count, f);
   if (num_elems_read != elem_count) {
     futhark_panic(1, "binary-input: tried to read %i elements of an array, but only got %i elements.\n",
           elem_count, num_elems_read);
@@ -643,18 +646,18 @@ static int read_bin_array(const struct primtype_info_t *expected_type, void **da
   return 0;
 }
 
-static int read_array(const struct primtype_info_t *expected_type, void **data, int64_t *shape, int64_t dims) {
-  if (!read_is_binary()) {
-    return read_str_array(expected_type->size, (str_reader)expected_type->read_str, expected_type->type_name, data, shape, dims);
+static int read_array(FILE *f, const struct primtype_info_t *expected_type, void **data, int64_t *shape, int64_t dims) {
+  if (!read_is_binary(f)) {
+    return read_str_array(f, expected_type->size, (str_reader)expected_type->read_str, expected_type->type_name, data, shape, dims);
   } else {
-    return read_bin_array(expected_type, data, shape, dims);
+    return read_bin_array(f, expected_type, data, shape, dims);
   }
 }
 
-static int end_of_input() {
-  skipspaces();
+static int end_of_input(FILE *f) {
+  skipspaces(f);
   char token[2];
-  next_token(token, sizeof(token));
+  next_token(f, token, sizeof(token));
   if (strcmp(token, "") == 0) {
     return 0;
   } else {
@@ -752,15 +755,16 @@ static int write_array(FILE *out, int write_binary,
   }
 }
 
-static int read_scalar(const struct primtype_info_t *expected_type, void *dest) {
-  if (!read_is_binary()) {
+static int read_scalar(FILE *f,
+                       const struct primtype_info_t *expected_type, void *dest) {
+  if (!read_is_binary(f)) {
     char buf[100];
-    next_token(buf, sizeof(buf));
+    next_token(f, buf, sizeof(buf));
     return expected_type->read_str(buf, dest);
   } else {
-    read_bin_ensure_scalar(expected_type);
+    read_bin_ensure_scalar(f, expected_type);
     int64_t elem_size = expected_type->size;
-    int num_elems_read = fread(dest, (size_t)elem_size, 1, stdin);
+    int num_elems_read = fread(dest, (size_t)elem_size, 1, f);
     if (IS_BIG_ENDIAN) {
       flip_bytes(elem_size, (unsigned char*) dest);
     }

--- a/rts/c/values.h
+++ b/rts/c/values.h
@@ -551,10 +551,10 @@ static int read_is_binary(FILE *f) {
   return 0;
 }
 
-static const struct primtype_info_t* read_bin_read_type_enum() {
+static const struct primtype_info_t* read_bin_read_type_enum(FILE *f) {
   char read_binname[4];
 
-  int num_matched = scanf("%4c", read_binname);
+  int num_matched = fscanf(f, "%4c", read_binname);
   if (num_matched != 1) { futhark_panic(1, "binary-input: Couldn't read element type.\n"); }
 
   const struct primtype_info_t **type = primtypes;
@@ -580,7 +580,7 @@ static void read_bin_ensure_scalar(FILE *f, const struct primtype_info_t *expect
           bin_dims);
   }
 
-  const struct primtype_info_t *bin_type = read_bin_read_type_enum();
+  const struct primtype_info_t *bin_type = read_bin_read_type_enum(f);
   if (bin_type != expected_type) {
     futhark_panic(1, "binary-input: Expected scalar of type %s but got scalar of type %s.\n",
           expected_type->type_name,
@@ -591,7 +591,7 @@ static void read_bin_ensure_scalar(FILE *f, const struct primtype_info_t *expect
 //// High-level interface
 
 static int read_bin_array(FILE *f,
-                            const struct primtype_info_t *expected_type, void **data, int64_t *shape, int64_t dims) {
+                          const struct primtype_info_t *expected_type, void **data, int64_t *shape, int64_t dims) {
   int ret;
 
   int8_t bin_dims;
@@ -603,7 +603,7 @@ static int read_bin_array(FILE *f,
           dims, bin_dims);
   }
 
-  const struct primtype_info_t *bin_primtype = read_bin_read_type_enum();
+  const struct primtype_info_t *bin_primtype = read_bin_read_type_enum(f);
   if (expected_type != bin_primtype) {
     futhark_panic(1, "binary-input: Expected %iD-array with element type '%s' but got %iD-array with element type '%s'.\n",
           dims, expected_type->type_name, dims, bin_primtype->type_name);

--- a/src/Futhark/Actions.hs
+++ b/src/Futhark/Actions.hs
@@ -144,7 +144,7 @@ runCC cpath outpath cflags_def ldflags = do
 compileCAction :: FutharkConfig -> CompilerMode -> FilePath -> Action SeqMem
 compileCAction fcfg mode outpath =
   Action
-    { actionName = "Compile to to sequential C",
+    { actionName = "Compile to sequential C",
       actionDescription = "Compile to sequential C",
       actionProcedure = helper
     }

--- a/src/Futhark/CodeGen/Backends/GenericC.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC.hs
@@ -1030,41 +1030,68 @@ opaqueToCType desc vds = do
       ct <- valueDescToCType vd
       return [C.csdecl|$ty:ct *$id:(tupleField i);|]
 
-prepareEntryInputs :: [ExternalValue] -> CompilerM op s [C.Param]
-prepareEntryInputs = zipWithM prepare [(0 :: Int) ..]
+allTrue :: [C.Exp] -> C.Exp
+allTrue [] = [C.cexp|true|]
+allTrue [x] = x
+allTrue (x : xs) = [C.cexp|$exp:x && $exp:(allTrue xs)|]
+
+prepareEntryInputs ::
+  [ExternalValue] ->
+  CompilerM op s ([(C.Param, C.Exp)], [C.BlockItem])
+prepareEntryInputs args = collect' $ zipWithM prepare [(0 :: Int) ..] args
   where
+    arg_names = namesFromList $ concatMap evNames args
+    evNames (OpaqueValue _ vds) = map vdName vds
+    evNames (TransparentValue vd) = [vdName vd]
+    vdName (ArrayValue v _ _ _ _) = v
+    vdName (ScalarValue _ _ v) = v
+
     prepare pno (TransparentValue vd) = do
       let pname = "in" ++ show pno
-      ty <- prepareValue [C.cexp|$id:pname|] vd
-      return [C.cparam|const $ty:ty $id:pname|]
+      (ty, check) <- prepareValue [C.cexp|$id:pname|] vd
+      return
+        ( [C.cparam|const $ty:ty $id:pname|],
+          allTrue check
+        )
     prepare pno (OpaqueValue desc vds) = do
       ty <- opaqueToCType desc vds
       let pname = "in" ++ show pno
           field i ScalarValue {} = [C.cexp|$id:pname->$id:(tupleField i)|]
           field i ArrayValue {} = [C.cexp|$id:pname->$id:(tupleField i)|]
-      zipWithM_ prepareValue (zipWith field [0 ..] vds) vds
-      return [C.cparam|const $ty:ty *$id:pname|]
+      checks <- map snd <$> zipWithM prepareValue (zipWith field [0 ..] vds) vds
+      return
+        ( [C.cparam|const $ty:ty *$id:pname|],
+          allTrue $ concat checks
+        )
 
     prepareValue src (ScalarValue pt signed name) = do
       let pt' = signedPrimTypeToCType signed pt
       stm [C.cstm|$id:name = $exp:src;|]
-      return pt'
+      return (pt', [])
     prepareValue src vd@(ArrayValue mem _ _ _ shape) = do
       ty <- valueDescToCType vd
 
       stm [C.cstm|$exp:mem = $exp:src->mem;|]
 
       let rank = length shape
-          maybeCopyDim (Var d) i =
-            Just [C.cstm|$id:d = $exp:src->shape[$int:i];|]
-          maybeCopyDim _ _ = Nothing
+          maybeCopyDim (Var d) i
+            | not $ d `nameIn` arg_names =
+              ( Just [C.cstm|$id:d = $exp:src->shape[$int:i];|],
+                [C.cexp|$id:d == $exp:src->shape[$int:i]|]
+              )
+          maybeCopyDim x i =
+            ( Nothing,
+              [C.cexp|$exp:x == $exp:src->shape[$int:i]|]
+            )
 
-      stms $ catMaybes $ zipWith maybeCopyDim shape [0 .. rank -1]
+      let (sets, checks) =
+            unzip $ zipWith maybeCopyDim shape [0 .. rank -1]
+      stms $ catMaybes sets
 
-      return [C.cty|$ty:ty*|]
+      return ([C.cty|$ty:ty*|], checks)
 
-prepareEntryOutputs :: [ExternalValue] -> CompilerM op s [C.Param]
-prepareEntryOutputs = zipWithM prepare [(0 :: Int) ..]
+prepareEntryOutputs :: [ExternalValue] -> CompilerM op s ([C.Param], [C.BlockItem])
+prepareEntryOutputs = collect' . zipWithM prepare [(0 :: Int) ..]
   where
     prepare pno (TransparentValue vd) = do
       let pname = "out" ++ show pno
@@ -1107,10 +1134,11 @@ prepareEntryOutputs = zipWithM prepare [(0 :: Int) ..]
       stms $ zipWith maybeCopyDim shape [0 .. rank -1]
 
 onEntryPoint ::
+  [C.BlockItem] ->
   Name ->
   Function op ->
   CompilerM op s C.Definition
-onEntryPoint fname (Function _ outputs inputs _ results args) = do
+onEntryPoint get_consts fname (Function _ outputs inputs _ results args) = do
   let out_args = map (\p -> [C.cexp|&$id:(paramName p)|]) outputs
       in_args = map (\p -> [C.cexp|$id:(paramName p)|]) inputs
 
@@ -1120,10 +1148,11 @@ onEntryPoint fname (Function _ outputs inputs _ results args) = do
   let entry_point_name = nameToString fname
   entry_point_function_name <- publicName $ "entry_" ++ entry_point_name
 
-  (entry_point_input_params, unpack_entry_inputs) <-
-    collect' $ prepareEntryInputs args
+  (inputs', unpack_entry_inputs) <- prepareEntryInputs args
+  let (entry_point_input_params, entry_point_input_checks) = unzip inputs'
+
   (entry_point_output_params, pack_entry_outputs) <-
-    collect' $ prepareEntryOutputs results
+    prepareEntryOutputs results
 
   ctx_ty <- contextType
 
@@ -1138,10 +1167,19 @@ onEntryPoint fname (Function _ outputs inputs _ results args) = do
         [C.citems|
          $items:unpack_entry_inputs
 
-         int ret = $id:(funName fname)(ctx, $args:out_args, $args:in_args);
+         if (!($exp:(allTrue entry_point_input_checks))) {
+           ret = 1;
+           if (!ctx->error) {
+             ctx->error = msgprintf("Error: entry point arguments have invalid sizes.\n");
+           }
+         } else {
+           ret = $id:(funName fname)(ctx, $args:out_args, $args:in_args);
 
-         if (ret == 0) {
-           $items:pack_entry_outputs
+           if (ret == 0) {
+             $items:get_consts
+
+             $items:pack_entry_outputs
+           }
          }
         |]
 
@@ -1155,6 +1193,8 @@ onEntryPoint fname (Function _ outputs inputs _ results args) = do
             $params:entry_point_input_params) {
          $items:inputdecls
          $items:outputdecls
+
+         int ret = 0;
 
          $items:(criticalSection ops critical)
 
@@ -1332,7 +1372,7 @@ $edecls:entry_point_decls
 
       mapM_ earlyDecl memstructs
       entry_points <-
-        mapM (uncurry onEntryPoint) $ filter (functionEntry . snd) funs
+        mapM (uncurry (onEntryPoint get_consts)) $ filter (functionEntry . snd) funs
 
       extra
 

--- a/src/Futhark/CodeGen/Backends/GenericC.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC.hs
@@ -1544,10 +1544,10 @@ compileFun get_constants extra (fname, func@(Function _ outputs inputs body _ _)
       return ([C.cparam|$ty:ty *$id:p_name|], [C.cexp|$id:p_name|])
 
 compilePrimValue :: PrimValue -> C.Exp
-compilePrimValue (IntValue (Int8Value k)) = [C.cexp|$int:k|]
-compilePrimValue (IntValue (Int16Value k)) = [C.cexp|$int:k|]
+compilePrimValue (IntValue (Int8Value k)) = [C.cexp|(typename int8_t)$int:k|]
+compilePrimValue (IntValue (Int16Value k)) = [C.cexp|(typename int16_t)$int:k|]
 compilePrimValue (IntValue (Int32Value k)) = [C.cexp|$int:k|]
-compilePrimValue (IntValue (Int64Value k)) = [C.cexp|$int:k|]
+compilePrimValue (IntValue (Int64Value k)) = [C.cexp|(typename int64_t)$int:k|]
 compilePrimValue (FloatValue (Float64Value x))
   | isInfinite x =
     if x > 0 then [C.cexp|INFINITY|] else [C.cexp|-INFINITY|]

--- a/src/Futhark/CodeGen/Backends/GenericC/CLI.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC/CLI.hs
@@ -126,7 +126,7 @@ primTypeInfo Cert _ = [C.cexp|bool_info|]
 
 readPrimStm :: C.ToIdent a => a -> Int -> PrimType -> Signedness -> C.Stm
 readPrimStm place i t ept =
-  [C.cstm|if (read_scalar(&$exp:(primTypeInfo t ept), &$id:place) != 0) {
+  [C.cstm|if (read_scalar(stdin, &$exp:(primTypeInfo t ept), &$id:place) != 0) {
             futhark_panic(1, "Error when reading input #%d of type %s (errno: %s).\n",
                           $int:i,
                           $exp:(primTypeInfo t ept).type_name,
@@ -172,7 +172,8 @@ readInput i (TransparentValue (ArrayValue _ _ t ept dims)) =
            typename int64_t $id:shape[$int:rank];
            $ty:t' *$id:arr = NULL;
            errno = 0;
-           if (read_array(&$exp:(primTypeInfo t ept),
+           if (read_array(stdin,
+                          &$exp:(primTypeInfo t ept),
                           (void**) &$id:arr,
                           $id:shape,
                           $int:(length dims))
@@ -323,7 +324,7 @@ cliEntryPoint fname (Function _ _ _ _ results args) =
     set_binary_mode(stdin);
     $items:(mconcat input_items)
 
-    if (end_of_input() != 0) {
+    if (end_of_input(stdin) != 0) {
       futhark_panic(1, "Expected EOF on stdin after reading input for %s.\n", $string:(quote (pretty fname)));
     }
 

--- a/src/Futhark/CodeGen/Backends/GenericPython.hs
+++ b/src/Futhark/CodeGen/Backends/GenericPython.hs
@@ -53,7 +53,7 @@ import Futhark.CodeGen.Backends.GenericPython.Definitions
 import Futhark.CodeGen.Backends.GenericPython.Options
 import qualified Futhark.CodeGen.ImpCode as Imp
 import Futhark.IR.Primitive hiding (Bool)
-import Futhark.IR.Prop (isBuiltInFunction)
+import Futhark.IR.Prop (isBuiltInFunction, subExpVars)
 import Futhark.IR.Syntax (Space (..))
 import Futhark.MonadFreshNames
 import Futhark.Util (zEncodeString)
@@ -459,9 +459,9 @@ simpleCall fname = Call (Var fname) . map Arg
 compileName :: VName -> String
 compileName = zEncodeString . pretty
 
-compileDim :: Imp.DimSize -> PyExp
-compileDim (Imp.Constant v) = compilePrimValue v
-compileDim (Imp.Var v) = Var $ compileName v
+compileDim :: Imp.DimSize -> CompilerM op s PyExp
+compileDim (Imp.Constant v) = pure $ compilePrimValue v
+compileDim (Imp.Var v) = compileVar v
 
 unpackDim :: PyExp -> Imp.DimSize -> Int32 -> CompilerM op s ()
 unpackDim arr_name (Imp.Constant c) i = do
@@ -470,12 +470,18 @@ unpackDim arr_name (Imp.Constant c) i = do
   let constant_i = Integer $ toInteger i
   stm $
     Assert (BinOp "==" constant_c (Index shape_name $ IdxExp constant_i)) $
-      String "constant dimension wrong"
+      String "Entry point arguments have invalid sizes."
 unpackDim arr_name (Imp.Var var) i = do
   let shape_name = Field arr_name "shape"
       src = Index shape_name $ IdxExp $ Integer $ toInteger i
   var' <- compileVar var
-  stm $ Assign var' $ simpleCall "np.int64" [src]
+  stm $
+    If
+      (BinOp "==" var' None)
+      [Assign var' $ simpleCall "np.int64" [src]]
+      [ Assert (BinOp "==" var' src) $
+          String "Error: entry point arguments have invalid sizes."
+      ]
 
 entryPointOutput :: Imp.ExternalValue -> CompilerM op s PyExp
 entryPointOutput (Imp.OpaqueValue desc vs) =
@@ -492,7 +498,8 @@ entryPointOutput (Imp.TransparentValue (Imp.ArrayValue mem (Imp.Space sid) bt ep
 entryPointOutput (Imp.TransparentValue (Imp.ArrayValue mem _ bt ept dims)) = do
   mem' <- compileVar mem
   let cast = Cast mem' (compilePrimTypeExt bt ept)
-  return $ simpleCall "createArray" [cast, Tuple $ map compileDim dims]
+  dims' <- mapM compileDim dims
+  return $ simpleCall "createArray" [cast, Tuple dims']
 
 badInput :: Int -> PyExp -> String -> PyStmt
 badInput i e t =
@@ -550,6 +557,15 @@ badInputDim i e typ dimf =
           "Bad Python value passed",
           "Actual Futhark type: {}"
         ]
+
+declEntryPointInputSizes :: [Imp.ExternalValue] -> CompilerM op s ()
+declEntryPointInputSizes = mapM_ onSize . concatMap sizes
+  where
+    sizes (Imp.TransparentValue v) = valueSizes v
+    sizes (Imp.OpaqueValue _ vs) = concatMap valueSizes vs
+    valueSizes (Imp.ArrayValue _ _ _ _ dims) = subExpVars dims
+    valueSizes Imp.ScalarValue {} = []
+    onSize v = stm $ Assign (Var (compileName v)) None
 
 entryPointInput :: (Int, Imp.ExternalValue, PyExp) -> CompilerM op s ()
 entryPointInput (i, Imp.OpaqueValue desc vs, e) = do
@@ -750,11 +766,11 @@ prepareEntry (fname, Imp.Function _ outputs inputs _ results args) = do
         return $ Just $ compileName name'
       _ -> return Nothing
 
-  prepareIn <-
-    collect $
-      mapM_ entryPointInput $
-        zip3 [0 ..] args $
-          map (Var . extValueDescName) args
+  prepareIn <- collect $ do
+    declEntryPointInputSizes args
+    mapM_ entryPointInput $
+      zip3 [0 ..] args $
+        map (Var . extValueDescName) args
   (res, prepareOut) <- collect' $ mapM entryPointOutput results
 
   let argexps_lib = map (compileName . Imp.paramName) inputs

--- a/src/Futhark/CodeGen/Backends/MPIC.hs
+++ b/src/Futhark/CodeGen/Backends/MPIC.hs
@@ -170,3 +170,5 @@ compileOp :: GC.OpCompiler MPIOp ()
 compileOp (CrashWithThisMessage s) = do
   GC.stm [C.cstm|fprintf(stderr, "%s\n", $string:s);|]
   GC.stm [C.cstm|exit(1);|]
+compileOp (Segop name params seq_task retvals) = pure ()
+compileOp (DistributedLoop s' i prebody body postbody free tid) = pure ()

--- a/src/Futhark/CodeGen/Backends/MulticoreC.hs
+++ b/src/Futhark/CodeGen/Backends/MulticoreC.hs
@@ -207,7 +207,6 @@ operations :: GC.Operations Multicore ()
 operations =
   GC.defaultOperations
     { GC.opsCompiler = compileOp,
-      GC.opsCopy = copyMulticoreMemory,
       GC.opsCritical =
         -- The thread entering an API function is always considered
         -- the "first worker" - note that this might differ from the
@@ -218,12 +217,6 @@ operations =
           []
         )
     }
-
-copyMulticoreMemory :: GC.Copy Multicore ()
-copyMulticoreMemory destmem destidx DefaultSpace srcmem srcidx DefaultSpace nbytes =
-  GC.copyMemoryDefaultSpace destmem destidx srcmem srcidx nbytes
-copyMulticoreMemory _ _ destspace _ _ srcspace _ =
-  error $ "Cannot copy to " ++ show destspace ++ " from " ++ show srcspace
 
 closureFreeStructField :: VName -> Name
 closureFreeStructField v =

--- a/src/Futhark/CodeGen/Backends/PyOpenCL.hs
+++ b/src/Futhark/CodeGen/Backends/PyOpenCL.hs
@@ -410,11 +410,12 @@ staticOpenCLArray _ space _ _ =
 packArrayOutput :: Py.EntryOutput Imp.OpenCL ()
 packArrayOutput mem "device" bt ept dims = do
   mem' <- Py.compileVar mem
+  dims' <- mapM Py.compileDim dims
   return $
     Call
       (Var "cl.array.Array")
       [ Arg $ Var "self.queue",
-        Arg $ Tuple $ map Py.compileDim dims,
+        Arg $ Tuple dims',
         Arg $ Var $ Py.compilePrimTypeExt bt ept,
         ArgKeyword "data" mem'
       ]

--- a/src/Futhark/CodeGen/Backends/SequentialC.hs
+++ b/src/Futhark/CodeGen/Backends/SequentialC.hs
@@ -29,8 +29,7 @@ compileProg =
     operations :: GC.Operations Imp.Sequential ()
     operations =
       GC.defaultOperations
-        { GC.opsCompiler = const $ return (),
-          GC.opsCopy = copySequentialMemory
+        { GC.opsCompiler = const $ return ()
         }
 
     generateContext = do
@@ -130,9 +129,3 @@ compileProg =
                                  return 0;
                                }|]
         )
-
-copySequentialMemory :: GC.Copy Imp.Sequential ()
-copySequentialMemory destmem destidx DefaultSpace srcmem srcidx DefaultSpace nbytes =
-  GC.copyMemoryDefaultSpace destmem destidx srcmem srcidx nbytes
-copySequentialMemory _ _ destspace _ _ srcspace _ =
-  error $ "Cannot copy to " ++ show destspace ++ " from " ++ show srcspace

--- a/src/Futhark/CodeGen/Backends/SimpleRep.hs
+++ b/src/Futhark/CodeGen/Backends/SimpleRep.hs
@@ -588,7 +588,7 @@ $esc:("#else")
      return x == 0 ? 32 :  __builtin_ctz(x);
    }
    static typename int32_t $id:(funName' "ctz64") (typename int64_t x) {
-     return x == 0 ? 64 : __builtin_ctzl(x);
+     return x == 0 ? 64 : __builtin_ctzll(x);
    }
 $esc:("#endif")
                 |]

--- a/src/Futhark/CodeGen/ImpCode/Kernels.hs
+++ b/src/Futhark/CodeGen/ImpCode/Kernels.hs
@@ -82,7 +82,7 @@ data KernelUse
   = ScalarUse VName PrimType
   | MemoryUse VName
   | ConstUse VName KernelConstExp
-  deriving (Eq, Show)
+  deriving (Eq, Ord, Show)
 
 instance Pretty KernelConst where
   ppr (SizeConst key) = text "get_size" <> parens (ppr key)

--- a/src/Futhark/CodeGen/ImpCode/MPI.hs
+++ b/src/Futhark/CodeGen/ImpCode/MPI.hs
@@ -24,16 +24,33 @@ type Code = Imp.Code MPIOp
 
 -- | Some kind of MPI-level imperative operation, that will presumably
 -- be turned into some particular C code.
-data MPIOp = Segop String [Param] Code [Param]
+data MPIOp = Segop String [Param] Code [Param] Imp.Exp
    | DistributedLoop String VName Code Code Code [Param] VName
    | CrashWithThisMessage String
 
 instance Pretty MPIOp where
   ppr (CrashWithThisMessage s) = text "crash" <+> parens (ppr s)
-  ppr _ = text ""
+  ppr (Segop name free seq_code retval iterations) =
+    text name
+      <+> ppr free
+      <+> text "seq_code"
+      <+> nestedBlock "{" "}" (ppr seq_code)
+      <+> text "retvals"
+      <+> ppr retval
+      <+> text "iterations"
+      <+> ppr iterations
+  ppr (DistributedLoop s i prebody body postbody params info) =
+    text "parloop" <+> ppr s <+> ppr i
+      <+> ppr prebody
+      <+> ppr params
+      <+> ppr info
+      <+> langle
+      <+> nestedBlock "{" "}" (ppr body)
+      <+> ppr postbody
+
 
 -- The free variables of an MPIOp.
 instance FreeIn MPIOp where
   freeIn' (CrashWithThisMessage _) = mempty
   freeIn' (DistributedLoop _ _ prebody body postbody _ _) = freeIn' prebody <> fvBind (Imp.declaredIn prebody) (freeIn' $ body <> postbody)
-  freeIn' (Segop _ _ code _) = freeIn' code
+  freeIn' (Segop _ _ code _ _) = freeIn' code

--- a/src/Futhark/CodeGen/ImpCode/MPI.hs
+++ b/src/Futhark/CodeGen/ImpCode/MPI.hs
@@ -24,11 +24,16 @@ type Code = Imp.Code MPIOp
 
 -- | Some kind of MPI-level imperative operation, that will presumably
 -- be turned into some particular C code.
-data MPIOp = CrashWithThisMessage String
+data MPIOp = Segop String [Param] Code [Param]
+   | DistributedLoop String VName Code Code Code [Param] VName
+   | CrashWithThisMessage String
 
 instance Pretty MPIOp where
   ppr (CrashWithThisMessage s) = text "crash" <+> parens (ppr s)
+  ppr _ = text ""
 
 -- The free variables of an MPIOp.
 instance FreeIn MPIOp where
   freeIn' (CrashWithThisMessage _) = mempty
+  freeIn' (DistributedLoop _ _ prebody body postbody _ _) = freeIn' prebody <> fvBind (Imp.declaredIn prebody) (freeIn' $ body <> postbody)
+  freeIn' (Segop _ _ code _) = freeIn' code

--- a/src/Futhark/CodeGen/ImpGen/Kernels/Base.hs
+++ b/src/Futhark/CodeGen/ImpGen/Kernels/Base.hs
@@ -35,7 +35,7 @@ module Futhark.CodeGen.ImpGen.Kernels.Base
 where
 
 import Control.Monad.Except
-import Data.List (elemIndex, find, nub, zip4)
+import Data.List (elemIndex, find, zip4)
 import qualified Data.Map.Strict as M
 import Data.Maybe
 import qualified Data.Set as S
@@ -46,7 +46,7 @@ import Futhark.IR.KernelsMem
 import qualified Futhark.IR.Mem.IxFun as IxFun
 import Futhark.MonadFreshNames
 import Futhark.Transform.Rename
-import Futhark.Util (chunks, dropLast, mapAccumLM, maybeNth, takeLast)
+import Futhark.Util (chunks, dropLast, mapAccumLM, maybeNth, nubOrd, takeLast)
 import Futhark.Util.IntegralExp (divUp, quot, rem)
 import Prelude hiding (quot, rem)
 
@@ -749,7 +749,7 @@ computeKernelUses ::
 computeKernelUses kernel_body bound_in_kernel = do
   let actually_free = freeIn kernel_body `namesSubtract` namesFromList bound_in_kernel
   -- Compute the variables that we need to pass to the kernel.
-  nub <$> readsFromSet actually_free
+  nubOrd <$> readsFromSet actually_free
 
 readsFromSet :: Names -> CallKernelGen [Imp.KernelUse]
 readsFromSet free =

--- a/src/Futhark/CodeGen/ImpGen/MPI.hs
+++ b/src/Futhark/CodeGen/ImpGen/MPI.hs
@@ -15,7 +15,6 @@ import Futhark.MonadFreshNames
 import Futhark.CodeGen.ImpGen.MPI.Base
 import Futhark.CodeGen.ImpGen.MPI.SegMap
 import Prelude hiding (quot, rem)
-import Debug.Trace
 
 
 -- Compile inner code
@@ -29,9 +28,6 @@ compileProg = Futhark.CodeGen.ImpGen.compileProg Env ops Imp.DefaultSpace
     opCompiler dest (Alloc e space) = compileAlloc dest e space
     opCompiler dest (Inner op) = compileMCOp dest op
 
-dumTrace :: (Applicative f, Show a) => [Char] -> a -> f ()
-dumTrace name var = traceM ("--"++name++"\n" ++ show var ++ "\n--")
-
 -- Compile seg
 compileMCOp ::
   Pattern MCMem ->
@@ -40,19 +36,20 @@ compileMCOp ::
 compileMCOp _ (OtherOp ()) = pure ()
 compileMCOp pat (ParOp _par_op op) = do
   -- Contains the arrray size
-  let _space = getSpace op
+  let space = getSpace op
   -- Declare a Int64 with the value 0, the name is in the segFlat part of the arg space ("flat_tid").
   -- I comment it for now I don't ("flat_tid") for now.
   -- dPrimV_ (segFlat space) (0 :: Imp.TExp Int64)
 
   seq_code <- compileSegOp pat op
   retvals <- getReturnParams pat op
+  iterations <- getIterationDomain op space
 
   let non_free = map Imp.paramName retvals
 
   s <- segOpString op
   free_params <- freeParams seq_code non_free
-  emit $ Imp.Op $ Imp.Segop s free_params seq_code retvals
+  emit $ Imp.Op $ Imp.Segop s free_params seq_code retvals (untyped iterations)
   pure ()
   {-- For a start, ignore the _par_op, which may contain nested
   -- parallelism.

--- a/src/Futhark/CodeGen/ImpGen/MPI/Base.hs
+++ b/src/Futhark/CodeGen/ImpGen/MPI/Base.hs
@@ -1,0 +1,94 @@
+module Futhark.CodeGen.ImpGen.MPI.Base
+  ( Env (..),
+    MPIGen,
+    getReturnParams,
+    segOpString,
+    freeParams,
+    extractAllocations
+  )
+where
+
+
+import qualified Futhark.CodeGen.ImpCode.MPI as Imp
+import Futhark.CodeGen.ImpGen
+import Futhark.IR.MCMem
+import Prelude hiding (quot, rem)
+import Control.Monad
+import Data.Bifunctor
+
+
+data Env = Env
+
+type MPIGen = ImpM MCMem Env Imp.MPIOp
+
+segOpString :: SegOp () MCMem -> MPIGen String
+segOpString SegMap {} = return "segmap"
+segOpString SegRed {} = return "segred"
+segOpString SegScan {} = return "segscan"
+segOpString SegHist {} = return "seghist"
+
+getReturnParams :: Pattern MCMem -> SegOp () MCMem -> MPIGen [Imp.Param]
+getReturnParams _ _ = return mempty
+
+freeVariables :: Imp.Code -> [VName] -> [VName]
+freeVariables code names =
+  namesToList $ freeIn code `namesSubtract` namesFromList names
+
+toParam :: VName -> TypeBase shape u -> MPIGen Imp.Param
+toParam name (Prim pt) = return $ Imp.ScalarParam name pt
+toParam name (Mem space) = return $ Imp.MemParam name space
+toParam name Array {} = do
+  name_entry <- lookupVar name
+  case name_entry of
+    ArrayVar _ (ArrayEntry (MemLocation mem _ _) _) ->
+      return $ Imp.MemParam mem DefaultSpace
+    _ -> error $ "[toParam] Could not handle array for " ++ show name
+
+freeParams :: Imp.Code -> [VName] -> MPIGen [Imp.Param]
+freeParams code names = do
+  let freeVars = freeVariables code names
+  ts <- mapM lookupType freeVars
+  zipWithM toParam freeVars ts
+
+-- | Try to extract invariant allocations.  If we assume that the
+-- given 'Code' is the body of a 'SegOp', then it is always safe to
+-- move the immediate allocations to the prebody.
+extractAllocations :: Imp.Code -> (Imp.Code, Imp.Code)
+extractAllocations segop_code = f segop_code
+  where
+    declared = Imp.declaredIn segop_code
+    f (Imp.DeclareMem name space) =
+      -- Hoisting declarations out is always safe.
+      (Imp.DeclareMem name space, mempty)
+    f (Imp.Allocate name size space)
+      | not $ freeIn size `namesIntersect` declared =
+        (Imp.Allocate name size space, mempty)
+    f (x Imp.:>>: y) = f x <> f y
+    f (Imp.While cond body) =
+      (mempty, Imp.While cond body)
+    f (Imp.For i bound body) =
+      (mempty, Imp.For i bound body)
+    f (Imp.Comment s code) =
+      second (Imp.Comment s) (f code)
+    f Imp.Free {} =
+      mempty
+    f (Imp.If cond tcode fcode) =
+      let (ta, tcode') = f tcode
+          (fa, fcode') = f fcode
+       in (ta <> fa, Imp.If cond tcode' fcode')
+    f (Imp.Op (Imp.DistributedLoop s i prebody body postbody free info)) =
+      let (body_allocs, body') = extractAllocations body
+          (free_allocs, here_allocs) = f body_allocs
+          free' =
+            filter
+              ( not
+                  . (`nameIn` Imp.declaredIn body_allocs)
+                  . Imp.paramName
+              )
+              free
+       in ( free_allocs,
+            here_allocs
+              <> Imp.Op (Imp.DistributedLoop s i prebody body' postbody free' info)
+          )
+    f code =
+      (mempty, code)

--- a/src/Futhark/CodeGen/ImpGen/MPI/SegMap.hs
+++ b/src/Futhark/CodeGen/ImpGen/MPI/SegMap.hs
@@ -1,0 +1,75 @@
+module Futhark.CodeGen.ImpGen.MPI.SegMap
+  ( compileSegMap,
+  )
+where
+
+import Control.Monad
+import qualified Futhark.CodeGen.ImpCode.MPI as Imp
+import Futhark.CodeGen.ImpGen
+import Futhark.CodeGen.ImpGen.MPI.Base
+import Futhark.IR.MCMem
+import Futhark.Transform.Rename
+import Debug.Trace
+
+dumTrace :: (Applicative f, Show a) => [Char] -> a -> f ()
+dumTrace name var = traceM ("--"++name++"\n" ++ show var ++ "\n--")
+
+writeResult ::
+  [VName] ->
+  PatElemT dec ->
+  KernelResult ->
+  MPIGen ()
+writeResult is pe (Returns _ se) =
+  copyDWIMFix (patElemName pe) (map Imp.vi64 is) se []
+writeResult _ pe (WriteReturns rws _ idx_vals) = do
+  let (iss, vs) = unzip idx_vals
+      rws' = map toInt64Exp rws
+  forM_ (zip iss vs) $ \(slice, v) -> do
+    let slice' = map (fmap toInt64Exp) slice
+        condInBounds (DimFix i) rw =
+          0 .<=. i .&&. i .<. rw
+        condInBounds (DimSlice i n s) rw =
+          0 .<=. i .&&. i + n * s .<. rw
+        in_bounds = foldl1 (.&&.) $ zipWith condInBounds slice' rws'
+        when_in_bounds = copyDWIM (patElemName pe) slice' v []
+    sWhen in_bounds when_in_bounds
+writeResult _ _ res =
+  error $ "writeResult: cannot handle " ++ pretty res
+
+
+compileSegMapBody ::
+  TV Int64 ->
+  Pattern MCMem ->
+  SegSpace ->
+  KernelBody MCMem ->
+  MPIGen Imp.Code
+compileSegMapBody flat_idx pat space (KernelBody _ kstms kres) = do
+  --ns = nb iterations
+  let (is, ns) = unzip $ unSegSpace space
+      ns' = map toInt64Exp ns
+  --Rename statements to give an unique name to each statement
+  kstms' <- mapM renameStm kstms
+  collect $ do
+    emit $ Imp.DebugPrint "SegMap fbody" Nothing
+    -- Continue here --------
+    zipWithM_ dPrimV_ is $ map sExt64 $ unflattenIndex ns' $ tvExp flat_idx
+    compileStms (freeIn kres) kstms' $
+      zipWithM_ (writeResult is) (patternElements pat) kres
+
+
+compileSegMap ::
+  Pattern MCMem ->
+  SegSpace ->
+  KernelBody MCMem -> 
+    MPIGen  Imp.Code
+compileSegMap pat space kbody = do
+  collect $ do
+    --iteration variable
+    flat_par_idx <- dPrim "iter" int64
+    --Loop body
+    body <- compileSegMapBody flat_par_idx pat space kbody
+    free_params <- freeParams body [segFlat space, tvVar flat_par_idx]
+    -- Moove allocs outside of body
+    let (body_allocs, body') = extractAllocations body
+    emit $ Imp.Op $ Imp.DistributedLoop "segmap" (tvVar flat_par_idx) body_allocs body' mempty free_params $ segFlat space
+    --emit $ Imp.Op $ Imp.ParLoop "segmap" (tvVar flat_par_idx) body_allocs body' mempty free_params $ segFlat space

--- a/src/Futhark/CodeGen/ImpGen/Multicore/Base.hs
+++ b/src/Futhark/CodeGen/ImpGen/Multicore/Base.hs
@@ -1,6 +1,5 @@
 module Futhark.CodeGen.ImpGen.Multicore.Base
-  ( toParam,
-    compileKBody,
+  ( compileKBody,
     extractAllocations,
     compileThreadResult,
     HostEnv (..),
@@ -10,7 +9,6 @@ module Futhark.CodeGen.ImpGen.Multicore.Base
     decideScheduling',
     groupResultArrays,
     renameSegBinOp,
-    resultArrays,
     freeParams,
     renameHistOpLambda,
     atomicUpdateLocking,
@@ -130,15 +128,6 @@ freeParams code names = do
   let freeVars = freeVariables code names
   ts <- mapM lookupType freeVars
   zipWithM toParam freeVars ts
-
--- | Arrays for storing group results.
-resultArrays :: String -> [SegBinOp MCMem] -> MulticoreGen [[VName]]
-resultArrays s segops =
-  forM segops $ \(SegBinOp _ lam _ shape) ->
-    forM (lambdaReturnType lam) $ \t -> do
-      let pt = elemType t
-          full_shape = shape <> arrayShape t
-      sAllocArray s pt full_shape DefaultSpace
 
 -- | Arrays for storing group results shared between threads
 groupResultArrays ::

--- a/src/Futhark/CodeGen/ImpGen/Multicore/SegScan.hs
+++ b/src/Futhark/CodeGen/ImpGen/Multicore/SegScan.hs
@@ -35,6 +35,15 @@ yParams scan =
 lamBody :: SegBinOp MCMem -> Body MCMem
 lamBody = lambdaBody . segBinOpLambda
 
+-- Arrays for storing worker results.
+resultArrays :: String -> [SegBinOp MCMem] -> MulticoreGen [[VName]]
+resultArrays s segops =
+  forM segops $ \(SegBinOp _ lam _ shape) ->
+    forM (lambdaReturnType lam) $ \t -> do
+      let pt = elemType t
+          full_shape = shape <> arrayShape t
+      sAllocArray s pt full_shape DefaultSpace
+
 nonsegmentedScan ::
   Pattern MCMem ->
   SegSpace ->

--- a/src/Futhark/Internalise.hs
+++ b/src/Futhark/Internalise.hs
@@ -12,8 +12,6 @@
 module Futhark.Internalise (internaliseProg) where
 
 import Control.Monad.Reader
-import Control.Monad.State
-import Data.Bitraversable
 import Data.List (find, intercalate, intersperse, transpose)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
@@ -113,93 +111,11 @@ internaliseValBind fb@(E.ValBind entry fname retdecl (Info (rettype, _)) tparams
   where
     zeroExts ts = generaliseExtTypes ts ts
 
-allDimsFreshInType :: MonadFreshNames m => E.PatternType -> m E.PatternType
-allDimsFreshInType = bitraverse onDim pure
-  where
-    onDim (E.NamedDim v) =
-      E.NamedDim . E.qualName <$> newVName (baseString $ E.qualLeaf v)
-    onDim _ =
-      E.NamedDim . E.qualName <$> newVName "size"
-
--- | Replace all named dimensions with a fresh name, and remove all
--- constant dimensions.  The point is to remove the constraints, but
--- keep the names around.  We use this for constructing the entry
--- point parameters.
-allDimsFreshInPat :: MonadFreshNames m => E.Pattern -> m E.Pattern
-allDimsFreshInPat (PatternAscription p _ _) =
-  allDimsFreshInPat p
-allDimsFreshInPat (PatternParens p _) =
-  allDimsFreshInPat p
-allDimsFreshInPat (Id v (Info t) loc) =
-  Id v <$> (Info <$> allDimsFreshInType t) <*> pure loc
-allDimsFreshInPat (TuplePattern ps loc) =
-  TuplePattern <$> mapM allDimsFreshInPat ps <*> pure loc
-allDimsFreshInPat (RecordPattern ps loc) =
-  RecordPattern <$> mapM (traverse allDimsFreshInPat) ps <*> pure loc
-allDimsFreshInPat (Wildcard (Info t) loc) =
-  Wildcard <$> (Info <$> allDimsFreshInType t) <*> pure loc
-allDimsFreshInPat (PatternLit e (Info t) loc) =
-  PatternLit e <$> (Info <$> allDimsFreshInType t) <*> pure loc
-allDimsFreshInPat (PatternConstr c (Info t) pats loc) =
-  PatternConstr c <$> (Info <$> allDimsFreshInType t)
-    <*> mapM allDimsFreshInPat pats
-    <*> pure loc
-
-data EntryTrust
-  = -- | This parameter or return value is an opaque type.  When a
-    -- parameter, this implies that it must have been returned by a
-    -- previous call to Futhark, and hence we can preserve (constant)
-    -- size constraints.
-    EntryTrusted
-  | -- | The type is directly exposed.  Any size constraint cannot be
-    -- trusted.
-    EntryUntrusted
-
-entryTrust :: EntryType -> EntryTrust
-entryTrust t
-  | E.Scalar (E.Prim E.Unsigned {}) <- E.entryType t =
-    EntryUntrusted
-  | E.Array _ _ (E.Prim E.Unsigned {}) _ <- E.entryType t =
-    EntryUntrusted
-  | E.Scalar E.Prim {} <- E.entryType t =
-    EntryUntrusted
-  | E.Array _ _ E.Prim {} _ <- E.entryType t =
-    EntryUntrusted
-  | otherwise =
-    EntryTrusted
-
-fixEntryParamSizes :: MonadFreshNames m => E.Pattern -> EntryTrust -> m E.Pattern
-fixEntryParamSizes p EntryTrusted = pure p
-fixEntryParamSizes p EntryUntrusted = allDimsFreshInPat p
-
--- When we are returning a value from the entry point, we fully
--- existentialise the return type.  This is because it might otherwise
--- refer to sizes that are not in scope, because the generated entry
--- point function does not keep the size parameters of the original
--- entry point.
-fullyExistential ::
-  [[I.TypeBase ExtShape u]] ->
-  [[I.TypeBase ExtShape u]]
-fullyExistential tss =
-  evalState (mapM (mapM (bitraverse (traverse onDim) pure)) tss) 0
-  where
-    onDim _ = do
-      i <- get
-      modify (+ 1)
-      pure $ Ext i
-
 generateEntryPoint :: E.EntryPoint -> E.ValBind -> InternaliseM ()
 generateEntryPoint (E.EntryPoint e_paramts e_rettype) vb = localConstsScope $ do
-  let (E.ValBind _ ofname _ (Info (rettype, _)) _ params _ _ attrs loc) = vb
-  -- We replace all shape annotations, so there should be no constant
-  -- parameters here.
-  params_fresh <- zipWithM fixEntryParamSizes params $ map entryTrust e_paramts
-  let tparams =
-        map (`E.TypeParamDim` mempty) $
-          S.toList $
-            mconcat $ map E.patternDimNames params_fresh
-  bindingParams tparams params_fresh $ \shapeparams params' -> do
-    entry_rettype <- fullyExistential <$> internaliseEntryReturnType rettype
+  let (E.ValBind _ ofname _ (Info (rettype, _)) tparams params _ _ attrs loc) = vb
+  bindingParams tparams params $ \shapeparams params' -> do
+    entry_rettype <- internaliseEntryReturnType rettype
     let entry' = entryPoint (zip e_paramts params') (e_rettype, entry_rettype)
         args = map (I.Var . I.paramName) $ concat params'
 

--- a/src/Futhark/Internalise/Defunctionalise.hs
+++ b/src/Futhark/Internalise/Defunctionalise.hs
@@ -21,6 +21,7 @@ import qualified Data.Set as S
 import Futhark.IR.Pretty ()
 import qualified Futhark.Internalise.FreeVars as FV
 import Futhark.MonadFreshNames
+import Futhark.Util (nubOrd)
 import Language.Futhark
 import Language.Futhark.Traversals
 
@@ -42,12 +43,25 @@ data StaticVal
   | -- | The constructor that is actually present, plus
     -- the others that are not.
     SumSV Name [StaticVal] [(Name, [PatternType])]
-  | DynamicFun (Exp, StaticVal) StaticVal
+  | -- | The pair is the StaticVal and residual expression of this
+    -- function as a whole, while the second StaticVal is its
+    -- body. (Don't trust this too much, my understanding may have
+    -- holes.)
+    DynamicFun (Exp, StaticVal) StaticVal
   | IntrinsicSV
   deriving (Show)
 
--- | Environment mapping variable names to their associated static value.
-type Env = M.Map VName StaticVal
+-- | The type is Just if this is a polymorphic binding that must be
+-- instantiated.
+data Binding = Binding (Maybe ([VName], StructType)) StaticVal
+  deriving (Show)
+
+bindingSV :: Binding -> StaticVal
+bindingSV (Binding _ sv) = sv
+
+-- | Environment mapping variable names to their associated static
+-- value.
+type Env = M.Map VName Binding
 
 localEnv :: Env -> DefM a -> DefM a
 localEnv env = local $ Arrow.second (env <>)
@@ -58,95 +72,135 @@ localNewEnv :: Env -> DefM a -> DefM a
 localNewEnv env = local $ \(globals, old_env) ->
   (globals, M.filterWithKey (\k _ -> k `S.member` globals) old_env <> env)
 
-extendEnv :: VName -> StaticVal -> DefM a -> DefM a
-extendEnv vn sv = localEnv (M.singleton vn sv)
-
 askEnv :: DefM Env
 askEnv = asks snd
 
 isGlobal :: VName -> DefM a -> DefM a
 isGlobal v = local $ Arrow.first (S.insert v)
 
-replaceStaticValSizes :: M.Map VName VName -> StaticVal -> StaticVal
-replaceStaticValSizes orig_substs sv =
+replaceStaticValSizes ::
+  S.Set VName ->
+  M.Map VName SizeSubst ->
+  StaticVal ->
+  StaticVal
+replaceStaticValSizes globals orig_substs sv =
   case sv of
     _ | M.null orig_substs -> sv
     LambdaSV sizes param t e closure_env ->
-      -- We ignore substitutions that we shadow.
       let substs =
             foldl' (flip M.delete) orig_substs $
-              patternNames param <> S.fromList sizes
+              S.fromList (M.keys closure_env)
        in LambdaSV
-            sizes
-            (onAST orig_substs param) -- intentional
+            (nubOrd $ mapMaybe (onSizeParam orig_substs) sizes)
+            (onAST substs param)
             (onType substs t)
             (onExtExp substs e)
-            (onEnv orig_substs closure_env)
+            (onEnv orig_substs closure_env) --intentional
     Dynamic t ->
       Dynamic $ onType orig_substs t
     RecordSV fs ->
-      RecordSV $ map (fmap (replaceStaticValSizes orig_substs)) fs
+      RecordSV $ map (fmap (replaceStaticValSizes globals orig_substs)) fs
     SumSV c svs ts ->
-      SumSV c (map (replaceStaticValSizes orig_substs) svs) $
-        map (fmap (map (onType orig_substs))) ts
+      SumSV c (map (replaceStaticValSizes globals orig_substs) svs) $
+        map (fmap $ map $ onType orig_substs) ts
     DynamicFun (e, sv1) sv2 ->
-      DynamicFun (onAST orig_substs e, replaceStaticValSizes orig_substs sv1) $
-        replaceStaticValSizes orig_substs sv2
+      DynamicFun (onExp orig_substs e, replaceStaticValSizes globals orig_substs sv1) $
+        replaceStaticValSizes globals orig_substs sv2
     IntrinsicSV ->
       IntrinsicSV
   where
-    onName substs v = fromMaybe v $ M.lookup v substs
-    onQualName substs v = maybe v qualName $ M.lookup (qualLeaf v) substs
-
     tv substs =
       identityMapper
         { mapOnPatternType = pure . onType substs,
           mapOnStructType = pure . onType substs,
-          mapOnQualName = pure . onQualName substs,
-          mapOnExp = pure . onAST substs
+          mapOnExp = pure . onExp substs
         }
 
-    onExtExp substs (ExtExp e) =
-      ExtExp $ onAST substs e
-    onExtExp substs (ExtLambda dims params e (als, t) loc) =
-      let substs' = foldl' (flip M.delete) substs $ map typeParamName dims
-          (params', e', t') = onExtLambda substs' params e t
-       in ExtLambda dims params' e' (als, t') loc
+    -- If a size is replaced by a constant, then we remove it entirely.
+    onSizeParam substs d =
+      case M.lookup d substs of
+        Just (SubstNamed d')
+          | qualLeaf d' `S.member` globals -> Nothing
+          | otherwise -> Just $ qualLeaf d'
+        Just (SubstConst _) -> Nothing
+        Nothing -> Just d
 
-    onExtLambda substs (p : ps) e t =
-      -- We ignore substitutions that we shadow.
-      let substs' = foldl' (flip M.delete) substs (patternNames p)
-          (ps', e', t') = onExtLambda substs' ps e t
-       in (onAST substs p : ps', e', t')
-    onExtLambda substs [] e t =
-      ([], onAST substs e, onType substs t)
+    onExp substs (Var v t loc) =
+      case M.lookup (qualLeaf v) substs of
+        Just (SubstNamed v') ->
+          Var v' t loc
+        Just (SubstConst d) ->
+          Literal (SignedValue (Int64Value (fromIntegral d))) loc
+        Nothing ->
+          Var v (onType substs <$> t) loc
+    onExp substs (Coerce e tdecl t loc) =
+      Coerce (onExp substs e) tdecl' (first (fmap (onType substs)) t) loc
+      where
+        tdecl' =
+          TypeDecl
+            { declaredType = onTypeExp substs $ declaredType tdecl,
+              expandedType = onType substs <$> expandedType tdecl
+            }
+    onExp substs e = onAST substs e
+
+    onTypeExpDim substs d@(DimExpNamed v loc) =
+      case M.lookup (qualLeaf v) substs of
+        Just (SubstNamed v') ->
+          DimExpNamed v' loc
+        Just (SubstConst x) ->
+          DimExpConst x loc
+        Nothing ->
+          d
+    onTypeExpDim _ d = d
+
+    onTypeArgExp substs (TypeArgExpDim d loc) =
+      TypeArgExpDim (onTypeExpDim substs d) loc
+    onTypeArgExp substs (TypeArgExpType te) =
+      TypeArgExpType (onTypeExp substs te)
+
+    onTypeExp substs (TEArray te d loc) =
+      TEArray (onTypeExp substs te) (onTypeExpDim substs d) loc
+    onTypeExp substs (TEUnique t loc) =
+      TEUnique (onTypeExp substs t) loc
+    onTypeExp substs (TEApply t1 t2 loc) =
+      TEApply (onTypeExp substs t1) (onTypeArgExp substs t2) loc
+    onTypeExp substs (TEArrow p t1 t2 loc) =
+      TEArrow p (onTypeExp substs t1) (onTypeExp substs t2) loc
+    onTypeExp substs (TETuple ts loc) =
+      TETuple (map (onTypeExp substs) ts) loc
+    onTypeExp substs (TERecord ts loc) =
+      TERecord (map (fmap $ onTypeExp substs) ts) loc
+    onTypeExp substs (TESum ts loc) =
+      TESum (map (fmap $ map $ onTypeExp substs) ts) loc
+    onTypeExp _ (TEVar v loc) =
+      TEVar v loc
+
+    onExtExp substs (ExtExp e) =
+      ExtExp $ onExp substs e
+    onExtExp substs (ExtLambda dims params e (als, t) loc) =
+      ExtLambda dims (map (onAST substs) params) (onExp substs e) (als, onType substs t) loc
 
     onEnv substs =
       M.fromList
-        . map (bimap (onName substs) (replaceStaticValSizes substs))
+        . map (second (onBinding substs))
         . M.toList
 
-    onAST :: ASTMappable x => M.Map VName VName -> x -> x
-    onAST substs x
-      | M.null substs = x
-      | otherwise = runIdentity $ astMap (tv substs) x
+    onBinding substs (Binding t bsv) =
+      Binding
+        (second (onType substs) <$> t)
+        (replaceStaticValSizes globals substs bsv)
+
+    onAST :: ASTMappable x => M.Map VName SizeSubst -> x -> x
+    onAST substs = runIdentity . astMap (tv substs)
 
     onType substs = first onDim
       where
         onDim (NamedDim v) =
-          NamedDim $ maybe v qualName $ M.lookup (qualLeaf v) substs
+          case M.lookup (qualLeaf v) substs of
+            Just (SubstNamed v') -> NamedDim v'
+            Just (SubstConst d) -> ConstDim d
+            Nothing -> NamedDim v
         onDim d = d
-
--- | Construct new sizes for a LambdaSV (if that is what it is).  This
--- is needed because sizes must be unique when we substitute the
--- closure for the LambdaSV into another function, because sizes float
--- to the top (see issue #1147).
-newSizesForLambda :: StaticVal -> DefM StaticVal
-newSizesForLambda (LambdaSV sizes param t e closure_env) = do
-  sizes' <- mapM newName sizes
-  let substs = M.fromList $ zip sizes sizes'
-  pure $ replaceStaticValSizes substs $ LambdaSV sizes' param t e closure_env
-newSizesForLambda sv = pure sv
 
 -- | Returns the defunctionalization environment restricted
 -- to the given set of variable names and types.
@@ -155,16 +209,16 @@ restrictEnvTo (FV.NameSet m) = restrict <$> ask
   where
     restrict (globals, env) = M.mapMaybeWithKey keep env
       where
-        keep k sv = do
+        keep k (Binding t sv) = do
           guard $ not $ k `S.member` globals
           u <- uniqueness <$> M.lookup k m
-          Just $ restrict' u sv
+          Just $ Binding t $ restrict' u sv
     restrict' Nonunique (Dynamic t) =
       Dynamic $ t `setUniqueness` Nonunique
     restrict' _ (Dynamic t) =
       Dynamic t
     restrict' u (LambdaSV dims pat t e env) =
-      LambdaSV dims pat t e $ M.map (restrict' u) env
+      LambdaSV dims pat t e $ M.map (restrict'' u) env
     restrict' u (RecordSV fields) =
       RecordSV $ map (fmap $ restrict' u) fields
     restrict' u (SumSV c svs fields) =
@@ -172,6 +226,7 @@ restrictEnvTo (FV.NameSet m) = restrict <$> ask
     restrict' u (DynamicFun (e, sv1) sv2) =
       DynamicFun (e, restrict' u sv1) $ restrict' u sv2
     restrict' _ IntrinsicSV = IntrinsicSV
+    restrict'' u (Binding t sv) = Binding t $ restrict' u sv
 
 -- | Defunctionalization monad.  The Reader environment tracks both
 -- the current Env as well as the set of globally defined dynamic
@@ -198,11 +253,15 @@ collectFuns m = pass $ do
   return ((x, decs), const mempty)
 
 -- | Looks up the associated static value for a given name in the environment.
-lookupVar :: SrcLoc -> VName -> DefM StaticVal
-lookupVar loc x = do
+lookupVar :: StructType -> SrcLoc -> VName -> DefM StaticVal
+lookupVar t loc x = do
   env <- askEnv
   case M.lookup x env of
-    Just sv -> return sv
+    Just (Binding (Just (dims, sv_t)) sv) -> do
+      globals <- asks fst
+      pure $ instStaticVal globals dims t sv_t sv
+    Just (Binding Nothing sv) ->
+      pure sv
     Nothing -- If the variable is unknown, it may refer to the 'intrinsics'
     -- module, which we will have to treat specially.
       | baseTag x <= maxIntrinsicTag -> return IntrinsicSV
@@ -238,17 +297,41 @@ arraySizes (Array _ _ t shape) =
 patternArraySizes :: Pattern -> S.Set VName
 patternArraySizes = arraySizes . patternStructType
 
+data SizeSubst
+  = SubstNamed (QualName VName)
+  | SubstConst Int
+  deriving (Eq, Ord, Show)
+
 dimMapping ::
   Monoid a =>
   TypeBase (DimDecl VName) a ->
   TypeBase (DimDecl VName) a ->
-  M.Map VName VName
+  M.Map VName SizeSubst
 dimMapping t1 t2 = execState (matchDims f t1 t2) mempty
   where
     f (NamedDim d1) (NamedDim d2) = do
-      modify $ M.insert (qualLeaf d1) (qualLeaf d2)
+      modify $ M.insert (qualLeaf d1) $ SubstNamed d2
+      return $ NamedDim d1
+    f (NamedDim d1) (ConstDim d2) = do
+      modify $ M.insert (qualLeaf d1) $ SubstConst d2
       return $ NamedDim d1
     f d _ = return d
+
+dimMapping' ::
+  Monoid a =>
+  TypeBase (DimDecl VName) a ->
+  TypeBase (DimDecl VName) a ->
+  M.Map VName VName
+dimMapping' t1 t2 = M.mapMaybe f $ dimMapping t1 t2
+  where
+    f (SubstNamed d) = Just $ qualLeaf d
+    f _ = Nothing
+
+instStaticVal :: S.Set VName -> [VName] -> StructType -> StructType -> StaticVal -> StaticVal
+instStaticVal globals dim t sv_t sv =
+  let isDim k _ = k `elem` dim
+      substs = M.filterWithKey isDim $ dimMapping sv_t t
+   in replaceStaticValSizes globals substs sv
 
 defuncFun ::
   [TypeParam] ->
@@ -290,14 +373,14 @@ defuncFun tparams pats e0 (closure, ret) loc = do
   -- The closure parts that are sizes are proactively turned into size
   -- parameters.
   let sizes_of_arrays =
-        foldMap (arraySizes . toStruct . typeFromSV') used_env
+        foldMap (arraySizes . toStruct . typeFromSV' . bindingSV) used_env
           <> patternArraySizes pat
       notSize = not . (`S.member` sizes_of_arrays)
       (fields, env) =
-        unzip $
-          map closureFromDynamicFun $
-            filter (notSize . fst) $ M.toList used_env
-      env' = M.fromList env
+        second M.fromList $
+          unzip $
+            map closureFromDynamicFun $
+              filter (notSize . fst) $ M.toList used_env
       closure_dims = S.toList sizes_of_arrays
 
   global <- asks fst
@@ -312,20 +395,22 @@ defuncFun tparams pats e0 (closure, ret) loc = do
         pat
         ret'
         e0'
-        env'
+        env
     )
   where
-    closureFromDynamicFun (vn, DynamicFun (clsr_env, sv) _) =
+    closureFromDynamicFun (vn, Binding _ (DynamicFun (clsr_env, sv) _)) =
       let name = nameFromString $ pretty vn
-       in (RecordFieldExplicit name clsr_env mempty, (vn, sv))
-    closureFromDynamicFun (vn, sv) =
+       in ( RecordFieldExplicit name clsr_env mempty,
+            (vn, Binding Nothing sv)
+          )
+    closureFromDynamicFun (vn, Binding _ sv) =
       let name = nameFromString $ pretty vn
           tp' = typeFromSV' sv
        in ( RecordFieldExplicit
               name
               (Var (qualName vn) (Info tp') mempty)
               mempty,
-            (vn, sv)
+            (vn, Binding Nothing sv)
           )
 
 -- | Defunctionalization of an expression. Returns the residual expression and
@@ -355,8 +440,8 @@ defuncExp (RecordLit fs loc) = do
     defuncField (RecordFieldExplicit vn e loc') = do
       (e', sv) <- defuncExp e
       return (RecordFieldExplicit vn e' loc', (vn, sv))
-    defuncField (RecordFieldImplicit vn _ loc') = do
-      sv <- lookupVar loc' vn
+    defuncField (RecordFieldImplicit vn (Info t) loc') = do
+      sv <- lookupVar (toStruct t) loc' vn
       case sv of
         -- If the implicit field refers to a dynamic function, we
         -- convert it to an explicit field with a record closing over
@@ -380,8 +465,8 @@ defuncExp (Range e1 me incl t@(Info t', _) loc) = do
   me' <- mapM defuncExp' me
   incl' <- mapM defuncExp' incl
   return (Range e1' me' incl' t loc, Dynamic t')
-defuncExp e@(Var qn _ loc) = do
-  sv <- lookupVar loc (qualLeaf qn)
+defuncExp e@(Var qn (Info t) loc) = do
+  sv <- lookupVar (toStruct t) loc (qualLeaf qn)
   case sv of
     -- If the variable refers to a dynamic function, we return its closure
     -- representation (i.e., a record expression capturing the free variables
@@ -413,7 +498,7 @@ defuncExp (LetPat pat e1 e2 (Info t, retext) loc) = do
   -- To maintain any sizes going out of scope, we need to compute the
   -- old size substitution induced by retext and also apply it to the
   -- newly computed body type.
-  let mapping = dimMapping (typeOf e2) t
+  let mapping = dimMapping' (typeOf e2) t
       subst v = fromMaybe v $ M.lookup v mapping
       t' = first (fmap subst) $ typeOf e2'
   return (LetPat pat' e1' e2' (Info t', retext) loc, sv2)
@@ -463,7 +548,7 @@ defuncExp (DoLoop sparams pat e1 form e3 ret loc) = do
   return (DoLoop sparams pat e1' form' e3' ret loc, sv)
   where
     envFromIdent (Ident vn (Info tp) _) =
-      M.singleton vn $ Dynamic tp
+      M.singleton vn $ Binding Nothing $ Dynamic tp
 defuncExp e@BinOp {} =
   error $ "defuncExp: unexpected binary operator: " ++ pretty e
 defuncExp (Project vn e0 tp@(Info tp') loc) = do
@@ -476,9 +561,11 @@ defuncExp (Project vn e0 tp@(Info tp') loc) = do
     _ -> error $ "Projection of an expression with static value " ++ show sv0
 defuncExp (LetWith id1 id2 idxs e1 body t loc) = do
   e1' <- defuncExp' e1
-  sv1 <- lookupVar (identSrcLoc id2) $ identName id2
   idxs' <- mapM defuncDimIndex idxs
-  (body', sv) <- extendEnv (identName id1) sv1 $ defuncExp body
+  let id1_binding = Binding Nothing $ Dynamic $ unInfo $ identType id1
+  (body', sv) <-
+    localEnv (M.singleton (identName id1) id1_binding) $
+      defuncExp body
   return (LetWith id1 id2 idxs' e1' body' t loc, sv)
 defuncExp expr@(Index e0 idxs info loc) = do
   e0' <- defuncExp' e0
@@ -562,7 +649,7 @@ defuncExp' = fmap fst . defuncExp
 defuncExtExp :: ExtExp -> DefM (Exp, StaticVal)
 defuncExtExp (ExtExp e) = defuncExp e
 defuncExtExp (ExtLambda tparams pats e0 (closure, ret) loc) =
-  traverse newSizesForLambda
+  pure -- traverse newSizesForLambda
     =<< defuncFun tparams pats e0 (closure, ret) loc
 
 defuncCase :: StaticVal -> Case -> DefM (Case, StaticVal)
@@ -646,7 +733,12 @@ defuncLet dims ps@(pat : pats) body rettype
         env = envFromPattern pat <> envFromShapeParams pat_dims
     (rest_dims', pats', body', sv) <- localEnv env $ defuncLet rest_dims pats body rettype
     closure <- defuncFun dims ps body (mempty, rettype) mempty
-    return (pat_dims ++ rest_dims', pat : pats', body', DynamicFun closure sv)
+    return
+      ( pat_dims ++ rest_dims',
+        pat : pats',
+        body',
+        DynamicFun closure sv
+      )
   | otherwise = do
     (e, sv) <- defuncFun dims ps body (mempty, rettype) mempty
     return ([], [], e, sv)
@@ -686,9 +778,11 @@ defuncApply depth e@(Apply e1 e2 d t@(Info ret, Info ext) loc) = do
     LambdaSV dims pat e0_t e0 closure_env -> do
       let env' = matchPatternSV pat sv2
           env_dim = envFromDimNames dims
-      (e0', sv) <- localNewEnv (env' <> closure_env <> env_dim) $ defuncExtExp e0
+      (e0', sv) <-
+        localNewEnv (env' <> closure_env <> env_dim) $
+          defuncExtExp e0
 
-      let closure_pat = buildEnvPattern closure_env
+      let closure_pat = buildEnvPattern dims closure_env
           pat' = updatePattern pat sv2
 
       globals <- asks fst
@@ -706,6 +800,7 @@ defuncApply depth e@(Apply e1 e2 d t@(Info ret, Info ext) loc) = do
           already_bound =
             globals <> S.fromList dims
               <> S.map identName (foldMap patternIdents params)
+
           more_dims =
             S.toList $
               S.filter (`S.notMember` already_bound) $
@@ -786,8 +881,7 @@ defuncApply depth e@(Apply e1 e2 d t@(Info ret, Info ext) loc) = do
             | orderZero ret = (Info ret, Info ext)
             | otherwise = (Info restype, Info ext)
           apply_e = Apply e1' e2' d callret loc
-      sv' <- newSizesForLambda sv
-      return (apply_e, sv')
+      return (apply_e, sv)
     -- Propagate the 'IntrinsicsSV' until we reach the outermost application,
     -- where we construct a dynamic static value with the appropriate type.
     IntrinsicSV
@@ -810,17 +904,18 @@ defuncApply depth e@(Apply e1 e2 d t@(Info ret, Info ext) loc) = do
           ++ show sv1
 defuncApply depth e@(Var qn (Info t) loc) = do
   let (argtypes, _) = unfoldFunType t
-  sv <- lookupVar loc (qualLeaf qn)
+  sv <- lookupVar (toStruct t) loc (qualLeaf qn)
+
   case sv of
     DynamicFun _ _
-      | fullyApplied sv depth ->
+      | fullyApplied sv depth -> do
         -- We still need to update the types in case the dynamic
         -- function returns a higher-order term.
         let (argtypes', rettype) = dynamicFunType sv argtypes
-         in return (Var qn (Info (foldFunType argtypes' rettype)) loc, sv)
+        return (Var qn (Info (foldFunType argtypes' rettype)) loc, sv)
       | otherwise -> do
         fname <- newName $ qualLeaf qn
-        let (dims, pats, e0, sv') = liftDynFun sv depth
+        let (dims, pats, e0, sv') = liftDynFun (pretty qn) sv depth
             pats_names = S.map identName $ mconcat $ map patternIdents pats
             notInPats = (`S.notMember` pats_names)
             dims' = filter notInPats dims
@@ -856,16 +951,19 @@ fullyApplied _ _ = True
 -- dimensions, a list of parameters, a function body, and the
 -- appropriate static value for applying the function at the given
 -- depth of partial application.
-liftDynFun :: StaticVal -> Int -> ([VName], [Pattern], Exp, StaticVal)
-liftDynFun (DynamicFun (e, sv) _) 0 = ([], [], e, sv)
-liftDynFun (DynamicFun clsr@(_, LambdaSV dims pat _ _ _) sv) d
+liftDynFun :: String -> StaticVal -> Int -> ([VName], [Pattern], Exp, StaticVal)
+liftDynFun _ (DynamicFun (e, sv) _) 0 = ([], [], e, sv)
+liftDynFun s (DynamicFun clsr@(_, LambdaSV dims pat _ _ _) sv) d
   | d > 0 =
-    let (dims', pats, e', sv') = liftDynFun sv (d -1)
+    let (dims', pats, e', sv') = liftDynFun s sv (d -1)
      in (nub $ dims ++ dims', pat : pats, e', DynamicFun clsr sv')
-liftDynFun sv _ =
+liftDynFun s sv d =
   error $
-    "Tried to lift a StaticVal " ++ show sv
-      ++ ", but expected a dynamic function."
+    s
+      ++ " Tried to lift a StaticVal "
+      ++ take 100 (show sv)
+      ++ ", but expected a dynamic function.\n"
+      ++ pretty d
 
 -- | Converts a pattern to an environment that binds the individual names of the
 -- pattern to their corresponding types wrapped in a 'Dynamic' static value.
@@ -874,7 +972,7 @@ envFromPattern pat = case pat of
   TuplePattern ps _ -> foldMap envFromPattern ps
   RecordPattern fs _ -> foldMap (envFromPattern . snd) fs
   PatternParens p _ -> envFromPattern p
-  Id vn (Info t) _ -> M.singleton vn $ Dynamic t
+  Id vn (Info t) _ -> M.singleton vn $ Binding Nothing $ Dynamic t
   Wildcard _ _ -> mempty
   PatternAscription p _ _ -> envFromPattern p
   PatternLit {} -> mempty
@@ -895,7 +993,9 @@ envFromShapeParams = envFromDimNames . map dim
           ++ "."
 
 envFromDimNames :: [VName] -> Env
-envFromDimNames = M.fromList . flip zip (repeat $ Dynamic $ Scalar $ Prim $ Signed Int64)
+envFromDimNames = M.fromList . flip zip (repeat d)
+  where
+    d = Binding Nothing $ Dynamic $ Scalar $ Prim $ Signed Int64
 
 -- | Create a new top-level value declaration with the given function name,
 -- return type, list of parameters, and body expression.
@@ -929,13 +1029,16 @@ liftValDec fname rettype dims pats body = tell $ Seq.singleton dec
         }
 
 -- | Given a closure environment, construct a record pattern that
--- binds the closed over variables.
-buildEnvPattern :: Env -> Pattern
-buildEnvPattern env = RecordPattern (map buildField $ M.toList env) mempty
+-- binds the closed over variables.  Insert wildcard for any patterns
+-- that would otherwise clash with size parameters.
+buildEnvPattern :: [VName] -> Env -> Pattern
+buildEnvPattern sizes env = RecordPattern (map buildField $ M.toList env) mempty
   where
-    buildField (vn, sv) =
+    buildField (vn, Binding _ sv) =
       ( nameFromString (pretty vn),
-        Id vn (Info $ snd $ typeFromSV sv) mempty
+        if vn `elem` sizes
+          then Wildcard (Info $ snd $ typeFromSV sv) mempty
+          else Id vn (Info $ snd $ typeFromSV sv) mempty
       )
 
 -- | Given a closure environment pattern and the type of a term,
@@ -968,7 +1071,8 @@ buildRetType env pats = comb
     descend (Scalar (Record t)) = Scalar $ Record $ fmap descend t
     descend t = t
 
--- | Compute the corresponding type for a given static value.
+-- | Compute the corresponding type for the *representation* of a
+-- given static value (not the original possibly higher-order value).
 typeFromSV :: StaticVal -> ([VName], PatternType)
 typeFromSV (Dynamic tp) =
   (mempty, tp)
@@ -977,7 +1081,9 @@ typeFromSV (LambdaSV sizes _ _ _ env) =
     Scalar $ Record $ M.fromList $ map (fmap snd) env'
   )
   where
-    env' = map (bimap (nameFromString . pretty) typeFromSV) $ M.toList env
+    env' =
+      map (bimap (nameFromString . pretty) (typeFromSV . bindingSV)) $
+        M.toList env
     env_sizes = concatMap (fst . snd) env'
 typeFromSV (RecordSV ls) =
   let ts = map (fmap typeFromSV) ls
@@ -1023,8 +1129,8 @@ matchPatternSV (Id vn (Info t) _) sv =
   -- the pattern wins out.  This is important when matching a
   -- nonunique pattern with a unique value.
   if orderZeroSV sv
-    then M.singleton vn $ Dynamic t
-    else M.singleton vn sv
+    then M.singleton vn $ Binding Nothing $ Dynamic t
+    else M.singleton vn $ Binding Nothing sv
 matchPatternSV (Wildcard _ _) _ = mempty
 matchPatternSV (PatternAscription pat _ _) sv = matchPatternSV pat sv
 matchPatternSV PatternLit {} _ = mempty
@@ -1166,7 +1272,15 @@ defuncValBind valbind@(ValBind _ name retdecl (Info (rettype, retext)) tparams p
           valBindParams = params'',
           valBindBody = body'
         },
-      M.singleton name sv,
+      M.singleton name $
+        Binding
+          ( Just
+              ( first
+                  (map typeParamName)
+                  (valBindTypeScheme valbind)
+              )
+          )
+          sv,
       case sv of
         DynamicFun {} -> True
         Dynamic {} -> True

--- a/src/Futhark/Optimise/Simplify.hs
+++ b/src/Futhark/Optimise/Simplify.hs
@@ -44,11 +44,11 @@ simplifyProg ::
 simplifyProg simpl rules blockers (Prog consts funs) = do
   (consts_vtable, consts') <-
     simplifyConsts
-      (UT.usages $ foldMap (freeIn . funDefBody) funs)
+      (UT.usages $ foldMap freeIn funs)
       (mempty, consts)
 
   funs' <- parPass (simplifyFun' consts_vtable) funs
-  let funs_uses = UT.usages $ foldMap (freeIn . funDefBody) funs'
+  let funs_uses = UT.usages $ foldMap freeIn funs'
 
   (_, consts'') <- simplifyConsts funs_uses (mempty, consts')
 

--- a/src/Futhark/Optimise/Simplify/Engine.hs
+++ b/src/Futhark/Optimise/Simplify/Engine.hs
@@ -66,7 +66,7 @@ where
 import Control.Monad.Reader
 import Control.Monad.State.Strict
 import Data.Either
-import Data.List (find, foldl', mapAccumL, nub)
+import Data.List (find, foldl', mapAccumL)
 import Data.Maybe
 import qualified Futhark.Analysis.SymbolTable as ST
 import qualified Futhark.Analysis.UsageTable as UT
@@ -75,7 +75,7 @@ import Futhark.IR
 import Futhark.IR.Prop.Aliases
 import Futhark.Optimise.Simplify.Lore
 import Futhark.Optimise.Simplify.Rule
-import Futhark.Util (splitFromEnd)
+import Futhark.Util (nubOrd, splitFromEnd)
 
 data HoistBlockers lore = HoistBlockers
   { -- | Blocker for hoisting out of parallel loops.
@@ -1011,7 +1011,7 @@ consumeResult = mconcat . map inspect
     inspect _ = mempty
 
 instance Simplifiable Certificates where
-  simplify (Certificates ocs) = Certificates . nub . concat <$> mapM check ocs
+  simplify (Certificates ocs) = Certificates . nubOrd . concat <$> mapM check ocs
     where
       check idd = do
         vv <- ST.lookupSubExp idd <$> askVtable

--- a/src/Futhark/TypeCheck.hs
+++ b/src/Futhark/TypeCheck.hs
@@ -876,8 +876,13 @@ checkBasicOp (Copy e) =
   void $ checkArrIdent e
 checkBasicOp (Manifest perm arr) =
   checkBasicOp $ Rearrange perm arr -- Basically same thing!
-checkBasicOp (Assert e _ _) =
+checkBasicOp (Assert e (ErrorMsg parts) _) = do
   require [Prim Bool] e
+  mapM_ checkPart parts
+  where
+    checkPart ErrorString {} = return ()
+    checkPart (ErrorInt32 x) = require [Prim int32] x
+    checkPart (ErrorInt64 x) = require [Prim int64] x
 
 matchLoopResultExt ::
   Checkable lore =>

--- a/src/Language/Futhark/Prop.hs
+++ b/src/Language/Futhark/Prop.hs
@@ -113,13 +113,13 @@ import Data.Bifunctor
 import Data.Bitraversable (bitraverse)
 import Data.Char
 import Data.Foldable
-import Data.List (genericLength, isPrefixOf, nub, sortOn)
+import Data.List (genericLength, isPrefixOf, sortOn)
 import qualified Data.Map.Strict as M
 import Data.Maybe
 import Data.Ord
 import qualified Data.Set as S
 import qualified Futhark.IR.Primitive as Primitive
-import Futhark.Util (maxinum)
+import Futhark.Util (maxinum, nubOrd)
 import Futhark.Util.Pretty
 import Language.Futhark.Syntax
 
@@ -140,13 +140,13 @@ nestedDims :: TypeBase (DimDecl VName) as -> [DimDecl VName]
 nestedDims t =
   case t of
     Array _ _ a ds ->
-      nub $ nestedDims (Scalar a) <> shapeDims ds
+      nubOrd $ nestedDims (Scalar a) <> shapeDims ds
     Scalar (Record fs) ->
-      nub $ foldMap nestedDims fs
+      nubOrd $ foldMap nestedDims fs
     Scalar Prim {} ->
       mempty
     Scalar (Sum cs) ->
-      nub $ foldMap (foldMap nestedDims) cs
+      nubOrd $ foldMap (foldMap nestedDims) cs
     Scalar (Arrow _ v t1 t2) ->
       filter (notV v) $ nestedDims t1 <> nestedDims t2
     Scalar (TypeVar _ _ _ targs) ->

--- a/src/Language/Futhark/TypeChecker/Terms.hs
+++ b/src/Language/Futhark/TypeChecker/Terms.hs
@@ -27,12 +27,13 @@ import Control.Monad.Writer hiding (Sum)
 import Data.Bifunctor
 import Data.Char (isAscii)
 import Data.Either
-import Data.List (find, foldl', isPrefixOf, nub, sort)
+import Data.List (find, foldl', isPrefixOf, sort)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 import Data.Maybe
 import qualified Data.Set as S
 import Futhark.IR.Primitive (intByteSize)
+import Futhark.Util (nubOrd)
 import Futhark.Util.Pretty hiding (bool, group, space)
 import Language.Futhark hiding (unscopeType)
 import Language.Futhark.Semantic (includeToString)
@@ -1806,7 +1807,7 @@ checkExp (DoLoop _ mergepat mergeexp form loopbody NoInfo loc) =
           mapM_ dimToInit $ M.toList init_substs'
 
           mergepat'' <- applySubst (`M.lookup` init_substs') <$> updateTypes mergepat'
-          return (nub sparams, mergepat'')
+          return (nubOrd sparams, mergepat'')
 
     -- First we do a basic check of the loop body to figure out which of
     -- the merge parameters are being consumed.  For this, we first need

--- a/src/Language/Futhark/TypeChecker/Types.hs
+++ b/src/Language/Futhark/TypeChecker/Types.hs
@@ -26,9 +26,10 @@ import Control.Monad.Identity
 import Control.Monad.Reader
 import Control.Monad.State
 import Data.Bifunctor
-import Data.List (foldl', nub, sort)
+import Data.List (foldl', sort)
 import qualified Data.Map.Strict as M
 import Data.Maybe
+import Futhark.Util (nubOrd)
 import Futhark.Util.Pretty
 import Language.Futhark
 import Language.Futhark.Traversals
@@ -144,7 +145,7 @@ checkTypeExp (TETuple ts loc) = do
 checkTypeExp t@(TERecord fs loc) = do
   -- Check for duplicate field names.
   let field_names = map fst fs
-  unless (sort field_names == sort (nub field_names)) $
+  unless (sort field_names == sort (nubOrd field_names)) $
     typeError loc mempty $ "Duplicate record fields in" <+> ppr t <> "."
 
   fs_ts_ls <- traverse checkTypeExp $ M.fromList fs
@@ -265,7 +266,7 @@ checkTypeExp ote@TEApply {} = do
           <+> ppr p <> "."
 checkTypeExp t@(TESum cs loc) = do
   let constructors = map fst cs
-  unless (sort constructors == sort (nub constructors)) $
+  unless (sort constructors == sort (nubOrd constructors)) $
     typeError loc mempty $ "Duplicate constructors in" <+> ppr t
 
   unless (length constructors < 256) $

--- a/tests/issue1192.fut
+++ b/tests/issue1192.fut
@@ -1,0 +1,7 @@
+-- ==
+-- input { [1f32,2f32,3f32] }
+-- output { [[1.0f32, 2.0f32, 3.0f32], [3.0f32, 1.0f32, 2.0f32], [2.0f32, 3.0f32, 1.0f32]] }
+
+let main [n] (Irow1: [n]f32) =
+  let In: [n][n]f32 = map (\i -> rotate (-i) Irow1) (iota n)
+  in In

--- a/tests/issue1194.fut
+++ b/tests/issue1194.fut
@@ -1,0 +1,6 @@
+-- ==
+-- input { 8i64 } output { 511i64 }
+
+let main (n: i64) =
+  loop i = 0 for d in n..n-1...0 do
+    i + (1 << n - d)

--- a/tests/issue436.fut
+++ b/tests/issue436.fut
@@ -5,5 +5,5 @@
 -- input { 2i64 [1] }
 -- error:
 
-let main (n: i64) (xs: []i32) =
-  map (+2) (map (+1) (xs: [n]i32))
+let main [m] (n: i64) (xs: [m]i32) =
+  map (+2) (map (+1) (xs :> [n]i32))

--- a/tests/shapes/hof0.fut
+++ b/tests/shapes/hof0.fut
@@ -1,7 +1,7 @@
 -- A dubious test - what we want to ensure is an absence of too many
 -- dynamic casts just after internalisation.
 -- ==
--- structure internalised { Assert 6 }
+-- structure internalised { Assert 5 }
 
 let f [k] 'a (dest: [k]a) (f: [k]a -> [k]a) : [k]a =
   f dest

--- a/tests/shapes/hof0.fut
+++ b/tests/shapes/hof0.fut
@@ -1,0 +1,12 @@
+-- A dubious test - what we want to ensure is an absence of too many
+-- dynamic casts just after internalisation.
+-- ==
+-- structure internalised { Assert 6 }
+
+let f [k] 'a (dest: [k]a) (f: [k]a -> [k]a) : [k]a =
+  f dest
+
+let operation [n][m] (b: [m]i32) (as: [n][m]i32) =
+  copy as with [0] = b
+
+let main xs b = f xs (operation b)

--- a/tests/shapes/hof1.fut
+++ b/tests/shapes/hof1.fut
@@ -1,0 +1,18 @@
+type^ network 'p =
+  { zero: p
+  , sum: (k:i64) -> [k]p -> p }
+
+let chain 'p1 'p2 (a:network p1) (b:network p2) : network (p1, p2) =
+  let zero = (a.zero, b.zero)
+  let sum k ps = let (as, bs) = unzip ps
+                 in (a.sum k as, b.sum k bs)
+  in {zero, sum}
+
+let linear [m][n] (weights:[m][n]f32) : network ([m][n]f32) =
+  let zero = replicate m (replicate n 0)
+  let sum k (ps:[k][m][n]f32) = map (map (reduce (+) 0)) (map transpose (transpose ps))
+  in {zero, sum}
+
+let main [m][n] (ws1: [n][m]f32) (ws2: [n][n]f32) =
+  let inet = chain (linear ws1) (linear ws2)
+  in inet.zero

--- a/tests/uniqueness/uniqueness26.fut
+++ b/tests/uniqueness/uniqueness26.fut
@@ -1,0 +1,10 @@
+-- Carefully handle the case where there is a lot of alias overlapping
+-- going on between the target of an in-place update and the source,
+-- including inside a section!  It was actually the section that we
+-- mishandled in lambda-lifting.
+-- ==
+-- input { 0i64 3i64 [3f32,4f32,5f32,6f32] }
+-- output { [1.0f32, 1.3333334f32, 1.6666666f32, 6.0f32] }
+
+let main [n] (i: i64) (j: i64) (A: *[n]f32): []f32 =
+  A with [i:j] = map (/A[0]) A[i:j]

--- a/tools/bench-compilers.py
+++ b/tools/bench-compilers.py
@@ -170,7 +170,7 @@ def ensure_repo(what, url):
     if os.path.exists(dir):
         shell('cd {} && git checkout master && git pull'.format(dir))
     else:
-        shell('git clone --recursive {} dir'.format(url, dir))
+        shell('git clone --recursive {} {}'.format(url, dir))
     return dir
 
 def ensure_futhark_repo():


### PR DESCRIPTION
Right now, the mpi backend support simple map without nested segop. For exemple : ```entry ex_map (_i:i64) : []i8 = map (+2) [1,2,3,4]```