### PR TITLE
No arg fix

### DIFF
--- a/src/Futhark/CLI/Bench.hs
+++ b/src/Futhark/CLI/Bench.hs
@@ -467,7 +467,9 @@ commandLineOptions =
 -- | Run @futhark bench@.
 main :: String -> [String] -> IO ()
 main = mainWithOptions initialBenchOptions commandLineOptions "options... programs..." $ \progs config ->
-  Just $ runBenchmarks config progs
+  case progs of
+    [] -> Nothing
+    _ -> Just $ runBenchmarks config progs
 
 --- The following extracted from hstats package by Marshall Beddoe:
 --- https://hackage.haskell.org/package/hstats-0.3

--- a/src/Futhark/CLI/Test.hs
+++ b/src/Futhark/CLI/Test.hs
@@ -719,4 +719,6 @@ commandLineOptions =
 -- | Run @futhark test@.
 main :: String -> [String] -> IO ()
 main = mainWithOptions defaultConfig commandLineOptions "options... programs..." $ \progs config ->
-  Just $ runTests config progs
+  case progs of
+    [] -> Nothing
+    _ -> Just $ runTests config progs


### PR DESCRIPTION
Before this change

```
$ futhark test
┌──────────┬────────┬────────┬───────────┐
│          │ passed │ failed │ remaining │
├──────────┼────────┼────────┼───────────┤
│ programs │ 0      │ 0      │ 0/0       │
├──────────┼────────┼────────┼───────────┤
│ runs     │ 0      │ 0      │ 0/0       │
└──────────┴────────┴────────┴───────────┘

$ futhark bench
Reporting average runtime of 10 runs for each dataset.
```
After the change 

```
$ futhark test
Usage: futhark test options... programs...
Options:

  -V      --version                   Print version information and exit.
  -h      --help                      Print help and exit.
  -t      --typecheck                 Only perform type-checking
  -i      --interpreted               Only interpret
  -c      --compiled                  Only run compiled code
  -C      --compile                   Only compile, do not run.
          --no-terminal, --notty      Provide simpler line-based output.
          --backend=BACKEND           Backend used for compilation (defaults to 'c').
          --futhark=PROGRAM           Program to run for subcommands (defaults to same binary as 'futhark test').
          --runner=PROGRAM            The program used to run the Futhark-generated programs (defaults to nothing).
          --exclude=TAG               Exclude test programs that define this tag.
  -p OPT  --pass-option=OPT           Pass this option to programs being run.
          --pass-compiler-option=OPT  Pass this option to the compiler (or typechecker if in -t mode).
          --no-tuning                 Do not load tuning files.
          --concurrency=NUM           Number of tests to run concurrently.
$ futhark bench
Usage: futhark bench options... programs...
Options:

  -V       --version                   Print version information and exit.
  -h       --help                      Print help and exit.
  -r RUNS  --runs=RUNS                 Run each test case this many times.
           --backend=PROGRAM           The compiler used (defaults to 'futhark-c').
           --futhark=PROGRAM           The binary used for operations (defaults to same binary as 'futhark bench').
           --runner=PROGRAM            The program used to run the Futhark-generated programs (defaults to nothing).
  -p OPT   --pass-option=OPT           Pass this option to programs being run.
           --pass-compiler-option=OPT  Pass this option to the compiler (or typechecker if in -t mode).
           --json=FILE                 Scatter results in JSON format here.
           --timeout=SECONDS           Number of seconds before a dataset is aborted.
           --skip-compilation          Use already compiled program.
           --exclude-case=TAG          Do not run test cases with this tag.
           --ignore-files=REGEX        Ignore files matching this regular expression.
  -e NAME  --entry-point=NAME          Only run this entry point.
           --tuning=EXTENSION          Look for tuning files with this extension (defaults to .tuning).
           --no-tuning                 Do not load tuning files.
           --concurrency=NUM           Number of benchmarks to prepare (not run) concurrently.
  -v       --verbose                   Enable logging.  Pass multiple times for more.
```