### PR TITLE
Add memory info to futhark bench json output

### DIFF
--- a/src/Futhark/CodeGen/Backends/CCUDA/Boilerplate.hs
+++ b/src/Futhark/CodeGen/Backends/CCUDA/Boilerplate.hs
@@ -337,6 +337,7 @@ generateContextFuns cfg cost_centres kernels sizes failures = do
                          int debugging;
                          int profiling;
                          int profiling_paused;
+                         int logging;
                          typename lock_t lock;
                          char *error;
                          $sdecls:fields
@@ -371,6 +372,7 @@ generateContextFuns cfg cost_centres kernels sizes failures = do
                  ctx->debugging = ctx->detail_memory = cfg->cu_cfg.debugging;
                  ctx->profiling = cfg->profiling;
                  ctx->profiling_paused = 0;
+                 ctx->logging = cfg->cu_cfg.logging;
                  ctx->error = NULL;
                  ctx->cuda.profiling_records_capacity = 200;
                  ctx->cuda.profiling_records_used = 0;

--- a/src/Futhark/CodeGen/Backends/GenericC.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC.hs
@@ -1504,7 +1504,7 @@ commonLibFuns memreport = do
       [C.cedecl|char* $id:s($ty:ctx *ctx) {
                  struct str_builder builder;
                  str_builder_init(&builder);
-                 if (ctx->detail_memory || ctx->profiling) {
+                 if (ctx->detail_memory || ctx->profiling || ctx->logging) {
                    $items:memreport
                  }
                  if (ctx->profiling) {

--- a/src/Futhark/CodeGen/Backends/MulticoreC.hs
+++ b/src/Futhark/CodeGen/Backends/MulticoreC.hs
@@ -114,6 +114,7 @@ compileProg =
                           int debugging;
                           int profiling;
                           int profiling_paused;
+                          int logging;
                           typename lock_t lock;
                           char *error;
                           int total_runs;
@@ -140,6 +141,7 @@ compileProg =
                  ctx->debugging = cfg->debugging;
                  ctx->profiling = cfg->profiling;
                  ctx->profiling_paused = 0;
+                 ctx->logging = 0;
                  ctx->error = NULL;
                  create_lock(&ctx->lock);
 

--- a/src/Futhark/CodeGen/Backends/SequentialC.hs
+++ b/src/Futhark/CodeGen/Backends/SequentialC.hs
@@ -80,6 +80,7 @@ compileProg =
                           int detail_memory;
                           int debugging;
                           int profiling;
+                          int logging;
                           typename lock_t lock;
                           char *error;
                           int profiling_paused;
@@ -97,6 +98,7 @@ compileProg =
                                   ctx->detail_memory = cfg->debugging;
                                   ctx->debugging = cfg->debugging;
                                   ctx->profiling = cfg->debugging;
+                                  ctx->logging = cfg->debugging;
                                   ctx->error = NULL;
                                   create_lock(&ctx->lock);
                                   $stms:init_fields

--- a/tools/cmp-bench-json.py
+++ b/tools/cmp-bench-json.py
@@ -7,6 +7,14 @@ import sys
 import numpy as np
 from collections import OrderedDict
 
+def mem_dict(a, b):
+    result = {}
+    try:
+        for k in set(a['bytes'].keys()) & set(b['bytes'].keys()):
+            result[k] = float(b['bytes'][k]) / float(a['bytes'][k])
+    finally:
+        return result
+
 class bcolors:
     HEADER = '\033[95m'
     OKBLUE = '\033[94m'
@@ -40,16 +48,19 @@ def compare(a_json, b_json):
                     b_dataset_results = b_prog_datasets[dataset]
                     if 'runtimes' in a_dataset_results:
                         a_runtimes = a_dataset_results['runtimes']
+                        a_bytes = a_dataset_results.get('bytes')
                         if not ('runtimes' in b_dataset_results):
                             print('In %s but failed in %s: program %s dataset %s' % (a_file, b_file, prog, dataset))
                             continue
                         b_runtimes = b_dataset_results['runtimes']
+                        b_bytes = b_dataset_results.get('bytes')
+                        mem_usage = mem_dict(a_dataset_results, b_dataset_results)
                         speedup = np.mean(a_runtimes)/np.mean(b_runtimes)
                         diff = abs(np.mean(a_runtimes)-np.mean(b_runtimes))
                         significant = diff > np.std(a_runtimes)/2 + np.std(a_runtimes)/2
                         # Apart from speedups, we also calculate whether the
                         # change is statistically significant.
-                        speedups[prog][dataset] = (speedup, significant)
+                        speedups[prog][dataset] = (speedup, mem_usage, significant)
 
     for prog,b_prog in b_json.items():
         if not prog in a_json:
@@ -67,14 +78,21 @@ def compare(a_json, b_json):
         prog_speedups = speedups[prog]
         if len(prog_speedups) > 0:
             print('\n%s%s%s' % (bcolors.HEADER+bcolors.BOLD, prog, bcolors.ENDC))
-            for dataset,(dataset_speedup,significant) in prog_speedups.items():
+            for dataset,(dataset_speedup,mem_usage,significant) in prog_speedups.items():
                 if significant and dataset_speedup > 1.01:
                     color = bcolors.OKGREEN
                 elif significant and dataset_speedup < 0.99:
                     color = bcolors.FAIL
                 else:
                     color = ''
-                print('  %s%s%10.2fx%s' % ((dataset+':').ljust(64), color, dataset_speedup, bcolors.ENDC))
+                mem_strings = []
+                for k, v in mem_usage.items():
+                    if v < 0.99:
+                        mem_strings.append("%s%4.2fx@%s%s" % (bcolors.OKGREEN, v, k, bcolors.ENDC))
+                    elif v > 1.01:
+                        mem_strings.append("%s%4.2fx@%s%s" % (bcolors.FAIL, v, k, bcolors.ENDC))
+                mem_string = "" if not mem_strings else " (mem: %s)" % ", ".join(mem_strings)
+                print('  %s%s%10.2fx%s%s' % ((dataset+':').ljust(64), color, dataset_speedup, bcolors.ENDC, mem_string))
 
 
 if __name__ == '__main__':

--- a/unittests/Futhark/BenchTests.hs
+++ b/unittests/Futhark/BenchTests.hs
@@ -2,6 +2,7 @@
 
 module Futhark.BenchTests (tests) where
 
+import qualified Data.Map as M
 import qualified Data.Text as T
 import Futhark.Bench
 import Test.Tasty
@@ -19,10 +20,11 @@ instance Arbitrary DataResult where
       <$> printable
       <*> oneof
         [ Left <$> arbText,
-          Right <$> ((,) <$> arbitrary <*> arbText)
+          Right <$> (Result <$> arbitrary <*> arbMap <*> arbText)
         ]
     where
       arbText = T.pack <$> printable
+      arbMap = M.fromList <$> listOf ((,) <$> arbText <*> arbitrary)
 
 -- XXX: we restrict this generator to single datasets to we don't have
 -- to worry about duplicates.


### PR DESCRIPTION
This commit adds support for benchmarking memory usage. It does so by changing `futhark bench` to always run with `-P`, and parses the output, searching for memory information. If any is found, it is added to the json output.

I've also added support in tools/cmp-bench-json.py for reporting the memory usage improvements, if present and significant.

![screenshot](https://user-images.githubusercontent.com/230613/103532264-344fd580-4e8b-11eb-9a34-6df82892c6f1.png)
