### PR TITLE
Add the -L flag to python backends

### DIFF
--- a/src/Futhark/CodeGen/Backends/GenericPython.hs
+++ b/src/Futhark/CodeGen/Backends/GenericPython.hs
@@ -305,6 +305,12 @@ standardOptions =
         optionShortName = Nothing,
         optionArgument = RequiredArgument "open",
         optionAction = [Exp $ simpleCall "read_tuning_file" [Var "sizes", Var "optarg"]]
+      },
+    Option
+      { optionLongName = "log",
+        optionShortName = Just 'L',
+        optionArgument = NoArgument,
+        optionAction = [Pass]
       }
   ]
 


### PR DESCRIPTION
This fixes the buildbot failure caused by #1215:
http://buildbot.futhark-lang.org/#/builders/11/builds/1149/steps/14/logs/stdio