### PR TITLE
Use i64 indexes, fix stringlit definition

### DIFF
--- a/docs/language-reference.rst
+++ b/docs/language-reference.rst
@@ -554,8 +554,8 @@ A variable name; evaluates to its value in the current environment.
 `stringlit`
 ...........
 
-Evaluates to an array of type ``[]i32`` that contains the code points
-of the characters as integers.
+Evaluates to an array of type ``[]u8`` that contains the characters
+encoded as UTF-8.
 
 ``()``
 ......
@@ -611,7 +611,7 @@ former inclusive and the latter exclusive, taking every ``s``-th
 element.  The ``s`` parameter may not be zero.  If ``s`` is negative,
 it means to start at ``i`` and descend by steps of size ``s`` to ``j``
 (not inclusive).  Slicing can be done only with expressions of type
-``i32``.
+``i64``.
 
 It is generally a bad idea for ``s`` to be non-constant.
 Slicing of multiple dimensions can be done by separating with commas,
@@ -782,7 +782,7 @@ run-time.
 
 Due to ambiguities, this syntactic form cannot appear as an array
 index expression unless it is first enclosed in parentheses.  However,
-as an array index must always be of type ``i32``, there is never a
+as an array index must always be of type ``i64``, there is never a
 reason to put an explicit type ascription there.
 
 ``e :> t``

--- a/docs/man/futhark-dataset.rst
+++ b/docs/man/futhark-dataset.rst
@@ -68,7 +68,7 @@ Generate a 4 by 2 integer matrix::
 
 Generate an array of floating-point numbers and an array of indices into that array::
 
-  futhark dataset -g [10]f32 --i32-bounds=0:9 -g [100]i32
+  futhark dataset -g [10]f32 --i64-bounds=0:9 -g [100]i64
 
 To generate binary data, the ``--binary`` must come before the ``--generate``::
 

--- a/docs/man/futhark-test.rst
+++ b/docs/man/futhark-test.rst
@@ -191,12 +191,12 @@ The following program tests simple indexing and bounds checking::
   -- Test simple indexing of an array.
   -- ==
   -- tags { firsttag secondtag }
-  -- input { [4,3,2,1] 1 }
+  -- input { [4,3,2,1] 1i64 }
   -- output { 3 }
-  -- input { [4,3,2,1] 5 }
+  -- input { [4,3,2,1] 5i64 }
   -- error: Assertion.*failed
 
-  let main (a: []i32) (i: i32): i32 =
+  let main (a: []i32) (i: i64): i32 =
     a[i]
 
 The following program contains two entry points, both of which are


### PR DESCRIPTION
Bit unrelated, but I found it surprising that while any signed type can be used to index an array, only `i64` can be used to slice an array. The docs mention the latter, but "array index must always be of type `i64`" implies that code like `a[0i8]` shouldn't work.

On that note, perhaps it should be more clearly stated somewhere that indexes are `i64`. Unless I've missed something, it's only mentioned in:

* The blog posts about switching to 64-bit indexes
* Chapter 2 of the Futhark book: "Size parameters are always of type `i64`"
* Chapter 3 of the Futhark User's Guide: `3.4.3.9. a[i:j:s]` and `3.4.3.21. e : t` under the "Semantics of Simple Expressions" (Also, the language grammar for `index` implies that any `exp` is valid, though maybe the grammar only cares about syntax and not semantics.)

Maybe it would be good to mention this when arrays are introduced in the book and in the language reference under `3.4.3.8. a[i]`. I can add this if needed.