### PR TITLE
Add `--no-check` flag to `futhark dev`

### DIFF
--- a/src/Futhark/CLI/Dev.hs
+++ b/src/Futhark/CLI/Dev.hs
@@ -383,6 +383,13 @@ commandLineOptions =
       "Print on standard output the type-checked program.",
     Option
       []
+      ["no-check"]
+      ( NoArg $
+          Right $ changeFutharkConfig $ \opts -> opts {futharkTypeCheck = False}
+      )
+      "Disable type-checking.",
+    Option
+      []
       ["pretty-print"]
       ( NoArg $
           Right $ \opts ->
@@ -692,7 +699,7 @@ runPolyPasses config base initial_prog = do
     pipeline_config =
       PipelineConfig
         { pipelineVerbose = fst (futharkVerbose $ futharkConfig config) > NotVerbose,
-          pipelineValidate = True
+          pipelineValidate = futharkTypeCheck $ futharkConfig config
         }
 
 runPolyPass ::

--- a/src/Futhark/Compiler.hs
+++ b/src/Futhark/Compiler.hs
@@ -46,7 +46,9 @@ data FutharkConfig = FutharkConfig
     -- | If True, ignore @unsafe@.
     futharkSafe :: Bool,
     -- | Additional functions that should be exposed as entry points.
-    futharkEntryPoints :: [Name]
+    futharkEntryPoints :: [Name],
+    -- | If false, disable type-checking
+    futharkTypeCheck :: Bool
   }
 
 -- | The default compiler configuration.
@@ -57,7 +59,8 @@ newFutharkConfig =
       futharkWarn = True,
       futharkWerror = False,
       futharkSafe = False,
-      futharkEntryPoints = []
+      futharkEntryPoints = [],
+      futharkTypeCheck = True
     }
 
 -- | Print a compiler error to stdout.  The 'FutharkConfig' controls
@@ -140,7 +143,7 @@ runPipelineOnProgram config pipeline file = do
     pipeline_config =
       PipelineConfig
         { pipelineVerbose = fst (futharkVerbose config) > NotVerbose,
-          pipelineValidate = True
+          pipelineValidate = futharkTypeCheck config
         }
 
 typeCheckInternalProgram :: I.Prog I.SOACS -> FutharkM ()


### PR DESCRIPTION
This flag disables type checking after each pass when running `futhark
dev`.

It can be useful when manipulating the IR directly.

Suggestions for a better name are welcome.