### PR TITLE
Fix unknown tuning name error for short names

### DIFF
--- a/rts/c/tuning.h
+++ b/rts/c/tuning.h
@@ -21,9 +21,10 @@ static char* load_tuning_file(const char *fname,
       *eql = 0;
       int value = atoi(eql+1);
       if (set_size(cfg, line, value) != 0) {
-        strncpy(eql+1, line, max_line_len-strlen(line)-1);
-        snprintf(line, max_line_len, "Unknown name '%s' on line %d.", eql+1, lineno);
-        return line;
+        char* err = (char*) malloc(max_line_len + 50);
+        snprintf(err, max_line_len + 50, "Unknown name '%s' on line %d.", line, lineno);
+        free(line);
+        return err;
       }
     } else {
       snprintf(line, max_line_len, "Invalid line %d (must be of form 'name=int').",


### PR DESCRIPTION
If a tuning file has an unknown name that is shorter than 13 characters (probably won't happen in practice, but it might eventually), then `snprintf` will overwrite past `eql+1`, which results in part of `Unknown name '` being printed as the name. For example, a tuning file with `abcd=` will print `Unknown name 'wn n' on line 1.`:
```
               +-- eql+1
               v
line    : abcd=
strncpy : abcd=abcd
snprintf: Unknown name '
               ^^^^
```

The extra `malloc` could be avoided by copying the name to at least 13 characters past `line`, but that seems more complicated.

`max_line_len + 50` is to handle the worst case of a 1022 character name, the format string, and a 9 digit line number (assuming `int` is 32 bits). Might be unnecessary, honestly, since no names will be that long in practice.