### PR TITLE
fix futhark-test examples in docs, and add tests.

### DIFF
--- a/docs/man/futhark-bench.rst
+++ b/docs/man/futhark-bench.rst
@@ -134,20 +134,20 @@ EXAMPLES
 The following program benchmarks how quickly we can sum arrays of
 different sizes::
 
-  -- How quickly can we reduce arrays?
-  --
-  -- ==
-  -- nobench input { 0 }
-  -- output { 0 }
-  -- input { 100 }
-  -- output { 4950 }
-  -- compiled input { 100000 }
-  -- output { 704982704 }
-  -- compiled input { 100000000 }
-  -- output { 887459712 }
-
-  let main(n: i32): i32 =
-    reduce (+) 0 (iota n)
+ -- How quickly can we reduce arrays?
+ --
+ -- ==
+ -- nobench input { 0i64 }
+ -- output { 0i64 }
+ -- input { 100i64 }
+ -- output { 4950i64 }
+ -- compiled input { 10000i64 }
+ -- output { 49995000i64 }
+ -- compiled input { 1000000i64 }
+ -- output { 499999500000i64 }
+ 
+ let main(n: i64): i64 =
+   reduce (+) 0 (iota n)
 
 SEE ALSO
 ========

--- a/docs/man/futhark-test.rst
+++ b/docs/man/futhark-test.rst
@@ -194,7 +194,7 @@ The following program tests simple indexing and bounds checking::
   -- input { [4,3,2,1] 1i64 }
   -- output { 3 }
   -- input { [4,3,2,1] 5i64 }
-  -- error: Assertion.*failed
+  -- error: Error*
 
   let main (a: []i32) (i: i64): i32 =
     a[i]
@@ -202,7 +202,7 @@ The following program tests simple indexing and bounds checking::
 The following program contains two entry points, both of which are
 tested::
 
-  let add(x: i32, y: i32): i32 = x + y
+  let add (x: i32) (y: i32): i32 = x + y
 
   -- Test the add1 function.
   -- ==

--- a/tests/man/bench/example1.fut
+++ b/tests/man/bench/example1.fut
@@ -1,0 +1,14 @@
+-- How quickly can we reduce arrays?
+--
+-- ==
+-- nobench input { 0i64 }
+-- output { 0i64 }
+-- input { 100i64 }
+-- output { 4950i64 }
+-- compiled input { 10000i64 }
+-- output { 49995000i64 }
+-- compiled input { 1000000i64 }
+-- output { 499999500000i64 }
+
+let main(n: i64): i64 =
+  reduce (+) 0 (iota n)

--- a/tests/man/test/example1.fut
+++ b/tests/man/test/example1.fut
@@ -1,0 +1,10 @@
+-- Test simple indexing of an array.
+-- ==
+-- tags { firsttag secondtag }
+-- input { [4,3,2,1] 1i64 }
+-- output { 3 }
+-- input { [4,3,2,1] 5i64 }
+-- error: Error*
+
+let main (a: []i32) (i: i64): i32 =
+  a[i]

--- a/tests/man/test/example2.fut
+++ b/tests/man/test/example2.fut
@@ -1,0 +1,15 @@
+let add (x: i32) (y: i32): i32 = x + y
+
+-- Test the add1 function.
+-- ==
+-- entry: add1
+-- input { 1 } output { 2 }
+
+entry add1 (x: i32): i32 = add x 1
+
+-- Test the sub1 function.
+-- ==
+-- entry: sub1
+-- input { 1 } output { 0 }
+
+entry sub1 (x: i32): i32 = add x (-1)

--- a/tests/man/test/example3.fut
+++ b/tests/man/test/example3.fut
@@ -1,0 +1,5 @@
+-- ==
+-- random input { [100]i32 [100]i32 } auto output
+-- random input { [1000]i32 [1000]i32 } auto output
+
+let main xs ys = i32.product (map2 (*) xs ys)


### PR DESCRIPTION
I think there are some uncaught mistakes. In the man pages, specifically with regards to `futhark-test`. 

The first program example gives the following when run with vanilla `futhark test`
```
futhark test example1.fut
example1.fut:
Compiling with --backend=c:
Running compiled program:
Running ./example1:
Entry point: main; dataset: #1 ("[4i32, 3i32, 2i32, 1i32] 5i64"):
Expected error:
  Assertion.*failed
Got error:
  Error: Index [5] out of bounds for array of shape [4].

Backtrace:
-> #0  example1.fut:10:3-6
   #1  example1.fut:9:1-10:6


┌──────────┬────────┬────────┬───────────┐
│          │ passed │ failed │ remaining │
├──────────┼────────┼────────┼───────────┤
│ programs │ 0      │ 1      │ 0/1       │
├──────────┼────────┼────────┼───────────┤
│ runs     │ 1      │ 1      │ 0/2       │
└──────────┴────────┴────────┴───────────┘
```

The second example program also doesn't pass the test suite provided for it. In fact it doesn't even compile.
```
futhark test example2.fut
example2.fut:
Compiling with --backend=c:
Error at example2.fut:8:32-32:
Cannot apply "add" to "x" (invalid type).
Expected: (i32, i32)
Actual:   i32

If you find this error message confusing, uninformative, or wrong, please open an issue at
https://github.com/diku-dk/futhark/issues.
```
I have gone on to fix the tests so that they compile, and pass the test suites provided for them. I have also added test cases in a new folder `man/test` so that if some changes break the examples in the doc the CI will fail. 