### PR TITLE
Threshold sizes should all be printed on one line

### DIFF
--- a/src/Futhark/IR/Kernels/Sizes.hs
+++ b/src/Futhark/IR/Kernels/Sizes.hs
@@ -47,7 +47,7 @@ data SizeClass
 
 instance Pretty SizeClass where
   ppr (SizeThreshold path def) =
-    "threshold(" <> ppr (map pStep path) <> def' <> ")"
+    "threshold(" <> spread (map pStep path) <> def' <> ")"
     where
       pStep (v, True) = ppr v
       pStep (v, False) = "!" <> ppr v


### PR DESCRIPTION
Otherwise autotune stops working.

Fixes #1269