### PR TITLE
Pyopencl typedeprecation issue1281

### DIFF
--- a/rts/python/scalar.py
+++ b/rts/python/scalar.py
@@ -152,7 +152,7 @@ def sext_T_i64(x):
   return np.int64(x)
 
 def itob_T_bool(x):
-  return np.bool(x)
+  return bool(x)
 
 def btoi_bool_i8(x):
   return np.int8(x)

--- a/rts/python/server.py
+++ b/rts/python/server.py
@@ -91,7 +91,7 @@ class Server:
                 # In case we are using the PyOpenCL backend, we first
                 # need to convert OpenCL arrays to ordinary NumPy
                 # arrays.  We do this in a nasty way.
-                if isinstance(value, np.number) or isinstance(value, np.bool) or isinstance(value, np.bool_) or isinstance(value, np.ndarray):
+                if isinstance(value, np.number) or isinstance(value, bool) or isinstance(value, np.bool_) or isinstance(value, np.ndarray):
                     # Ordinary NumPy value.
                     f.write(construct_binary_value(self._vars[vname]))
                 else:

--- a/rts/python/values.py
+++ b/rts/python/values.py
@@ -478,7 +478,7 @@ FUTHARK_PRIMTYPES = {
              'bin_reader': read_bin_bool,
              'str_reader': read_str_bool,
              'bin_format': 'b',
-             'numpy_type': np.bool }
+             'numpy_type': bool }
 }
 
 def read_bin_read_type(f):

--- a/src/Futhark/CodeGen/Backends/PyOpenCL.hs
+++ b/src/Futhark/CodeGen/Backends/PyOpenCL.hs
@@ -185,7 +185,7 @@ compileProg mode class_name prog = do
 -- We have many casts to 'long', because PyOpenCL may get confused at
 -- the 32-bit numbers that ImpCode uses for offsets and the like.
 asLong :: PyExp -> PyExp
-asLong x = Py.simpleCall "np.long" [x]
+asLong x = Py.simpleCall "int" [x]
 
 callKernel :: Py.OpCompiler Imp.OpenCL ()
 callKernel (Imp.GetSize v key) = do

--- a/src/Futhark/CodeGen/Backends/PyOpenCL.hs
+++ b/src/Futhark/CodeGen/Backends/PyOpenCL.hs
@@ -185,7 +185,7 @@ compileProg mode class_name prog = do
 -- We have many casts to 'long', because PyOpenCL may get confused at
 -- the 32-bit numbers that ImpCode uses for offsets and the like.
 asLong :: PyExp -> PyExp
-asLong x = Py.simpleCall "int" [x]
+asLong x = Py.simpleCall "np.int64" [x]
 
 callKernel :: Py.OpCompiler Imp.OpenCL ()
 callKernel (Imp.GetSize v key) = do


### PR DESCRIPTION
Fix for issue #1281: replaced deprecated NumPy types: np.bool => bool (built-in) and np.long => np.int64.