### PR TITLE
Correctly handle multi-dimensional scatters when simplifying and fusing

### DIFF
--- a/tests/issue1284.fut
+++ b/tests/issue1284.fut
@@ -1,0 +1,18 @@
+let one_scatter (n: i64) (m: i64) : [n][m]i32 =
+  let res = tabulate_2d n m (\i j -> 0)
+  in scatter_2d res [(0, 0)] [1]
+
+entry foo = one_scatter 2 2
+
+let another_scatter [n] (inp: *[n][n]i32): *[n][n]i32 =
+  scatter_2d inp [(0, 1)] [2]
+
+entry bar = another_scatter (one_scatter 2 2)
+
+-- ==
+-- entry: foo
+-- input {} output { [[1, 0], [0, 0]] }
+
+-- ==
+-- entry: bar
+-- input {} output { [[1, 2], [0, 0]] }


### PR DESCRIPTION
The SOAC simplifier assumed that there was always just one index value per
output value. Since 624c7f77a and the associated #1258 that is no longer the
case.

Fixes #1284