### PR TITLE
Remove uncalled return statement; add check for non matched regex

### DIFF
--- a/rts/python/values.py
+++ b/rts/python/values.py
@@ -567,12 +567,11 @@ representation of the Futhark type."""
     if m:
         dims = int(len(m.group(1))/2)
         basetype = m.group(2)
-        assert basetype in FUTHARK_PRIMTYPES, "Unknown type: {}".format(type_desc)
-        if dims > 0:
-            return read_array(reader, basetype, dims)
-        else:
-            return read_scalar(reader, basetype)
-        return (dims, basetype)
+    assert m and basetype in FUTHARK_PRIMTYPES, "Unknown type: {}".format(type_desc)
+    if dims > 0:
+        return read_array(reader, basetype, dims)
+    else:
+        return read_scalar(reader, basetype)
 
 def end_of_input(entry, f=input_reader):
     skip_spaces(f)


### PR DESCRIPTION
In the case where there is no regex match for m, `None` is returned. I don't believe this is expected behaviour, as it means that the type passed in is not a futhark type. In the case of a partial regex match an exception is thrown. 

Unrelated, the last line of the old implementation was a return statement that would never be reached. 

I have rewritten the function to fix both things. 