### PR TITLE
Add option for compile free test runs

### DIFF
--- a/src/Futhark/CLI/Test.hs
+++ b/src/Futhark/CLI/Test.hs
@@ -27,6 +27,7 @@ import Futhark.Util.Pretty (prettyText)
 import Futhark.Util.Table
 import System.Console.ANSI
 import qualified System.Console.Terminal.Size as Terminal
+import System.Directory
 import System.Environment
 import System.Exit
 import System.FilePath
@@ -235,6 +236,11 @@ runTestCase (TestCase mode program testcase progs) = do
           ExitSuccess -> return ()
           ExitFailure 127 -> throwError $ progNotFound $ T.pack futhark
           ExitFailure _ -> throwError $ T.decodeUtf8 err
+    RunCases ios _ _ | mode == SkipCompile -> do
+      exists <- liftIO $ doesFileExist $ binaryName program
+      if exists
+        then runCompiledProgram (FutharkExe futhark) program progs ios
+        else throwError $ T.pack (binaryName program) <> " does not exist, but --skip-compilation passed.\n"
     RunCases ios structures warnings -> do
       -- Compile up-front and reuse same executable for several entry points.
       let backend = configBackend progs
@@ -250,19 +256,22 @@ runTestCase (TestCase mode program testcase progs) = do
         context ("Compiling with --backend=" <> T.pack backend) $ do
           compileTestProgram extra_compiler_options (FutharkExe futhark) backend program warnings
           mapM_ (testMetrics progs program) structures
-          unless (mode == Compile) $ do
-            (tuning_opts, _) <-
-              liftIO $ determineTuning (configTuning progs) program
-            let extra_options = tuning_opts ++ configExtraOptions progs
-                runner = configRunner progs
-            context "Running compiled program" $
-              withProgramServer program runner extra_options $ \server -> do
-                let run = runCompiledEntry (FutharkExe futhark) server program
-                concat <$> mapM run ios
+          unless (mode == Compile) $ runCompiledProgram (FutharkExe futhark) program progs ios
 
       unless (mode == Compile || mode == Compiled) $
         context "Interpreting" $
           accErrors_ $ map (runInterpretedEntry (FutharkExe futhark) program) ios
+
+runCompiledProgram :: FutharkExe -> FilePath -> ProgConfig -> [InputOutputs] -> TestM ()
+runCompiledProgram (FutharkExe futhark) program progs ios = do
+  (tuning_opts, _) <-
+    liftIO $ determineTuning (configTuning progs) program
+  let extra_options = tuning_opts ++ configExtraOptions progs
+      runner = configRunner progs
+  context "Running compiled program" $
+    withProgramServer program runner extra_options $ \server -> do
+      let run = runCompiledEntry (FutharkExe futhark) server program
+      concat <$> mapM run ios
 
 liftCommand ::
   (MonadError T.Text m, MonadIO m) =>
@@ -661,6 +670,7 @@ data TestMode
   | Compile
   | Compiled
   | Interpreted
+  | SkipCompile
   | Everything
   deriving (Eq, Show)
 
@@ -676,6 +686,11 @@ commandLineOptions =
       ["interpreted"]
       (NoArg $ Right $ \config -> config {configTestMode = Interpreted})
       "Only interpret",
+    Option
+      []
+      ["skip-compilation"]
+      (NoArg $ Right $ \config -> config {configTestMode = SkipCompile})
+      "Use already compiled program.",
     Option
       "c"
       ["compiled"]


### PR DESCRIPTION
One of my main work flows that I need while developing the WASM/JS backend is the following
- Run a futhark test program
an example
`futhark test  example1.fut  --backend=wasm --runner=node --notty`

Then because my code is still quite raw, I fail the test. I then want to directly edit the executable `./example1` and run it through the test session again. This way I can quickly check which changes I need to make to the Javascript generation without having to recompile futhark everytime I make a minor tweek to get closer to the desired implementation.

As far as I can tell there is no way to run through the test suite again without having to recompile the source. Where all I really want to do it pass my edited executable back into the test session.

I have added a flag '-r' that operates like no flag, when there is no executable present. However when there is an executable present it will not recompile. But simply run it through the test session.

I though this might be helpful to others so I made a PR.

With regards to the implementation it may violate TOCTOU 

```
239  RunCases ios structures warnings -> do
240       exists <- liftIO $ doesFileExist $ "." </> dropExtension program
241       if mode == Run && exists
242         then runCompiledProgram (FutharkExe futhark) program progs ios
```

I think I can get rid of this issue without too much hassle, but I just wanted to check if there was interest in getting this into the compiler before I spend more time on this.