### PR TITLE
Suppress clang warnings fix

### DIFF
--- a/src/Futhark/CodeGen/Backends/GenericC.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC.hs
@@ -1338,7 +1338,12 @@ disableWarnings :: String
 disableWarnings =
   pretty
     [C.cunit|
-$esc:("#ifdef __GNUC__")
+$esc:("#ifdef __clang__")
+$esc:("#pragma clang diagnostic ignored \"-Wunused-function\"")
+$esc:("#pragma clang diagnostic ignored \"-Wunused-variable\"")
+$esc:("#pragma clang diagnostic ignored \"-Wparentheses\"")
+$esc:("#pragma clang diagnostic ignored \"-Wunused-label\"")
+$esc:("#elif __GNUC__")
 $esc:("#pragma GCC diagnostic ignored \"-Wunused-function\"")
 $esc:("#pragma GCC diagnostic ignored \"-Wunused-variable\"")
 $esc:("#pragma GCC diagnostic ignored \"-Wparentheses\"")
@@ -1346,12 +1351,6 @@ $esc:("#pragma GCC diagnostic ignored \"-Wunused-label\"")
 $esc:("#pragma GCC diagnostic ignored \"-Wunused-but-set-variable\"")
 $esc:("#endif")
 
-$esc:("#ifdef __clang__")
-$esc:("#pragma clang diagnostic ignored \"-Wunused-function\"")
-$esc:("#pragma clang diagnostic ignored \"-Wunused-variable\"")
-$esc:("#pragma clang diagnostic ignored \"-Wparentheses\"")
-$esc:("#pragma clang diagnostic ignored \"-Wunused-label\"")
-$esc:("#endif")
 |]
 
 -- | Produce header and implementation files.


### PR DESCRIPTION
Weirdly when Futhark's generated C code is compiled with MacOS, we get the following warning...

```
$ clang min.c
min.c:9:32: warning: unknown warning group '-Wunused-but-set-variable', ignored [-Wunknown-warning-option]
#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
                               ^
1 warning generated.
```
 On further inspection it seems that MacOS or clang weidly defines `__GNUC__`

With the following clang version
```
$ clang --version
Apple clang version 11.0.3 (clang-1103.0.32.62)
Target: x86_64-apple-darwin20.3.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
``` 
Inspecting the predefined macros with clang
```
$ clang -dM -E - < /dev/null | grep GNUC
#define __GNUC_MINOR__ 2
#define __GNUC_PATCHLEVEL__ 1
#define __GNUC_STDC_INLINE__ 1
#define __GNUC__ 4
```
So it seems when compiling with clang, it reads the block that is intended for compilation with gcc. I checked on another MacOS, and `#define __GNUC__ 4` was also set. 

This PR is a workaround for this issue so that when compiled with clang the correct preprocessor directives are followed. 