### PR TITLE
Conceptually rename "lore" to "representation".

### DIFF
--- a/futhark.cabal
+++ b/futhark.cabal
@@ -62,9 +62,9 @@ library
       Futhark.Analysis.Metrics
       Futhark.Analysis.Metrics.Type
       Futhark.Analysis.PrimExp
-      Futhark.Analysis.PrimExp.Parse
       Futhark.Analysis.PrimExp.Convert
       Futhark.Analysis.PrimExp.Generalize
+      Futhark.Analysis.PrimExp.Parse
       Futhark.Analysis.PrimExp.Simplify
       Futhark.Analysis.Rephrase
       Futhark.Analysis.SymbolTable
@@ -98,8 +98,8 @@ library
       Futhark.CodeGen.Backends.COpenCL.Boilerplate
       Futhark.CodeGen.Backends.GenericC
       Futhark.CodeGen.Backends.GenericC.CLI
-      Futhark.CodeGen.Backends.GenericC.Server
       Futhark.CodeGen.Backends.GenericC.Options
+      Futhark.CodeGen.Backends.GenericC.Server
       Futhark.CodeGen.Backends.GenericPython
       Futhark.CodeGen.Backends.GenericPython.AST
       Futhark.CodeGen.Backends.GenericPython.Definitions
@@ -112,22 +112,22 @@ library
       Futhark.CodeGen.Backends.SequentialPython
       Futhark.CodeGen.Backends.SimpleRep
       Futhark.CodeGen.ImpCode
-      Futhark.CodeGen.ImpCode.Kernels
+      Futhark.CodeGen.ImpCode.GPU
       Futhark.CodeGen.ImpCode.Multicore
       Futhark.CodeGen.ImpCode.OpenCL
       Futhark.CodeGen.ImpCode.Sequential
       Futhark.CodeGen.ImpGen
       Futhark.CodeGen.ImpGen.CUDA
-      Futhark.CodeGen.ImpGen.Kernels
-      Futhark.CodeGen.ImpGen.Kernels.Base
-      Futhark.CodeGen.ImpGen.Kernels.SegHist
-      Futhark.CodeGen.ImpGen.Kernels.SegMap
-      Futhark.CodeGen.ImpGen.Kernels.SegRed
-      Futhark.CodeGen.ImpGen.Kernels.SegScan
-      Futhark.CodeGen.ImpGen.Kernels.SegScan.SinglePass
-      Futhark.CodeGen.ImpGen.Kernels.SegScan.TwoPass
-      Futhark.CodeGen.ImpGen.Kernels.ToOpenCL
-      Futhark.CodeGen.ImpGen.Kernels.Transpose
+      Futhark.CodeGen.ImpGen.GPU
+      Futhark.CodeGen.ImpGen.GPU.Base
+      Futhark.CodeGen.ImpGen.GPU.SegHist
+      Futhark.CodeGen.ImpGen.GPU.SegMap
+      Futhark.CodeGen.ImpGen.GPU.SegRed
+      Futhark.CodeGen.ImpGen.GPU.SegScan
+      Futhark.CodeGen.ImpGen.GPU.SegScan.SinglePass
+      Futhark.CodeGen.ImpGen.GPU.SegScan.TwoPass
+      Futhark.CodeGen.ImpGen.GPU.ToOpenCL
+      Futhark.CodeGen.ImpGen.GPU.Transpose
       Futhark.CodeGen.ImpGen.Multicore
       Futhark.CodeGen.ImpGen.Multicore.Base
       Futhark.CodeGen.ImpGen.Multicore.SegHist
@@ -149,19 +149,18 @@ library
       Futhark.FreshNames
       Futhark.IR
       Futhark.IR.Aliases
-      Futhark.IR.Rep
-      Futhark.IR.Parse
-      Futhark.IR.Kernels
-      Futhark.IR.Kernels.Kernel
-      Futhark.IR.Kernels.Simplify
-      Futhark.IR.Kernels.Sizes
-      Futhark.IR.KernelsMem
+      Futhark.IR.GPU
+      Futhark.IR.GPU.Kernel
+      Futhark.IR.GPU.Simplify
+      Futhark.IR.GPU.Sizes
+      Futhark.IR.GPUMem
       Futhark.IR.MC
       Futhark.IR.MC.Op
       Futhark.IR.MCMem
       Futhark.IR.Mem
       Futhark.IR.Mem.IxFun
       Futhark.IR.Mem.Simplify
+      Futhark.IR.Parse
       Futhark.IR.Pretty
       Futhark.IR.Primitive
       Futhark.IR.Primitive.Parse
@@ -175,6 +174,7 @@ library
       Futhark.IR.Prop.Scope
       Futhark.IR.Prop.TypeOf
       Futhark.IR.Prop.Types
+      Futhark.IR.Rep
       Futhark.IR.RetType
       Futhark.IR.SOACS
       Futhark.IR.SOACS.SOAC
@@ -227,10 +227,10 @@ library
       Futhark.Pass
       Futhark.Pass.ExpandAllocations
       Futhark.Pass.ExplicitAllocations
-      Futhark.Pass.ExplicitAllocations.Kernels
+      Futhark.Pass.ExplicitAllocations.GPU
+      Futhark.Pass.ExplicitAllocations.MC
       Futhark.Pass.ExplicitAllocations.SegOp
       Futhark.Pass.ExplicitAllocations.Seq
-      Futhark.Pass.ExplicitAllocations.MC
       Futhark.Pass.ExtractKernels
       Futhark.Pass.ExtractKernels.BlockedKernel
       Futhark.Pass.ExtractKernels.DistributeNests
@@ -239,7 +239,7 @@ library
       Futhark.Pass.ExtractKernels.Interchange
       Futhark.Pass.ExtractKernels.Intragroup
       Futhark.Pass.ExtractKernels.StreamKernel
-      Futhark.Pass.ExtractKernels.ToKernels
+      Futhark.Pass.ExtractKernels.ToGPU
       Futhark.Pass.ExtractMulticore
       Futhark.Pass.FirstOrderTransform
       Futhark.Pass.KernelBabysitting

--- a/futhark.cabal
+++ b/futhark.cabal
@@ -149,7 +149,7 @@ library
       Futhark.FreshNames
       Futhark.IR
       Futhark.IR.Aliases
-      Futhark.IR.Decorations
+      Futhark.IR.Rep
       Futhark.IR.Parse
       Futhark.IR.Kernels
       Futhark.IR.Kernels.Kernel
@@ -212,7 +212,7 @@ library
       Futhark.Optimise.ReuseAllocations.GreedyColoring
       Futhark.Optimise.Simplify
       Futhark.Optimise.Simplify.Engine
-      Futhark.Optimise.Simplify.Lore
+      Futhark.Optimise.Simplify.Rep
       Futhark.Optimise.Simplify.Rule
       Futhark.Optimise.Simplify.Rules
       Futhark.Optimise.Simplify.Rules.BasicOp

--- a/src/Futhark/Actions.hs
+++ b/src/Futhark/Actions.hs
@@ -29,12 +29,12 @@ import qualified Futhark.CodeGen.Backends.MulticoreC as MulticoreC
 import qualified Futhark.CodeGen.Backends.PyOpenCL as PyOpenCL
 import qualified Futhark.CodeGen.Backends.SequentialC as SequentialC
 import qualified Futhark.CodeGen.Backends.SequentialPython as SequentialPy
-import qualified Futhark.CodeGen.ImpGen.Kernels as ImpGenKernels
+import qualified Futhark.CodeGen.ImpGen.GPU as ImpGenGPU
 import qualified Futhark.CodeGen.ImpGen.Multicore as ImpGenMulticore
 import qualified Futhark.CodeGen.ImpGen.Sequential as ImpGenSequential
 import Futhark.Compiler.CLI
 import Futhark.IR
-import Futhark.IR.KernelsMem (KernelsMem)
+import Futhark.IR.GPUMem (GPUMem)
 import Futhark.IR.MCMem (MCMem)
 import Futhark.IR.Prop.Aliases
 import Futhark.IR.SeqMem (SeqMem)
@@ -82,12 +82,12 @@ impCodeGenAction =
     }
 
 -- | Convert the program to GPU ImpCode and print it to stdout.
-kernelImpCodeGenAction :: Action KernelsMem
+kernelImpCodeGenAction :: Action GPUMem
 kernelImpCodeGenAction =
   Action
     { actionName = "Compile imperative kernels",
       actionDescription = "Translate program into imperative IL with kernels and write it on standard output.",
-      actionProcedure = liftIO . putStrLn . pretty . snd <=< ImpGenKernels.compileProgOpenCL
+      actionProcedure = liftIO . putStrLn . pretty . snd <=< ImpGenGPU.compileProgOpenCL
     }
 
 -- | Convert the program to CPU multicore ImpCode and print it to stdout.
@@ -173,7 +173,7 @@ compileCAction fcfg mode outpath =
           runCC cpath outpath ["-O3", "-std=c99"] ["-lm"]
 
 -- | The @futhark opencl@ action.
-compileOpenCLAction :: FutharkConfig -> CompilerMode -> FilePath -> Action KernelsMem
+compileOpenCLAction :: FutharkConfig -> CompilerMode -> FilePath -> Action GPUMem
 compileOpenCLAction fcfg mode outpath =
   Action
     { actionName = "Compile to OpenCL",
@@ -206,7 +206,7 @@ compileOpenCLAction fcfg mode outpath =
           runCC cpath outpath ["-O", "-std=c99"] ("-lm" : extra_options)
 
 -- | The @futhark cuda@ action.
-compileCUDAAction :: FutharkConfig -> CompilerMode -> FilePath -> Action KernelsMem
+compileCUDAAction :: FutharkConfig -> CompilerMode -> FilePath -> Action GPUMem
 compileCUDAAction fcfg mode outpath =
   Action
     { actionName = "Compile to CUDA",
@@ -291,7 +291,7 @@ compilePythonAction fcfg mode outpath =
       actionProcedure = pythonCommon SequentialPy.compileProg fcfg mode outpath
     }
 
-compilePyOpenCLAction :: FutharkConfig -> CompilerMode -> FilePath -> Action KernelsMem
+compilePyOpenCLAction :: FutharkConfig -> CompilerMode -> FilePath -> Action GPUMem
 compilePyOpenCLAction fcfg mode outpath =
   Action
     { actionName = "Compile to PyOpenCL",

--- a/src/Futhark/Actions.hs
+++ b/src/Futhark/Actions.hs
@@ -46,7 +46,7 @@ import System.FilePath
 import qualified System.Info
 
 -- | Print the result to stdout.
-printAction :: ASTLore lore => Action lore
+printAction :: ASTRep rep => Action rep
 printAction =
   Action
     { actionName = "Prettyprint",
@@ -55,7 +55,7 @@ printAction =
     }
 
 -- | Print the result to stdout, alias annotations.
-printAliasesAction :: (ASTLore lore, CanBeAliased (Op lore)) => Action lore
+printAliasesAction :: (ASTRep rep, CanBeAliased (Op rep)) => Action rep
 printAliasesAction =
   Action
     { actionName = "Prettyprint",
@@ -64,7 +64,7 @@ printAliasesAction =
     }
 
 -- | Print metrics about AST node counts to stdout.
-metricsAction :: OpMetrics (Op lore) => Action lore
+metricsAction :: OpMetrics (Op rep) => Action rep
 metricsAction =
   Action
     { actionName = "Compute metrics",

--- a/src/Futhark/Analysis/Alias.hs
+++ b/src/Futhark/Analysis/Alias.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 
 -- | Alias analysis of a full Futhark program.  Takes as input a
--- program with an arbitrary lore and produces one with aliases.  This
+-- program with an arbitrary rep and produces one with aliases.  This
 -- module does not implement the aliasing logic itself, and derives
 -- its information from definitions in
 -- "Futhark.IR.Prop.Aliases" and
@@ -26,37 +26,37 @@ import Futhark.IR.Aliases
 
 -- | Perform alias analysis on a Futhark program.
 aliasAnalysis ::
-  (ASTLore lore, CanBeAliased (Op lore)) =>
-  Prog lore ->
-  Prog (Aliases lore)
+  (ASTRep rep, CanBeAliased (Op rep)) =>
+  Prog rep ->
+  Prog (Aliases rep)
 aliasAnalysis (Prog consts funs) =
   Prog (fst (analyseStms mempty consts)) (map analyseFun funs)
 
 analyseFun ::
-  (ASTLore lore, CanBeAliased (Op lore)) =>
-  FunDef lore ->
-  FunDef (Aliases lore)
+  (ASTRep rep, CanBeAliased (Op rep)) =>
+  FunDef rep ->
+  FunDef (Aliases rep)
 analyseFun (FunDef entry attrs fname restype params body) =
   FunDef entry attrs fname restype params body'
   where
     body' = analyseBody mempty body
 
 analyseBody ::
-  ( ASTLore lore,
-    CanBeAliased (Op lore)
+  ( ASTRep rep,
+    CanBeAliased (Op rep)
   ) =>
   AliasTable ->
-  Body lore ->
-  Body (Aliases lore)
-analyseBody atable (Body lore stms result) =
+  Body rep ->
+  Body (Aliases rep)
+analyseBody atable (Body rep stms result) =
   let (stms', _atable') = analyseStms atable stms
-   in mkAliasedBody lore stms' result
+   in mkAliasedBody rep stms' result
 
 analyseStms ::
-  (ASTLore lore, CanBeAliased (Op lore)) =>
+  (ASTRep rep, CanBeAliased (Op rep)) =>
   AliasTable ->
-  Stms lore ->
-  (Stms (Aliases lore), AliasesAndConsumed)
+  Stms rep ->
+  (Stms (Aliases rep), AliasesAndConsumed)
 analyseStms orig_aliases =
   foldl' f (mempty, (orig_aliases, mempty)) . stmsToList
   where
@@ -66,21 +66,21 @@ analyseStms orig_aliases =
        in (stms <> oneStm stm', atable')
 
 analyseStm ::
-  (ASTLore lore, CanBeAliased (Op lore)) =>
+  (ASTRep rep, CanBeAliased (Op rep)) =>
   AliasTable ->
-  Stm lore ->
-  Stm (Aliases lore)
+  Stm rep ->
+  Stm (Aliases rep)
 analyseStm aliases (Let pat (StmAux cs attrs dec) e) =
   let e' = analyseExp aliases e
       pat' = addAliasesToPattern pat e'
-      lore' = (AliasDec $ consumedInExp e', dec)
-   in Let pat' (StmAux cs attrs lore') e'
+      rep' = (AliasDec $ consumedInExp e', dec)
+   in Let pat' (StmAux cs attrs rep') e'
 
 analyseExp ::
-  (ASTLore lore, CanBeAliased (Op lore)) =>
+  (ASTRep rep, CanBeAliased (Op rep)) =>
   AliasTable ->
-  Exp lore ->
-  Exp (Aliases lore)
+  Exp rep ->
+  Exp (Aliases rep)
 -- Would be better to put this in a BranchType annotation, but that
 -- requires a lot of other work.
 analyseExp aliases (If cond tb fb dec) =
@@ -115,10 +115,10 @@ analyseExp aliases e = mapExp analyse e
         }
 
 analyseLambda ::
-  (ASTLore lore, CanBeAliased (Op lore)) =>
+  (ASTRep rep, CanBeAliased (Op rep)) =>
   AliasTable ->
-  Lambda lore ->
-  Lambda (Aliases lore)
+  Lambda rep ->
+  Lambda (Aliases rep)
 analyseLambda aliases lam =
   let body = analyseBody aliases $ lambdaBody lam
    in lam

--- a/src/Futhark/Analysis/DataDependencies.hs
+++ b/src/Futhark/Analysis/DataDependencies.hs
@@ -18,13 +18,13 @@ import Futhark.IR
 type Dependencies = M.Map VName Names
 
 -- | Compute the data dependencies for an entire body.
-dataDependencies :: ASTLore lore => Body lore -> Dependencies
+dataDependencies :: ASTRep rep => Body rep -> Dependencies
 dataDependencies = dataDependencies' M.empty
 
 dataDependencies' ::
-  ASTLore lore =>
+  ASTRep rep =>
   Dependencies ->
-  Body lore ->
+  Body rep ->
   Dependencies
 dataDependencies' startdeps = foldl grow startdeps . bodyStms
   where

--- a/src/Futhark/Analysis/HORep/MapNest.hs
+++ b/src/Futhark/Analysis/HORep/MapNest.hs
@@ -24,7 +24,7 @@ import Futhark.IR hiding (typeOf)
 import qualified Futhark.IR.SOACS.SOAC as Futhark
 import Futhark.Transform.Substitute
 
-data Nesting lore = Nesting
+data Nesting rep = Nesting
   { nestingParamNames :: [VName],
     nestingResult :: [VName],
     nestingReturnType :: [Type],
@@ -32,25 +32,25 @@ data Nesting lore = Nesting
   }
   deriving (Eq, Ord, Show)
 
-data MapNest lore = MapNest SubExp (Lambda lore) [Nesting lore] [SOAC.Input]
+data MapNest rep = MapNest SubExp (Lambda rep) [Nesting rep] [SOAC.Input]
   deriving (Show)
 
-typeOf :: MapNest lore -> [Type]
+typeOf :: MapNest rep -> [Type]
 typeOf (MapNest w lam [] _) =
   map (`arrayOfRow` w) $ lambdaReturnType lam
 typeOf (MapNest w _ (nest : _) _) =
   map (`arrayOfRow` w) $ nestingReturnType nest
 
-params :: MapNest lore -> [VName]
+params :: MapNest rep -> [VName]
 params (MapNest _ lam [] _) =
   map paramName $ lambdaParams lam
 params (MapNest _ _ (nest : _) _) =
   nestingParamNames nest
 
-inputs :: MapNest lore -> [SOAC.Input]
+inputs :: MapNest rep -> [SOAC.Input]
 inputs (MapNest _ _ _ inps) = inps
 
-setInputs :: [SOAC.Input] -> MapNest lore -> MapNest lore
+setInputs :: [SOAC.Input] -> MapNest rep -> MapNest rep
 setInputs [] (MapNest w body ns _) = MapNest w body ns []
 setInputs (inp : inps) (MapNest _ body ns _) = MapNest w body ns' (inp : inps)
   where
@@ -60,24 +60,24 @@ setInputs (inp : inps) (MapNest _ body ns _) = MapNest w body ns' (inp : inps)
     setDepth n nw = n {nestingWidth = nw}
 
 fromSOAC ::
-  ( Bindable lore,
+  ( Bindable rep,
     MonadFreshNames m,
-    LocalScope lore m,
-    Op lore ~ Futhark.SOAC lore
+    LocalScope rep m,
+    Op rep ~ Futhark.SOAC rep
   ) =>
-  SOAC lore ->
-  m (Maybe (MapNest lore))
+  SOAC rep ->
+  m (Maybe (MapNest rep))
 fromSOAC = fromSOAC' mempty
 
 fromSOAC' ::
-  ( Bindable lore,
+  ( Bindable rep,
     MonadFreshNames m,
-    LocalScope lore m,
-    Op lore ~ Futhark.SOAC lore
+    LocalScope rep m,
+    Op rep ~ Futhark.SOAC rep
   ) =>
   [Ident] ->
-  SOAC lore ->
-  m (Maybe (MapNest lore))
+  SOAC rep ->
+  m (Maybe (MapNest rep))
 fromSOAC' bound (SOAC.Screma w (SOAC.ScremaForm [] [] lam) inps) = do
   maybenest <- case ( stmsToList $ bodyStms $ lambdaBody lam,
                       bodyResult $ lambdaBody lam
@@ -142,13 +142,13 @@ fromSOAC' _ _ = return Nothing
 
 toSOAC ::
   ( MonadFreshNames m,
-    HasScope lore m,
-    Bindable lore,
-    BinderOps lore,
-    Op lore ~ Futhark.SOAC lore
+    HasScope rep m,
+    Bindable rep,
+    BinderOps rep,
+    Op rep ~ Futhark.SOAC rep
   ) =>
-  MapNest lore ->
-  m (SOAC lore)
+  MapNest rep ->
+  m (SOAC rep)
 toSOAC (MapNest w lam [] inps) =
   return $ SOAC.Screma w (Futhark.mapSOAC lam) inps
 toSOAC (MapNest w lam (Nesting npnames nres nrettype nw : ns) inps) = do

--- a/src/Futhark/Analysis/Interference.hs
+++ b/src/Futhark/Analysis/Interference.hs
@@ -296,7 +296,7 @@ analyseKernels' lumap stms =
     helper stm =
       inScopeOf stm $ return mempty
 
-nameInfoToMemInfo :: Mem lore => NameInfo lore -> MemBound NoUniqueness
+nameInfoToMemInfo :: Mem rep => NameInfo rep -> MemBound NoUniqueness
 nameInfoToMemInfo info =
   case info of
     FParamName summary -> noUniquenessReturns summary

--- a/src/Futhark/Analysis/Metrics.hs
+++ b/src/Futhark/Analysis/Metrics.hs
@@ -80,7 +80,7 @@ inside what m = seen what >> censor addWhat m
     addWhat' (ctx, k) = (what : ctx, k)
 
 -- | Compute the metrics for a program.
-progMetrics :: OpMetrics (Op lore) => Prog lore -> AstMetrics
+progMetrics :: OpMetrics (Op rep) => Prog rep -> AstMetrics
 progMetrics prog =
   actualMetrics $
     execWriter $
@@ -88,17 +88,17 @@ progMetrics prog =
         mapM_ funDefMetrics $ progFuns prog
         mapM_ stmMetrics $ progConsts prog
 
-funDefMetrics :: OpMetrics (Op lore) => FunDef lore -> MetricsM ()
+funDefMetrics :: OpMetrics (Op rep) => FunDef rep -> MetricsM ()
 funDefMetrics = bodyMetrics . funDefBody
 
-bodyMetrics :: OpMetrics (Op lore) => Body lore -> MetricsM ()
+bodyMetrics :: OpMetrics (Op rep) => Body rep -> MetricsM ()
 bodyMetrics = mapM_ stmMetrics . bodyStms
 
 -- | Compute metrics for this statement.
-stmMetrics :: OpMetrics (Op lore) => Stm lore -> MetricsM ()
+stmMetrics :: OpMetrics (Op rep) => Stm rep -> MetricsM ()
 stmMetrics = expMetrics . stmExp
 
-expMetrics :: OpMetrics (Op lore) => Exp lore -> MetricsM ()
+expMetrics :: OpMetrics (Op rep) => Exp rep -> MetricsM ()
 expMetrics (BasicOp op) =
   seen "BasicOp" >> primOpMetrics op
 expMetrics (DoLoop _ _ ForLoop {} body) =
@@ -139,5 +139,5 @@ primOpMetrics Rotate {} = seen "Rotate"
 primOpMetrics UpdateAcc {} = seen "UpdateAcc"
 
 -- | Compute metrics for this lambda.
-lambdaMetrics :: OpMetrics (Op lore) => Lambda lore -> MetricsM ()
+lambdaMetrics :: OpMetrics (Op rep) => Lambda rep -> MetricsM ()
 lambdaMetrics = bodyMetrics . lambdaBody

--- a/src/Futhark/Analysis/PrimExp/Convert.hs
+++ b/src/Futhark/Analysis/PrimExp/Convert.hs
@@ -60,9 +60,9 @@ instance ToExp v => ToExp (TPrimExp t v) where
 -- This includes constants and variable names, which are passed as
 -- t'SubExp's.
 primExpFromExp ::
-  (Fail.MonadFail m, Decorations lore) =>
+  (Fail.MonadFail m, RepTypes rep) =>
   (VName -> m (PrimExp v)) ->
-  Exp lore ->
+  Exp rep ->
   m (PrimExp v)
 primExpFromExp f (BasicOp (BinOp op x y)) =
   BinOpExp op <$> primExpFromSubExpM f x <*> primExpFromSubExpM f y

--- a/src/Futhark/Analysis/PrimExp/Simplify.hs
+++ b/src/Futhark/Analysis/PrimExp/Simplify.hs
@@ -11,9 +11,9 @@ import Futhark.Optimise.Simplify.Engine as Engine
 -- refers to a name that is a 'Constant', the node turns into a
 -- 'ValueExp'.
 simplifyPrimExp ::
-  SimplifiableLore lore =>
+  SimplifiableRep rep =>
   PrimExp VName ->
-  SimpleM lore (PrimExp VName)
+  SimpleM rep (PrimExp VName)
 simplifyPrimExp = simplifyAnyPrimExp onLeaf
   where
     onLeaf v pt = do
@@ -24,9 +24,9 @@ simplifyPrimExp = simplifyAnyPrimExp onLeaf
 
 -- | Like 'simplifyPrimExp', but where leaves may be 'Ext's.
 simplifyExtPrimExp ::
-  SimplifiableLore lore =>
+  SimplifiableRep rep =>
   PrimExp (Ext VName) ->
-  SimpleM lore (PrimExp (Ext VName))
+  SimpleM rep (PrimExp (Ext VName))
 simplifyExtPrimExp = simplifyAnyPrimExp onLeaf
   where
     onLeaf (Free v) pt = do
@@ -37,10 +37,10 @@ simplifyExtPrimExp = simplifyAnyPrimExp onLeaf
     onLeaf (Ext i) pt = return $ LeafExp (Ext i) pt
 
 simplifyAnyPrimExp ::
-  SimplifiableLore lore =>
-  (a -> PrimType -> SimpleM lore (PrimExp a)) ->
+  SimplifiableRep rep =>
+  (a -> PrimType -> SimpleM rep (PrimExp a)) ->
   PrimExp a ->
-  SimpleM lore (PrimExp a)
+  SimpleM rep (PrimExp a)
 simplifyAnyPrimExp f (LeafExp v pt) = f v pt
 simplifyAnyPrimExp _ (ValueExp pv) =
   return $ ValueExp pv

--- a/src/Futhark/Analysis/Rephrase.hs
+++ b/src/Futhark/Analysis/Rephrase.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE ConstraintKinds #-}
 
--- | Facilities for changing the lore of some fragment, with no
+-- | Facilities for changing the rep of some fragment, with no
 -- context.  We call this "rephrasing", for no deep reason.
 module Futhark.Analysis.Rephrase
   ( rephraseProg,
@@ -20,14 +20,14 @@ import Futhark.IR
 -- | A collection of functions that together allow us to rephrase some
 -- IR fragment, in some monad @m@.  If we let @m@ be the 'Maybe'
 -- monad, we can conveniently do rephrasing that might fail.  This is
--- useful if you want to see if some IR in e.g. the @Kernels@ lore
+-- useful if you want to see if some IR in e.g. the @Kernels@ rep
 -- actually uses any @Kernels@-specific operations.
 data Rephraser m from to = Rephraser
-  { rephraseExpLore :: ExpDec from -> m (ExpDec to),
-    rephraseLetBoundLore :: LetDec from -> m (LetDec to),
-    rephraseFParamLore :: FParamInfo from -> m (FParamInfo to),
-    rephraseLParamLore :: LParamInfo from -> m (LParamInfo to),
-    rephraseBodyLore :: BodyDec from -> m (BodyDec to),
+  { rephraseExpDec :: ExpDec from -> m (ExpDec to),
+    rephraseLetBoundDec :: LetDec from -> m (LetDec to),
+    rephraseFParamDec :: FParamInfo from -> m (FParamInfo to),
+    rephraseLParamDec :: LParamInfo from -> m (LParamInfo to),
+    rephraseBodyDec :: BodyDec from -> m (BodyDec to),
     rephraseRetType :: RetType from -> m (RetType to),
     rephraseBranchType :: BranchType from -> m (BranchType to),
     rephraseOp :: Op from -> m (Op to)
@@ -44,7 +44,7 @@ rephraseProg rephraser (Prog consts funs) =
 rephraseFunDef :: Monad m => Rephraser m from to -> FunDef from -> m (FunDef to)
 rephraseFunDef rephraser fundec = do
   body' <- rephraseBody rephraser $ funDefBody fundec
-  params' <- mapM (rephraseParam $ rephraseFParamLore rephraser) $ funDefParams fundec
+  params' <- mapM (rephraseParam $ rephraseFParamDec rephraser) $ funDefParams fundec
   rettype' <- mapM (rephraseRetType rephraser) $ funDefRetType fundec
   return fundec {funDefBody = body', funDefParams = params', funDefRetType = rettype'}
 
@@ -56,8 +56,8 @@ rephraseExp = mapExpM . mapper
 rephraseStm :: Monad m => Rephraser m from to -> Stm from -> m (Stm to)
 rephraseStm rephraser (Let pat (StmAux cs attrs dec) e) =
   Let
-    <$> rephrasePattern (rephraseLetBoundLore rephraser) pat
-    <*> (StmAux cs attrs <$> rephraseExpLore rephraser dec)
+    <$> rephrasePattern (rephraseLetBoundDec rephraser) pat
+    <*> (StmAux cs attrs <$> rephraseExpDec rephraser dec)
     <*> rephraseExp rephraser e
 
 -- | Rephrase a pattern.
@@ -80,9 +80,9 @@ rephraseParam rephraser (Param name from) =
 
 -- | Rephrase a body.
 rephraseBody :: Monad m => Rephraser m from to -> Body from -> m (Body to)
-rephraseBody rephraser (Body lore bnds res) =
+rephraseBody rephraser (Body rep bnds res) =
   Body
-    <$> rephraseBodyLore rephraser lore
+    <$> rephraseBodyDec rephraser rep
     <*> (stmsFromList <$> mapM (rephraseStm rephraser) (stmsToList bnds))
     <*> pure res
 
@@ -90,7 +90,7 @@ rephraseBody rephraser (Body lore bnds res) =
 rephraseLambda :: Monad m => Rephraser m from to -> Lambda from -> m (Lambda to)
 rephraseLambda rephraser lam = do
   body' <- rephraseBody rephraser $ lambdaBody lam
-  params' <- mapM (rephraseParam $ rephraseLParamLore rephraser) $ lambdaParams lam
+  params' <- mapM (rephraseParam $ rephraseLParamDec rephraser) $ lambdaParams lam
   return lam {lambdaBody = body', lambdaParams = params'}
 
 mapper :: Monad m => Rephraser m from to -> Mapper from to m
@@ -99,7 +99,7 @@ mapper rephraser =
     { mapOnBody = const $ rephraseBody rephraser,
       mapOnRetType = rephraseRetType rephraser,
       mapOnBranchType = rephraseBranchType rephraser,
-      mapOnFParam = rephraseParam (rephraseFParamLore rephraser),
-      mapOnLParam = rephraseParam (rephraseLParamLore rephraser),
+      mapOnFParam = rephraseParam (rephraseFParamDec rephraser),
+      mapOnLParam = rephraseParam (rephraseLParamDec rephraser),
       mapOnOp = rephraseOp rephraser
     }

--- a/src/Futhark/Analysis/SymbolTable.hs
+++ b/src/Futhark/Analysis/SymbolTable.hs
@@ -61,9 +61,9 @@ import qualified Futhark.IR as AST
 import qualified Futhark.IR.Prop.Aliases as Aliases
 import Prelude hiding (elem, lookup)
 
-data SymbolTable lore = SymbolTable
+data SymbolTable rep = SymbolTable
   { loopDepth :: Int,
-    bindings :: M.Map VName (Entry lore),
+    bindings :: M.Map VName (Entry rep),
     -- | Which names are available just before the most enclosing
     -- loop?
     availableAtClosestLoop :: Names,
@@ -73,7 +73,7 @@ data SymbolTable lore = SymbolTable
     simplifyMemory :: Bool
   }
 
-instance Semigroup (SymbolTable lore) where
+instance Semigroup (SymbolTable rep) where
   table1 <> table2 =
     SymbolTable
       { loopDepth = max (loopDepth table1) (loopDepth table2),
@@ -84,21 +84,21 @@ instance Semigroup (SymbolTable lore) where
         simplifyMemory = simplifyMemory table1 || simplifyMemory table2
       }
 
-instance Monoid (SymbolTable lore) where
+instance Monoid (SymbolTable rep) where
   mempty = empty
 
-empty :: SymbolTable lore
+empty :: SymbolTable rep
 empty = SymbolTable 0 M.empty mempty False
 
-fromScope :: ASTLore lore => Scope lore -> SymbolTable lore
+fromScope :: ASTRep rep => Scope rep -> SymbolTable rep
 fromScope = M.foldlWithKey' insertFreeVar' empty
   where
     insertFreeVar' m k dec = insertFreeVar k dec m
 
-toScope :: SymbolTable lore -> Scope lore
+toScope :: SymbolTable rep -> Scope rep
 toScope = M.map entryInfo . bindings
 
-deepen :: SymbolTable lore -> SymbolTable lore
+deepen :: SymbolTable rep -> SymbolTable rep
 deepen vtable =
   vtable
     { loopDepth = loopDepth vtable + 1,
@@ -125,59 +125,59 @@ instance FreeIn Indexed where
 -- | Indexing a delayed array if possible.
 type IndexArray = [TPrimExp Int64 VName] -> Maybe Indexed
 
-data Entry lore = Entry
+data Entry rep = Entry
   { -- | True if consumed.
     entryConsumed :: Bool,
     entryDepth :: Int,
     -- | True if this name has been used as an array size,
     -- implying that it is non-negative.
     entryIsSize :: Bool,
-    entryType :: EntryType lore
+    entryType :: EntryType rep
   }
 
-data EntryType lore
-  = LoopVar (LoopVarEntry lore)
-  | LetBound (LetBoundEntry lore)
-  | FParam (FParamEntry lore)
-  | LParam (LParamEntry lore)
-  | FreeVar (FreeVarEntry lore)
+data EntryType rep
+  = LoopVar (LoopVarEntry rep)
+  | LetBound (LetBoundEntry rep)
+  | FParam (FParamEntry rep)
+  | LParam (LParamEntry rep)
+  | FreeVar (FreeVarEntry rep)
 
-data LoopVarEntry lore = LoopVarEntry
+data LoopVarEntry rep = LoopVarEntry
   { loopVarType :: IntType,
     loopVarBound :: SubExp
   }
 
-data LetBoundEntry lore = LetBoundEntry
-  { letBoundDec :: LetDec lore,
+data LetBoundEntry rep = LetBoundEntry
+  { letBoundDec :: LetDec rep,
     letBoundAliases :: Names,
-    letBoundStm :: Stm lore,
+    letBoundStm :: Stm rep,
     -- | Index a delayed array, if possible.
     letBoundIndex :: Int -> IndexArray
   }
 
-data FParamEntry lore = FParamEntry
-  { fparamDec :: FParamInfo lore,
+data FParamEntry rep = FParamEntry
+  { fparamDec :: FParamInfo rep,
     fparamAliases :: Names,
     -- | If a loop parameter, the initial value and the eventual
     -- result.  The result need not be in scope in the symbol table.
     fparamMerge :: Maybe (SubExp, SubExp)
   }
 
-data LParamEntry lore = LParamEntry
-  { lparamDec :: LParamInfo lore,
+data LParamEntry rep = LParamEntry
+  { lparamDec :: LParamInfo rep,
     lparamIndex :: IndexArray
   }
 
-data FreeVarEntry lore = FreeVarEntry
-  { freeVarDec :: NameInfo lore,
+data FreeVarEntry rep = FreeVarEntry
+  { freeVarDec :: NameInfo rep,
     -- | Index a delayed array, if possible.
     freeVarIndex :: VName -> IndexArray
   }
 
-instance ASTLore lore => Typed (Entry lore) where
+instance ASTRep rep => Typed (Entry rep) where
   typeOf = typeOf . entryInfo
 
-entryInfo :: Entry lore -> NameInfo lore
+entryInfo :: Entry rep -> NameInfo rep
 entryInfo e = case entryType e of
   LetBound entry -> LetName $ letBoundDec entry
   LoopVar entry -> IndexName $ loopVarType entry
@@ -185,54 +185,54 @@ entryInfo e = case entryType e of
   LParam entry -> LParamName $ lparamDec entry
   FreeVar entry -> freeVarDec entry
 
-isLetBound :: Entry lore -> Maybe (LetBoundEntry lore)
+isLetBound :: Entry rep -> Maybe (LetBoundEntry rep)
 isLetBound e = case entryType e of
   LetBound entry -> Just entry
   _ -> Nothing
 
-entryStm :: Entry lore -> Maybe (Stm lore)
+entryStm :: Entry rep -> Maybe (Stm rep)
 entryStm = fmap letBoundStm . isLetBound
 
-entryFParam :: Entry lore -> Maybe (FParamInfo lore)
+entryFParam :: Entry rep -> Maybe (FParamInfo rep)
 entryFParam e = case entryType e of
   FParam e' -> Just $ fparamDec e'
   _ -> Nothing
 
-entryLetBoundDec :: Entry lore -> Maybe (LetDec lore)
+entryLetBoundDec :: Entry rep -> Maybe (LetDec rep)
 entryLetBoundDec = fmap letBoundDec . isLetBound
 
-elem :: VName -> SymbolTable lore -> Bool
+elem :: VName -> SymbolTable rep -> Bool
 elem name = isJust . lookup name
 
-lookup :: VName -> SymbolTable lore -> Maybe (Entry lore)
+lookup :: VName -> SymbolTable rep -> Maybe (Entry rep)
 lookup name = M.lookup name . bindings
 
-lookupStm :: VName -> SymbolTable lore -> Maybe (Stm lore)
+lookupStm :: VName -> SymbolTable rep -> Maybe (Stm rep)
 lookupStm name vtable = entryStm =<< lookup name vtable
 
-lookupExp :: VName -> SymbolTable lore -> Maybe (Exp lore, Certificates)
+lookupExp :: VName -> SymbolTable rep -> Maybe (Exp rep, Certificates)
 lookupExp name vtable = (stmExp &&& stmCerts) <$> lookupStm name vtable
 
-lookupBasicOp :: VName -> SymbolTable lore -> Maybe (BasicOp, Certificates)
+lookupBasicOp :: VName -> SymbolTable rep -> Maybe (BasicOp, Certificates)
 lookupBasicOp name vtable = case lookupExp name vtable of
   Just (BasicOp e, cs) -> Just (e, cs)
   _ -> Nothing
 
-lookupType :: ASTLore lore => VName -> SymbolTable lore -> Maybe Type
+lookupType :: ASTRep rep => VName -> SymbolTable rep -> Maybe Type
 lookupType name vtable = typeOf <$> lookup name vtable
 
-lookupSubExpType :: ASTLore lore => SubExp -> SymbolTable lore -> Maybe Type
+lookupSubExpType :: ASTRep rep => SubExp -> SymbolTable rep -> Maybe Type
 lookupSubExpType (Var v) = lookupType v
 lookupSubExpType (Constant v) = const $ Just $ Prim $ primValueType v
 
-lookupSubExp :: VName -> SymbolTable lore -> Maybe (SubExp, Certificates)
+lookupSubExp :: VName -> SymbolTable rep -> Maybe (SubExp, Certificates)
 lookupSubExp name vtable = do
   (e, cs) <- lookupExp name vtable
   case e of
     BasicOp (SubExp se) -> Just (se, cs)
     _ -> Nothing
 
-lookupAliases :: VName -> SymbolTable lore -> Names
+lookupAliases :: VName -> SymbolTable rep -> Names
 lookupAliases name vtable =
   case entryType <$> M.lookup name (bindings vtable) of
     Just (LetBound e) -> letBoundAliases e
@@ -241,25 +241,25 @@ lookupAliases name vtable =
 
 -- | If the given variable name is the name of a 'ForLoop' parameter,
 -- then return the bound of that loop.
-lookupLoopVar :: VName -> SymbolTable lore -> Maybe SubExp
+lookupLoopVar :: VName -> SymbolTable rep -> Maybe SubExp
 lookupLoopVar name vtable = do
   LoopVar e <- entryType <$> M.lookup name (bindings vtable)
   return $ loopVarBound e
 
-lookupLoopParam :: VName -> SymbolTable lore -> Maybe (SubExp, SubExp)
+lookupLoopParam :: VName -> SymbolTable rep -> Maybe (SubExp, SubExp)
 lookupLoopParam name vtable = do
   FParam e <- entryType <$> M.lookup name (bindings vtable)
   fparamMerge e
 
 -- | In symbol table and not consumed.
-available :: VName -> SymbolTable lore -> Bool
+available :: VName -> SymbolTable rep -> Bool
 available name = maybe False (not . entryConsumed) . M.lookup name . bindings
 
 index ::
-  ASTLore lore =>
+  ASTRep rep =>
   VName ->
   [SubExp] ->
-  SymbolTable lore ->
+  SymbolTable rep ->
   Maybe Indexed
 index name is table = do
   is' <- mapM asPrimExp is
@@ -272,7 +272,7 @@ index name is table = do
 index' ::
   VName ->
   [TPrimExp Int64 VName] ->
-  SymbolTable lore ->
+  SymbolTable rep ->
   Maybe Indexed
 index' name is vtable = do
   entry <- lookup name vtable
@@ -290,8 +290,8 @@ index' name is vtable = do
 
 class IndexOp op where
   indexOp ::
-    (ASTLore lore, IndexOp (Op lore)) =>
-    SymbolTable lore ->
+    (ASTRep rep, IndexOp (Op rep)) =>
+    SymbolTable rep ->
     Int ->
     op ->
     [TPrimExp Int64 VName] ->
@@ -301,9 +301,9 @@ class IndexOp op where
 instance IndexOp ()
 
 indexExp ::
-  (IndexOp (Op lore), ASTLore lore) =>
-  SymbolTable lore ->
-  Exp lore ->
+  (IndexOp (Op rep), ASTRep rep) =>
+  SymbolTable rep ->
+  Exp rep ->
   Int ->
   IndexArray
 indexExp vtable (Op op) k is =
@@ -345,12 +345,12 @@ indexExp table (BasicOp (Index v slice)) _ is =
 indexExp _ _ _ _ = Nothing
 
 defBndEntry ::
-  (ASTLore lore, IndexOp (Op lore)) =>
-  SymbolTable lore ->
-  PatElem lore ->
+  (ASTRep rep, IndexOp (Op rep)) =>
+  SymbolTable rep ->
+  PatElem rep ->
   Names ->
-  Stm lore ->
-  LetBoundEntry lore
+  Stm rep ->
+  LetBoundEntry rep
 defBndEntry vtable patElem als bnd =
   LetBoundEntry
     { letBoundDec = patElemDec patElem,
@@ -362,10 +362,10 @@ defBndEntry vtable patElem als bnd =
     }
 
 bindingEntries ::
-  (ASTLore lore, Aliases.Aliased lore, IndexOp (Op lore)) =>
-  Stm lore ->
-  SymbolTable lore ->
-  [LetBoundEntry lore]
+  (ASTRep rep, Aliases.Aliased rep, IndexOp (Op rep)) =>
+  Stm rep ->
+  SymbolTable rep ->
+  [LetBoundEntry rep]
 bindingEntries bnd@(Let pat _ _) vtable = do
   pat_elem <- patternElements pat
   return $ defBndEntry vtable pat_elem (Aliases.aliasesOf pat_elem) bnd
@@ -374,11 +374,11 @@ adjustSeveral :: Ord k => (v -> v) -> [k] -> M.Map k v -> M.Map k v
 adjustSeveral f = flip $ foldl' $ flip $ M.adjust f
 
 insertEntry ::
-  ASTLore lore =>
+  ASTRep rep =>
   VName ->
-  EntryType lore ->
-  SymbolTable lore ->
-  SymbolTable lore
+  EntryType rep ->
+  SymbolTable rep ->
+  SymbolTable rep
 insertEntry name entry vtable =
   let entry' =
         Entry
@@ -396,20 +396,20 @@ insertEntry name entry vtable =
         }
 
 insertEntries ::
-  ASTLore lore =>
-  [(VName, EntryType lore)] ->
-  SymbolTable lore ->
-  SymbolTable lore
+  ASTRep rep =>
+  [(VName, EntryType rep)] ->
+  SymbolTable rep ->
+  SymbolTable rep
 insertEntries entries vtable =
   foldl' add vtable entries
   where
     add vtable' (name, entry) = insertEntry name entry vtable'
 
 insertStm ::
-  (ASTLore lore, IndexOp (Op lore), Aliases.Aliased lore) =>
-  Stm lore ->
-  SymbolTable lore ->
-  SymbolTable lore
+  (ASTRep rep, IndexOp (Op rep), Aliases.Aliased rep) =>
+  Stm rep ->
+  SymbolTable rep ->
+  SymbolTable rep
 insertStm stm vtable =
   flip (foldl' $ flip consume) (namesToList stm_consumed) $
     flip (foldl' addRevAliases) (patternElements $ stmPattern stm) $
@@ -435,23 +435,23 @@ insertStm stm vtable =
         update' e = e
 
 insertStms ::
-  (ASTLore lore, IndexOp (Op lore), Aliases.Aliased lore) =>
-  Stms lore ->
-  SymbolTable lore ->
-  SymbolTable lore
+  (ASTRep rep, IndexOp (Op rep), Aliases.Aliased rep) =>
+  Stms rep ->
+  SymbolTable rep ->
+  SymbolTable rep
 insertStms stms vtable = foldl' (flip insertStm) vtable $ stmsToList stms
 
-expandAliases :: Names -> SymbolTable lore -> Names
+expandAliases :: Names -> SymbolTable rep -> Names
 expandAliases names vtable = names <> aliasesOfAliases
   where
     aliasesOfAliases =
       mconcat . map (`lookupAliases` vtable) . namesToList $ names
 
 insertFParam ::
-  ASTLore lore =>
-  AST.FParam lore ->
-  SymbolTable lore ->
-  SymbolTable lore
+  ASTRep rep =>
+  AST.FParam rep ->
+  SymbolTable rep ->
+  SymbolTable rep
 insertFParam fparam = insertEntry name entry
   where
     name = AST.paramName fparam
@@ -464,13 +464,13 @@ insertFParam fparam = insertEntry name entry
           }
 
 insertFParams ::
-  ASTLore lore =>
-  [AST.FParam lore] ->
-  SymbolTable lore ->
-  SymbolTable lore
+  ASTRep rep =>
+  [AST.FParam rep] ->
+  SymbolTable rep ->
+  SymbolTable rep
 insertFParams fparams symtable = foldl' (flip insertFParam) symtable fparams
 
-insertLParam :: ASTLore lore => LParam lore -> SymbolTable lore -> SymbolTable lore
+insertLParam :: ASTRep rep => LParam rep -> SymbolTable rep -> SymbolTable rep
 insertLParam param = insertEntry name bind
   where
     bind =
@@ -489,10 +489,10 @@ insertLParam param = insertEntry name bind
 -- used to help some loop optimisations detect invariant loop
 -- parameters.
 insertLoopMerge ::
-  ASTLore lore =>
-  [(AST.FParam lore, SubExp, SubExp)] ->
-  SymbolTable lore ->
-  SymbolTable lore
+  ASTRep rep =>
+  [(AST.FParam rep, SubExp, SubExp)] ->
+  SymbolTable rep ->
+  SymbolTable rep
 insertLoopMerge = flip $ foldl' $ flip bind
   where
     bind (p, initial, res) =
@@ -504,7 +504,7 @@ insertLoopMerge = flip $ foldl' $ flip bind
               fparamMerge = Just (initial, res)
             }
 
-insertLoopVar :: ASTLore lore => VName -> IntType -> SubExp -> SymbolTable lore -> SymbolTable lore
+insertLoopVar :: ASTRep rep => VName -> IntType -> SubExp -> SymbolTable rep -> SymbolTable rep
 insertLoopVar name it bound = insertEntry name bind
   where
     bind =
@@ -514,7 +514,7 @@ insertLoopVar name it bound = insertEntry name bind
             loopVarBound = bound
           }
 
-insertFreeVar :: ASTLore lore => VName -> NameInfo lore -> SymbolTable lore -> SymbolTable lore
+insertFreeVar :: ASTRep rep => VName -> NameInfo rep -> SymbolTable rep -> SymbolTable rep
 insertFreeVar name dec = insertEntry name entry
   where
     entry =
@@ -524,7 +524,7 @@ insertFreeVar name dec = insertEntry name entry
             freeVarIndex = \_ _ -> Nothing
           }
 
-consume :: VName -> SymbolTable lore -> SymbolTable lore
+consume :: VName -> SymbolTable rep -> SymbolTable rep
 consume consumee vtable =
   foldl' consume' vtable $
     namesToList $
@@ -535,7 +535,7 @@ consume consumee vtable =
     consume'' e = e {entryConsumed = True}
 
 -- | Hide definitions of those entries that satisfy some predicate.
-hideIf :: (Entry lore -> Bool) -> SymbolTable lore -> SymbolTable lore
+hideIf :: (Entry rep -> Bool) -> SymbolTable rep -> SymbolTable rep
 hideIf hide vtable = vtable {bindings = M.map maybeHide $ bindings vtable}
   where
     maybeHide entry
@@ -552,7 +552,7 @@ hideIf hide vtable = vtable {bindings = M.map maybeHide $ bindings vtable}
 
 -- | Hide these definitions, if they are protected by certificates in
 -- the set of names.
-hideCertified :: Names -> SymbolTable lore -> SymbolTable lore
+hideCertified :: Names -> SymbolTable rep -> SymbolTable rep
 hideCertified to_hide = hideIf $ maybe False hide . entryStm
   where
     hide = any (`nameIn` to_hide) . unCertificates . stmCerts

--- a/src/Futhark/Analysis/UsageTable.hs
+++ b/src/Futhark/Analysis/UsageTable.hs
@@ -141,16 +141,16 @@ matches (Usages x) (Usages y) = x == (x .&. y)
 withoutU :: Usages -> Usages -> Usages
 withoutU (Usages x) (Usages y) = Usages $ x .&. complement y
 
-usageInBody :: Aliased lore => Body lore -> UsageTable
+usageInBody :: Aliased rep => Body rep -> UsageTable
 usageInBody = foldMap consumedUsage . namesToList . consumedInBody
 
 -- | Produce a usage table reflecting the use of the free variables in
 -- a single statement.
-usageInStm :: (ASTLore lore, Aliased lore) => Stm lore -> UsageTable
-usageInStm (Let pat lore e) =
+usageInStm :: (ASTRep rep, Aliased rep) => Stm rep -> UsageTable
+usageInStm (Let pat rep e) =
   mconcat
     [ usageInPat,
-      usageInExpLore,
+      usageInExpDec,
       usageInExp e,
       usages (freeIn e)
     ]
@@ -161,10 +161,10 @@ usageInStm (Let pat lore e) =
             `namesSubtract` namesFromList (patternNames pat)
         )
         <> sizeUsages (foldMap (freeIn . patElemType) (patternElements pat))
-    usageInExpLore =
-      usages $ freeIn lore
+    usageInExpDec =
+      usages $ freeIn rep
 
-usageInExp :: Aliased lore => Exp lore -> UsageTable
+usageInExp :: Aliased rep => Exp rep -> UsageTable
 usageInExp (Apply _ args _ _) =
   mconcat
     [ mconcat $

--- a/src/Futhark/Binder/Class.hs
+++ b/src/Futhark/Binder/Class.hs
@@ -26,33 +26,33 @@ import qualified Data.Kind
 import Futhark.IR
 import Futhark.MonadFreshNames
 
--- | The class of lores that can be constructed solely from an
--- expression, within some monad.  Very important: the methods should
--- not have any significant side effects!  They may be called more
--- often than you think, and the results thrown away.  If used
+-- | The class of representations that can be constructed solely from
+-- an expression, within some monad.  Very important: the methods
+-- should not have any significant side effects!  They may be called
+-- more often than you think, and the results thrown away.  If used
 -- exclusively within a 'MonadBinder' instance, it is acceptable for
 -- them to create new bindings, however.
 class
-  ( ASTLore lore,
-    FParamInfo lore ~ DeclType,
-    LParamInfo lore ~ Type,
-    RetType lore ~ DeclExtType,
-    BranchType lore ~ ExtType,
-    SetType (LetDec lore)
+  ( ASTRep rep,
+    FParamInfo rep ~ DeclType,
+    LParamInfo rep ~ Type,
+    RetType rep ~ DeclExtType,
+    BranchType rep ~ ExtType,
+    SetType (LetDec rep)
   ) =>
-  Bindable lore
+  Bindable rep
   where
-  mkExpPat :: [Ident] -> [Ident] -> Exp lore -> Pattern lore
-  mkExpDec :: Pattern lore -> Exp lore -> ExpDec lore
-  mkBody :: Stms lore -> Result -> Body lore
+  mkExpPat :: [Ident] -> [Ident] -> Exp rep -> Pattern rep
+  mkExpDec :: Pattern rep -> Exp rep -> ExpDec rep
+  mkBody :: Stms rep -> Result -> Body rep
   mkLetNames ::
-    (MonadFreshNames m, HasScope lore m) =>
+    (MonadFreshNames m, HasScope rep m) =>
     [VName] ->
-    Exp lore ->
-    m (Stm lore)
+    Exp rep ->
+    m (Stm rep)
 
 -- | A monad that supports the creation of bindings from expressions
--- and bodies from bindings, with a specific lore.  This is the main
+-- and bodies from bindings, with a specific rep.  This is the main
 -- typeclass that a monad must implement in order for it to be useful
 -- for generating or modifying Futhark code.  Most importantly
 -- maintains a current state of 'Stms' (as well as a 'Scope') that
@@ -63,29 +63,29 @@ class
 -- results thrown away.  It is acceptable for them to create new
 -- bindings, however.
 class
-  ( ASTLore (Lore m),
+  ( ASTRep (Rep m),
     MonadFreshNames m,
     Applicative m,
     Monad m,
-    LocalScope (Lore m) m
+    LocalScope (Rep m) m
   ) =>
   MonadBinder m
   where
-  type Lore m :: Data.Kind.Type
-  mkExpDecM :: Pattern (Lore m) -> Exp (Lore m) -> m (ExpDec (Lore m))
-  mkBodyM :: Stms (Lore m) -> Result -> m (Body (Lore m))
-  mkLetNamesM :: [VName] -> Exp (Lore m) -> m (Stm (Lore m))
+  type Rep m :: Data.Kind.Type
+  mkExpDecM :: Pattern (Rep m) -> Exp (Rep m) -> m (ExpDec (Rep m))
+  mkBodyM :: Stms (Rep m) -> Result -> m (Body (Rep m))
+  mkLetNamesM :: [VName] -> Exp (Rep m) -> m (Stm (Rep m))
 
   -- | Add a statement to the 'Stms' under construction.
-  addStm :: Stm (Lore m) -> m ()
+  addStm :: Stm (Rep m) -> m ()
   addStm = addStms . oneStm
 
   -- | Add multiple statements to the 'Stms' under construction.
-  addStms :: Stms (Lore m) -> m ()
+  addStms :: Stms (Rep m) -> m ()
 
   -- | Obtain the statements constructed during a monadic action,
   -- instead of adding them to the state.
-  collectStms :: m a -> m (a, Stms (Lore m))
+  collectStms :: m a -> m (a, Stms (Rep m))
 
   -- | Add the provided certificates to any statements added during
   -- execution of the action.
@@ -95,7 +95,7 @@ class
 -- | Apply a function to the statements added by this action.
 censorStms ::
   MonadBinder m =>
-  (Stms (Lore m) -> Stms (Lore m)) ->
+  (Stms (Rep m) -> Stms (Rep m)) ->
   m a ->
   m a
 censorStms f m = do
@@ -112,7 +112,7 @@ attributing attrs = censorStms $ fmap onStm
 
 -- | Add the certificates and attributes to any statements added by
 -- this action.
-auxing :: MonadBinder m => StmAux anylore -> m a -> m a
+auxing :: MonadBinder m => StmAux anyrep -> m a -> m a
 auxing (StmAux cs attrs _) = censorStms $ fmap onStm
   where
     onStm (Let pat aux e) =
@@ -127,15 +127,15 @@ auxing (StmAux cs attrs _) = censorStms $ fmap onStm
 -- | Add a statement with the given pattern and expression.
 letBind ::
   MonadBinder m =>
-  Pattern (Lore m) ->
-  Exp (Lore m) ->
+  Pattern (Rep m) ->
+  Exp (Rep m) ->
   m ()
 letBind pat e =
   addStm =<< Let pat <$> (defAux <$> mkExpDecM pat e) <*> pure e
 
 -- | Construct a 'Stm' from identifiers for the context- and value
 -- part of the pattern, as well as the expression.
-mkLet :: Bindable lore => [Ident] -> [Ident] -> Exp lore -> Stm lore
+mkLet :: Bindable rep => [Ident] -> [Ident] -> Exp rep -> Stm rep
 mkLet ctx val e =
   let pat = mkExpPat ctx val e
       dec = mkExpDec pat e
@@ -143,7 +143,7 @@ mkLet ctx val e =
 
 -- | Like mkLet, but also take attributes and certificates from the
 -- given 'StmAux'.
-mkLet' :: Bindable lore => [Ident] -> [Ident] -> StmAux a -> Exp lore -> Stm lore
+mkLet' :: Bindable rep => [Ident] -> [Ident] -> StmAux a -> Exp rep -> Stm rep
 mkLet' ctx val (StmAux cs attrs _) e =
   let pat = mkExpPat ctx val e
       dec = mkExpDec pat e
@@ -151,23 +151,23 @@ mkLet' ctx val (StmAux cs attrs _) e =
 
 -- | Add a statement with the given pattern element names and
 -- expression.
-letBindNames :: MonadBinder m => [VName] -> Exp (Lore m) -> m ()
+letBindNames :: MonadBinder m => [VName] -> Exp (Rep m) -> m ()
 letBindNames names e = addStm =<< mkLetNamesM names e
 
 -- | As 'collectStms', but throw away the ordinary result.
-collectStms_ :: MonadBinder m => m a -> m (Stms (Lore m))
+collectStms_ :: MonadBinder m => m a -> m (Stms (Rep m))
 collectStms_ = fmap snd . collectStms
 
 -- | Add the statements of the body, then return the body result.
-bodyBind :: MonadBinder m => Body (Lore m) -> m [SubExp]
+bodyBind :: MonadBinder m => Body (Rep m) -> m [SubExp]
 bodyBind (Body _ stms es) = do
   addStms stms
   return es
 
 -- | Add several bindings at the outermost level of a t'Body'.
-insertStms :: Bindable lore => Stms lore -> Body lore -> Body lore
+insertStms :: Bindable rep => Stms rep -> Body rep -> Body rep
 insertStms stms1 (Body _ stms2 res) = mkBody (stms1 <> stms2) res
 
 -- | Add a single binding at the outermost level of a t'Body'.
-insertStm :: Bindable lore => Stm lore -> Body lore -> Body lore
+insertStm :: Bindable rep => Stm rep -> Body rep -> Body rep
 insertStm = insertStms . oneStm

--- a/src/Futhark/CLI/Dev.hs
+++ b/src/Futhark/CLI/Dev.hs
@@ -15,7 +15,7 @@ import Futhark.Actions
 import qualified Futhark.Analysis.Alias as Alias
 import Futhark.Analysis.Metrics (OpMetrics)
 import Futhark.Compiler.CLI
-import Futhark.IR (ASTLore, Op, Prog, pretty)
+import Futhark.IR (ASTRep, Op, Prog, pretty)
 import qualified Futhark.IR.Kernels as Kernels
 import qualified Futhark.IR.KernelsMem as KernelsMem
 import qualified Futhark.IR.MC as MC
@@ -145,12 +145,12 @@ data UntypedAction
   | MCMemAction (FilePath -> Action MCMem.MCMem)
   | SeqMemAction (FilePath -> Action SeqMem.SeqMem)
   | PolyAction
-      ( forall lore.
-        ( ASTLore lore,
-          (CanBeAliased (Op lore)),
-          (OpMetrics (Op lore))
+      ( forall rep.
+        ( ASTRep rep,
+          (CanBeAliased (Op rep)),
+          (OpMetrics (Op rep))
         ) =>
-        Action lore
+        Action rep
       )
 
 untypedActionName :: UntypedAction -> String
@@ -222,10 +222,10 @@ kernelsProg name rep =
     "Pass " ++ name ++ " expects Kernels representation, but got " ++ representation rep
 
 typedPassOption ::
-  Checkable tolore =>
-  (String -> UntypedPassState -> FutharkM (Prog fromlore)) ->
-  (Prog tolore -> UntypedPassState) ->
-  Pass fromlore tolore ->
+  Checkable torep =>
+  (String -> UntypedPassState -> FutharkM (Prog fromrep)) ->
+  (Prog torep -> UntypedPassState) ->
+  Pass fromrep torep ->
   String ->
   FutharkOption
 typedPassOption getProg putProg pass short =
@@ -334,11 +334,11 @@ cseOption short =
     pass = performCSE True :: Pass SOACS.SOACS SOACS.SOACS
 
 pipelineOption ::
-  (UntypedPassState -> Maybe (Prog fromlore)) ->
+  (UntypedPassState -> Maybe (Prog fromrep)) ->
   String ->
-  (Prog tolore -> UntypedPassState) ->
+  (Prog torep -> UntypedPassState) ->
   String ->
-  Pipeline fromlore tolore ->
+  Pipeline fromrep torep ->
   String ->
   [String] ->
   FutharkOption

--- a/src/Futhark/CodeGen/Backends/CCUDA.hs
+++ b/src/Futhark/CodeGen/Backends/CCUDA.hs
@@ -20,7 +20,7 @@ import qualified Futhark.CodeGen.Backends.GenericC as GC
 import Futhark.CodeGen.Backends.GenericC.Options
 import Futhark.CodeGen.ImpCode.OpenCL
 import qualified Futhark.CodeGen.ImpGen.CUDA as ImpGen
-import Futhark.IR.KernelsMem hiding
+import Futhark.IR.GPUMem hiding
   ( CmpSizeLe,
     GetSize,
     GetSizeMax,
@@ -29,7 +29,7 @@ import Futhark.MonadFreshNames
 import qualified Language.C.Quote.OpenCL as C
 
 -- | Compile the program to C with calls to CUDA.
-compileProg :: MonadFreshNames m => Prog KernelsMem -> m (ImpGen.Warnings, GC.CParts)
+compileProg :: MonadFreshNames m => Prog GPUMem -> m (ImpGen.Warnings, GC.CParts)
 compileProg prog = do
   (ws, Program cuda_code cuda_prelude kernels _ sizes failures prog') <-
     ImpGen.compileProg prog

--- a/src/Futhark/CodeGen/Backends/COpenCL.hs
+++ b/src/Futhark/CodeGen/Backends/COpenCL.hs
@@ -19,7 +19,7 @@ import qualified Futhark.CodeGen.Backends.GenericC as GC
 import Futhark.CodeGen.Backends.GenericC.Options
 import Futhark.CodeGen.ImpCode.OpenCL
 import qualified Futhark.CodeGen.ImpGen.OpenCL as ImpGen
-import Futhark.IR.KernelsMem hiding
+import Futhark.IR.GPUMem hiding
   ( CmpSizeLe,
     GetSize,
     GetSizeMax,
@@ -29,7 +29,7 @@ import qualified Language.C.Quote.OpenCL as C
 import qualified Language.C.Syntax as C
 
 -- | Compile the program to C with calls to OpenCL.
-compileProg :: MonadFreshNames m => Prog KernelsMem -> m (ImpGen.Warnings, GC.CParts)
+compileProg :: MonadFreshNames m => Prog GPUMem -> m (ImpGen.Warnings, GC.CParts)
 compileProg prog = do
   ( ws,
     Program

--- a/src/Futhark/CodeGen/Backends/PyOpenCL.hs
+++ b/src/Futhark/CodeGen/Backends/PyOpenCL.hs
@@ -15,7 +15,7 @@ import Futhark.CodeGen.Backends.GenericPython.Options
 import Futhark.CodeGen.Backends.PyOpenCL.Boilerplate
 import qualified Futhark.CodeGen.ImpCode.OpenCL as Imp
 import qualified Futhark.CodeGen.ImpGen.OpenCL as ImpGen
-import Futhark.IR.KernelsMem (KernelsMem, Prog)
+import Futhark.IR.GPUMem (GPUMem, Prog)
 import Futhark.MonadFreshNames
 import Futhark.Util (zEncodeString)
 
@@ -24,7 +24,7 @@ compileProg ::
   MonadFreshNames m =>
   Py.CompilerMode ->
   String ->
-  Prog KernelsMem ->
+  Prog GPUMem ->
   m (ImpGen.Warnings, String)
 compileProg mode class_name prog = do
   ( ws,

--- a/src/Futhark/CodeGen/ImpCode.hs
+++ b/src/Futhark/CodeGen/ImpCode.hs
@@ -55,7 +55,7 @@ module Futhark.CodeGen.ImpCode
     module Language.Futhark.Core,
     module Futhark.IR.Primitive,
     module Futhark.Analysis.PrimExp,
-    module Futhark.IR.Kernels.Sizes,
+    module Futhark.IR.GPU.Sizes,
     module Futhark.IR.Prop.Names,
   )
 where
@@ -65,7 +65,7 @@ import qualified Data.Map as M
 import qualified Data.Set as S
 import Data.Traversable
 import Futhark.Analysis.PrimExp
-import Futhark.IR.Kernels.Sizes (Count (..))
+import Futhark.IR.GPU.Sizes (Count (..))
 import Futhark.IR.Pretty ()
 import Futhark.IR.Primitive
 import Futhark.IR.Prop.Names

--- a/src/Futhark/CodeGen/ImpCode/GPU.hs
+++ b/src/Futhark/CodeGen/ImpCode/GPU.hs
@@ -3,7 +3,7 @@
 
 -- | Variation of "Futhark.CodeGen.ImpCode" that contains the notion
 -- of a kernel invocation.
-module Futhark.CodeGen.ImpCode.Kernels
+module Futhark.CodeGen.ImpCode.GPU
   ( Program,
     Function,
     FunctionT (Function),
@@ -18,13 +18,13 @@ module Futhark.CodeGen.ImpCode.Kernels
     Kernel (..),
     KernelUse (..),
     module Futhark.CodeGen.ImpCode,
-    module Futhark.IR.Kernels.Sizes,
+    module Futhark.IR.GPU.Sizes,
   )
 where
 
 import Futhark.CodeGen.ImpCode hiding (Code, Function)
 import qualified Futhark.CodeGen.ImpCode as Imp
-import Futhark.IR.Kernels.Sizes
+import Futhark.IR.GPU.Sizes
 import Futhark.IR.Pretty ()
 import Futhark.Util.Pretty
 

--- a/src/Futhark/CodeGen/ImpCode/OpenCL.hs
+++ b/src/Futhark/CodeGen/ImpCode/OpenCL.hs
@@ -19,14 +19,14 @@ module Futhark.CodeGen.ImpCode.OpenCL
     KernelTarget (..),
     FailureMsg (..),
     module Futhark.CodeGen.ImpCode,
-    module Futhark.IR.Kernels.Sizes,
+    module Futhark.IR.GPU.Sizes,
   )
 where
 
 import qualified Data.Map as M
 import Futhark.CodeGen.ImpCode hiding (Code, Function)
 import qualified Futhark.CodeGen.ImpCode as Imp
-import Futhark.IR.Kernels.Sizes
+import Futhark.IR.GPU.Sizes
 import Futhark.Util.Pretty
 
 -- | An program calling OpenCL kernels.

--- a/src/Futhark/CodeGen/ImpGen/CUDA.hs
+++ b/src/Futhark/CodeGen/ImpGen/CUDA.hs
@@ -7,11 +7,11 @@ where
 
 import Data.Bifunctor (second)
 import Futhark.CodeGen.ImpCode.OpenCL
-import Futhark.CodeGen.ImpGen.Kernels
-import Futhark.CodeGen.ImpGen.Kernels.ToOpenCL
-import Futhark.IR.KernelsMem
+import Futhark.CodeGen.ImpGen.GPU
+import Futhark.CodeGen.ImpGen.GPU.ToOpenCL
+import Futhark.IR.GPUMem
 import Futhark.MonadFreshNames
 
 -- | Compile the program to ImpCode with CUDA kernels.
-compileProg :: MonadFreshNames m => Prog KernelsMem -> m (Warnings, Program)
+compileProg :: MonadFreshNames m => Prog GPUMem -> m (Warnings, Program)
 compileProg prog = second kernelsToCUDA <$> compileProgCUDA prog

--- a/src/Futhark/CodeGen/ImpGen/GPU/Base.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/Base.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TypeFamilies #-}
 
-module Futhark.CodeGen.ImpGen.Kernels.Base
+module Futhark.CodeGen.ImpGen.GPU.Base
   ( KernelConstants (..),
     keyWithEntryPoint,
     CallKernelGen,
@@ -40,10 +40,10 @@ import Data.List (zip4)
 import qualified Data.Map.Strict as M
 import Data.Maybe
 import qualified Data.Set as S
-import qualified Futhark.CodeGen.ImpCode.Kernels as Imp
+import qualified Futhark.CodeGen.ImpCode.GPU as Imp
 import Futhark.CodeGen.ImpGen
 import Futhark.Error
-import Futhark.IR.KernelsMem
+import Futhark.IR.GPUMem
 import qualified Futhark.IR.Mem.IxFun as IxFun
 import Futhark.MonadFreshNames
 import Futhark.Transform.Rename
@@ -75,9 +75,9 @@ data KernelEnv = KernelEnv
     kernelLocks :: M.Map VName Locks
   }
 
-type CallKernelGen = ImpM KernelsMem HostEnv Imp.HostOp
+type CallKernelGen = ImpM GPUMem HostEnv Imp.HostOp
 
-type InKernelGen = ImpM KernelsMem KernelEnv Imp.KernelOp
+type InKernelGen = ImpM GPUMem KernelEnv Imp.KernelOp
 
 data KernelConstants = KernelConstants
   { kernelGlobalThreadId :: Imp.TExp Int32,
@@ -96,7 +96,7 @@ data KernelConstants = KernelConstants
     kernelLocalIdMap :: M.Map [SubExp] [Imp.TExp Int32]
   }
 
-segOpSizes :: Stms KernelsMem -> S.Set [SubExp]
+segOpSizes :: Stms GPUMem -> S.Set [SubExp]
 segOpSizes = onStms
   where
     onStms = foldMap (onExp . stmExp)
@@ -108,7 +108,7 @@ segOpSizes = onStms
       onStms (bodyStms body)
     onExp _ = mempty
 
-precomputeSegOpIDs :: Stms KernelsMem -> InKernelGen a -> InKernelGen a
+precomputeSegOpIDs :: Stms GPUMem -> InKernelGen a -> InKernelGen a
 precomputeSegOpIDs stms m = do
   ltid <- kernelLocalThreadId . kernelConstants <$> askEnv
   new_ids <- M.fromList <$> mapM (mkMap ltid) (S.toList (segOpSizes stms))
@@ -128,12 +128,12 @@ keyWithEntryPoint :: Maybe Name -> Name -> Name
 keyWithEntryPoint fname key =
   nameFromString $ maybe "" ((++ ".") . nameToString) fname ++ nameToString key
 
-allocLocal :: AllocCompiler KernelsMem r Imp.KernelOp
+allocLocal :: AllocCompiler GPUMem r Imp.KernelOp
 allocLocal mem size =
   sOp $ Imp.LocalAlloc mem size
 
 kernelAlloc ::
-  Pattern KernelsMem ->
+  Pattern GPUMem ->
   SubExp ->
   Space ->
   InKernelGen ()
@@ -150,7 +150,7 @@ kernelAlloc dest _ _ =
 
 splitSpace ::
   (ToExp w, ToExp i, ToExp elems_per_thread) =>
-  Pattern KernelsMem ->
+  Pattern GPUMem ->
   SplitOrdering ->
   w ->
   i ->
@@ -193,7 +193,7 @@ updateAcc acc is vs = sComment "UpdateAcc" $ do
               Nothing ->
                 error $ "Missing locks for " ++ pretty acc
 
-compileThreadExp :: ExpCompiler KernelsMem KernelEnv Imp.KernelOp
+compileThreadExp :: ExpCompiler GPUMem KernelEnv Imp.KernelOp
 compileThreadExp (Pattern _ [dest]) (BasicOp (ArrayLit es _)) =
   forM_ (zip [0 ..] es) $ \(i, e) ->
     copyDWIMFix (patElemName dest) [fromIntegral (i :: Int64)] e []
@@ -249,7 +249,7 @@ groupCoverSpace ::
 groupCoverSpace ds f =
   groupLoop (product ds) $ f . unflattenIndex ds
 
-compileGroupExp :: ExpCompiler KernelsMem KernelEnv Imp.KernelOp
+compileGroupExp :: ExpCompiler GPUMem KernelEnv Imp.KernelOp
 -- The static arrays stuff does not work inside kernels.
 compileGroupExp (Pattern _ [dest]) (BasicOp (ArrayLit es _)) =
   forM_ (zip [0 ..] es) $ \(i, e) ->
@@ -314,7 +314,7 @@ compileGroupSpace lvl space = do
 -- Construct the necessary lock arrays for an intra-group histogram.
 prepareIntraGroupSegHist ::
   Count GroupSize SubExp ->
-  [HistOp KernelsMem] ->
+  [HistOp GPUMem] ->
   InKernelGen [[Imp.TExp Int64] -> InKernelGen ()]
 prepareIntraGroupSegHist group_size =
   fmap snd . mapAccumLM onOp Nothing
@@ -360,7 +360,7 @@ whenActive lvl space m
       then m
       else sWhen (isActive $ unSegSpace space) m
 
-compileGroupOp :: OpCompiler KernelsMem KernelEnv Imp.KernelOp
+compileGroupOp :: OpCompiler GPUMem KernelEnv Imp.KernelOp
 compileGroupOp pat (Alloc size space) =
   kernelAlloc pat size space
 compileGroupOp pat (Inner (SizeOp (SplitSpace o w i elems_per_thread))) =
@@ -540,7 +540,7 @@ compileGroupOp pat (Inner (SegOp (SegHist lvl space ops _ kbody))) = do
 compileGroupOp pat _ =
   compilerBugS $ "compileGroupOp: cannot compile rhs of binding " ++ pretty pat
 
-compileThreadOp :: OpCompiler KernelsMem KernelEnv Imp.KernelOp
+compileThreadOp :: OpCompiler GPUMem KernelEnv Imp.KernelOp
 compileThreadOp pat (Alloc size space) =
   kernelAlloc pat size space
 compileThreadOp pat (Inner (SizeOp (SplitSpace o w i elems_per_thread))) =
@@ -588,8 +588,8 @@ type AtomicBinOp =
 -- | Do an atomic update corresponding to a binary operator lambda.
 atomicUpdateLocking ::
   AtomicBinOp ->
-  Lambda KernelsMem ->
-  AtomicUpdate KernelsMem KernelEnv
+  Lambda GPUMem ->
+  AtomicUpdate GPUMem KernelEnv
 atomicUpdateLocking atomicBinOp lam
   | Just ops_and_ts <- lamIsBinOp lam,
     all (\(_, t, _, _) -> primBitSize t `elem` [32, 64]) ops_and_ts =
@@ -802,7 +802,7 @@ readsFromSet free =
             Nothing -> return $ Just $ Imp.ScalarUse var bt
 
 isConstExp ::
-  VTable KernelsMem ->
+  VTable GPUMem ->
   Imp.Exp ->
   ImpM rep r op (Maybe Imp.KernelConstExp)
 isConstExp vtable size = do
@@ -925,7 +925,7 @@ makeAllMemoryGlobal =
 
 groupReduce ::
   Imp.TExp Int32 ->
-  Lambda KernelsMem ->
+  Lambda GPUMem ->
   [VName] ->
   InKernelGen ()
 groupReduce w lam arrs = do
@@ -935,7 +935,7 @@ groupReduce w lam arrs = do
 groupReduceWithOffset ::
   TV Int32 ->
   Imp.TExp Int32 ->
-  Lambda KernelsMem ->
+  Lambda GPUMem ->
   [VName] ->
   InKernelGen ()
 groupReduceWithOffset offset w lam arrs = do
@@ -1025,7 +1025,7 @@ groupScan ::
   Maybe (Imp.TExp Int32 -> Imp.TExp Int32 -> Imp.TExp Bool) ->
   Imp.TExp Int64 ->
   Imp.TExp Int64 ->
-  Lambda KernelsMem ->
+  Lambda GPUMem ->
   [VName] ->
   InKernelGen ()
 groupScan seg_flag arrs_full_size w lam arrs = do
@@ -1179,7 +1179,7 @@ inBlockScan ::
   Imp.TExp Bool ->
   [VName] ->
   InKernelGen () ->
-  Lambda KernelsMem ->
+  Lambda GPUMem ->
   InKernelGen ()
 inBlockScan constants seg_flag arrs_full_size lockstep_width block_size active arrs barrier scan_lam = everythingVolatile $ do
   skip_threads <- dPrim "skip_threads" int32
@@ -1358,7 +1358,7 @@ sKernelGroup = sKernel groupOperations kernelGroupId
 
 sKernelFailureTolerant ::
   Bool ->
-  Operations KernelsMem KernelEnv Imp.KernelOp ->
+  Operations GPUMem KernelEnv Imp.KernelOp ->
   KernelConstants ->
   Name ->
   InKernelGen () ->
@@ -1380,7 +1380,7 @@ sKernelFailureTolerant tol ops constants name m = do
           }
 
 sKernel ::
-  Operations KernelsMem KernelEnv Imp.KernelOp ->
+  Operations GPUMem KernelEnv Imp.KernelOp ->
   (KernelConstants -> Imp.TExp Int32) ->
   String ->
   Count NumGroups (Imp.TExp Int64) ->
@@ -1396,7 +1396,7 @@ sKernel ops flatf name num_groups group_size v f = do
     dPrimV_ v $ flatf constants
     f
 
-copyInGroup :: CopyCompiler KernelsMem KernelEnv Imp.KernelOp
+copyInGroup :: CopyCompiler GPUMem KernelEnv Imp.KernelOp
 copyInGroup pt destloc destslice srcloc srcslice = do
   dest_space <- entryMemSpace <$> lookupMemory (memLocationName destloc)
   src_space <- entryMemSpace <$> lookupMemory (memLocationName srcloc)
@@ -1420,7 +1420,7 @@ copyInGroup pt destloc destslice srcloc srcslice = do
           (map DimFix $ fixSlice srcslice is)
       sOp $ Imp.Barrier Imp.FenceLocal
 
-threadOperations, groupOperations :: Operations KernelsMem KernelEnv Imp.KernelOp
+threadOperations, groupOperations :: Operations GPUMem KernelEnv Imp.KernelOp
 threadOperations =
   (defaultOperations compileThreadOp)
     { opsCopyCompiler = copyElementWise,
@@ -1606,7 +1606,7 @@ sIota arr n x s et = do
           [Imp.MemArg arr_mem, Imp.ExpArg $ untyped n, Imp.ExpArg x, Imp.ExpArg s]
     else sIotaKernel arr n x s et
 
-sCopy :: CopyCompiler KernelsMem HostEnv Imp.HostOp
+sCopy :: CopyCompiler GPUMem HostEnv Imp.HostOp
 sCopy
   bt
   destloc@(MemLocation destmem _ _)
@@ -1646,7 +1646,7 @@ sCopy
 
 compileGroupResult ::
   SegSpace ->
-  PatElem KernelsMem ->
+  PatElem GPUMem ->
   KernelResult ->
   InKernelGen ()
 compileGroupResult _ pe (TileReturns [(w, per_group_elems)] what) = do
@@ -1739,7 +1739,7 @@ compileGroupResult _ _ ConcatReturns {} =
 
 compileThreadResult ::
   SegSpace ->
-  PatElem KernelsMem ->
+  PatElem GPUMem ->
   KernelResult ->
   InKernelGen ()
 compileThreadResult _ _ RegTileReturns {} =

--- a/src/Futhark/CodeGen/ImpGen/GPU/SegMap.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/SegMap.hs
@@ -5,22 +5,22 @@
 -- trick is virtualisation in case the physical number of threads is
 -- not sufficient to cover the logical thread space.  This is handled
 -- by having actual workgroups run a loop to imitate multiple workgroups.
-module Futhark.CodeGen.ImpGen.Kernels.SegMap (compileSegMap) where
+module Futhark.CodeGen.ImpGen.GPU.SegMap (compileSegMap) where
 
 import Control.Monad.Except
-import qualified Futhark.CodeGen.ImpCode.Kernels as Imp
+import qualified Futhark.CodeGen.ImpCode.GPU as Imp
 import Futhark.CodeGen.ImpGen
-import Futhark.CodeGen.ImpGen.Kernels.Base
-import Futhark.IR.KernelsMem
+import Futhark.CodeGen.ImpGen.GPU.Base
+import Futhark.IR.GPUMem
 import Futhark.Util.IntegralExp (divUp)
 import Prelude hiding (quot, rem)
 
 -- | Compile 'SegMap' instance code.
 compileSegMap ::
-  Pattern KernelsMem ->
+  Pattern GPUMem ->
   SegLevel ->
   SegSpace ->
-  KernelBody KernelsMem ->
+  KernelBody GPUMem ->
   CallKernelGen ()
 compileSegMap pat lvl space kbody = do
   let (is, dims) = unzip $ unSegSpace space

--- a/src/Futhark/CodeGen/ImpGen/GPU/SegScan/SinglePass.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/SegScan/SinglePass.hs
@@ -4,22 +4,22 @@
 -- | Code generation for segmented and non-segmented scans.  Uses a
 -- fast single-pass algorithm, but which only works on NVIDIA GPUs and
 -- with some constraints on the operator.  We use this when we can.
-module Futhark.CodeGen.ImpGen.Kernels.SegScan.SinglePass (compileSegScan) where
+module Futhark.CodeGen.ImpGen.GPU.SegScan.SinglePass (compileSegScan) where
 
 import Control.Monad.Except
 import Data.List (zip4)
 import Data.Maybe
-import qualified Futhark.CodeGen.ImpCode.Kernels as Imp
+import qualified Futhark.CodeGen.ImpCode.GPU as Imp
 import Futhark.CodeGen.ImpGen
-import Futhark.CodeGen.ImpGen.Kernels.Base
-import Futhark.IR.KernelsMem
+import Futhark.CodeGen.ImpGen.GPU.Base
+import Futhark.IR.GPUMem
 import qualified Futhark.IR.Mem.IxFun as IxFun
 import Futhark.Transform.Rename
 import Futhark.Util (takeLast)
 import Futhark.Util.IntegralExp (IntegralExp (mod, rem), divUp, quot)
 import Prelude hiding (mod, quot, rem)
 
-xParams, yParams :: SegBinOp KernelsMem -> [LParam KernelsMem]
+xParams, yParams :: SegBinOp GPUMem -> [LParam GPUMem]
 xParams scan =
   take (length (segBinOpNeutral scan)) (lambdaParams (segBinOpLambda scan))
 yParams scan =
@@ -103,11 +103,11 @@ createLocalArrays (Count groupSize) m types = do
 -- | Compile 'SegScan' instance to host-level code with calls to a
 -- single-pass kernel.
 compileSegScan ::
-  Pattern KernelsMem ->
+  Pattern GPUMem ->
   SegLevel ->
   SegSpace ->
-  SegBinOp KernelsMem ->
-  KernelBody KernelsMem ->
+  SegBinOp GPUMem ->
+  KernelBody GPUMem ->
   CallKernelGen ()
 compileSegScan pat lvl space scanOp kbody = do
   let Pattern _ all_pes = pat

--- a/src/Futhark/CodeGen/ImpGen/GPU/Transpose.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/Transpose.hs
@@ -1,13 +1,13 @@
 -- | Carefully optimised implementations of GPU transpositions.
 -- Written in ImpCode so we can compile it to both CUDA and OpenCL.
-module Futhark.CodeGen.ImpGen.Kernels.Transpose
+module Futhark.CodeGen.ImpGen.GPU.Transpose
   ( TransposeType (..),
     TransposeArgs,
     mapTransposeKernel,
   )
 where
 
-import Futhark.CodeGen.ImpCode.Kernels
+import Futhark.CodeGen.ImpCode.GPU
 import Futhark.IR.Prop.Types
 import Futhark.Util.IntegralExp (divUp, quot, rem)
 import Prelude hiding (quot, rem)

--- a/src/Futhark/CodeGen/ImpGen/Kernels/Base.hs
+++ b/src/Futhark/CodeGen/ImpGen/Kernels/Base.hs
@@ -155,7 +155,7 @@ splitSpace ::
   w ->
   i ->
   elems_per_thread ->
-  ImpM lore r op ()
+  ImpM rep r op ()
 splitSpace (Pattern [] [size]) o w i elems_per_thread = do
   num_elements <- Imp.elements . TPrimExp <$> toExp w
   let i' = toInt64Exp i
@@ -566,19 +566,19 @@ data Locking = Locking
 
 -- | A function for generating code for an atomic update.  Assumes
 -- that the bucket is in-bounds.
-type DoAtomicUpdate lore r =
-  Space -> [VName] -> [Imp.TExp Int64] -> ImpM lore r Imp.KernelOp ()
+type DoAtomicUpdate rep r =
+  Space -> [VName] -> [Imp.TExp Int64] -> ImpM rep r Imp.KernelOp ()
 
 -- | The mechanism that will be used for performing the atomic update.
 -- Approximates how efficient it will be.  Ordered from most to least
 -- efficient.
-data AtomicUpdate lore r
+data AtomicUpdate rep r
   = -- | Supported directly by primitive.
-    AtomicPrim (DoAtomicUpdate lore r)
+    AtomicPrim (DoAtomicUpdate rep r)
   | -- | Can be done by efficient swaps.
-    AtomicCAS (DoAtomicUpdate lore r)
+    AtomicCAS (DoAtomicUpdate rep r)
   | -- | Requires explicit locking.
-    AtomicLocking (Locking -> DoAtomicUpdate lore r)
+    AtomicLocking (Locking -> DoAtomicUpdate rep r)
 
 -- | Is there an atomic t'BinOp' corresponding to this t'BinOp'?
 type AtomicBinOp =
@@ -804,7 +804,7 @@ readsFromSet free =
 isConstExp ::
   VTable KernelsMem ->
   Imp.Exp ->
-  ImpM lore r op (Maybe Imp.KernelConstExp)
+  ImpM rep r op (Maybe Imp.KernelConstExp)
 isConstExp vtable size = do
   fname <- askFunction
   let onLeaf (Imp.ScalarVar name) _ = lookupConstExp name
@@ -827,7 +827,7 @@ computeThreadChunkSize ::
   Imp.Count Imp.Elements (Imp.TExp Int64) ->
   Imp.Count Imp.Elements (Imp.TExp Int64) ->
   TV Int64 ->
-  ImpM lore r op ()
+  ImpM rep r op ()
 computeThreadChunkSize (SplitStrided stride) thread_index elements_per_thread num_elements chunk_var =
   chunk_var
     <-- sMin64

--- a/src/Futhark/CodeGen/ImpGen/Multicore/Base.hs
+++ b/src/Futhark/CodeGen/ImpGen/Multicore/Base.hs
@@ -154,10 +154,10 @@ isLoadBalanced Imp.While {} = False
 isLoadBalanced (Imp.Op (Imp.ParLoop _ _ _ code _ _ _)) = isLoadBalanced code
 isLoadBalanced _ = True
 
-segBinOpComm' :: [SegBinOp lore] -> Commutativity
+segBinOpComm' :: [SegBinOp rep] -> Commutativity
 segBinOpComm' = mconcat . map segBinOpComm
 
-decideScheduling' :: SegOp () lore -> Imp.Code -> Imp.Scheduling
+decideScheduling' :: SegOp () rep -> Imp.Code -> Imp.Scheduling
 decideScheduling' SegHist {} _ = Imp.Static
 decideScheduling' SegScan {} _ = Imp.Static
 decideScheduling' (SegRed _ _ reds _ _) code =
@@ -242,18 +242,18 @@ data Locking = Locking
 
 -- | A function for generating code for an atomic update.  Assumes
 -- that the bucket is in-bounds.
-type DoAtomicUpdate lore r =
+type DoAtomicUpdate rep r =
   [VName] -> [Imp.TExp Int64] -> MulticoreGen ()
 
 -- | The mechanism that will be used for performing the atomic update.
 -- Approximates how efficient it will be.  Ordered from most to least
 -- efficient.
-data AtomicUpdate lore r
-  = AtomicPrim (DoAtomicUpdate lore r)
+data AtomicUpdate rep r
+  = AtomicPrim (DoAtomicUpdate rep r)
   | -- | Can be done by efficient swaps.
-    AtomicCAS (DoAtomicUpdate lore r)
+    AtomicCAS (DoAtomicUpdate rep r)
   | -- | Requires explicit locking.
-    AtomicLocking (Locking -> DoAtomicUpdate lore r)
+    AtomicLocking (Locking -> DoAtomicUpdate rep r)
 
 atomicUpdateLocking ::
   AtomicBinOp ->

--- a/src/Futhark/CodeGen/ImpGen/Multicore/SegHist.hs
+++ b/src/Futhark/CodeGen/ImpGen/Multicore/SegHist.hs
@@ -30,7 +30,7 @@ compileSegHist pat space histops kbody nsubtasks
 
 -- | Split some list into chunks equal to the number of values
 -- returned by each 'SegBinOp'
-segHistOpChunks :: [HistOp lore] -> [a] -> [[a]]
+segHistOpChunks :: [HistOp rep] -> [a] -> [[a]]
 segHistOpChunks = chunks . map (length . histNeutral)
 
 nonsegmentedHist ::

--- a/src/Futhark/CodeGen/ImpGen/OpenCL.hs
+++ b/src/Futhark/CodeGen/ImpGen/OpenCL.hs
@@ -7,11 +7,11 @@ where
 
 import Data.Bifunctor (second)
 import qualified Futhark.CodeGen.ImpCode.OpenCL as OpenCL
-import Futhark.CodeGen.ImpGen.Kernels
-import Futhark.CodeGen.ImpGen.Kernels.ToOpenCL
-import Futhark.IR.KernelsMem
+import Futhark.CodeGen.ImpGen.GPU
+import Futhark.CodeGen.ImpGen.GPU.ToOpenCL
+import Futhark.IR.GPUMem
 import Futhark.MonadFreshNames
 
 -- | Compile the program to ImpCode with OpenCL kernels.
-compileProg :: MonadFreshNames m => Prog KernelsMem -> m (Warnings, OpenCL.Program)
+compileProg :: MonadFreshNames m => Prog GPUMem -> m (Warnings, OpenCL.Program)
 compileProg prog = second kernelsToOpenCL <$> compileProgOpenCL prog

--- a/src/Futhark/Compiler.hs
+++ b/src/Futhark/Compiler.hs
@@ -70,8 +70,8 @@ dumpError config err =
 -- 'Pipeline', and finish up with the given 'Action'.
 runCompilerOnProgram ::
   FutharkConfig ->
-  Pipeline I.SOACS lore ->
-  Action lore ->
+  Pipeline I.SOACS rep ->
+  Action rep ->
   FilePath ->
   IO ()
 runCompilerOnProgram config pipeline action file = do
@@ -95,9 +95,9 @@ runCompilerOnProgram config pipeline action file = do
 -- 'Pipeline', and return it.
 runPipelineOnProgram ::
   FutharkConfig ->
-  Pipeline I.SOACS tolore ->
+  Pipeline I.SOACS torep ->
   FilePath ->
-  FutharkM (Prog tolore)
+  FutharkM (Prog torep)
 runPipelineOnProgram config pipeline file = do
   when (pipelineVerbose pipeline_config) $
     logMsg ("Reading and type-checking source program" :: String)

--- a/src/Futhark/Compiler/CLI.hs
+++ b/src/Futhark/Compiler/CLI.hs
@@ -32,13 +32,13 @@ compilerMain ::
   -- | The longer action description.
   String ->
   -- | The pipeline to use.
-  Pipeline SOACS lore ->
+  Pipeline SOACS rep ->
   -- | The action to take on the result of the pipeline.
   ( FutharkConfig ->
     cfg ->
     CompilerMode ->
     FilePath ->
-    Prog lore ->
+    Prog rep ->
     FutharkM ()
   ) ->
   -- | Program name

--- a/src/Futhark/IR.hs
+++ b/src/Futhark/IR.hs
@@ -1,7 +1,4 @@
--- | A convenient re-export of basic AST modules.  Note that
--- "Futhark.IR.Lore" is not exported, as this would
--- cause name clashes.  You are advised to use a qualified import of
--- the lore module, if you need it.
+-- | A convenient re-export of basic AST modules.
 module Futhark.IR
   ( module Futhark.IR.Prop,
     module Futhark.IR.Traversals,

--- a/src/Futhark/IR/GPU.hs
+++ b/src/Futhark/IR/GPU.hs
@@ -2,24 +2,24 @@
 {-# LANGUAGE TypeFamilies #-}
 
 -- | A representation with flat parallelism via GPU-oriented kernels.
-module Futhark.IR.Kernels
-  ( Kernels,
+module Futhark.IR.GPU
+  ( GPU,
 
     -- * Module re-exports
     module Futhark.IR.Prop,
     module Futhark.IR.Traversals,
     module Futhark.IR.Pretty,
     module Futhark.IR.Syntax,
-    module Futhark.IR.Kernels.Kernel,
-    module Futhark.IR.Kernels.Sizes,
+    module Futhark.IR.GPU.Kernel,
+    module Futhark.IR.GPU.Sizes,
     module Futhark.IR.SOACS.SOAC,
   )
 where
 
 import Futhark.Binder
 import Futhark.Construct
-import Futhark.IR.Kernels.Kernel
-import Futhark.IR.Kernels.Sizes
+import Futhark.IR.GPU.Kernel
+import Futhark.IR.GPU.Sizes
 import Futhark.IR.Pretty
 import Futhark.IR.Prop
 import Futhark.IR.SOACS.SOAC hiding (HistOp (..))
@@ -28,34 +28,34 @@ import Futhark.IR.Traversals
 import qualified Futhark.TypeCheck as TypeCheck
 
 -- | The phantom data type for the kernels representation.
-data Kernels
+data GPU
 
-instance RepTypes Kernels where
-  type Op Kernels = HostOp Kernels (SOAC Kernels)
+instance RepTypes GPU where
+  type Op GPU = HostOp GPU (SOAC GPU)
 
-instance ASTRep Kernels where
+instance ASTRep GPU where
   expTypesFromPattern = return . expExtTypesFromPattern
 
-instance TypeCheck.CheckableOp Kernels where
-  checkOp = typeCheckKernelsOp Nothing
+instance TypeCheck.CheckableOp GPU where
+  checkOp = typeCheckGPUOp Nothing
     where
-      typeCheckKernelsOp lvl =
-        typeCheckHostOp (typeCheckKernelsOp . Just) lvl typeCheckSOAC
+      typeCheckGPUOp lvl =
+        typeCheckHostOp (typeCheckGPUOp . Just) lvl typeCheckSOAC
 
-instance TypeCheck.Checkable Kernels
+instance TypeCheck.Checkable GPU
 
-instance Bindable Kernels where
+instance Bindable GPU where
   mkBody = Body ()
   mkExpPat ctx val _ = basicPattern ctx val
   mkExpDec _ _ = ()
   mkLetNames = simpleMkLetNames
 
-instance BinderOps Kernels
+instance BinderOps GPU
 
-instance PrettyRep Kernels
+instance PrettyRep GPU
 
-instance HasSegOp Kernels where
-  type SegOpLevel Kernels = SegLevel
+instance HasSegOp GPU where
+  type SegOpLevel GPU = SegLevel
   asSegOp (SegOp op) = Just op
   asSegOp _ = Nothing
   segOp = SegOp

--- a/src/Futhark/IR/GPU/Kernel.hs
+++ b/src/Futhark/IR/GPU/Kernel.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Futhark.IR.Kernels.Kernel
+module Futhark.IR.GPU.Kernel
   ( -- * Size operations
     SizeOp (..),
 
@@ -19,7 +19,7 @@ module Futhark.IR.Kernels.Kernel
     SegLevel (..),
 
     -- * Reexports
-    module Futhark.IR.Kernels.Sizes,
+    module Futhark.IR.GPU.Sizes,
     module Futhark.IR.SegOp,
   )
 where
@@ -28,7 +28,7 @@ import Futhark.Analysis.Metrics
 import qualified Futhark.Analysis.SymbolTable as ST
 import Futhark.IR
 import Futhark.IR.Aliases (Aliases)
-import Futhark.IR.Kernels.Sizes
+import Futhark.IR.GPU.Sizes
 import Futhark.IR.Prop.Aliases
 import Futhark.IR.SegOp
 import qualified Futhark.Optimise.Simplify.Engine as Engine

--- a/src/Futhark/IR/GPU/Sizes.hs
+++ b/src/Futhark/IR/GPU/Sizes.hs
@@ -4,7 +4,7 @@
 
 -- | In the context of this module, a "size" is any kind of tunable
 -- (run-time) constant.
-module Futhark.IR.Kernels.Sizes
+module Futhark.IR.GPU.Sizes
   ( SizeClass (..),
     sizeDefault,
     KernelPath,

--- a/src/Futhark/IR/Kernels.hs
+++ b/src/Futhark/IR/Kernels.hs
@@ -3,8 +3,7 @@
 
 -- | A representation with flat parallelism via GPU-oriented kernels.
 module Futhark.IR.Kernels
-  ( -- * The Lore definition
-    Kernels,
+  ( Kernels,
 
     -- * Module re-exports
     module Futhark.IR.Prop,
@@ -31,10 +30,10 @@ import qualified Futhark.TypeCheck as TypeCheck
 -- | The phantom data type for the kernels representation.
 data Kernels
 
-instance Decorations Kernels where
+instance RepTypes Kernels where
   type Op Kernels = HostOp Kernels (SOAC Kernels)
 
-instance ASTLore Kernels where
+instance ASTRep Kernels where
   expTypesFromPattern = return . expExtTypesFromPattern
 
 instance TypeCheck.CheckableOp Kernels where
@@ -53,7 +52,7 @@ instance Bindable Kernels where
 
 instance BinderOps Kernels
 
-instance PrettyLore Kernels
+instance PrettyRep Kernels
 
 instance HasSegOp Kernels where
   type SegOpLevel Kernels = SegLevel

--- a/src/Futhark/IR/Kernels/Kernel.hs
+++ b/src/Futhark/IR/Kernels/Kernel.hs
@@ -32,7 +32,7 @@ import Futhark.IR.Kernels.Sizes
 import Futhark.IR.Prop.Aliases
 import Futhark.IR.SegOp
 import qualified Futhark.Optimise.Simplify.Engine as Engine
-import Futhark.Optimise.Simplify.Lore
+import Futhark.Optimise.Simplify.Rep
 import Futhark.Transform.Rename
 import Futhark.Transform.Substitute
 import qualified Futhark.TypeCheck as TC
@@ -220,7 +220,7 @@ instance OpMetrics SizeOp where
   opMetrics CmpSizeLe {} = seen "CmpSizeLe"
   opMetrics CalcNumGroups {} = seen "CalcNumGroups"
 
-typeCheckSizeOp :: TC.Checkable lore => SizeOp -> TC.TypeM lore ()
+typeCheckSizeOp :: TC.Checkable rep => SizeOp -> TC.TypeM rep ()
 typeCheckSizeOp (SplitSpace o w i elems_per_thread) = do
   case o of
     SplitContiguous -> return ()
@@ -234,14 +234,14 @@ typeCheckSizeOp (CalcNumGroups w _ group_size) = do
   TC.require [Prim int64] group_size
 
 -- | A host-level operation; parameterised by what else it can do.
-data HostOp lore op
+data HostOp rep op
   = -- | A segmented operation.
-    SegOp (SegOp SegLevel lore)
+    SegOp (SegOp SegLevel rep)
   | SizeOp SizeOp
   | OtherOp op
   deriving (Eq, Ord, Show)
 
-instance (ASTLore lore, Substitute op) => Substitute (HostOp lore op) where
+instance (ASTRep rep, Substitute op) => Substitute (HostOp rep op) where
   substituteNames substs (SegOp op) =
     SegOp $ substituteNames substs op
   substituteNames substs (OtherOp op) =
@@ -249,12 +249,12 @@ instance (ASTLore lore, Substitute op) => Substitute (HostOp lore op) where
   substituteNames substs (SizeOp op) =
     SizeOp $ substituteNames substs op
 
-instance (ASTLore lore, Rename op) => Rename (HostOp lore op) where
+instance (ASTRep rep, Rename op) => Rename (HostOp rep op) where
   rename (SegOp op) = SegOp <$> rename op
   rename (OtherOp op) = OtherOp <$> rename op
   rename (SizeOp op) = SizeOp <$> rename op
 
-instance (ASTLore lore, IsOp op) => IsOp (HostOp lore op) where
+instance (ASTRep rep, IsOp op) => IsOp (HostOp rep op) where
   safeOp (SegOp op) = safeOp op
   safeOp (OtherOp op) = safeOp op
   safeOp (SizeOp op) = safeOp op
@@ -263,12 +263,12 @@ instance (ASTLore lore, IsOp op) => IsOp (HostOp lore op) where
   cheapOp (OtherOp op) = cheapOp op
   cheapOp (SizeOp op) = cheapOp op
 
-instance TypedOp op => TypedOp (HostOp lore op) where
+instance TypedOp op => TypedOp (HostOp rep op) where
   opType (SegOp op) = opType op
   opType (OtherOp op) = opType op
   opType (SizeOp op) = opType op
 
-instance (Aliased lore, AliasedOp op, ASTLore lore) => AliasedOp (HostOp lore op) where
+instance (Aliased rep, AliasedOp op, ASTRep rep) => AliasedOp (HostOp rep op) where
   opAliases (SegOp op) = opAliases op
   opAliases (OtherOp op) = opAliases op
   opAliases (SizeOp op) = opAliases op
@@ -277,13 +277,13 @@ instance (Aliased lore, AliasedOp op, ASTLore lore) => AliasedOp (HostOp lore op
   consumedInOp (OtherOp op) = consumedInOp op
   consumedInOp (SizeOp op) = consumedInOp op
 
-instance (ASTLore lore, FreeIn op) => FreeIn (HostOp lore op) where
+instance (ASTRep rep, FreeIn op) => FreeIn (HostOp rep op) where
   freeIn' (SegOp op) = freeIn' op
   freeIn' (OtherOp op) = freeIn' op
   freeIn' (SizeOp op) = freeIn' op
 
-instance (CanBeAliased (Op lore), CanBeAliased op, ASTLore lore) => CanBeAliased (HostOp lore op) where
-  type OpWithAliases (HostOp lore op) = HostOp (Aliases lore) (OpWithAliases op)
+instance (CanBeAliased (Op rep), CanBeAliased op, ASTRep rep) => CanBeAliased (HostOp rep op) where
+  type OpWithAliases (HostOp rep op) = HostOp (Aliases rep) (OpWithAliases op)
 
   addOpAliases aliases (SegOp op) = SegOp $ addOpAliases aliases op
   addOpAliases aliases (OtherOp op) = OtherOp $ addOpAliases aliases op
@@ -293,33 +293,33 @@ instance (CanBeAliased (Op lore), CanBeAliased op, ASTLore lore) => CanBeAliased
   removeOpAliases (OtherOp op) = OtherOp $ removeOpAliases op
   removeOpAliases (SizeOp op) = SizeOp op
 
-instance (CanBeWise (Op lore), CanBeWise op, ASTLore lore) => CanBeWise (HostOp lore op) where
-  type OpWithWisdom (HostOp lore op) = HostOp (Wise lore) (OpWithWisdom op)
+instance (CanBeWise (Op rep), CanBeWise op, ASTRep rep) => CanBeWise (HostOp rep op) where
+  type OpWithWisdom (HostOp rep op) = HostOp (Wise rep) (OpWithWisdom op)
 
   removeOpWisdom (SegOp op) = SegOp $ removeOpWisdom op
   removeOpWisdom (OtherOp op) = OtherOp $ removeOpWisdom op
   removeOpWisdom (SizeOp op) = SizeOp op
 
-instance (ASTLore lore, ST.IndexOp op) => ST.IndexOp (HostOp lore op) where
+instance (ASTRep rep, ST.IndexOp op) => ST.IndexOp (HostOp rep op) where
   indexOp vtable k (SegOp op) is = ST.indexOp vtable k op is
   indexOp vtable k (OtherOp op) is = ST.indexOp vtable k op is
   indexOp _ _ _ _ = Nothing
 
-instance (PrettyLore lore, PP.Pretty op) => PP.Pretty (HostOp lore op) where
+instance (PrettyRep rep, PP.Pretty op) => PP.Pretty (HostOp rep op) where
   ppr (SegOp op) = ppr op
   ppr (OtherOp op) = ppr op
   ppr (SizeOp op) = ppr op
 
-instance (OpMetrics (Op lore), OpMetrics op) => OpMetrics (HostOp lore op) where
+instance (OpMetrics (Op rep), OpMetrics op) => OpMetrics (HostOp rep op) where
   opMetrics (SegOp op) = opMetrics op
   opMetrics (OtherOp op) = opMetrics op
   opMetrics (SizeOp op) = opMetrics op
 
 checkSegLevel ::
-  TC.Checkable lore =>
+  TC.Checkable rep =>
   Maybe SegLevel ->
   SegLevel ->
-  TC.TypeM lore ()
+  TC.TypeM rep ()
 checkSegLevel Nothing lvl = do
   TC.require [Prim int64] $ unCount $ segNumGroups lvl
   TC.require [Prim int64] $ unCount $ segGroupSize lvl
@@ -333,12 +333,12 @@ checkSegLevel (Just x) y
     return ()
 
 typeCheckHostOp ::
-  TC.Checkable lore =>
-  (SegLevel -> OpWithAliases (Op lore) -> TC.TypeM lore ()) ->
+  TC.Checkable rep =>
+  (SegLevel -> OpWithAliases (Op rep) -> TC.TypeM rep ()) ->
   Maybe SegLevel ->
-  (op -> TC.TypeM lore ()) ->
-  HostOp (Aliases lore) op ->
-  TC.TypeM lore ()
+  (op -> TC.TypeM rep ()) ->
+  HostOp (Aliases rep) op ->
+  TC.TypeM rep ()
 typeCheckHostOp checker lvl _ (SegOp op) =
   TC.checkOpWith (checker $ segLevel op) $
     typeCheckSegOp (checkSegLevel lvl) op

--- a/src/Futhark/IR/Kernels/Simplify.hs
+++ b/src/Futhark/IR/Kernels/Simplify.hs
@@ -21,7 +21,7 @@ import qualified Futhark.IR.SOACS.Simplify as SOAC
 import Futhark.MonadFreshNames
 import qualified Futhark.Optimise.Simplify as Simplify
 import qualified Futhark.Optimise.Simplify.Engine as Engine
-import Futhark.Optimise.Simplify.Lore
+import Futhark.Optimise.Simplify.Rep
 import Futhark.Optimise.Simplify.Rule
 import Futhark.Optimise.Simplify.Rules
 import Futhark.Pass
@@ -43,12 +43,12 @@ simplifyLambda =
   Simplify.simplifyLambda simpleKernels kernelRules Engine.noExtraHoistBlockers
 
 simplifyKernelOp ::
-  ( Engine.SimplifiableLore lore,
-    BodyDec lore ~ ()
+  ( Engine.SimplifiableRep rep,
+    BodyDec rep ~ ()
   ) =>
-  Simplify.SimplifyOp lore op ->
-  HostOp lore op ->
-  Engine.SimpleM lore (HostOp (Wise lore) (OpWithWisdom op), Stms (Wise lore))
+  Simplify.SimplifyOp rep op ->
+  HostOp rep op ->
+  Engine.SimpleM rep (HostOp (Wise rep) (OpWithWisdom op), Stms (Wise rep))
 simplifyKernelOp f (OtherOp op) = do
   (op', stms) <- f op
   return (OtherOp op', stms)

--- a/src/Futhark/IR/KernelsMem.hs
+++ b/src/Futhark/IR/KernelsMem.hs
@@ -32,7 +32,7 @@ import qualified Futhark.TypeCheck as TC
 
 data KernelsMem
 
-instance Decorations KernelsMem where
+instance RepTypes KernelsMem where
   type LetDec KernelsMem = LetDecMem
   type FParamInfo KernelsMem = FParamMem
   type LParamInfo KernelsMem = LParamMem
@@ -40,7 +40,7 @@ instance Decorations KernelsMem where
   type BranchType KernelsMem = BranchTypeMem
   type Op KernelsMem = MemOp (HostOp KernelsMem ())
 
-instance ASTLore KernelsMem where
+instance ASTRep KernelsMem where
   expTypesFromPattern = return . map snd . snd . bodyReturnsFromPattern
 
 instance OpReturns KernelsMem where
@@ -49,7 +49,7 @@ instance OpReturns KernelsMem where
   opReturns (Inner (SegOp op)) = segOpReturns op
   opReturns k = extReturns <$> opType k
 
-instance PrettyLore KernelsMem
+instance PrettyRep KernelsMem
 
 instance TC.CheckableOp KernelsMem where
   checkOp = typeCheckMemoryOp Nothing
@@ -60,9 +60,9 @@ instance TC.CheckableOp KernelsMem where
         typeCheckHostOp (typeCheckMemoryOp . Just) lvl (const $ return ()) op
 
 instance TC.Checkable KernelsMem where
-  checkFParamLore = checkMemInfo
-  checkLParamLore = checkMemInfo
-  checkLetBoundLore = checkMemInfo
+  checkFParamDec = checkMemInfo
+  checkLParamDec = checkMemInfo
+  checkLetBoundDec = checkMemInfo
   checkRetType = mapM_ $ TC.checkExtType . declExtTypeOf
   primFParam name t = return $ Param name (MemPrim t)
   matchPattern = matchPatternToExp

--- a/src/Futhark/IR/MC.hs
+++ b/src/Futhark/IR/MC.hs
@@ -4,8 +4,7 @@
 
 -- | A representation for multicore CPU parallelism.
 module Futhark.IR.MC
-  ( -- * The Lore definition
-    MC,
+  ( MC,
 
     -- * Simplification
     simplifyProg,
@@ -39,10 +38,10 @@ import qualified Futhark.TypeCheck as TypeCheck
 
 data MC
 
-instance Decorations MC where
+instance RepTypes MC where
   type Op MC = MCOp MC (SOAC MC)
 
-instance ASTLore MC where
+instance ASTRep MC where
   expTypesFromPattern = return . expExtTypesFromPattern
 
 instance TypeCheck.CheckableOp MC where
@@ -60,7 +59,7 @@ instance BinderOps MC
 
 instance BinderOps (Engine.Wise MC)
 
-instance PrettyLore MC
+instance PrettyRep MC
 
 simpleMC :: Simplify.SimpleOps MC
 simpleMC = Simplify.bindableSimpleOps $ simplifyMCOp SOAC.simplifySOAC

--- a/src/Futhark/IR/MCMem.hs
+++ b/src/Futhark/IR/MCMem.hs
@@ -29,7 +29,7 @@ import qualified Futhark.TypeCheck as TC
 
 data MCMem
 
-instance Decorations MCMem where
+instance RepTypes MCMem where
   type LetDec MCMem = LetDecMem
   type FParamInfo MCMem = FParamMem
   type LParamInfo MCMem = LParamMem
@@ -37,7 +37,7 @@ instance Decorations MCMem where
   type BranchType MCMem = BranchTypeMem
   type Op MCMem = MemOp (MCOp MCMem ())
 
-instance ASTLore MCMem where
+instance ASTRep MCMem where
   expTypesFromPattern = return . map snd . snd . bodyReturnsFromPattern
 
 instance OpReturns MCMem where
@@ -45,7 +45,7 @@ instance OpReturns MCMem where
   opReturns (Inner (ParOp _ op)) = segOpReturns op
   opReturns (Inner (OtherOp ())) = pure []
 
-instance PrettyLore MCMem
+instance PrettyRep MCMem
 
 instance TC.CheckableOp MCMem where
   checkOp = typeCheckMemoryOp
@@ -56,9 +56,9 @@ instance TC.CheckableOp MCMem where
         typeCheckMCOp pure op
 
 instance TC.Checkable MCMem where
-  checkFParamLore = checkMemInfo
-  checkLParamLore = checkMemInfo
-  checkLetBoundLore = checkMemInfo
+  checkFParamDec = checkMemInfo
+  checkLParamDec = checkMemInfo
+  checkLetBoundDec = checkMemInfo
   checkRetType = mapM_ (TC.checkExtType . declExtTypeOf)
   primFParam name t = return $ Param name (MemPrim t)
   matchPattern = matchPatternToExp

--- a/src/Futhark/IR/Mem.hs
+++ b/src/Futhark/IR/Mem.hs
@@ -128,7 +128,7 @@ import Futhark.IR.Prop.Aliases
 import Futhark.IR.Syntax
 import Futhark.IR.Traversals
 import qualified Futhark.Optimise.Simplify.Engine as Engine
-import Futhark.Optimise.Simplify.Lore
+import Futhark.Optimise.Simplify.Rep
 import Futhark.Transform.Rename
 import Futhark.Transform.Substitute
 import qualified Futhark.TypeCheck as TC
@@ -151,16 +151,15 @@ type BranchTypeMem = BodyReturns
 class AllocOp op where
   allocOp :: SubExp -> Space -> op
 
-type Mem lore =
-  ( AllocOp (Op lore),
-    FParamInfo lore ~ FParamMem,
-    LParamInfo lore ~ LParamMem,
-    LetDec lore ~ LetDecMem,
-    RetType lore ~ RetTypeMem,
-    BranchType lore ~ BranchTypeMem,
-    ASTLore lore,
-    Decorations lore,
-    OpReturns lore
+type Mem rep =
+  ( AllocOp (Op rep),
+    FParamInfo rep ~ FParamMem,
+    LParamInfo rep ~ LParamMem,
+    LetDec rep ~ LetDecMem,
+    RetType rep ~ RetTypeMem,
+    BranchType rep ~ BranchTypeMem,
+    ASTRep rep,
+    OpReturns rep
   )
 
 instance IsRetType FunReturns where
@@ -324,15 +323,15 @@ instance (Substitute d, Substitute ret) => Rename (MemInfo d u ret) where
   rename = substituteRename
 
 simplifyIxFun ::
-  Engine.SimplifiableLore lore =>
+  Engine.SimplifiableRep rep =>
   IxFun ->
-  Engine.SimpleM lore IxFun
+  Engine.SimpleM rep IxFun
 simplifyIxFun = traverse $ fmap isInt64 . simplifyPrimExp . untyped
 
 simplifyExtIxFun ::
-  Engine.SimplifiableLore lore =>
+  Engine.SimplifiableRep rep =>
   ExtIxFun ->
-  Engine.SimpleM lore ExtIxFun
+  Engine.SimpleM rep ExtIxFun
 simplifyExtIxFun = traverse $ fmap isInt64 . simplifyExtPrimExp . untyped
 
 isStaticIxFun :: ExtIxFun -> Maybe IxFun
@@ -533,20 +532,20 @@ bodyReturnsToExpReturns :: BodyReturns -> ExpReturns
 bodyReturnsToExpReturns = noUniquenessReturns . maybeReturns
 
 matchRetTypeToResult ::
-  (Mem lore, TC.Checkable lore) =>
+  (Mem rep, TC.Checkable rep) =>
   [FunReturns] ->
   Result ->
-  TC.TypeM lore ()
+  TC.TypeM rep ()
 matchRetTypeToResult rettype result = do
   scope <- askScope
   result_ts <- runReaderT (mapM subExpMemInfo result) $ removeScopeAliases scope
   matchReturnType rettype result result_ts
 
 matchFunctionReturnType ::
-  (Mem lore, TC.Checkable lore) =>
+  (Mem rep, TC.Checkable rep) =>
   [FunReturns] ->
   Result ->
-  TC.TypeM lore ()
+  TC.TypeM rep ()
 matchFunctionReturnType rettype result = do
   matchRetTypeToResult rettype result
   mapM_ checkResultSubExp result
@@ -570,11 +569,11 @@ matchFunctionReturnType rettype result = do
                   ++ pretty ixfun
 
 matchLoopResultMem ::
-  (Mem lore, TC.Checkable lore) =>
-  [FParam (Aliases lore)] ->
-  [FParam (Aliases lore)] ->
+  (Mem rep, TC.Checkable rep) =>
+  [FParam (Aliases rep)] ->
+  [FParam (Aliases rep)] ->
   [SubExp] ->
-  TC.TypeM lore ()
+  TC.TypeM rep ()
 matchLoopResultMem ctx val = matchRetTypeToResult rettype
   where
     ctx_names = map paramName ctx
@@ -607,10 +606,10 @@ matchLoopResultMem ctx val = matchRetTypeToResult rettype
         ixfun' = existentialiseIxFun ctx_names ixfun
 
 matchBranchReturnType ::
-  (Mem lore, TC.Checkable lore) =>
+  (Mem rep, TC.Checkable rep) =>
   [BodyReturns] ->
-  Body (Aliases lore) ->
-  TC.TypeM lore ()
+  Body (Aliases rep) ->
+  TC.TypeM rep ()
 matchBranchReturnType rettype (Body _ stms res) = do
   scope <- askScope
   ts <- runReaderT (mapM subExpMemInfo res) $ removeScopeAliases (scope <> scopeOf stms)
@@ -649,7 +648,7 @@ matchReturnType ::
   [MemInfo ExtSize u MemReturn] ->
   [SubExp] ->
   [MemInfo SubExp NoUniqueness MemBind] ->
-  TC.TypeM lore ()
+  TC.TypeM rep ()
 matchReturnType rettype res ts = do
   let (ctx_ts, val_ts) = splitFromEnd (length rettype) ts
       (ctx_res, _val_res) = splitFromEnd (length rettype) res
@@ -769,7 +768,7 @@ matchReturnType rettype res ts = do
               pretty y
             ]
 
-      bad :: String -> TC.TypeM lore a
+      bad :: String -> TC.TypeM rep a
       bad s =
         TC.bad $
           TC.TypeError $
@@ -792,10 +791,10 @@ matchReturnType rettype res ts = do
   either bad return =<< runExceptT (zipWithM_ checkReturn rettype val_ts)
 
 matchPatternToExp ::
-  (Mem lore, TC.Checkable lore) =>
-  Pattern (Aliases lore) ->
-  Exp (Aliases lore) ->
-  TC.TypeM lore ()
+  (Mem rep, TC.Checkable rep) =>
+  Pattern (Aliases rep) ->
+  Exp (Aliases rep) ->
+  TC.TypeM rep ()
 matchPatternToExp pat e = do
   scope <- asksScope removeScopeAliases
   rt <- runReaderT (expReturns $ removeExpAliases e) scope
@@ -866,9 +865,9 @@ extInIxFn :: ExtIxFun -> S.Set Int
 extInIxFn ixfun = S.fromList $ concatMap (mapMaybe isExt . toList) ixfun
 
 varMemInfo ::
-  Mem lore =>
+  Mem rep =>
   VName ->
-  TC.TypeM lore (MemInfo SubExp NoUniqueness MemBind)
+  TC.TypeM rep (MemInfo SubExp NoUniqueness MemBind)
 varMemInfo name = do
   dec <- TC.lookupVar name
 
@@ -878,7 +877,7 @@ varMemInfo name = do
     LParamName summary -> return summary
     IndexName it -> return $ MemPrim $ IntType it
 
-nameInfoToMemInfo :: Mem lore => NameInfo lore -> MemBound NoUniqueness
+nameInfoToMemInfo :: Mem rep => NameInfo rep -> MemBound NoUniqueness
 nameInfoToMemInfo info =
   case info of
     FParamName summary -> noUniquenessReturns summary
@@ -887,20 +886,20 @@ nameInfoToMemInfo info =
     IndexName it -> MemPrim $ IntType it
 
 lookupMemInfo ::
-  (HasScope lore m, Mem lore) =>
+  (HasScope rep m, Mem rep) =>
   VName ->
   m (MemInfo SubExp NoUniqueness MemBind)
 lookupMemInfo = fmap nameInfoToMemInfo . lookupInfo
 
 subExpMemInfo ::
-  (HasScope lore m, Monad m, Mem lore) =>
+  (HasScope rep m, Monad m, Mem rep) =>
   SubExp ->
   m (MemInfo SubExp NoUniqueness MemBind)
 subExpMemInfo (Var v) = lookupMemInfo v
 subExpMemInfo (Constant v) = return $ MemPrim $ primValueType v
 
 lookupArraySummary ::
-  (Mem lore, HasScope lore m, Monad m) =>
+  (Mem rep, HasScope rep m, Monad m) =>
   VName ->
   m (VName, IxFun.IxFun (TPrimExp Int64 VName))
 lookupArraySummary name = do
@@ -912,10 +911,10 @@ lookupArraySummary name = do
       error $ "Variable " ++ pretty name ++ " does not look like an array."
 
 checkMemInfo ::
-  TC.Checkable lore =>
+  TC.Checkable rep =>
   VName ->
   MemInfo SubExp u MemBind ->
-  TC.TypeM lore ()
+  TC.TypeM rep ()
 checkMemInfo _ (MemPrim _) = return ()
 checkMemInfo _ (MemMem (ScalarSpace d _)) = mapM_ (TC.require [Prim int64]) d
 checkMemInfo _ (MemMem _) = return ()
@@ -1002,7 +1001,7 @@ extReturns ets =
     convert (Free v) = Free <$> pe64 v
 
 arrayVarReturns ::
-  (HasScope lore m, Monad m, Mem lore) =>
+  (HasScope rep m, Monad m, Mem rep) =>
   VName ->
   m (PrimType, Shape, VName, IxFun)
 arrayVarReturns v = do
@@ -1014,7 +1013,7 @@ arrayVarReturns v = do
       error $ "arrayVarReturns: " ++ pretty v ++ " is not an array."
 
 varReturns ::
-  (HasScope lore m, Monad m, Mem lore) =>
+  (HasScope rep m, Monad m, Mem rep) =>
   VName ->
   m ExpReturns
 varReturns v = do
@@ -1031,7 +1030,7 @@ varReturns v = do
     MemAcc acc ispace ts u ->
       return $ MemAcc acc ispace ts u
 
-subExpReturns :: (HasScope lore m, Monad m, Mem lore) => SubExp -> m ExpReturns
+subExpReturns :: (HasScope rep m, Monad m, Mem rep) => SubExp -> m ExpReturns
 subExpReturns (Var v) =
   varReturns v
 subExpReturns (Constant v) =
@@ -1041,10 +1040,10 @@ subExpReturns (Constant v) =
 -- "return type with memory annotations" of the expression.
 expReturns ::
   ( Monad m,
-    LocalScope lore m,
-    Mem lore
+    LocalScope rep m,
+    Mem rep
   ) =>
-  Exp lore ->
+  Exp rep ->
   m [ExpReturns]
 expReturns (BasicOp (SubExp se)) =
   pure <$> subExpReturns se
@@ -1137,7 +1136,7 @@ expReturns (WithAcc inputs lam) =
     num_accs = length inputs
 
 sliceInfo ::
-  (Monad m, HasScope lore m, Mem lore) =>
+  (Monad m, HasScope rep m, Mem rep) =>
   VName ->
   Slice SubExp ->
   m (MemInfo SubExp NoUniqueness MemBind)
@@ -1153,10 +1152,10 @@ sliceInfo v slice = do
               ixfun
               (map (fmap (isInt64 . primExpFromSubExp int64)) slice)
 
-class TypedOp (Op lore) => OpReturns lore where
+class TypedOp (Op rep) => OpReturns rep where
   opReturns ::
-    (Monad m, HasScope lore m) =>
-    Op lore ->
+    (Monad m, HasScope rep m) =>
+    Op rep ->
     m [ExpReturns]
   opReturns op = extReturns <$> opType op
 

--- a/src/Futhark/IR/Mem/Simplify.hs
+++ b/src/Futhark/IR/Mem/Simplify.hs
@@ -22,7 +22,7 @@ import qualified Futhark.IR.Mem.IxFun as IxFun
 import qualified Futhark.IR.Syntax as AST
 import qualified Futhark.Optimise.Simplify as Simplify
 import qualified Futhark.Optimise.Simplify.Engine as Engine
-import Futhark.Optimise.Simplify.Lore
+import Futhark.Optimise.Simplify.Rep
 import Futhark.Optimise.Simplify.Rule
 import Futhark.Optimise.Simplify.Rules
 import Futhark.Pass
@@ -30,17 +30,17 @@ import Futhark.Pass.ExplicitAllocations (simplifiable)
 import Futhark.Util
 
 simpleGeneric ::
-  (SimplifyMemory lore, Op lore ~ MemOp inner) =>
+  (SimplifyMemory rep, Op rep ~ MemOp inner) =>
   (OpWithWisdom inner -> UT.UsageTable) ->
-  Simplify.SimplifyOp lore inner ->
-  Simplify.SimpleOps lore
+  Simplify.SimplifyOp rep inner ->
+  Simplify.SimpleOps rep
 simpleGeneric = simplifiable
 
 simplifyProgGeneric ::
-  (SimplifyMemory lore, Op lore ~ MemOp inner) =>
-  Simplify.SimpleOps lore ->
-  Prog lore ->
-  PassM (Prog lore)
+  (SimplifyMemory rep, Op rep ~ MemOp inner) =>
+  Simplify.SimpleOps rep ->
+  Prog rep ->
+  PassM (Prog rep)
 simplifyProgGeneric ops =
   Simplify.simplifyProg
     ops
@@ -59,14 +59,14 @@ simplifyProgGeneric ops =
       not $ all primType $ patternTypes pat
 
 simplifyStmsGeneric ::
-  ( HasScope lore m,
+  ( HasScope rep m,
     MonadFreshNames m,
-    SimplifyMemory lore,
-    Op lore ~ MemOp inner
+    SimplifyMemory rep,
+    Op rep ~ MemOp inner
   ) =>
-  Simplify.SimpleOps lore ->
-  Stms lore ->
-  m (ST.SymbolTable (Wise lore), Stms lore)
+  Simplify.SimpleOps rep ->
+  Stms rep ->
+  m (ST.SymbolTable (Wise rep), Stms rep)
 simplifyStmsGeneric ops stms = do
   scope <- askScope
   Simplify.simplifyStms
@@ -76,18 +76,18 @@ simplifyStmsGeneric ops stms = do
     scope
     stms
 
-isResultAlloc :: Op lore ~ MemOp op => Engine.BlockPred lore
+isResultAlloc :: Op rep ~ MemOp op => Engine.BlockPred rep
 isResultAlloc _ usage (Let (AST.Pattern [] [bindee]) _ (Op Alloc {})) =
   UT.isInResult (patElemName bindee) usage
 isResultAlloc _ _ _ = False
 
-isAlloc :: Op lore ~ MemOp op => Engine.BlockPred lore
+isAlloc :: Op rep ~ MemOp op => Engine.BlockPred rep
 isAlloc _ _ (Let _ _ (Op Alloc {})) = True
 isAlloc _ _ _ = False
 
 blockers ::
-  (Op lore ~ MemOp inner) =>
-  Simplify.HoistBlockers lore
+  (Op rep ~ MemOp inner) =>
+  Simplify.HoistBlockers rep
 blockers =
   Engine.noExtraHoistBlockers
     { Engine.blockHoistPar = isAlloc,
@@ -96,17 +96,17 @@ blockers =
     }
 
 -- | Some constraints that must hold for the simplification rules to work.
-type SimplifyMemory lore =
-  ( Simplify.SimplifiableLore lore,
-    ExpDec lore ~ (),
-    BodyDec lore ~ (),
-    AllocOp (Op (Wise lore)),
-    CanBeWise (Op lore),
-    BinderOps (Wise lore),
-    Mem lore
+type SimplifyMemory rep =
+  ( Simplify.SimplifiableRep rep,
+    ExpDec rep ~ (),
+    BodyDec rep ~ (),
+    AllocOp (Op (Wise rep)),
+    CanBeWise (Op rep),
+    BinderOps (Wise rep),
+    Mem rep
   )
 
-callKernelRules :: SimplifyMemory lore => RuleBook (Wise lore)
+callKernelRules :: SimplifyMemory rep => RuleBook (Wise rep)
 callKernelRules =
   standardRules
     <> ruleBook
@@ -121,7 +121,7 @@ callKernelRules =
 -- the array is not existential, and the index function of the array
 -- does not refer to any names in the pattern, then we can create a
 -- block of the proper size and always return there.
-unExistentialiseMemory :: SimplifyMemory lore => TopDownRuleIf (Wise lore)
+unExistentialiseMemory :: SimplifyMemory rep => TopDownRuleIf (Wise rep)
 unExistentialiseMemory vtable pat _ (cond, tbranch, fbranch, ifdec)
   | ST.simplifyMemory vtable,
     fixable <- foldl hasConcretisableMemory mempty $ patternElements pat,
@@ -192,10 +192,10 @@ unExistentialiseMemory _ _ _ _ = Skip
 -- | If we are copying something that is itself a copy, just copy the
 -- original one instead.
 copyCopyToCopy ::
-  ( BinderOps lore,
-    LetDec lore ~ (VarWisdom, MemBound u)
+  ( BinderOps rep,
+    LetDec rep ~ (VarWisdom, MemBound u)
   ) =>
-  TopDownRuleBasicOp lore
+  TopDownRuleBasicOp rep
 copyCopyToCopy vtable pat@(Pattern [] [pat_elem]) _ (Copy v1)
   | Just (BasicOp (Copy v2), v1_cs) <- ST.lookupExp v1 vtable,
     Just (_, MemArray _ _ _ (ArrayIn srcmem src_ixfun)) <-
@@ -218,10 +218,10 @@ copyCopyToCopy _ _ _ _ = Skip
 -- | If the destination of a copy is the same as the source, just
 -- remove it.
 removeIdentityCopy ::
-  ( BinderOps lore,
-    LetDec lore ~ (VarWisdom, MemBound u)
+  ( BinderOps rep,
+    LetDec rep ~ (VarWisdom, MemBound u)
   ) =>
-  TopDownRuleBasicOp lore
+  TopDownRuleBasicOp rep
 removeIdentityCopy vtable pat@(Pattern [] [pe]) _ (Copy v)
   | (_, MemArray _ _ _ (ArrayIn dest_mem dest_ixfun)) <- patElemDec pe,
     Just (_, MemArray _ _ _ (ArrayIn src_mem src_ixfun)) <-
@@ -234,7 +234,7 @@ removeIdentityCopy _ _ _ _ = Skip
 -- If an allocation is statically known to be safe, then we can remove
 -- the certificates on it.  This can help hoist things that would
 -- otherwise be stuck inside loops or branches.
-decertifySafeAlloc :: SimplifyMemory lore => TopDownRuleOp (Wise lore)
+decertifySafeAlloc :: SimplifyMemory rep => TopDownRuleOp (Wise rep)
 decertifySafeAlloc _ pat (StmAux cs attrs _) op
   | cs /= mempty,
     [Mem _] <- patternTypes pat,

--- a/src/Futhark/IR/Parse.hs
+++ b/src/Futhark/IR/Parse.hs
@@ -5,8 +5,8 @@
 -- | Parser for the Futhark core language.
 module Futhark.IR.Parse
   ( parseSOACS,
-    parseKernels,
-    parseKernelsMem,
+    parseGPU,
+    parseGPUMem,
     parseMC,
     parseMCMem,
     parseSeq,
@@ -23,9 +23,9 @@ import qualified Data.Text as T
 import Data.Void
 import Futhark.Analysis.PrimExp.Parse
 import Futhark.IR
-import Futhark.IR.Kernels (Kernels)
-import qualified Futhark.IR.Kernels.Kernel as Kernel
-import Futhark.IR.KernelsMem (KernelsMem)
+import Futhark.IR.GPU (GPU)
+import qualified Futhark.IR.GPU.Kernel as Kernel
+import Futhark.IR.GPUMem (GPUMem)
 import Futhark.IR.MC (MC)
 import qualified Futhark.IR.MC.Op as MC
 import Futhark.IR.MCMem (MCMem)
@@ -946,17 +946,17 @@ prSeqMem =
   where
     op = pMemOp empty
 
-prKernels :: PR Kernels
-prKernels =
+prGPU :: PR GPU
+prGPU =
   PR pDeclExtType pExtType pDeclType pType pType op () ()
   where
-    op = pHostOp prKernels (pSOAC prKernels)
+    op = pHostOp prGPU (pSOAC prGPU)
 
-prKernelsMem :: PR KernelsMem
-prKernelsMem =
+prGPUMem :: PR GPUMem
+prGPUMem =
   PR pRetTypeMem pBranchTypeMem pFParamMem pLParamMem pLetDecMem op () ()
   where
-    op = pMemOp $ pHostOp prKernelsMem empty
+    op = pMemOp $ pHostOp prGPUMem empty
 
 prMC :: PR MC
 prMC =
@@ -984,11 +984,11 @@ parseSeq = parseRep prSeq
 parseSeqMem :: FilePath -> T.Text -> Either T.Text (Prog SeqMem)
 parseSeqMem = parseRep prSeqMem
 
-parseKernels :: FilePath -> T.Text -> Either T.Text (Prog Kernels)
-parseKernels = parseRep prKernels
+parseGPU :: FilePath -> T.Text -> Either T.Text (Prog GPU)
+parseGPU = parseRep prGPU
 
-parseKernelsMem :: FilePath -> T.Text -> Either T.Text (Prog KernelsMem)
-parseKernelsMem = parseRep prKernelsMem
+parseGPUMem :: FilePath -> T.Text -> Either T.Text (Prog GPUMem)
+parseGPUMem = parseRep prGPUMem
 
 parseMC :: FilePath -> T.Text -> Either T.Text (Prog MC)
 parseMC = parseRep prMC

--- a/src/Futhark/IR/Parse.hs
+++ b/src/Futhark/IR/Parse.hs
@@ -335,46 +335,46 @@ pComm =
 -- bits.  Essentially a manually passed-around type class dictionary,
 -- because ambiguities make it impossible to write this with actual
 -- type classes.
-data PR lore = PR
-  { pRetType :: Parser (RetType lore),
-    pBranchType :: Parser (BranchType lore),
-    pFParamInfo :: Parser (FParamInfo lore),
-    pLParamInfo :: Parser (LParamInfo lore),
-    pLetDec :: Parser (LetDec lore),
-    pOp :: Parser (Op lore),
-    pBodyDec :: BodyDec lore,
-    pExpDec :: ExpDec lore
+data PR rep = PR
+  { pRetType :: Parser (RetType rep),
+    pBranchType :: Parser (BranchType rep),
+    pFParamInfo :: Parser (FParamInfo rep),
+    pLParamInfo :: Parser (LParamInfo rep),
+    pLetDec :: Parser (LetDec rep),
+    pOp :: Parser (Op rep),
+    pBodyDec :: BodyDec rep,
+    pExpDec :: ExpDec rep
   }
 
-pRetTypes :: PR lore -> Parser [RetType lore]
+pRetTypes :: PR rep -> Parser [RetType rep]
 pRetTypes pr = braces $ pRetType pr `sepBy` pComma
 
-pBranchTypes :: PR lore -> Parser [BranchType lore]
+pBranchTypes :: PR rep -> Parser [BranchType rep]
 pBranchTypes pr = braces $ pBranchType pr `sepBy` pComma
 
 pParam :: Parser t -> Parser (Param t)
 pParam p = Param <$> pVName <*> (pColon *> p)
 
-pFParam :: PR lore -> Parser (FParam lore)
+pFParam :: PR rep -> Parser (FParam rep)
 pFParam = pParam . pFParamInfo
 
-pFParams :: PR lore -> Parser [FParam lore]
+pFParams :: PR rep -> Parser [FParam rep]
 pFParams pr = parens $ pFParam pr `sepBy` pComma
 
-pLParam :: PR lore -> Parser (LParam lore)
+pLParam :: PR rep -> Parser (LParam rep)
 pLParam = pParam . pLParamInfo
 
-pLParams :: PR lore -> Parser [LParam lore]
+pLParams :: PR rep -> Parser [LParam rep]
 pLParams pr = braces $ pLParam pr `sepBy` pComma
 
-pPatElem :: PR lore -> Parser (PatElem lore)
+pPatElem :: PR rep -> Parser (PatElem rep)
 pPatElem pr =
   (PatElem <$> pVName <*> (pColon *> pLetDec pr)) <?> "pattern element"
 
-pPattern :: PR lore -> Parser (Pattern lore)
+pPattern :: PR rep -> Parser (Pattern rep)
 pPattern pr = uncurry Pattern <$> pPatternLike (pPatElem pr)
 
-pIf :: PR lore -> Parser (Exp lore)
+pIf :: PR rep -> Parser (Exp rep)
 pIf pr =
   keyword "if" $> f <*> pSort <*> pSubExp
     <*> (keyword "then" *> pBranchBody)
@@ -395,7 +395,7 @@ pIf pr =
           braces (pBody pr)
         ]
 
-pApply :: PR lore -> Parser (Exp lore)
+pApply :: PR rep -> Parser (Exp rep)
 pApply pr =
   keyword "apply" *> (p =<< choice [lexeme "<unsafe>" $> Unsafe, pure Safe])
   where
@@ -412,7 +412,7 @@ pApply pr =
           (,Observe) <$> pSubExp
         ]
 
-pLoop :: PR lore -> Parser (Exp lore)
+pLoop :: PR rep -> Parser (Exp rep)
 pLoop pr =
   keyword "loop" $> uncurry DoLoop
     <*> pLoopParams
@@ -436,7 +436,7 @@ pLoop pr =
           keyword "while" $> WhileLoop <*> pVName
         ]
 
-pLambda :: PR lore -> Parser (Lambda lore)
+pLambda :: PR rep -> Parser (Lambda rep)
 pLambda pr =
   choice
     [ lexeme "\\"
@@ -449,20 +449,20 @@ pLambda pr =
   where
     lam params ret body = Lambda params body ret
 
-pReduce :: PR lore -> Parser (SOAC.Reduce lore)
+pReduce :: PR rep -> Parser (SOAC.Reduce rep)
 pReduce pr =
   SOAC.Reduce
     <$> pComm
     <*> pLambda pr <* pComma
     <*> braces (pSubExp `sepBy` pComma)
 
-pScan :: PR lore -> Parser (SOAC.Scan lore)
+pScan :: PR rep -> Parser (SOAC.Scan rep)
 pScan pr =
   SOAC.Scan
     <$> pLambda pr <* pComma
     <*> braces (pSubExp `sepBy` pComma)
 
-pWithAcc :: PR lore -> Parser (Exp lore)
+pWithAcc :: PR rep -> Parser (Exp rep)
 pWithAcc pr =
   keyword "with_acc"
     *> parens (WithAcc <$> braces (pInput `sepBy` pComma) <* pComma <*> pLambda pr)
@@ -476,7 +476,7 @@ pWithAcc pr =
         )
     pCombFun = parens ((,) <$> pLambda pr <* pComma <*> pSubExps)
 
-pExp :: PR lore -> Parser (Exp lore)
+pExp :: PR rep -> Parser (Exp rep)
 pExp pr =
   choice
     [ pIf pr,
@@ -487,7 +487,7 @@ pExp pr =
       BasicOp <$> pBasicOp
     ]
 
-pStm :: PR lore -> Parser (Stm lore)
+pStm :: PR rep -> Parser (Stm rep)
 pStm pr =
   keyword "let" $> Let <*> pPattern pr <* pEqual <*> pStmAux <*> pExp pr
   where
@@ -499,10 +499,10 @@ pStm pr =
           pure mempty
         ]
 
-pStms :: PR lore -> Parser (Stms lore)
+pStms :: PR rep -> Parser (Stms rep)
 pStms pr = stmsFromList <$> many (pStm pr)
 
-pBody :: PR lore -> Parser (Body lore)
+pBody :: PR rep -> Parser (Body rep)
 pBody pr =
   choice
     [ Body (pBodyDec pr) <$> pStms pr <* keyword "in" <*> pResult,
@@ -526,7 +526,7 @@ pEntry =
           "opaque" *> parens (TypeOpaque <$> pStringLiteral <* pComma <*> pInt)
         ]
 
-pFunDef :: PR lore -> Parser (FunDef lore)
+pFunDef :: PR rep -> Parser (FunDef rep)
 pFunDef pr = do
   attrs <- pAttrs
   entry <-
@@ -540,10 +540,10 @@ pFunDef pr = do
   FunDef entry attrs fname ret fparams
     <$> (pEqual *> braces (pBody pr))
 
-pProg :: PR lore -> Parser (Prog lore)
+pProg :: PR rep -> Parser (Prog rep)
 pProg pr = Prog <$> pStms pr <*> many (pFunDef pr)
 
-pSOAC :: PR lore -> Parser (SOAC.SOAC lore)
+pSOAC :: PR rep -> Parser (SOAC.SOAC rep)
 pSOAC pr =
   choice
     [ keyword "map" *> pScrema pMapForm,
@@ -744,13 +744,13 @@ pKernelResult =
         pure (dim, blk_tile, reg_tile)
     pWrite = (,) <$> pSlice <* pEqual <*> pSubExp
 
-pKernelBody :: PR lore -> Parser (SegOp.KernelBody lore)
+pKernelBody :: PR rep -> Parser (SegOp.KernelBody rep)
 pKernelBody pr =
   SegOp.KernelBody (pBodyDec pr)
     <$> pStms pr <* keyword "return"
     <*> braces (pKernelResult `sepBy` pComma)
 
-pSegOp :: PR lore -> Parser lvl -> Parser (SegOp.SegOp lvl lore)
+pSegOp :: PR rep -> Parser lvl -> Parser (SegOp.SegOp lvl rep)
 pSegOp pr pLvl =
   choice
     [ keyword "segmap" *> pSegMap,
@@ -807,7 +807,7 @@ pSegLevel =
           pure SegOp.SegNoVirt
         ]
 
-pHostOp :: PR lore -> Parser op -> Parser (Kernel.HostOp lore op)
+pHostOp :: PR rep -> Parser op -> Parser (Kernel.HostOp rep op)
 pHostOp pr pOther =
   choice
     [ Kernel.SegOp <$> pSegOp pr pSegLevel,
@@ -815,7 +815,7 @@ pHostOp pr pOther =
       Kernel.OtherOp <$> pOther
     ]
 
-pMCOp :: PR lore -> Parser op -> Parser (MC.MCOp lore op)
+pMCOp :: PR rep -> Parser op -> Parser (MC.MCOp rep op)
 pMCOp pr pOther =
   choice
     [ MC.ParOp . Just
@@ -970,28 +970,28 @@ prMCMem =
   where
     op = pMemOp $ pMCOp prMCMem empty
 
-parseLore :: PR lore -> FilePath -> T.Text -> Either T.Text (Prog lore)
-parseLore pr fname s =
+parseRep :: PR rep -> FilePath -> T.Text -> Either T.Text (Prog rep)
+parseRep pr fname s =
   either (Left . T.pack . errorBundlePretty) Right $
     parse (whitespace *> pProg pr <* eof) fname s
 
 parseSOACS :: FilePath -> T.Text -> Either T.Text (Prog SOACS)
-parseSOACS = parseLore prSOACS
+parseSOACS = parseRep prSOACS
 
 parseSeq :: FilePath -> T.Text -> Either T.Text (Prog Seq)
-parseSeq = parseLore prSeq
+parseSeq = parseRep prSeq
 
 parseSeqMem :: FilePath -> T.Text -> Either T.Text (Prog SeqMem)
-parseSeqMem = parseLore prSeqMem
+parseSeqMem = parseRep prSeqMem
 
 parseKernels :: FilePath -> T.Text -> Either T.Text (Prog Kernels)
-parseKernels = parseLore prKernels
+parseKernels = parseRep prKernels
 
 parseKernelsMem :: FilePath -> T.Text -> Either T.Text (Prog KernelsMem)
-parseKernelsMem = parseLore prKernelsMem
+parseKernelsMem = parseRep prKernelsMem
 
 parseMC :: FilePath -> T.Text -> Either T.Text (Prog MC)
-parseMC = parseLore prMC
+parseMC = parseRep prMC
 
 parseMCMem :: FilePath -> T.Text -> Either T.Text (Prog MCMem)
-parseMCMem = parseLore prMCMem
+parseMCMem = parseRep prMCMem

--- a/src/Futhark/IR/Pretty.hs
+++ b/src/Futhark/IR/Pretty.hs
@@ -11,7 +11,7 @@
 module Futhark.IR.Pretty
   ( prettyTuple,
     pretty,
-    PrettyLore (..),
+    PrettyRep (..),
     ppTuple',
   )
 where
@@ -21,20 +21,20 @@ import Data.Maybe
 import Futhark.IR.Syntax
 import Futhark.Util.Pretty
 
--- | The class of lores whose annotations can be prettyprinted.
+-- | The class of representations whose annotations can be prettyprinted.
 class
-  ( Decorations lore,
-    Pretty (RetType lore),
-    Pretty (BranchType lore),
-    Pretty (FParamInfo lore),
-    Pretty (LParamInfo lore),
-    Pretty (LetDec lore),
-    Pretty (Op lore)
+  ( RepTypes rep,
+    Pretty (RetType rep),
+    Pretty (BranchType rep),
+    Pretty (FParamInfo rep),
+    Pretty (LParamInfo rep),
+    Pretty (LetDec rep),
+    Pretty (Op rep)
   ) =>
-  PrettyLore lore
+  PrettyRep rep
   where
-  ppExpLore :: ExpDec lore -> Exp lore -> Maybe Doc
-  ppExpLore _ _ = Nothing
+  ppExpDec :: ExpDec rep -> Exp rep -> Maybe Doc
+  ppExpDec _ _ = Nothing
 
 instance Pretty VName where
   ppr (VName vn i) = ppr vn <> text "_" <> text (show i)
@@ -96,10 +96,10 @@ instance Pretty Certificates where
   ppr (Certificates []) = empty
   ppr (Certificates cs) = text "#" <> braces (commasep (map ppr cs))
 
-instance PrettyLore lore => Pretty (Stms lore) where
+instance PrettyRep rep => Pretty (Stms rep) where
   ppr = stack . map ppr . stmsToList
 
-instance PrettyLore lore => Pretty (Body lore) where
+instance PrettyRep rep => Pretty (Body rep) where
   ppr (Body _ stms res)
     | null stms = braces (commasep $ map ppr res)
     | otherwise =
@@ -115,7 +115,7 @@ attrAnnots = map f . toList . unAttrs
   where
     f v = text "#[" <> ppr v <> text "]"
 
-stmAttrAnnots :: Stm lore -> [Doc]
+stmAttrAnnots :: Stm rep -> [Doc]
 stmAttrAnnots = attrAnnots . stmAuxAttrs . stmAux
 
 certAnnots :: Certificates -> [Doc]
@@ -123,7 +123,7 @@ certAnnots cs
   | cs == mempty = []
   | otherwise = [ppr cs]
 
-stmCertAnnots :: Stm lore -> [Doc]
+stmCertAnnots :: Stm rep -> [Doc]
 stmCertAnnots = certAnnots . stmAuxCerts . stmAux
 
 instance Pretty (PatElemT dec) => Pretty (PatternT dec) where
@@ -135,7 +135,7 @@ instance Pretty t => Pretty (PatElemT t) where
 instance Pretty t => Pretty (Param t) where
   ppr (Param name t) = ppr name <+> colon <+> align (ppr t)
 
-instance PrettyLore lore => Pretty (Stm lore) where
+instance PrettyRep rep => Pretty (Stm rep) where
   ppr bnd@(Let pat aux e) =
     align . hang 2 $
       text "let" <+> align (ppr pat)
@@ -154,7 +154,7 @@ instance PrettyLore lore => Pretty (Stm lore) where
 
       stmannot =
         concat
-          [ maybeToList (ppExpLore (stmAuxDec aux) e),
+          [ maybeToList (ppExpDec (stmAuxDec aux) e),
             stmAttrAnnots bnd,
             stmCertAnnots bnd
           ]
@@ -210,7 +210,7 @@ instance Pretty a => Pretty (ErrorMsg a) where
       p (ErrorInt32 x) = ppr x <+> colon <+> text "i32"
       p (ErrorInt64 x) = ppr x <+> colon <+> text "i64"
 
-instance PrettyLore lore => Pretty (Exp lore) where
+instance PrettyRep rep => Pretty (Exp rep) where
   ppr (If c t f (IfDec ret ifsort)) =
     text "if" <+> info' <+> ppr c
       </> text "then"
@@ -283,7 +283,7 @@ instance PrettyLore lore => Pretty (Exp lore) where
                   comma </> parens (ppr op' <> comma </> ppTuple' (map ppr nes))
           )
 
-instance PrettyLore lore => Pretty (Lambda lore) where
+instance PrettyRep rep => Pretty (Lambda rep) where
   ppr (Lambda [] (Body _ stms []) []) | stms == mempty = text "nilFn"
   ppr (Lambda params body rettype) =
     text "\\" <+> ppTuple' params
@@ -295,7 +295,7 @@ instance Pretty EntryPointType where
   ppr TypeUnsigned = "unsigned"
   ppr (TypeOpaque desc n) = "opaque" <> apply [ppr (show desc), ppr n]
 
-instance PrettyLore lore => Pretty (FunDef lore) where
+instance PrettyRep rep => Pretty (FunDef rep) where
   ppr (FunDef entry attrs name rettype fparams body) =
     annot (attrAnnots attrs) $
       fun <+> text (nameToString name)
@@ -314,7 +314,7 @@ instance PrettyLore lore => Pretty (FunDef lore) where
                   </> ppTuple' ret_entry
               )
 
-instance PrettyLore lore => Pretty (Prog lore) where
+instance PrettyRep rep => Pretty (Prog rep) where
   ppr (Prog consts funs) =
     stack $ punctuate line $ ppr consts : map ppr funs
 

--- a/src/Futhark/IR/Prop.hs
+++ b/src/Futhark/IR/Prop.hs
@@ -38,7 +38,7 @@ module Futhark.IR.Prop
     lamIsBinOp,
     ASTConstraints,
     IsOp (..),
-    ASTLore (..),
+    ASTRep (..),
   )
 where
 
@@ -73,7 +73,7 @@ builtInFunctions = M.fromList $ map namify $ M.toList primFuns
     namify (k, (paramts, ret, _)) = (nameFromString k, (ret, paramts))
 
 -- | If the expression is a t'BasicOp', return it, otherwise 'Nothing'.
-asBasicOp :: Exp lore -> Maybe BasicOp
+asBasicOp :: Exp rep -> Maybe BasicOp
 asBasicOp (BasicOp op) = Just op
 asBasicOp _ = Nothing
 
@@ -81,7 +81,7 @@ asBasicOp _ = Nothing
 -- any required certificates have been checked) in any context.  For
 -- example, array indexing is not safe, as the index may be out of
 -- bounds.  On the other hand, adding two numbers cannot fail.
-safeExp :: IsOp (Op lore) => Exp lore -> Bool
+safeExp :: IsOp (Op rep) => Exp rep -> Bool
 safeExp (BasicOp op) = safeBasicOp op
   where
     safeBasicOp (BinOp (SDiv _ Safe) _ _) = True
@@ -134,7 +134,7 @@ safeExp (If _ tbranch fbranch _) =
 safeExp WithAcc {} = True -- Although unlikely to matter.
 safeExp (Op op) = safeOp op
 
-safeBody :: IsOp (Op lore) => Body lore -> Bool
+safeBody :: IsOp (Op rep) => Body rep -> Bool
 safeBody = all (safeExp . stmExp) . bodyStms
 
 -- | Return the variable names used in 'Var' subexpressions.  May contain
@@ -151,7 +151,7 @@ subExpVar Constant {} = Nothing
 -- Based on pattern matching and checking whether the lambda
 -- represents a known arithmetic operator; don't expect anything
 -- clever here.
-commutativeLambda :: Lambda lore -> Bool
+commutativeLambda :: Lambda rep -> Bool
 commutativeLambda lam =
   let body = lambdaBody lam
       n2 = length (lambdaParams lam) `div` 2
@@ -183,11 +183,11 @@ defAux :: dec -> StmAux dec
 defAux = StmAux mempty mempty
 
 -- | The certificates associated with a statement.
-stmCerts :: Stm lore -> Certificates
+stmCerts :: Stm rep -> Certificates
 stmCerts = stmAuxCerts . stmAux
 
 -- | Add certificates to a statement.
-certify :: Certificates -> Stm lore -> Stm lore
+certify :: Certificates -> Stm rep -> Stm rep
 certify cs1 (Let pat (StmAux cs2 attrs dec) e) =
   Let pat (StmAux (cs2 <> cs1) attrs dec) e
 
@@ -208,31 +208,31 @@ instance IsOp () where
   safeOp () = True
   cheapOp () = True
 
--- | Lore-specific attributes; also means the lore supports some basic
--- facilities.
+-- | Representation-specific attributes; also means the rep supports
+-- some basic facilities.
 class
-  ( Decorations lore,
-    PrettyLore lore,
-    Renameable lore,
-    Substitutable lore,
-    FreeDec (ExpDec lore),
-    FreeIn (LetDec lore),
-    FreeDec (BodyDec lore),
-    FreeIn (FParamInfo lore),
-    FreeIn (LParamInfo lore),
-    FreeIn (RetType lore),
-    FreeIn (BranchType lore),
-    IsOp (Op lore)
+  ( RepTypes rep,
+    PrettyRep rep,
+    Renameable rep,
+    Substitutable rep,
+    FreeDec (ExpDec rep),
+    FreeIn (LetDec rep),
+    FreeDec (BodyDec rep),
+    FreeIn (FParamInfo rep),
+    FreeIn (LParamInfo rep),
+    FreeIn (RetType rep),
+    FreeIn (BranchType rep),
+    IsOp (Op rep)
   ) =>
-  ASTLore lore
+  ASTRep rep
   where
   -- | Given a pattern, construct the type of a body that would match
-  -- it.  An implementation for many lores would be
+  -- it.  An implementation for many representations would be
   -- 'expExtTypesFromPattern'.
   expTypesFromPattern ::
-    (HasScope lore m, Monad m) =>
-    Pattern lore ->
-    m [BranchType lore]
+    (HasScope rep m, Monad m) =>
+    Pattern rep ->
+    m [BranchType rep]
 
 -- | Construct the type of an expression that would match the pattern.
 expExtTypesFromPattern :: Typed dec => PatternT dec -> [ExtType]
@@ -249,7 +249,7 @@ attrsForAssert (Attrs attrs) =
     attrForAssert = (== AttrComp "warn" ["safety_checks"])
 
 -- | Horizontally fission a lambda that models a binary operator.
-lamIsBinOp :: ASTLore lore => Lambda lore -> Maybe [(BinOp, PrimType, VName, VName)]
+lamIsBinOp :: ASTRep rep => Lambda rep -> Maybe [(BinOp, PrimType, VName, VName)]
 lamIsBinOp lam = mapM splitStm $ bodyResult $ lambdaBody lam
   where
     n = length $ lambdaReturnType lam

--- a/src/Futhark/IR/Prop/Aliases.hs
+++ b/src/Futhark/IR/Prop/Aliases.hs
@@ -40,19 +40,13 @@ import Futhark.IR.Prop.Patterns
 import Futhark.IR.Prop.Types
 import Futhark.IR.Syntax
 
--- | The class of lores that contain aliasing information.
-class
-  ( Decorations lore,
-    AliasedOp (Op lore),
-    AliasesOf (LetDec lore)
-  ) =>
-  Aliased lore
-  where
+-- | The class of representations that contain aliasing information.
+class (RepTypes rep, AliasedOp (Op rep), AliasesOf (LetDec rep)) => Aliased rep where
   -- | The aliases of the body results.
-  bodyAliases :: Body lore -> [Names]
+  bodyAliases :: Body rep -> [Names]
 
   -- | The variables consumed in the body.
-  consumedInBody :: Body lore -> Names
+  consumedInBody :: Body rep -> Names
 
 vnameAliases :: VName -> Names
 vnameAliases = oneName
@@ -95,7 +89,7 @@ funcallAliases args t =
   returnAliases t [(subExpAliases se, d) | (se, d) <- args]
 
 -- | The aliases of an expression, one per non-context value returned.
-expAliases :: (Aliased lore) => Exp lore -> [Names]
+expAliases :: (Aliased rep) => Exp rep -> [Names]
 expAliases (If _ tb fb dec) =
   drop (length all_aliases - length ts) all_aliases
   where
@@ -140,11 +134,11 @@ maskAliases _ ObservePrim = mempty
 maskAliases als Observe = als
 
 -- | The variables consumed in this statement.
-consumedInStm :: Aliased lore => Stm lore -> Names
+consumedInStm :: Aliased rep => Stm rep -> Names
 consumedInStm = consumedInExp . stmExp
 
 -- | The variables consumed in this expression.
-consumedInExp :: (Aliased lore) => Exp lore -> Names
+consumedInExp :: (Aliased rep) => Exp rep -> Names
 consumedInExp (Apply _ args _ _) =
   mconcat (map (consumeArg . first subExpAliases) args)
   where
@@ -178,7 +172,7 @@ consumedInExp (BasicOp _) = mempty
 consumedInExp (Op op) = consumedInOp op
 
 -- | The variables consumed by this lambda.
-consumedByLambda :: Aliased lore => Lambda lore -> Names
+consumedByLambda :: Aliased rep => Lambda rep -> Names
 consumedByLambda = consumedInBody . lambdaBody
 
 -- | The aliases of each pattern element (including the context).
@@ -197,7 +191,7 @@ instance AliasesOf dec => AliasesOf (PatElemT dec) where
   aliasesOf = aliasesOf . patElemDec
 
 -- | Also includes the name itself.
-lookupAliases :: AliasesOf (LetDec lore) => VName -> Scope lore -> Names
+lookupAliases :: AliasesOf (LetDec rep) => VName -> Scope rep -> Names
 lookupAliases v scope =
   case M.lookup v scope of
     Just (LetName dec) ->
@@ -220,7 +214,7 @@ type AliasTable = M.Map VName Names
 
 -- | The class of operations that can be given aliasing information.
 -- This is a somewhat subtle concept that is only used in the
--- simplifier and when using "lore adapters".
+-- simplifier and when using "rep adapters".
 class AliasedOp (OpWithAliases op) => CanBeAliased op where
   -- | The op that results when we add aliases to this op.
   type OpWithAliases op :: Data.Kind.Type

--- a/src/Futhark/IR/Prop/Names.hs
+++ b/src/Futhark/IR/Prop/Names.hs
@@ -132,16 +132,16 @@ fvNames :: Names -> FV
 fvNames = FV
 
 freeWalker ::
-  ( FreeDec (ExpDec lore),
-    FreeDec (BodyDec lore),
-    FreeIn (FParamInfo lore),
-    FreeIn (LParamInfo lore),
-    FreeIn (LetDec lore),
-    FreeIn (RetType lore),
-    FreeIn (BranchType lore),
-    FreeIn (Op lore)
+  ( FreeDec (ExpDec rep),
+    FreeDec (BodyDec rep),
+    FreeIn (FParamInfo rep),
+    FreeIn (LParamInfo rep),
+    FreeIn (LetDec rep),
+    FreeIn (RetType rep),
+    FreeIn (BranchType rep),
+    FreeIn (Op rep)
   ) =>
-  Walker lore (State FV)
+  Walker rep (State FV)
 freeWalker =
   Walker
     { walkOnSubExp = modify . (<>) . freeIn',
@@ -160,16 +160,16 @@ freeWalker =
 -- statements and result.  Filters away the names that are bound by
 -- the statements.
 freeInStmsAndRes ::
-  ( FreeIn (Op lore),
-    FreeIn (LetDec lore),
-    FreeIn (LParamInfo lore),
-    FreeIn (FParamInfo lore),
-    FreeDec (BodyDec lore),
-    FreeIn (RetType lore),
-    FreeIn (BranchType lore),
-    FreeDec (ExpDec lore)
+  ( FreeIn (Op rep),
+    FreeIn (LetDec rep),
+    FreeIn (LParamInfo rep),
+    FreeIn (FParamInfo rep),
+    FreeDec (BodyDec rep),
+    FreeIn (RetType rep),
+    FreeIn (BranchType rep),
+    FreeDec (ExpDec rep)
   ) =>
-  Stms lore ->
+  Stms rep ->
   Result ->
   FV
 freeInStmsAndRes stms res =
@@ -207,63 +207,63 @@ instance FreeIn a => FreeIn [a] where
   freeIn' = foldMap freeIn'
 
 instance
-  ( FreeDec (ExpDec lore),
-    FreeDec (BodyDec lore),
-    FreeIn (FParamInfo lore),
-    FreeIn (LParamInfo lore),
-    FreeIn (LetDec lore),
-    FreeIn (RetType lore),
-    FreeIn (BranchType lore),
-    FreeIn (Op lore)
+  ( FreeDec (ExpDec rep),
+    FreeDec (BodyDec rep),
+    FreeIn (FParamInfo rep),
+    FreeIn (LParamInfo rep),
+    FreeIn (LetDec rep),
+    FreeIn (RetType rep),
+    FreeIn (BranchType rep),
+    FreeIn (Op rep)
   ) =>
-  FreeIn (FunDef lore)
+  FreeIn (FunDef rep)
   where
   freeIn' (FunDef _ _ _ rettype params body) =
     fvBind (namesFromList $ map paramName params) $
       freeIn' rettype <> freeIn' params <> freeIn' body
 
 instance
-  ( FreeDec (ExpDec lore),
-    FreeDec (BodyDec lore),
-    FreeIn (FParamInfo lore),
-    FreeIn (LParamInfo lore),
-    FreeIn (LetDec lore),
-    FreeIn (RetType lore),
-    FreeIn (BranchType lore),
-    FreeIn (Op lore)
+  ( FreeDec (ExpDec rep),
+    FreeDec (BodyDec rep),
+    FreeIn (FParamInfo rep),
+    FreeIn (LParamInfo rep),
+    FreeIn (LetDec rep),
+    FreeIn (RetType rep),
+    FreeIn (BranchType rep),
+    FreeIn (Op rep)
   ) =>
-  FreeIn (Lambda lore)
+  FreeIn (Lambda rep)
   where
   freeIn' (Lambda params body rettype) =
     fvBind (namesFromList $ map paramName params) $
       freeIn' rettype <> freeIn' params <> freeIn' body
 
 instance
-  ( FreeDec (ExpDec lore),
-    FreeDec (BodyDec lore),
-    FreeIn (FParamInfo lore),
-    FreeIn (LParamInfo lore),
-    FreeIn (LetDec lore),
-    FreeIn (RetType lore),
-    FreeIn (BranchType lore),
-    FreeIn (Op lore)
+  ( FreeDec (ExpDec rep),
+    FreeDec (BodyDec rep),
+    FreeIn (FParamInfo rep),
+    FreeIn (LParamInfo rep),
+    FreeIn (LetDec rep),
+    FreeIn (RetType rep),
+    FreeIn (BranchType rep),
+    FreeIn (Op rep)
   ) =>
-  FreeIn (Body lore)
+  FreeIn (Body rep)
   where
   freeIn' (Body dec stms res) =
     precomputed dec $ freeIn' dec <> freeInStmsAndRes stms res
 
 instance
-  ( FreeDec (ExpDec lore),
-    FreeDec (BodyDec lore),
-    FreeIn (FParamInfo lore),
-    FreeIn (LParamInfo lore),
-    FreeIn (LetDec lore),
-    FreeIn (RetType lore),
-    FreeIn (BranchType lore),
-    FreeIn (Op lore)
+  ( FreeDec (ExpDec rep),
+    FreeDec (BodyDec rep),
+    FreeIn (FParamInfo rep),
+    FreeIn (LParamInfo rep),
+    FreeIn (LetDec rep),
+    FreeIn (RetType rep),
+    FreeIn (BranchType rep),
+    FreeIn (Op rep)
   ) =>
-  FreeIn (Exp lore)
+  FreeIn (Exp rep)
   where
   freeIn' (DoLoop ctxmerge valmerge form loopbody) =
     let (ctxparams, ctxinits) = unzip ctxmerge
@@ -282,22 +282,22 @@ instance
   freeIn' e = execState (walkExpM freeWalker e) mempty
 
 instance
-  ( FreeDec (ExpDec lore),
-    FreeDec (BodyDec lore),
-    FreeIn (FParamInfo lore),
-    FreeIn (LParamInfo lore),
-    FreeIn (LetDec lore),
-    FreeIn (RetType lore),
-    FreeIn (BranchType lore),
-    FreeIn (Op lore)
+  ( FreeDec (ExpDec rep),
+    FreeDec (BodyDec rep),
+    FreeIn (FParamInfo rep),
+    FreeIn (LParamInfo rep),
+    FreeIn (LetDec rep),
+    FreeIn (RetType rep),
+    FreeIn (BranchType rep),
+    FreeIn (Op rep)
   ) =>
-  FreeIn (Stm lore)
+  FreeIn (Stm rep)
   where
   freeIn' (Let pat (StmAux cs attrs dec) e) =
     freeIn' cs <> freeIn' attrs
       <> precomputed dec (freeIn' dec <> freeIn' e <> freeIn' pat)
 
-instance FreeIn (Stm lore) => FreeIn (Stms lore) where
+instance FreeIn (Stm rep) => FreeIn (Stms rep) where
   freeIn' = foldMap freeIn'
 
 instance FreeIn Names where
@@ -346,7 +346,7 @@ instance FreeIn dec => FreeIn (Param dec) where
 instance FreeIn dec => FreeIn (PatElemT dec) where
   freeIn' (PatElem _ dec) = freeIn' dec
 
-instance FreeIn (LParamInfo lore) => FreeIn (LoopForm lore) where
+instance FreeIn (LParamInfo rep) => FreeIn (LoopForm rep) where
   freeIn' (ForLoop _ _ bound loop_vars) = freeIn' bound <> freeIn' loop_vars
   freeIn' (WhileLoop cond) = freeIn' cond
 
@@ -398,17 +398,17 @@ instance FreeDec Names where
   precomputed _ fv = fv
 
 -- | The names bound by the bindings immediately in a t'Body'.
-boundInBody :: Body lore -> Names
+boundInBody :: Body rep -> Names
 boundInBody = boundByStms . bodyStms
 
 -- | The names bound by a binding.
-boundByStm :: Stm lore -> Names
+boundByStm :: Stm rep -> Names
 boundByStm = namesFromList . patternNames . stmPattern
 
 -- | The names bound by the bindings.
-boundByStms :: Stms lore -> Names
+boundByStms :: Stms rep -> Names
 boundByStms = foldMap boundByStm
 
 -- | The names of the lambda parameters plus the index parameter.
-boundByLambda :: Lambda lore -> [VName]
+boundByLambda :: Lambda rep -> [VName]
 boundByLambda lam = map paramName (lambdaParams lam)

--- a/src/Futhark/IR/Prop/Patterns.hs
+++ b/src/Futhark/IR/Prop/Patterns.hs
@@ -12,7 +12,7 @@ module Futhark.IR.Prop.Patterns
     -- * Pattern elements
     patElemIdent,
     patElemType,
-    setPatElemLore,
+    setPatElemDec,
     patternElements,
     patternIdents,
     patternContextIdents,
@@ -52,9 +52,9 @@ patElemIdent pelem = Ident (patElemName pelem) (typeOf pelem)
 patElemType :: Typed dec => PatElemT dec -> Type
 patElemType = typeOf
 
--- | Set the lore of a t'PatElem'.
-setPatElemLore :: PatElemT oldattr -> newattr -> PatElemT newattr
-setPatElemLore pe x = fmap (const x) pe
+-- | Set the rep of a t'PatElem'.
+setPatElemDec :: PatElemT oldattr -> newattr -> PatElemT newattr
+setPatElemDec pe x = fmap (const x) pe
 
 -- | All pattern elements in the pattern - context first, then values.
 patternElements :: PatternT dec -> [PatElemT dec]

--- a/src/Futhark/IR/Prop/Reshape.hs
+++ b/src/Futhark/IR/Prop/Reshape.hs
@@ -48,7 +48,7 @@ newShape = Shape . newDims
 
 -- | Construct a 'Reshape' where all dimension changes are
 -- 'DimCoercion's.
-shapeCoerce :: [SubExp] -> VName -> Exp lore
+shapeCoerce :: [SubExp] -> VName -> Exp rep
 shapeCoerce newdims arr =
   BasicOp $ Reshape (map DimCoercion newdims) arr
 

--- a/src/Futhark/IR/Prop/Scope.hs
+++ b/src/Futhark/IR/Prop/Scope.hs
@@ -41,22 +41,22 @@ import qualified Control.Monad.RWS.Lazy
 import qualified Control.Monad.RWS.Strict
 import Control.Monad.Reader
 import qualified Data.Map.Strict as M
-import Futhark.IR.Decorations
 import Futhark.IR.Pretty ()
 import Futhark.IR.Prop.Patterns
 import Futhark.IR.Prop.Types
+import Futhark.IR.Rep
 import Futhark.IR.Syntax
 
 -- | How some name in scope was bound.
-data NameInfo lore
-  = LetName (LetDec lore)
-  | FParamName (FParamInfo lore)
-  | LParamName (LParamInfo lore)
+data NameInfo rep
+  = LetName (LetDec rep)
+  | FParamName (FParamInfo rep)
+  | LParamName (LParamInfo rep)
   | IndexName IntType
 
-deriving instance Decorations lore => Show (NameInfo lore)
+deriving instance RepTypes rep => Show (NameInfo rep)
 
-instance Decorations lore => Typed (NameInfo lore) where
+instance RepTypes rep => Typed (NameInfo rep) where
   typeOf (LetName dec) = typeOf dec
   typeOf (FParamName dec) = typeOf dec
   typeOf (LParamName dec) = typeOf dec
@@ -64,14 +64,14 @@ instance Decorations lore => Typed (NameInfo lore) where
 
 -- | A scope is a mapping from variable names to information about
 -- that name.
-type Scope lore = M.Map VName (NameInfo lore)
+type Scope rep = M.Map VName (NameInfo rep)
 
 -- | The class of applicative functors (or more common in practice:
 -- monads) that permit the lookup of variable types.  A default method
 -- for 'lookupType' exists, which is sufficient (if not always
 -- maximally efficient, and using 'error' to fail) when 'askScope'
 -- is defined.
-class (Applicative m, Decorations lore) => HasScope lore m | m -> lore where
+class (Applicative m, RepTypes rep) => HasScope rep m | m -> rep where
   -- | Return the type of the given variable, or fail if it is not in
   -- the type environment.
   lookupType :: VName -> m Type
@@ -79,7 +79,7 @@ class (Applicative m, Decorations lore) => HasScope lore m | m -> lore where
 
   -- | Return the info of the given variable, or fail if it is not in
   -- the type environment.
-  lookupInfo :: VName -> m (NameInfo lore)
+  lookupInfo :: VName -> m (NameInfo rep)
   lookupInfo name =
     asksScope (M.findWithDefault notFound name)
     where
@@ -90,144 +90,144 @@ class (Applicative m, Decorations lore) => HasScope lore m | m -> lore where
 
   -- | Return the type environment contained in the applicative
   -- functor.
-  askScope :: m (Scope lore)
+  askScope :: m (Scope rep)
 
   -- | Return the result of applying some function to the type
   -- environment.
-  asksScope :: (Scope lore -> a) -> m a
+  asksScope :: (Scope rep -> a) -> m a
   asksScope f = f <$> askScope
 
 instance
-  (Applicative m, Monad m, Decorations lore) =>
-  HasScope lore (ReaderT (Scope lore) m)
+  (Applicative m, Monad m, RepTypes rep) =>
+  HasScope rep (ReaderT (Scope rep) m)
   where
   askScope = ask
 
-instance (Monad m, HasScope lore m) => HasScope lore (ExceptT e m) where
+instance (Monad m, HasScope rep m) => HasScope rep (ExceptT e m) where
   askScope = lift askScope
 
 instance
-  (Applicative m, Monad m, Monoid w, Decorations lore) =>
-  HasScope lore (Control.Monad.RWS.Strict.RWST (Scope lore) w s m)
+  (Applicative m, Monad m, Monoid w, RepTypes rep) =>
+  HasScope rep (Control.Monad.RWS.Strict.RWST (Scope rep) w s m)
   where
   askScope = ask
 
 instance
-  (Applicative m, Monad m, Monoid w, Decorations lore) =>
-  HasScope lore (Control.Monad.RWS.Lazy.RWST (Scope lore) w s m)
+  (Applicative m, Monad m, Monoid w, RepTypes rep) =>
+  HasScope rep (Control.Monad.RWS.Lazy.RWST (Scope rep) w s m)
   where
   askScope = ask
 
 -- | The class of monads that not only provide a 'Scope', but also
 -- the ability to locally extend it.  A 'Reader' containing a
 -- 'Scope' is the prototypical example of such a monad.
-class (HasScope lore m, Monad m) => LocalScope lore m where
+class (HasScope rep m, Monad m) => LocalScope rep m where
   -- | Run a computation with an extended type environment.  Note that
   -- this is intended to *add* to the current type environment, it
   -- does not replace it.
-  localScope :: Scope lore -> m a -> m a
+  localScope :: Scope rep -> m a -> m a
 
-instance (Monad m, LocalScope lore m) => LocalScope lore (ExceptT e m) where
+instance (Monad m, LocalScope rep m) => LocalScope rep (ExceptT e m) where
   localScope = mapExceptT . localScope
 
 instance
-  (Applicative m, Monad m, Decorations lore) =>
-  LocalScope lore (ReaderT (Scope lore) m)
+  (Applicative m, Monad m, RepTypes rep) =>
+  LocalScope rep (ReaderT (Scope rep) m)
   where
   localScope = local . M.union
 
 instance
-  (Applicative m, Monad m, Monoid w, Decorations lore) =>
-  LocalScope lore (Control.Monad.RWS.Strict.RWST (Scope lore) w s m)
+  (Applicative m, Monad m, Monoid w, RepTypes rep) =>
+  LocalScope rep (Control.Monad.RWS.Strict.RWST (Scope rep) w s m)
   where
   localScope = local . M.union
 
 instance
-  (Applicative m, Monad m, Monoid w, Decorations lore) =>
-  LocalScope lore (Control.Monad.RWS.Lazy.RWST (Scope lore) w s m)
+  (Applicative m, Monad m, Monoid w, RepTypes rep) =>
+  LocalScope rep (Control.Monad.RWS.Lazy.RWST (Scope rep) w s m)
   where
   localScope = local . M.union
 
 -- | The class of things that can provide a scope.  There is no
 -- overarching rule for what this means.  For a 'Stm', it is the
 -- corresponding pattern.  For a t'Lambda', is is the parameters.
-class Scoped lore a | a -> lore where
-  scopeOf :: a -> Scope lore
+class Scoped rep a | a -> rep where
+  scopeOf :: a -> Scope rep
 
 -- | Extend the monadic scope with the 'scopeOf' the given value.
-inScopeOf :: (Scoped lore a, LocalScope lore m) => a -> m b -> m b
+inScopeOf :: (Scoped rep a, LocalScope rep m) => a -> m b -> m b
 inScopeOf = localScope . scopeOf
 
-instance Scoped lore a => Scoped lore [a] where
+instance Scoped rep a => Scoped rep [a] where
   scopeOf = mconcat . map scopeOf
 
-instance Scoped lore (Stms lore) where
+instance Scoped rep (Stms rep) where
   scopeOf = foldMap scopeOf
 
-instance Scoped lore (Stm lore) where
+instance Scoped rep (Stm rep) where
   scopeOf = scopeOfPattern . stmPattern
 
-instance Scoped lore (FunDef lore) where
+instance Scoped rep (FunDef rep) where
   scopeOf = scopeOfFParams . funDefParams
 
-instance Scoped lore (VName, NameInfo lore) where
+instance Scoped rep (VName, NameInfo rep) where
   scopeOf = uncurry M.singleton
 
-instance Scoped lore (LoopForm lore) where
+instance Scoped rep (LoopForm rep) where
   scopeOf (WhileLoop _) = mempty
   scopeOf (ForLoop i it _ xs) =
     M.insert i (IndexName it) $ scopeOfLParams (map fst xs)
 
 -- | The scope of a pattern.
-scopeOfPattern :: LetDec lore ~ dec => PatternT dec -> Scope lore
+scopeOfPattern :: LetDec rep ~ dec => PatternT dec -> Scope rep
 scopeOfPattern =
   mconcat . map scopeOfPatElem . patternElements
 
 -- | The scope of a pattern element.
-scopeOfPatElem :: LetDec lore ~ dec => PatElemT dec -> Scope lore
+scopeOfPatElem :: LetDec rep ~ dec => PatElemT dec -> Scope rep
 scopeOfPatElem (PatElem name dec) = M.singleton name $ LetName dec
 
 -- | The scope of some lambda parameters.
 scopeOfLParams ::
-  LParamInfo lore ~ dec =>
+  LParamInfo rep ~ dec =>
   [Param dec] ->
-  Scope lore
+  Scope rep
 scopeOfLParams = M.fromList . map f
   where
     f param = (paramName param, LParamName $ paramDec param)
 
 -- | The scope of some function or loop parameters.
 scopeOfFParams ::
-  FParamInfo lore ~ dec =>
+  FParamInfo rep ~ dec =>
   [Param dec] ->
-  Scope lore
+  Scope rep
 scopeOfFParams = M.fromList . map f
   where
     f param = (paramName param, FParamName $ paramDec param)
 
-instance Scoped lore (Lambda lore) where
+instance Scoped rep (Lambda rep) where
   scopeOf lam = scopeOfLParams $ lambdaParams lam
 
--- | A constraint that indicates two lores have the same 'NameInfo'
+-- | A constraint that indicates two representations have the same 'NameInfo'
 -- representation.
-type SameScope lore1 lore2 =
-  ( LetDec lore1 ~ LetDec lore2,
-    FParamInfo lore1 ~ FParamInfo lore2,
-    LParamInfo lore1 ~ LParamInfo lore2
+type SameScope rep1 rep2 =
+  ( LetDec rep1 ~ LetDec rep2,
+    FParamInfo rep1 ~ FParamInfo rep2,
+    LParamInfo rep1 ~ LParamInfo rep2
   )
 
 -- | If two scopes are really the same, then you can convert one to
 -- the other.
 castScope ::
-  SameScope fromlore tolore =>
-  Scope fromlore ->
-  Scope tolore
+  SameScope fromrep torep =>
+  Scope fromrep ->
+  Scope torep
 castScope = M.map castNameInfo
 
 castNameInfo ::
-  SameScope fromlore tolore =>
-  NameInfo fromlore ->
-  NameInfo tolore
+  SameScope fromrep torep =>
+  NameInfo fromrep ->
+  NameInfo torep
 castNameInfo (LetName dec) = LetName dec
 castNameInfo (FParamName dec) = FParamName dec
 castNameInfo (LParamName dec) = LParamName dec
@@ -236,17 +236,17 @@ castNameInfo (IndexName it) = IndexName it
 -- | A monad transformer that carries around an extended 'Scope'.
 -- Its 'lookupType' method will first look in the extended 'Scope',
 -- and then use the 'lookupType' method of the underlying monad.
-newtype ExtendedScope lore m a = ExtendedScope (ReaderT (Scope lore) m a)
+newtype ExtendedScope rep m a = ExtendedScope (ReaderT (Scope rep) m a)
   deriving
     ( Functor,
       Applicative,
       Monad,
-      MonadReader (Scope lore)
+      MonadReader (Scope rep)
     )
 
 instance
-  (HasScope lore m, Monad m) =>
-  HasScope lore (ExtendedScope lore m)
+  (HasScope rep m, Monad m) =>
+  HasScope rep (ExtendedScope rep m)
   where
   lookupType name = do
     res <- asks $ fmap typeOf . M.lookup name
@@ -255,7 +255,7 @@ instance
 
 -- | Run a computation in the extended type environment.
 extendedScope ::
-  ExtendedScope lore m a ->
-  Scope lore ->
+  ExtendedScope rep m a ->
+  Scope rep ->
   m a
 extendedScope (ExtendedScope m) = runReaderT m

--- a/src/Futhark/IR/Prop/TypeOf.hs
+++ b/src/Futhark/IR/Prop/TypeOf.hs
@@ -51,14 +51,14 @@ subExpType (Var name) = lookupType name
 -- | @mapType f arrts@ wraps each element in the return type of @f@ in
 -- an array with size equal to the outermost dimension of the first
 -- element of @arrts@.
-mapType :: SubExp -> Lambda lore -> [Type]
+mapType :: SubExp -> Lambda rep -> [Type]
 mapType outersize f =
   [ arrayOf t (Shape [outersize]) NoUniqueness
     | t <- lambdaReturnType f
   ]
 
 -- | The type of a primitive operation.
-primOpType :: HasScope lore m => BasicOp -> m [Type]
+primOpType :: HasScope rep m => BasicOp -> m [Type]
 primOpType (SubExp se) =
   pure <$> subExpType se
 primOpType (Opaque se) =
@@ -121,8 +121,8 @@ primOpType (UpdateAcc v _ _) =
 
 -- | The type of an expression.
 expExtType ::
-  (HasScope lore m, TypedOp (Op lore)) =>
-  Exp lore ->
+  (HasScope rep m, TypedOp (Op rep)) =>
+  Exp rep ->
   m [ExtType]
 expExtType (Apply _ _ rt _) = pure $ map (fromDecl . declExtTypeOf) rt
 expExtType (If _ _ _ rt) = pure $ map extTypeOf $ ifReturns rt
@@ -141,22 +141,22 @@ expExtType (Op op) = opType op
 
 -- | The number of values returned by an expression.
 expExtTypeSize ::
-  (Decorations lore, TypedOp (Op lore)) =>
-  Exp lore ->
+  (RepTypes rep, TypedOp (Op rep)) =>
+  Exp rep ->
   Int
 expExtTypeSize = length . feelBad . expExtType
 
 -- FIXME, this is a horrible quick hack.
-newtype FeelBad lore a = FeelBad {feelBad :: a}
+newtype FeelBad rep a = FeelBad {feelBad :: a}
 
-instance Functor (FeelBad lore) where
+instance Functor (FeelBad rep) where
   fmap f = FeelBad . f . feelBad
 
-instance Applicative (FeelBad lore) where
+instance Applicative (FeelBad rep) where
   pure = FeelBad
   f <*> x = FeelBad $ feelBad f $ feelBad x
 
-instance Decorations lore => HasScope lore (FeelBad lore) where
+instance RepTypes rep => HasScope rep (FeelBad rep) where
   lookupType = const $ pure $ Prim $ IntType Int64
   askScope = pure mempty
 

--- a/src/Futhark/IR/Rep.hs
+++ b/src/Futhark/IR/Rep.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeFamilies #-}
 
--- | The core Futhark AST is parameterised by a @lore@ type parameter,
+-- | The core Futhark AST is parameterised by a @rep@ type parameter,
 -- which is then used to invoke the type families defined here.
-module Futhark.IR.Decorations
-  ( Decorations (..),
+module Futhark.IR.Rep
+  ( RepTypes (..),
     module Futhark.IR.RetType,
   )
 where
@@ -14,9 +14,9 @@ import Futhark.IR.Prop.Types
 import Futhark.IR.RetType
 import Futhark.IR.Syntax.Core
 
--- | A collection of type families, along with constraints specifying
--- that the types they map to should satisfy some minimal
--- requirements.
+-- | A collection of type families giving various common types for a
+-- representation, along with constraints specifying that the types
+-- they map to should satisfy some minimal requirements.
 class
   ( Show (LetDec l),
     Show (ExpDec l),
@@ -49,7 +49,7 @@ class
     Typed (LetDec l),
     DeclTyped (FParamInfo l)
   ) =>
-  Decorations l
+  RepTypes l
   where
   -- | Decoration for every let-pattern element.
   type LetDec l :: Data.Kind.Type

--- a/src/Futhark/IR/SOACS.hs
+++ b/src/Futhark/IR/SOACS.hs
@@ -3,8 +3,7 @@
 
 -- | A simple representation with SOACs and nested parallelism.
 module Futhark.IR.SOACS
-  ( -- * The Lore definition
-    SOACS,
+  ( SOACS,
 
     -- * Syntax types
     Body,
@@ -54,13 +53,13 @@ import qualified Futhark.TypeCheck as TypeCheck
 -- like Standard ML.  Instead, we have to abuse the namespace/module
 -- system.
 
--- | The lore for the basic representation.
+-- | The rep for the basic representation.
 data SOACS
 
-instance Decorations SOACS where
+instance RepTypes SOACS where
   type Op SOACS = SOAC SOACS
 
-instance ASTLore SOACS where
+instance ASTRep SOACS where
   expTypesFromPattern = return . expExtTypesFromPattern
 
 type Exp = AST.Exp SOACS
@@ -94,4 +93,4 @@ instance Bindable SOACS where
 
 instance BinderOps SOACS
 
-instance PrettyLore SOACS
+instance PrettyRep SOACS

--- a/src/Futhark/IR/SOACS/SOAC.hs
+++ b/src/Futhark/IR/SOACS/SOAC.hs
@@ -66,7 +66,7 @@ import Futhark.Construct
 import Futhark.IR
 import Futhark.IR.Aliases (Aliases, removeLambdaAliases)
 import Futhark.IR.Prop.Aliases
-import Futhark.Optimise.Simplify.Lore
+import Futhark.Optimise.Simplify.Rep
 import Futhark.Transform.Rename
 import Futhark.Transform.Substitute
 import qualified Futhark.TypeCheck as TC
@@ -76,8 +76,8 @@ import qualified Futhark.Util.Pretty as PP
 import Prelude hiding (id, (.))
 
 -- | A second-order array combinator (SOAC).
-data SOAC lore
-  = Stream SubExp [VName] (StreamForm lore) [SubExp] (Lambda lore)
+data SOAC rep
+  = Stream SubExp [VName] (StreamForm rep) [SubExp] (Lambda rep)
   | -- | @Scatter <length> <lambda> <inputs> <outputs>@
     --
     -- Scatter maps values from a set of input arrays to indices and values of a
@@ -115,27 +115,27 @@ data SOAC lore
     -- will correspond to the first two output values, and so on. For this
     -- example, <lambda> should return a total of 11 values, 8 index values and
     -- 3 output values.
-    Scatter SubExp (Lambda lore) [VName] [(Shape, Int, VName)]
+    Scatter SubExp (Lambda rep) [VName] [(Shape, Int, VName)]
   | -- | @Hist <length> <dest-arrays-and-ops> <bucket fun> <input arrays>@
     --
     -- The first SubExp is the length of the input arrays. The first
     -- list describes the operations to perform.  The t'Lambda' is the
     -- bucket function.  Finally comes the input images.
-    Hist SubExp [HistOp lore] (Lambda lore) [VName]
+    Hist SubExp [HistOp rep] (Lambda rep) [VName]
   | -- | A combination of scan, reduction, and map.  The first
     -- t'SubExp' is the size of the input arrays.
-    Screma SubExp [VName] (ScremaForm lore)
+    Screma SubExp [VName] (ScremaForm rep)
   deriving (Eq, Ord, Show)
 
 -- | Information about computing a single histogram.
-data HistOp lore = HistOp
+data HistOp rep = HistOp
   { histWidth :: SubExp,
     -- | Race factor @RF@ means that only @1/RF@
     -- bins are used.
     histRaceFactor :: SubExp,
     histDest :: [VName],
     histNeutral :: [SubExp],
-    histOp :: Lambda lore
+    histOp :: Lambda rep
   }
   deriving (Eq, Ord, Show)
 
@@ -147,21 +147,21 @@ data StreamOrd = InOrder | Disorder
   deriving (Eq, Ord, Show)
 
 -- | What kind of stream is this?
-data StreamForm lore
-  = Parallel StreamOrd Commutativity (Lambda lore)
+data StreamForm rep
+  = Parallel StreamOrd Commutativity (Lambda rep)
   | Sequential
   deriving (Eq, Ord, Show)
 
 -- | The essential parts of a 'Screma' factored out (everything
 -- except the input arrays).
-data ScremaForm lore
+data ScremaForm rep
   = ScremaForm
-      [Scan lore]
-      [Reduce lore]
-      (Lambda lore)
+      [Scan rep]
+      [Reduce rep]
+      (Lambda rep)
   deriving (Eq, Ord, Show)
 
-singleBinOp :: Bindable lore => [Lambda lore] -> Lambda lore
+singleBinOp :: Bindable rep => [Lambda rep] -> Lambda rep
 singleBinOp lams =
   Lambda
     { lambdaParams = concatMap xParams lams ++ concatMap yParams lams,
@@ -176,37 +176,37 @@ singleBinOp lams =
     yParams lam = drop (length (lambdaReturnType lam)) (lambdaParams lam)
 
 -- | How to compute a single scan result.
-data Scan lore = Scan
-  { scanLambda :: Lambda lore,
+data Scan rep = Scan
+  { scanLambda :: Lambda rep,
     scanNeutral :: [SubExp]
   }
   deriving (Eq, Ord, Show)
 
 -- | How many reduction results are produced by these 'Scan's?
-scanResults :: [Scan lore] -> Int
+scanResults :: [Scan rep] -> Int
 scanResults = sum . map (length . scanNeutral)
 
 -- | Combine multiple scan operators to a single operator.
-singleScan :: Bindable lore => [Scan lore] -> Scan lore
+singleScan :: Bindable rep => [Scan rep] -> Scan rep
 singleScan scans =
   let scan_nes = concatMap scanNeutral scans
       scan_lam = singleBinOp $ map scanLambda scans
    in Scan scan_lam scan_nes
 
 -- | How to compute a single reduction result.
-data Reduce lore = Reduce
+data Reduce rep = Reduce
   { redComm :: Commutativity,
-    redLambda :: Lambda lore,
+    redLambda :: Lambda rep,
     redNeutral :: [SubExp]
   }
   deriving (Eq, Ord, Show)
 
 -- | How many reduction results are produced by these 'Reduce's?
-redResults :: [Reduce lore] -> Int
+redResults :: [Reduce rep] -> Int
 redResults = sum . map (length . redNeutral)
 
 -- | Combine multiple reduction operators to a single operator.
-singleReduce :: Bindable lore => [Reduce lore] -> Reduce lore
+singleReduce :: Bindable rep => [Reduce rep] -> Reduce rep
 singleReduce reds =
   let red_nes = concatMap redNeutral reds
       red_lam = singleBinOp $ map redLambda reds
@@ -214,7 +214,7 @@ singleReduce reds =
 
 -- | The types produced by a single 'Screma', given the size of the
 -- input array.
-scremaType :: SubExp -> ScremaForm lore -> [Type]
+scremaType :: SubExp -> ScremaForm rep -> [Type]
 scremaType w (ScremaForm scans reds map_lam) =
   scan_tps ++ red_tps ++ map (`arrayOfRow` w) map_tps
   where
@@ -227,9 +227,9 @@ scremaType w (ScremaForm scans reds map_lam) =
 -- | Construct a lambda that takes parameters of the given types and
 -- simply returns them unchanged.
 mkIdentityLambda ::
-  (Bindable lore, MonadFreshNames m) =>
+  (Bindable rep, MonadFreshNames m) =>
   [Type] ->
-  m (Lambda lore)
+  m (Lambda rep)
 mkIdentityLambda ts = do
   params <- mapM (newParam "x") ts
   return
@@ -240,31 +240,31 @@ mkIdentityLambda ts = do
       }
 
 -- | Is the given lambda an identity lambda?
-isIdentityLambda :: Lambda lore -> Bool
+isIdentityLambda :: Lambda rep -> Bool
 isIdentityLambda lam =
   bodyResult (lambdaBody lam)
     == map (Var . paramName) (lambdaParams lam)
 
 -- | A lambda with no parameters that returns no values.
-nilFn :: Bindable lore => Lambda lore
+nilFn :: Bindable rep => Lambda rep
 nilFn = Lambda mempty (mkBody mempty mempty) mempty
 
 -- | Construct a Screma with possibly multiple scans, and
 -- the given map function.
-scanomapSOAC :: [Scan lore] -> Lambda lore -> ScremaForm lore
+scanomapSOAC :: [Scan rep] -> Lambda rep -> ScremaForm rep
 scanomapSOAC scans = ScremaForm scans []
 
 -- | Construct a Screma with possibly multiple reductions, and
 -- the given map function.
-redomapSOAC :: [Reduce lore] -> Lambda lore -> ScremaForm lore
+redomapSOAC :: [Reduce rep] -> Lambda rep -> ScremaForm rep
 redomapSOAC = ScremaForm []
 
 -- | Construct a Screma with possibly multiple scans, and identity map
 -- function.
 scanSOAC ::
-  (Bindable lore, MonadFreshNames m) =>
-  [Scan lore] ->
-  m (ScremaForm lore)
+  (Bindable rep, MonadFreshNames m) =>
+  [Scan rep] ->
+  m (ScremaForm rep)
 scanSOAC scans = scanomapSOAC scans <$> mkIdentityLambda ts
   where
     ts = concatMap (lambdaReturnType . scanLambda) scans
@@ -272,40 +272,40 @@ scanSOAC scans = scanomapSOAC scans <$> mkIdentityLambda ts
 -- | Construct a Screma with possibly multiple reductions, and
 -- identity map function.
 reduceSOAC ::
-  (Bindable lore, MonadFreshNames m) =>
-  [Reduce lore] ->
-  m (ScremaForm lore)
+  (Bindable rep, MonadFreshNames m) =>
+  [Reduce rep] ->
+  m (ScremaForm rep)
 reduceSOAC reds = redomapSOAC reds <$> mkIdentityLambda ts
   where
     ts = concatMap (lambdaReturnType . redLambda) reds
 
 -- | Construct a Screma corresponding to a map.
-mapSOAC :: Lambda lore -> ScremaForm lore
+mapSOAC :: Lambda rep -> ScremaForm rep
 mapSOAC = ScremaForm [] []
 
 -- | Does this Screma correspond to a scan-map composition?
-isScanomapSOAC :: ScremaForm lore -> Maybe ([Scan lore], Lambda lore)
+isScanomapSOAC :: ScremaForm rep -> Maybe ([Scan rep], Lambda rep)
 isScanomapSOAC (ScremaForm scans reds map_lam) = do
   guard $ null reds
   guard $ not $ null scans
   return (scans, map_lam)
 
 -- | Does this Screma correspond to pure scan?
-isScanSOAC :: ScremaForm lore -> Maybe [Scan lore]
+isScanSOAC :: ScremaForm rep -> Maybe [Scan rep]
 isScanSOAC form = do
   (scans, map_lam) <- isScanomapSOAC form
   guard $ isIdentityLambda map_lam
   return scans
 
 -- | Does this Screma correspond to a reduce-map composition?
-isRedomapSOAC :: ScremaForm lore -> Maybe ([Reduce lore], Lambda lore)
+isRedomapSOAC :: ScremaForm rep -> Maybe ([Reduce rep], Lambda rep)
 isRedomapSOAC (ScremaForm scans reds map_lam) = do
   guard $ null scans
   guard $ not $ null reds
   return (reds, map_lam)
 
 -- | Does this Screma correspond to a pure reduce?
-isReduceSOAC :: ScremaForm lore -> Maybe [Reduce lore]
+isReduceSOAC :: ScremaForm rep -> Maybe [Reduce rep]
 isReduceSOAC form = do
   (reds, map_lam) <- isRedomapSOAC form
   guard $ isIdentityLambda map_lam
@@ -313,7 +313,7 @@ isReduceSOAC form = do
 
 -- | Does this Screma correspond to a simple map, without any
 -- reduction or scan results?
-isMapSOAC :: ScremaForm lore -> Maybe (Lambda lore)
+isMapSOAC :: ScremaForm rep -> Maybe (Lambda rep)
 isMapSOAC (ScremaForm scans reds map_lam) = do
   guard $ null scans
   guard $ null reds
@@ -369,14 +369,14 @@ splitScatterResults output_spec results =
    in splitAt num_indices results
 
 -- | Like 'Mapper', but just for 'SOAC's.
-data SOACMapper flore tlore m = SOACMapper
+data SOACMapper frep trep m = SOACMapper
   { mapOnSOACSubExp :: SubExp -> m SubExp,
-    mapOnSOACLambda :: Lambda flore -> m (Lambda tlore),
+    mapOnSOACLambda :: Lambda frep -> m (Lambda trep),
     mapOnSOACVName :: VName -> m VName
   }
 
 -- | A mapper that simply returns the SOAC verbatim.
-identitySOACMapper :: Monad m => SOACMapper lore lore m
+identitySOACMapper :: Monad m => SOACMapper rep rep m
 identitySOACMapper =
   SOACMapper
     { mapOnSOACSubExp = return,
@@ -389,9 +389,9 @@ identitySOACMapper =
 -- and is done left-to-right.
 mapSOACM ::
   (Applicative m, Monad m) =>
-  SOACMapper flore tlore m ->
-  SOAC flore ->
-  m (SOAC tlore)
+  SOACMapper frep trep m ->
+  SOAC frep ->
+  m (SOAC trep)
 mapSOACM tv (Stream size arrs form accs lam) =
   Stream <$> mapOnSOACSubExp tv size
     <*> mapM (mapOnSOACVName tv) arrs
@@ -448,7 +448,7 @@ mapSOACM tv (Screma w arrs (ScremaForm scans reds map_lam)) =
             <*> mapOnSOACLambda tv map_lam
         )
 
-instance ASTLore lore => FreeIn (SOAC lore) where
+instance ASTRep rep => FreeIn (SOAC rep) where
   freeIn' = flip execState mempty . mapSOACM free
     where
       walk f x = modify (<> f x) >> return x
@@ -459,7 +459,7 @@ instance ASTLore lore => FreeIn (SOAC lore) where
             mapOnSOACVName = walk freeIn'
           }
 
-instance ASTLore lore => Substitute (SOAC lore) where
+instance ASTRep rep => Substitute (SOAC rep) where
   substituteNames subst =
     runIdentity . mapSOACM substitute
     where
@@ -470,13 +470,13 @@ instance ASTLore lore => Substitute (SOAC lore) where
             mapOnSOACVName = return . substituteNames subst
           }
 
-instance ASTLore lore => Rename (SOAC lore) where
+instance ASTRep rep => Rename (SOAC rep) where
   rename = mapSOACM renamer
     where
       renamer = SOACMapper rename rename rename
 
 -- | The type of a SOAC.
-soacType :: SOAC lore -> [Type]
+soacType :: SOAC rep -> [Type]
 soacType (Stream outersize _ _ accs lam) =
   map (substNamesInType substs) rtp
   where
@@ -495,10 +495,10 @@ soacType (Hist _len ops _bucket_fun _imgs) = do
 soacType (Screma w _arrs form) =
   scremaType w form
 
-instance TypedOp (SOAC lore) where
+instance TypedOp (SOAC rep) where
   opType = pure . staticShapes . soacType
 
-instance (ASTLore lore, Aliased lore) => AliasedOp (SOAC lore) where
+instance (ASTRep rep, Aliased rep) => AliasedOp (SOAC rep) where
   opAliases = map (const mempty) . soacType
 
   -- Only map functions can consume anything.  The operands to scan
@@ -527,20 +527,20 @@ instance (ASTLore lore, Aliased lore) => AliasedOp (SOAC lore) where
     namesFromList $ concatMap histDest ops
 
 mapHistOp ::
-  (Lambda flore -> Lambda tlore) ->
-  HistOp flore ->
-  HistOp tlore
+  (Lambda frep -> Lambda trep) ->
+  HistOp frep ->
+  HistOp trep
 mapHistOp f (HistOp w rf dests nes lam) =
   HistOp w rf dests nes $ f lam
 
 instance
-  ( ASTLore lore,
-    ASTLore (Aliases lore),
-    CanBeAliased (Op lore)
+  ( ASTRep rep,
+    ASTRep (Aliases rep),
+    CanBeAliased (Op rep)
   ) =>
-  CanBeAliased (SOAC lore)
+  CanBeAliased (SOAC rep)
   where
-  type OpWithAliases (SOAC lore) = SOAC (Aliases lore)
+  type OpWithAliases (SOAC rep) = SOAC (Aliases rep)
 
   addOpAliases aliases (Stream size arr form accs lam) =
     Stream size arr (analyseStreamForm form) accs $
@@ -571,7 +571,7 @@ instance
     where
       remove = SOACMapper return (return . removeLambdaAliases) return
 
-instance ASTLore lore => IsOp (SOAC lore) where
+instance ASTRep rep => IsOp (SOAC rep) where
   safeOp _ = False
   cheapOp _ = True
 
@@ -588,14 +588,14 @@ substNamesInSubExp _ e@(Constant _) = e
 substNamesInSubExp subs (Var idd) =
   M.findWithDefault (Var idd) idd subs
 
-instance (ASTLore lore, CanBeWise (Op lore)) => CanBeWise (SOAC lore) where
-  type OpWithWisdom (SOAC lore) = SOAC (Wise lore)
+instance (ASTRep rep, CanBeWise (Op rep)) => CanBeWise (SOAC rep) where
+  type OpWithWisdom (SOAC rep) = SOAC (Wise rep)
 
   removeOpWisdom = runIdentity . mapSOACM remove
     where
       remove = SOACMapper return (return . removeLambdaWisdom) return
 
-instance Decorations lore => ST.IndexOp (SOAC lore) where
+instance RepTypes rep => ST.IndexOp (SOAC rep) where
   indexOp vtable k soac [i] = do
     (lam, se, arr_params, arrs) <- lambdaAndSubExp soac
     let arr_indexes = M.fromList $ catMaybes $ zipWith arrIndex arr_params arrs
@@ -634,7 +634,7 @@ instance Decorations lore => ST.IndexOp (SOAC lore) where
   indexOp _ _ _ _ = Nothing
 
 -- | Type-check a SOAC.
-typeCheckSOAC :: TC.Checkable lore => SOAC (Aliases lore) -> TC.TypeM lore ()
+typeCheckSOAC :: TC.Checkable rep => SOAC (Aliases rep) -> TC.TypeM rep ()
 typeCheckSOAC (Stream size arrexps form accexps lam) = do
   TC.require [Prim int64] size
   accargs <- mapM TC.checkArg accexps
@@ -804,7 +804,7 @@ typeCheckSOAC (Screma w arrs (ScremaForm scans reds map_lam)) = do
         "Map function return type " ++ prettyTuple map_lam_ts
           ++ " wrong for given scan and reduction functions."
 
-instance OpMetrics (Op lore) => OpMetrics (SOAC lore) where
+instance OpMetrics (Op rep) => OpMetrics (SOAC rep) where
   opMetrics (Stream _ _ _ _ lam) =
     inside "Stream" $ lambdaMetrics lam
   opMetrics (Scatter _len lam _ivs _as) =
@@ -817,7 +817,7 @@ instance OpMetrics (Op lore) => OpMetrics (SOAC lore) where
       mapM_ (lambdaMetrics . redLambda) reds
       lambdaMetrics map_lam
 
-instance PrettyLore lore => PP.Pretty (SOAC lore) where
+instance PrettyRep rep => PP.Pretty (SOAC rep) where
   ppr (Stream size arrs form acc lam) =
     case form of
       Parallel o comm lam0 ->
@@ -879,7 +879,7 @@ instance PrettyLore lore => PP.Pretty (SOAC lore) where
 
 -- | Prettyprint the given Screma.
 ppScrema ::
-  (PrettyLore lore, Pretty inp) => SubExp -> [inp] -> ScremaForm lore -> Doc
+  (PrettyRep rep, Pretty inp) => SubExp -> [inp] -> ScremaForm rep -> Doc
 ppScrema w arrs (ScremaForm scans reds map_lam) =
   text "screma"
     <> parens
@@ -890,7 +890,7 @@ ppScrema w arrs (ScremaForm scans reds map_lam) =
           </> ppr map_lam
       )
 
-instance PrettyLore lore => Pretty (Scan lore) where
+instance PrettyRep rep => Pretty (Scan rep) where
   ppr (Scan scan_lam scan_nes) =
     ppr scan_lam <> comma </> PP.braces (commasep $ map ppr scan_nes)
 
@@ -898,17 +898,17 @@ ppComm :: Commutativity -> Doc
 ppComm Noncommutative = mempty
 ppComm Commutative = text "commutative "
 
-instance PrettyLore lore => Pretty (Reduce lore) where
+instance PrettyRep rep => Pretty (Reduce rep) where
   ppr (Reduce comm red_lam red_nes) =
     ppComm comm <> ppr red_lam <> comma
       </> PP.braces (commasep $ map ppr red_nes)
 
 -- | Prettyprint the given histogram operation.
 ppHist ::
-  (PrettyLore lore, Pretty inp) =>
+  (PrettyRep rep, Pretty inp) =>
   SubExp ->
-  [HistOp lore] ->
-  Lambda lore ->
+  [HistOp rep] ->
+  Lambda rep ->
   [inp] ->
   Doc
 ppHist len ops bucket_fun imgs =

--- a/src/Futhark/IR/SOACS/Simplify.hs
+++ b/src/Futhark/IR/SOACS/Simplify.hs
@@ -41,7 +41,7 @@ import Futhark.IR.SOACS
 import Futhark.MonadFreshNames
 import qualified Futhark.Optimise.Simplify as Simplify
 import qualified Futhark.Optimise.Simplify.Engine as Engine
-import Futhark.Optimise.Simplify.Lore
+import Futhark.Optimise.Simplify.Rep
 import Futhark.Optimise.Simplify.Rule
 import Futhark.Optimise.Simplify.Rules
 import Futhark.Optimise.Simplify.Rules.ClosedForm
@@ -93,8 +93,8 @@ simplifyConsts =
   Simplify.simplifyStms simpleSOACS soacRules Engine.noExtraHoistBlockers mempty
 
 simplifySOAC ::
-  Simplify.SimplifiableLore lore =>
-  Simplify.SimplifyOp lore (SOAC lore)
+  Simplify.SimplifiableRep rep =>
+  Simplify.SimplifyOp rep (SOAC rep)
 simplifySOAC (Stream outerdim arr form nes lam) = do
   outerdim' <- Engine.simplify outerdim
   (form', form_hoisted) <- simplifyStreamForm form
@@ -155,10 +155,10 @@ simplifySOAC (Screma w arrs (ScremaForm scans reds map_lam)) = do
 instance BinderOps (Wise SOACS)
 
 fixLambdaParams ::
-  (MonadBinder m, Bindable (Lore m), BinderOps (Lore m)) =>
-  AST.Lambda (Lore m) ->
+  (MonadBinder m, Bindable (Rep m), BinderOps (Rep m)) =>
+  AST.Lambda (Rep m) ->
   [Maybe SubExp] ->
-  m (AST.Lambda (Lore m))
+  m (AST.Lambda (Rep m))
 fixLambdaParams lam fixes = do
   body <- runBodyBinder $
     localScope (scopeOfLParams $ lambdaParams lam) $ do
@@ -177,7 +177,7 @@ fixLambdaParams lam fixes = do
     maybeFix p (Just x) = letBindNames [paramName p] $ BasicOp $ SubExp x
     maybeFix _ Nothing = return ()
 
-removeLambdaResults :: [Bool] -> AST.Lambda lore -> AST.Lambda lore
+removeLambdaResults :: [Bool] -> AST.Lambda rep -> AST.Lambda rep
 removeLambdaResults keep lam =
   lam
     { lambdaBody = lam_body',
@@ -193,11 +193,11 @@ removeLambdaResults keep lam =
 soacRules :: RuleBook (Wise SOACS)
 soacRules = standardRules <> ruleBook topDownRules bottomUpRules
 
--- | Does this lore contain 'SOAC's in its t'Op's?  A lore must be an
+-- | Does this rep contain 'SOAC's in its t'Op's?  A rep must be an
 -- instance of this class for the simplification rules to work.
-class HasSOAC lore where
-  asSOAC :: Op lore -> Maybe (SOAC lore)
-  soacOp :: SOAC lore -> Op lore
+class HasSOAC rep where
+  asSOAC :: Op rep -> Maybe (SOAC rep)
+  soacOp :: SOAC rep -> Op rep
 
 instance HasSOAC (Wise SOACS) where
   asSOAC = Just
@@ -256,11 +256,11 @@ hoistCertificates _ _ _ _ =
   Skip
 
 liftIdentityMapping ::
-  forall lore.
-  (Bindable lore, Simplify.SimplifiableLore lore, HasSOAC (Wise lore)) =>
-  TopDownRuleOp (Wise lore)
+  forall rep.
+  (Bindable rep, Simplify.SimplifiableRep rep, HasSOAC (Wise rep)) =>
+  TopDownRuleOp (Wise rep)
 liftIdentityMapping _ pat aux op
-  | Just (Screma w arrs form :: SOAC (Wise lore)) <- asSOAC op,
+  | Just (Screma w arrs form :: SOAC (Wise rep)) <- asSOAC op,
     Just fun <- isMapSOAC form = do
     let inputMap = M.fromList $ zip (map paramName $ lambdaParams fun) arrs
         free = freeIn $ lambdaBody fun
@@ -339,8 +339,8 @@ liftIdentityStreaming _ _ _ _ = Skip
 -- | Remove all arguments to the map that are simply replicates.
 -- These can be turned into free variables instead.
 removeReplicateMapping ::
-  (Bindable lore, Simplify.SimplifiableLore lore, HasSOAC (Wise lore)) =>
-  TopDownRuleOp (Wise lore)
+  (Bindable rep, Simplify.SimplifiableRep rep, HasSOAC (Wise rep)) =>
+  TopDownRuleOp (Wise rep)
 removeReplicateMapping vtable pat aux op
   | Just (Screma w arrs form) <- asSOAC op,
     Just fun <- isMapSOAC form,
@@ -358,13 +358,13 @@ removeReplicateWrite vtable pat aux (Scatter len lam ivs as)
 removeReplicateWrite _ _ _ _ = Skip
 
 removeReplicateInput ::
-  Aliased lore =>
-  ST.SymbolTable lore ->
-  AST.Lambda lore ->
+  Aliased rep =>
+  ST.SymbolTable rep ->
+  AST.Lambda rep ->
   [VName] ->
   Maybe
-    ( [([VName], Certificates, AST.Exp lore)],
-      AST.Lambda lore,
+    ( [([VName], Certificates, AST.Exp rep)],
+      AST.Lambda rep,
       [VName]
     )
 removeReplicateInput vtable fun arrs
@@ -659,8 +659,8 @@ simplifyClosedFormReduce _ _ _ _ = Skip
 
 -- For now we just remove singleton SOACs.
 simplifyKnownIterationSOAC ::
-  (Bindable lore, Simplify.SimplifiableLore lore, HasSOAC (Wise lore)) =>
-  TopDownRuleOp (Wise lore)
+  (Bindable rep, Simplify.SimplifiableRep rep, HasSOAC (Wise rep)) =>
+  TopDownRuleOp (Wise rep)
 simplifyKnownIterationSOAC _ pat _ op
   | Just (Screma (Constant k) arrs (ScremaForm scans reds map_lam)) <- asSOAC op,
     oneIsh k = Simplify $ do

--- a/src/Futhark/IR/SegOp.hs
+++ b/src/Futhark/IR/SegOp.hs
@@ -80,7 +80,7 @@ import Futhark.IR.Aliases
 import Futhark.IR.Mem
 import Futhark.IR.Prop.Aliases
 import qualified Futhark.Optimise.Simplify.Engine as Engine
-import Futhark.Optimise.Simplify.Lore
+import Futhark.Optimise.Simplify.Rep
 import Futhark.Optimise.Simplify.Rule
 import Futhark.Tools
 import Futhark.Transform.Rename
@@ -122,7 +122,7 @@ instance Rename SplitOrdering where
     SplitStrided <$> rename stride
 
 -- | An operator for 'SegHist'.
-data HistOp lore = HistOp
+data HistOp rep = HistOp
   { histWidth :: SubExp,
     histRaceFactor :: SubExp,
     histDest :: [VName],
@@ -133,14 +133,14 @@ data HistOp lore = HistOp
     -- "dimensions".  This is used to generate more efficient
     -- code.
     histShape :: Shape,
-    histOp :: Lambda lore
+    histOp :: Lambda rep
   }
   deriving (Eq, Ord, Show)
 
 -- | The type of a histogram produced by a 'HistOp'.  This can be
 -- different from the type of the 'histDest's in case we are
 -- dealing with a segmented histogram.
-histType :: HistOp lore -> [Type]
+histType :: HistOp rep -> [Type]
 histType op =
   map
     ( (`arrayOfRow` histWidth op)
@@ -149,9 +149,9 @@ histType op =
     $ lambdaReturnType $ histOp op
 
 -- | An operator for 'SegScan' and 'SegRed'.
-data SegBinOp lore = SegBinOp
+data SegBinOp rep = SegBinOp
   { segBinOpComm :: Commutativity,
-    segBinOpLambda :: Lambda lore,
+    segBinOpLambda :: Lambda rep,
     segBinOpNeutral :: [SubExp],
     -- | In case this operator is semantically a vectorised
     -- operator (corresponding to a perfect map nest in the
@@ -163,26 +163,26 @@ data SegBinOp lore = SegBinOp
   deriving (Eq, Ord, Show)
 
 -- | How many reduction results are produced by these 'SegBinOp's?
-segBinOpResults :: [SegBinOp lore] -> Int
+segBinOpResults :: [SegBinOp rep] -> Int
 segBinOpResults = sum . map (length . segBinOpNeutral)
 
 -- | Split some list into chunks equal to the number of values
 -- returned by each 'SegBinOp'
-segBinOpChunks :: [SegBinOp lore] -> [a] -> [[a]]
+segBinOpChunks :: [SegBinOp rep] -> [a] -> [[a]]
 segBinOpChunks = chunks . map (length . segBinOpNeutral)
 
 -- | The body of a 'SegOp'.
-data KernelBody lore = KernelBody
-  { kernelBodyLore :: BodyDec lore,
-    kernelBodyStms :: Stms lore,
+data KernelBody rep = KernelBody
+  { kernelBodyDec :: BodyDec rep,
+    kernelBodyStms :: Stms rep,
     kernelBodyResult :: [KernelResult]
   }
 
-deriving instance Decorations lore => Ord (KernelBody lore)
+deriving instance RepTypes rep => Ord (KernelBody rep)
 
-deriving instance Decorations lore => Show (KernelBody lore)
+deriving instance RepTypes rep => Show (KernelBody rep)
 
-deriving instance Decorations lore => Eq (KernelBody lore)
+deriving instance RepTypes rep => Eq (KernelBody rep)
 
 -- | Metadata about whether there is a subtle point to this
 -- 'KernelResult'.  This is used to protect things like tiling, which
@@ -250,13 +250,13 @@ instance FreeIn KernelResult where
   freeIn' (RegTileReturns dims_n_tiles v) =
     freeIn' dims_n_tiles <> freeIn' v
 
-instance ASTLore lore => FreeIn (KernelBody lore) where
+instance ASTRep rep => FreeIn (KernelBody rep) where
   freeIn' (KernelBody dec stms res) =
     fvBind bound_in_stms $ freeIn' dec <> freeIn' stms <> freeIn' res
     where
       bound_in_stms = foldMap boundByStm stms
 
-instance ASTLore lore => Substitute (KernelBody lore) where
+instance ASTRep rep => Substitute (KernelBody rep) where
   substituteNames subst (KernelBody dec stms res) =
     KernelBody
       (substituteNames subst dec)
@@ -284,7 +284,7 @@ instance Substitute KernelResult where
       (substituteNames subst dims_n_tiles)
       (substituteNames subst v)
 
-instance ASTLore lore => Rename (KernelBody lore) where
+instance ASTRep rep => Rename (KernelBody rep) where
   rename (KernelBody dec stms res) = do
     dec' <- rename dec
     renamingStms stms $ \stms' ->
@@ -295,35 +295,35 @@ instance Rename KernelResult where
 
 -- | Perform alias analysis on a 'KernelBody'.
 aliasAnalyseKernelBody ::
-  ( ASTLore lore,
-    CanBeAliased (Op lore)
+  ( ASTRep rep,
+    CanBeAliased (Op rep)
   ) =>
   AliasTable ->
-  KernelBody lore ->
-  KernelBody (Aliases lore)
+  KernelBody rep ->
+  KernelBody (Aliases rep)
 aliasAnalyseKernelBody aliases (KernelBody dec stms res) =
   let Body dec' stms' _ = Alias.analyseBody aliases $ Body dec stms []
    in KernelBody dec' stms' res
 
 removeKernelBodyAliases ::
-  CanBeAliased (Op lore) =>
-  KernelBody (Aliases lore) ->
-  KernelBody lore
+  CanBeAliased (Op rep) =>
+  KernelBody (Aliases rep) ->
+  KernelBody rep
 removeKernelBodyAliases (KernelBody (_, dec) stms res) =
   KernelBody dec (fmap removeStmAliases stms) res
 
 removeKernelBodyWisdom ::
-  CanBeWise (Op lore) =>
-  KernelBody (Wise lore) ->
-  KernelBody lore
+  CanBeWise (Op rep) =>
+  KernelBody (Wise rep) ->
+  KernelBody rep
 removeKernelBodyWisdom (KernelBody dec stms res) =
   let Body dec' stms' _ = removeBodyWisdom $ Body dec stms []
    in KernelBody dec' stms' res
 
 -- | The variables consumed in the kernel body.
 consumedInKernelBody ::
-  Aliased lore =>
-  KernelBody lore ->
+  Aliased rep =>
+  KernelBody rep ->
   Names
 consumedInKernelBody (KernelBody dec stms res) =
   consumedInBody (Body dec stms []) <> mconcat (map consumedByReturn res)
@@ -332,12 +332,12 @@ consumedInKernelBody (KernelBody dec stms res) =
     consumedByReturn _ = mempty
 
 checkKernelBody ::
-  TC.Checkable lore =>
+  TC.Checkable rep =>
   [Type] ->
-  KernelBody (Aliases lore) ->
-  TC.TypeM lore ()
+  KernelBody (Aliases rep) ->
+  TC.TypeM rep ()
 checkKernelBody ts (KernelBody (_, dec) stms kres) = do
-  TC.checkBodyLore dec
+  TC.checkBodyDec dec
   -- We consume the kernel results (when applicable) before
   -- type-checking the stms, so we will get an error if a statement
   -- uses an array that is written to in a result.
@@ -409,10 +409,10 @@ checkKernelBody ts (KernelBody (_, dec) stms kres) = do
         (dims, blk_tiles, reg_tiles) = unzip3 dims_n_tiles
         expected = t `arrayOfShape` Shape (blk_tiles ++ reg_tiles)
 
-kernelBodyMetrics :: OpMetrics (Op lore) => KernelBody lore -> MetricsM ()
+kernelBodyMetrics :: OpMetrics (Op rep) => KernelBody rep -> MetricsM ()
 kernelBodyMetrics = mapM_ stmMetrics . kernelBodyStms
 
-instance PrettyLore lore => Pretty (KernelBody lore) where
+instance PrettyRep rep => Pretty (KernelBody rep) where
   ppr (KernelBody _ stms res) =
     PP.stack (map ppr (stmsToList stms))
       </> text "return" <+> PP.braces (PP.commasep $ map ppr res)
@@ -478,11 +478,11 @@ segSpaceDims (SegSpace _ space) = map snd space
 
 -- | A 'Scope' containing all the identifiers brought into scope by
 -- this 'SegSpace'.
-scopeOfSegSpace :: SegSpace -> Scope lore
+scopeOfSegSpace :: SegSpace -> Scope rep
 scopeOfSegSpace (SegSpace phys space) =
   M.fromList $ zip (phys : map fst space) $ repeat $ IndexName Int64
 
-checkSegSpace :: TC.Checkable lore => SegSpace -> TC.TypeM lore ()
+checkSegSpace :: TC.Checkable rep => SegSpace -> TC.TypeM rep ()
 checkSegSpace (SegSpace _ dims) =
   mapM_ (TC.require [Prim int64] . snd) dims
 
@@ -496,31 +496,31 @@ checkSegSpace (SegSpace _ dims) =
 -- of information.  For example, in GPU backends, it is used to
 -- indicate whether the 'SegOp' is expected to run at the thread-level
 -- or the group-level.
-data SegOp lvl lore
-  = SegMap lvl SegSpace [Type] (KernelBody lore)
+data SegOp lvl rep
+  = SegMap lvl SegSpace [Type] (KernelBody rep)
   | -- | The KernelSpace must always have at least two dimensions,
     -- implying that the result of a SegRed is always an array.
-    SegRed lvl SegSpace [SegBinOp lore] [Type] (KernelBody lore)
-  | SegScan lvl SegSpace [SegBinOp lore] [Type] (KernelBody lore)
-  | SegHist lvl SegSpace [HistOp lore] [Type] (KernelBody lore)
+    SegRed lvl SegSpace [SegBinOp rep] [Type] (KernelBody rep)
+  | SegScan lvl SegSpace [SegBinOp rep] [Type] (KernelBody rep)
+  | SegHist lvl SegSpace [HistOp rep] [Type] (KernelBody rep)
   deriving (Eq, Ord, Show)
 
 -- | The level of a 'SegOp'.
-segLevel :: SegOp lvl lore -> lvl
+segLevel :: SegOp lvl rep -> lvl
 segLevel (SegMap lvl _ _ _) = lvl
 segLevel (SegRed lvl _ _ _ _) = lvl
 segLevel (SegScan lvl _ _ _ _) = lvl
 segLevel (SegHist lvl _ _ _ _) = lvl
 
 -- | The space of a 'SegOp'.
-segSpace :: SegOp lvl lore -> SegSpace
+segSpace :: SegOp lvl rep -> SegSpace
 segSpace (SegMap _ lvl _ _) = lvl
 segSpace (SegRed _ lvl _ _ _) = lvl
 segSpace (SegScan _ lvl _ _ _) = lvl
 segSpace (SegHist _ lvl _ _ _) = lvl
 
 -- | The body of a 'SegOp'.
-segBody :: SegOp lvl lore -> KernelBody lore
+segBody :: SegOp lvl rep -> KernelBody rep
 segBody segop =
   case segop of
     SegMap _ _ _ body -> body
@@ -541,7 +541,7 @@ segResultShape _ t (RegTileReturns dims_n_tiles _) =
   t `arrayOfShape` Shape (map (\(dim, _, _) -> dim) dims_n_tiles)
 
 -- | The return type of a 'SegOp'.
-segOpType :: SegOp lvl lore -> [Type]
+segOpType :: SegOp lvl rep -> [Type]
 segOpType (SegMap _ space ts kbody) =
   zipWith (segResultShape space) ts $ kernelBodyResult kbody
 segOpType (SegRed _ space reds ts kbody) =
@@ -577,12 +577,12 @@ segOpType (SegHist _ space ops _ _) = do
     dims = segSpaceDims space
     segment_dims = init dims
 
-instance TypedOp (SegOp lvl lore) where
+instance TypedOp (SegOp lvl rep) where
   opType = pure . staticShapes . segOpType
 
 instance
-  (ASTLore lore, Aliased lore, ASTConstraints lvl) =>
-  AliasedOp (SegOp lvl lore)
+  (ASTRep rep, Aliased rep, ASTConstraints lvl) =>
+  AliasedOp (SegOp lvl rep)
   where
   opAliases = map (const mempty) . segOpType
 
@@ -597,10 +597,10 @@ instance
 
 -- | Type check a 'SegOp', given a checker for its level.
 typeCheckSegOp ::
-  TC.Checkable lore =>
-  (lvl -> TC.TypeM lore ()) ->
-  SegOp lvl (Aliases lore) ->
-  TC.TypeM lore ()
+  TC.Checkable rep =>
+  (lvl -> TC.TypeM rep ()) ->
+  SegOp lvl (Aliases rep) ->
+  TC.TypeM rep ()
 typeCheckSegOp checkLvl (SegMap lvl space ts kbody) = do
   checkLvl lvl
   checkScanRed space [] ts kbody
@@ -670,12 +670,12 @@ typeCheckSegOp checkLvl (SegHist lvl space ops ts kbody) = do
     segment_dims = init $ segSpaceDims space
 
 checkScanRed ::
-  TC.Checkable lore =>
+  TC.Checkable rep =>
   SegSpace ->
-  [(Lambda (Aliases lore), [SubExp], Shape)] ->
+  [(Lambda (Aliases rep), [SubExp], Shape)] ->
   [Type] ->
-  KernelBody (Aliases lore) ->
-  TC.TypeM lore ()
+  KernelBody (Aliases rep) ->
+  TC.TypeM rep ()
 checkScanRed space ops ts kbody = do
   checkSegSpace space
   mapM_ TC.checkType ts
@@ -708,16 +708,16 @@ checkScanRed space ops ts kbody = do
     checkKernelBody ts kbody
 
 -- | Like 'Mapper', but just for 'SegOp's.
-data SegOpMapper lvl flore tlore m = SegOpMapper
+data SegOpMapper lvl frep trep m = SegOpMapper
   { mapOnSegOpSubExp :: SubExp -> m SubExp,
-    mapOnSegOpLambda :: Lambda flore -> m (Lambda tlore),
-    mapOnSegOpBody :: KernelBody flore -> m (KernelBody tlore),
+    mapOnSegOpLambda :: Lambda frep -> m (Lambda trep),
+    mapOnSegOpBody :: KernelBody frep -> m (KernelBody trep),
     mapOnSegOpVName :: VName -> m VName,
     mapOnSegOpLevel :: lvl -> m lvl
   }
 
 -- | A mapper that simply returns the 'SegOp' verbatim.
-identitySegOpMapper :: Monad m => SegOpMapper lvl lore lore m
+identitySegOpMapper :: Monad m => SegOpMapper lvl rep rep m
 identitySegOpMapper =
   SegOpMapper
     { mapOnSegOpSubExp = return,
@@ -729,7 +729,7 @@ identitySegOpMapper =
 
 mapOnSegSpace ::
   Monad f =>
-  SegOpMapper lvl flore tlore f ->
+  SegOpMapper lvl frep trep f ->
   SegSpace ->
   f SegSpace
 mapOnSegSpace tv (SegSpace phys dims) =
@@ -737,9 +737,9 @@ mapOnSegSpace tv (SegSpace phys dims) =
 
 mapSegBinOp ::
   Monad m =>
-  SegOpMapper lvl flore tlore m ->
-  SegBinOp flore ->
-  m (SegBinOp tlore)
+  SegOpMapper lvl frep trep m ->
+  SegBinOp frep ->
+  m (SegBinOp trep)
 mapSegBinOp tv (SegBinOp comm red_op nes shape) =
   SegBinOp comm
     <$> mapOnSegOpLambda tv red_op
@@ -749,9 +749,9 @@ mapSegBinOp tv (SegBinOp comm red_op nes shape) =
 -- | Apply a 'SegOpMapper' to the given 'SegOp'.
 mapSegOpM ::
   (Applicative m, Monad m) =>
-  SegOpMapper lvl flore tlore m ->
-  SegOp lvl flore ->
-  m (SegOp lvl tlore)
+  SegOpMapper lvl frep trep m ->
+  SegOp lvl frep ->
+  m (SegOp lvl trep)
 mapSegOpM tv (SegMap lvl space ts body) =
   SegMap
     <$> mapOnSegOpLevel tv lvl
@@ -790,7 +790,7 @@ mapSegOpM tv (SegHist lvl space ops ts body) =
 
 mapOnSegOpType ::
   Monad m =>
-  SegOpMapper lvl flore tlore m ->
+  SegOpMapper lvl frep trep m ->
   Type ->
   m Type
 mapOnSegOpType _tv t@Prim {} = pure t
@@ -805,8 +805,8 @@ mapOnSegOpType tv (Array et shape u) =
 mapOnSegOpType _tv (Mem s) = pure $ Mem s
 
 instance
-  (ASTLore lore, Substitute lvl) =>
-  Substitute (SegOp lvl lore)
+  (ASTRep rep, Substitute lvl) =>
+  Substitute (SegOp lvl rep)
   where
   substituteNames subst = runIdentity . mapSegOpM substitute
     where
@@ -820,16 +820,16 @@ instance
           }
 
 instance
-  (ASTLore lore, ASTConstraints lvl) =>
-  Rename (SegOp lvl lore)
+  (ASTRep rep, ASTConstraints lvl) =>
+  Rename (SegOp lvl rep)
   where
   rename = mapSegOpM renamer
     where
       renamer = SegOpMapper rename rename rename rename rename
 
 instance
-  (ASTLore lore, FreeIn (LParamInfo lore), FreeIn lvl) =>
-  FreeIn (SegOp lvl lore)
+  (ASTRep rep, FreeIn (LParamInfo rep), FreeIn lvl) =>
+  FreeIn (SegOp lvl rep)
   where
   freeIn' e = flip execState mempty $ mapSegOpM free e
     where
@@ -843,7 +843,7 @@ instance
             mapOnSegOpLevel = walk freeIn'
           }
 
-instance OpMetrics (Op lore) => OpMetrics (SegOp lvl lore) where
+instance OpMetrics (Op rep) => OpMetrics (SegOp lvl rep) where
   opMetrics (SegMap _ _ _ body) =
     inside "SegMap" $ kernelBodyMetrics body
   opMetrics (SegRed _ _ reds _ body) =
@@ -868,7 +868,7 @@ instance Pretty SegSpace where
       )
       <+> parens (text "~" <> ppr phys)
 
-instance PrettyLore lore => Pretty (SegBinOp lore) where
+instance PrettyRep rep => Pretty (SegBinOp rep) where
   ppr (SegBinOp comm lam nes shape) =
     PP.braces (PP.commasep $ map ppr nes) <> PP.comma
       </> ppr shape <> PP.comma
@@ -878,7 +878,7 @@ instance PrettyLore lore => Pretty (SegBinOp lore) where
         Commutative -> text "commutative "
         Noncommutative -> mempty
 
-instance (PrettyLore lore, PP.Pretty lvl) => PP.Pretty (SegOp lvl lore) where
+instance (PrettyRep rep, PP.Pretty lvl) => PP.Pretty (SegOp lvl rep) where
   ppr (SegMap lvl space ts body) =
     text "segmap" <> ppr lvl
       </> PP.align (ppr space)
@@ -915,14 +915,14 @@ instance (PrettyLore lore, PP.Pretty lvl) => PP.Pretty (SegOp lvl lore) where
           </> ppr op
 
 instance
-  ( ASTLore lore,
-    ASTLore (Aliases lore),
-    CanBeAliased (Op lore),
+  ( ASTRep rep,
+    ASTRep (Aliases rep),
+    CanBeAliased (Op rep),
     ASTConstraints lvl
   ) =>
-  CanBeAliased (SegOp lvl lore)
+  CanBeAliased (SegOp lvl rep)
   where
-  type OpWithAliases (SegOp lvl lore) = SegOp lvl (Aliases lore)
+  type OpWithAliases (SegOp lvl rep) = SegOp lvl (Aliases rep)
 
   addOpAliases aliases = runIdentity . mapSegOpM alias
     where
@@ -945,10 +945,10 @@ instance
           return
 
 instance
-  (CanBeWise (Op lore), ASTLore lore, ASTConstraints lvl) =>
-  CanBeWise (SegOp lvl lore)
+  (CanBeWise (Op rep), ASTRep rep, ASTConstraints lvl) =>
+  CanBeWise (SegOp lvl rep)
   where
-  type OpWithWisdom (SegOp lvl lore) = SegOp lvl (Wise lore)
+  type OpWithWisdom (SegOp lvl rep) = SegOp lvl (Wise rep)
 
   removeOpWisdom = runIdentity . mapSegOpM remove
     where
@@ -960,7 +960,7 @@ instance
           return
           return
 
-instance ASTLore lore => ST.IndexOp (SegOp lvl lore) where
+instance ASTRep rep => ST.IndexOp (SegOp lvl rep) where
   indexOp vtable k (SegMap _ space _ kbody) is = do
     Returns ResultMaySimplify se <- maybeNth k $ kernelBodyResult kbody
     guard $ length gtids <= length is
@@ -1005,8 +1005,8 @@ instance ASTLore lore => ST.IndexOp (SegOp lvl lore) where
   indexOp _ _ _ _ = Nothing
 
 instance
-  (ASTLore lore, ASTConstraints lvl) =>
-  IsOp (SegOp lvl lore)
+  (ASTRep rep, ASTConstraints lvl) =>
+  IsOp (SegOp lvl rep)
   where
   cheapOp _ = False
   safeOp _ = True
@@ -1042,11 +1042,11 @@ instance Engine.Simplifiable KernelResult where
       <*> Engine.simplify what
 
 mkWiseKernelBody ::
-  (ASTLore lore, CanBeWise (Op lore)) =>
-  BodyDec lore ->
-  Stms (Wise lore) ->
+  (ASTRep rep, CanBeWise (Op rep)) =>
+  BodyDec rep ->
+  Stms (Wise rep) ->
   [KernelResult] ->
-  KernelBody (Wise lore)
+  KernelBody (Wise rep)
 mkWiseKernelBody dec bnds res =
   let Body dec' _ _ = mkWiseBody dec bnds res_vs
    in KernelBody dec' bnds res
@@ -1055,9 +1055,9 @@ mkWiseKernelBody dec bnds res =
 
 mkKernelBodyM ::
   MonadBinder m =>
-  Stms (Lore m) ->
+  Stms (Rep m) ->
   [KernelResult] ->
-  m (KernelBody (Lore m))
+  m (KernelBody (Rep m))
 mkKernelBodyM stms kres = do
   Body dec' _ _ <- mkBodyM stms res_ses
   return $ KernelBody dec' stms kres
@@ -1065,10 +1065,10 @@ mkKernelBodyM stms kres = do
     res_ses = map kernelResultSubExp kres
 
 simplifyKernelBody ::
-  (Engine.SimplifiableLore lore, BodyDec lore ~ ()) =>
+  (Engine.SimplifiableRep rep, BodyDec rep ~ ()) =>
   SegSpace ->
-  KernelBody lore ->
-  Engine.SimpleM lore (KernelBody (Wise lore), Stms (Wise lore))
+  KernelBody rep ->
+  Engine.SimpleM rep (KernelBody (Wise rep), Stms (Wise rep))
 simplifyKernelBody space (KernelBody _ stms res) = do
   par_blocker <- Engine.asksEngineEnv $ Engine.blockHoistPar . Engine.envHoistBlockers
 
@@ -1100,16 +1100,16 @@ simplifyKernelBody space (KernelBody _ stms res) = do
     consumedInResult _ =
       []
 
-segSpaceSymbolTable :: ASTLore lore => SegSpace -> ST.SymbolTable lore
+segSpaceSymbolTable :: ASTRep rep => SegSpace -> ST.SymbolTable rep
 segSpaceSymbolTable (SegSpace flat gtids_and_dims) =
   foldl' f (ST.fromScope $ M.singleton flat $ IndexName Int64) gtids_and_dims
   where
     f vtable (gtid, dim) = ST.insertLoopVar gtid Int64 dim vtable
 
 simplifySegBinOp ::
-  Engine.SimplifiableLore lore =>
-  SegBinOp lore ->
-  Engine.SimpleM lore (SegBinOp (Wise lore), Stms (Wise lore))
+  Engine.SimplifiableRep rep =>
+  SegBinOp rep ->
+  Engine.SimpleM rep (SegBinOp (Wise rep), Stms (Wise rep))
 simplifySegBinOp (SegBinOp comm lam nes shape) = do
   (lam', hoisted) <-
     Engine.localVtable (\vtable -> vtable {ST.simplifyMemory = True}) $
@@ -1120,12 +1120,12 @@ simplifySegBinOp (SegBinOp comm lam nes shape) = do
 
 -- | Simplify the given 'SegOp'.
 simplifySegOp ::
-  ( Engine.SimplifiableLore lore,
-    BodyDec lore ~ (),
+  ( Engine.SimplifiableRep rep,
+    BodyDec rep ~ (),
     Engine.Simplifiable lvl
   ) =>
-  SegOp lvl lore ->
-  Engine.SimpleM lore (SegOp lvl (Wise lore), Stms (Wise lore))
+  SegOp lvl rep ->
+  Engine.SimpleM rep (SegOp lvl (Wise rep), Stms (Wise rep))
 simplifySegOp (SegMap lvl space ts kbody) = do
   (lvl', space', ts') <- Engine.simplify (lvl, space, ts)
   (kbody', body_hoisted) <- simplifyKernelBody space kbody
@@ -1191,23 +1191,23 @@ simplifySegOp (SegHist lvl space ops ts kbody) = do
     scope = scopeOfSegSpace space
     scope_vtable = ST.fromScope scope
 
--- | Does this lore contain 'SegOp's in its t'Op's?  A lore must be an
+-- | Does this rep contain 'SegOp's in its t'Op's?  A rep must be an
 -- instance of this class for the simplification rules to work.
-class HasSegOp lore where
-  type SegOpLevel lore
-  asSegOp :: Op lore -> Maybe (SegOp (SegOpLevel lore) lore)
-  segOp :: SegOp (SegOpLevel lore) lore -> Op lore
+class HasSegOp rep where
+  type SegOpLevel rep
+  asSegOp :: Op rep -> Maybe (SegOp (SegOpLevel rep) rep)
+  segOp :: SegOp (SegOpLevel rep) rep -> Op rep
 
 -- | Simplification rules for simplifying 'SegOp's.
 segOpRules ::
-  (HasSegOp lore, BinderOps lore, Bindable lore) =>
-  RuleBook lore
+  (HasSegOp rep, BinderOps rep, Bindable rep) =>
+  RuleBook rep
 segOpRules =
   ruleBook [RuleOp segOpRuleTopDown] [RuleOp segOpRuleBottomUp]
 
 segOpRuleTopDown ::
-  (HasSegOp lore, BinderOps lore, Bindable lore) =>
-  TopDownRuleOp lore
+  (HasSegOp rep, BinderOps rep, Bindable rep) =>
+  TopDownRuleOp rep
 segOpRuleTopDown vtable pat dec op
   | Just op' <- asSegOp op =
     topDownSegOp vtable pat dec op'
@@ -1215,8 +1215,8 @@ segOpRuleTopDown vtable pat dec op
     Skip
 
 segOpRuleBottomUp ::
-  (HasSegOp lore, BinderOps lore) =>
-  BottomUpRuleOp lore
+  (HasSegOp rep, BinderOps rep) =>
+  BottomUpRuleOp rep
 segOpRuleBottomUp vtable pat dec op
   | Just op' <- asSegOp op =
     bottomUpSegOp vtable pat dec op'
@@ -1224,12 +1224,12 @@ segOpRuleBottomUp vtable pat dec op
     Skip
 
 topDownSegOp ::
-  (HasSegOp lore, BinderOps lore, Bindable lore) =>
-  ST.SymbolTable lore ->
-  Pattern lore ->
-  StmAux (ExpDec lore) ->
-  SegOp (SegOpLevel lore) lore ->
-  Rule lore
+  (HasSegOp rep, BinderOps rep, Bindable rep) =>
+  ST.SymbolTable rep ->
+  Pattern rep ->
+  StmAux (ExpDec rep) ->
+  SegOp (SegOpLevel rep) rep ->
+  Rule rep
 -- If a SegOp produces something invariant to the SegOp, turn it
 -- into a replicate.
 topDownSegOp vtable (Pattern [] kpes) dec (SegMap lvl space ts (KernelBody _ kstms kres)) = Simplify $ do
@@ -1318,11 +1318,11 @@ topDownSegOp _ _ _ _ = Skip
 -- A convenient way of operating on the type and body of a SegOp,
 -- without worrying about exactly what kind it is.
 segOpGuts ::
-  SegOp (SegOpLevel lore) lore ->
+  SegOp (SegOpLevel rep) rep ->
   ( [Type],
-    KernelBody lore,
+    KernelBody rep,
     Int,
-    [Type] -> KernelBody lore -> SegOp (SegOpLevel lore) lore
+    [Type] -> KernelBody rep -> SegOp (SegOpLevel rep) rep
   )
 segOpGuts (SegMap lvl space kts body) =
   (kts, body, 0, SegMap lvl space)
@@ -1334,12 +1334,12 @@ segOpGuts (SegHist lvl space ops kts body) =
   (kts, body, sum $ map (length . histDest) ops, SegHist lvl space ops)
 
 bottomUpSegOp ::
-  (HasSegOp lore, BinderOps lore) =>
-  (ST.SymbolTable lore, UT.UsageTable) ->
-  Pattern lore ->
-  StmAux (ExpDec lore) ->
-  SegOp (SegOpLevel lore) lore ->
-  Rule lore
+  (HasSegOp rep, BinderOps rep) =>
+  (ST.SymbolTable rep, UT.UsageTable) ->
+  Pattern rep ->
+  StmAux (ExpDec rep) ->
+  SegOp (SegOpLevel rep) rep ->
+  Rule rep
 -- Some SegOp results can be moved outside the SegOp, which can
 -- simplify further analysis.
 bottomUpSegOp (vtable, used) (Pattern [] kpes) dec segop = Simplify $ do
@@ -1429,8 +1429,8 @@ bottomUpSegOp _ _ _ _ = Skip
 --- Memory
 
 kernelBodyReturns ::
-  (Mem lore, HasScope lore m, Monad m) =>
-  KernelBody lore ->
+  (Mem rep, HasScope rep m, Monad m) =>
+  KernelBody rep ->
   [ExpReturns] ->
   m [ExpReturns]
 kernelBodyReturns = zipWithM correct . kernelBodyResult
@@ -1440,8 +1440,8 @@ kernelBodyReturns = zipWithM correct . kernelBodyResult
 
 -- | Like 'segOpType', but for memory representations.
 segOpReturns ::
-  (Mem lore, Monad m, HasScope lore m) =>
-  SegOp lvl lore ->
+  (Mem rep, Monad m, HasScope rep m) =>
+  SegOp lvl rep ->
   m [ExpReturns]
 segOpReturns k@(SegMap _ _ _ kbody) =
   kernelBodyReturns kbody . extReturns =<< opType k

--- a/src/Futhark/IR/Seq.hs
+++ b/src/Futhark/IR/Seq.hs
@@ -3,8 +3,7 @@
 
 -- | A sequential representation.
 module Futhark.IR.Seq
-  ( -- * The Lore definition
-    Seq,
+  ( Seq,
 
     -- * Simplification
     simplifyProg,
@@ -32,10 +31,10 @@ import qualified Futhark.TypeCheck as TypeCheck
 -- | The phantom type for the Seq representation.
 data Seq
 
-instance Decorations Seq where
+instance RepTypes Seq where
   type Op Seq = ()
 
-instance ASTLore Seq where
+instance ASTRep Seq where
   expTypesFromPattern = return . expExtTypesFromPattern
 
 instance TypeCheck.CheckableOp Seq where
@@ -51,7 +50,7 @@ instance Bindable Seq where
 
 instance BinderOps Seq
 
-instance PrettyLore Seq
+instance PrettyRep Seq
 
 instance BinderOps (Engine.Wise Seq)
 

--- a/src/Futhark/IR/SeqMem.hs
+++ b/src/Futhark/IR/SeqMem.hs
@@ -13,12 +13,10 @@ module Futhark.IR.SeqMem
 
     -- * Module re-exports
     module Futhark.IR.Mem,
-    module Futhark.IR.Kernels.Kernel,
   )
 where
 
 import Futhark.Analysis.PrimExp.Convert
-import Futhark.IR.Kernels.Kernel
 import Futhark.IR.Mem
 import Futhark.IR.Mem.Simplify
 import qualified Futhark.Optimise.Simplify.Engine as Engine

--- a/src/Futhark/IR/SeqMem.hs
+++ b/src/Futhark/IR/SeqMem.hs
@@ -28,7 +28,7 @@ import qualified Futhark.TypeCheck as TC
 
 data SeqMem
 
-instance Decorations SeqMem where
+instance RepTypes SeqMem where
   type LetDec SeqMem = LetDecMem
   type FParamInfo SeqMem = FParamMem
   type LParamInfo SeqMem = LParamMem
@@ -36,14 +36,14 @@ instance Decorations SeqMem where
   type BranchType SeqMem = BranchTypeMem
   type Op SeqMem = MemOp ()
 
-instance ASTLore SeqMem where
+instance ASTRep SeqMem where
   expTypesFromPattern = return . map snd . snd . bodyReturnsFromPattern
 
 instance OpReturns SeqMem where
   opReturns (Alloc _ space) = return [MemMem space]
   opReturns (Inner ()) = pure []
 
-instance PrettyLore SeqMem
+instance PrettyRep SeqMem
 
 instance TC.CheckableOp SeqMem where
   checkOp (Alloc size _) =
@@ -52,9 +52,9 @@ instance TC.CheckableOp SeqMem where
     pure ()
 
 instance TC.Checkable SeqMem where
-  checkFParamLore = checkMemInfo
-  checkLParamLore = checkMemInfo
-  checkLetBoundLore = checkMemInfo
+  checkFParamDec = checkMemInfo
+  checkLParamDec = checkMemInfo
+  checkLetBoundDec = checkMemInfo
   checkRetType = mapM_ (TC.checkExtType . declExtTypeOf)
   primFParam name t = return $ Param name (MemPrim t)
   matchPattern = matchPatternToExp

--- a/src/Futhark/IR/Syntax.hs
+++ b/src/Futhark/IR/Syntax.hs
@@ -71,37 +71,36 @@
 -- in {b_13}
 -- @
 --
--- == Lores
+-- == Representations
 --
 -- Most AST types ('Stm', 'ExpT', t'Prog', etc) are parameterised by a
--- type parameter with the somewhat silly name @lore@.  The lore
--- specifies how to fill out various polymorphic parts of the AST.
--- For example, 'ExpT' has a constructor v'Op' whose payload depends
--- on @lore@, via the use of a type family called t'Op' (a kind of
--- type-level function) which is applied to the @lore@.  The SOACS
--- representation ("Futhark.IR.SOACS") thus uses a lore
--- called @SOACS@, and defines that @Op SOACS@ is a SOAC, while the
--- Kernels representation ("Futhark.IR.Kernels") defines
--- @Op Kernels@ as some kind of kernel construct.  Similarly, various
--- other decorations (e.g. what information we store in a t'PatElemT')
--- are also type families.
+-- type parameter @rep@.  The representation specifies how to fill out
+-- various polymorphic parts of the AST.  For example, 'ExpT' has a
+-- constructor v'Op' whose payload depends on @rep@, via the use of a
+-- type family called t'Op' (a kind of type-level function) which is
+-- applied to the @rep@.  The SOACS representation
+-- ("Futhark.IR.SOACS") thus uses a rep called @SOACS@, and defines
+-- that @Op SOACS@ is a SOAC, while the Kernels representation
+-- ("Futhark.IR.Kernels") defines @Op Kernels@ as some kind of kernel
+-- construct.  Similarly, various other decorations (e.g. what
+-- information we store in a t'PatElemT') are also type families.
 --
 -- The full list of possible decorations is defined as part of the
--- type class 'Decorations' (although other type families are also
+-- type class 'RepTypes' (although other type families are also
 -- used elsewhere in the compiler on an ad hoc basis).
 --
--- Essentially, the @lore@ type parameter functions as a kind of
+-- Essentially, the @rep@ type parameter functions as a kind of
 -- proxy, saving us from having to parameterise the AST type with all
 -- the different forms of decorations that we desire (it would easily
 -- become a type with a dozen type parameters).
 --
--- Defining a new representation (or /lore/) thus requires you to
+-- Defining a new representation (or /rep/) thus requires you to
 -- define an empty datatype and implement a handful of type class
 -- instances for it.  See the source of "Futhark.IR.Seq"
 -- for what is likely the simplest example.
 module Futhark.IR.Syntax
   ( module Language.Futhark.Core,
-    module Futhark.IR.Decorations,
+    module Futhark.IR.Rep,
     module Futhark.IR.Syntax.Core,
 
     -- * Types
@@ -172,7 +171,7 @@ import qualified Data.Sequence as Seq
 import qualified Data.Set as S
 import Data.String
 import Data.Traversable (fmapDefault, foldMapDefault)
-import Futhark.IR.Decorations
+import Futhark.IR.Rep
 import Futhark.IR.Syntax.Core
 import Language.Futhark.Core
 import Prelude hiding (id, (.))
@@ -204,7 +203,7 @@ withoutAttrs :: Attrs -> Attrs -> Attrs
 withoutAttrs (Attrs x) (Attrs y) = Attrs $ x `S.difference` y
 
 -- | A type alias for namespace control.
-type PatElem lore = PatElemT (LetDec lore)
+type PatElem rep = PatElemT (LetDec rep)
 
 -- | A pattern is conceptually just a list of names and their types.
 data PatternT dec = Pattern
@@ -232,7 +231,7 @@ instance Traversable PatternT where
     Pattern <$> traverse (traverse f) ctx <*> traverse (traverse f) vals
 
 -- | A type alias for namespace control.
-type Pattern lore = PatternT (LetDec lore)
+type Pattern rep = PatternT (LetDec rep)
 
 -- | Auxilliary Information associated with a statement.
 data StmAux dec = StmAux
@@ -247,38 +246,38 @@ instance Semigroup dec => Semigroup (StmAux dec) where
     StmAux (cs1 <> cs2) (attrs1 <> attrs2) (dec1 <> dec2)
 
 -- | A local variable binding.
-data Stm lore = Let
+data Stm rep = Let
   { -- | Pattern.
-    stmPattern :: Pattern lore,
+    stmPattern :: Pattern rep,
     -- | Auxiliary information statement.
-    stmAux :: StmAux (ExpDec lore),
+    stmAux :: StmAux (ExpDec rep),
     -- | Expression.
-    stmExp :: Exp lore
+    stmExp :: Exp rep
   }
 
-deriving instance Decorations lore => Ord (Stm lore)
+deriving instance RepTypes rep => Ord (Stm rep)
 
-deriving instance Decorations lore => Show (Stm lore)
+deriving instance RepTypes rep => Show (Stm rep)
 
-deriving instance Decorations lore => Eq (Stm lore)
+deriving instance RepTypes rep => Eq (Stm rep)
 
 -- | A sequence of statements.
-type Stms lore = Seq.Seq (Stm lore)
+type Stms rep = Seq.Seq (Stm rep)
 
 -- | A single statement.
-oneStm :: Stm lore -> Stms lore
+oneStm :: Stm rep -> Stms rep
 oneStm = Seq.singleton
 
 -- | Convert a statement list to a statement sequence.
-stmsFromList :: [Stm lore] -> Stms lore
+stmsFromList :: [Stm rep] -> Stms rep
 stmsFromList = Seq.fromList
 
 -- | Convert a statement sequence to a statement list.
-stmsToList :: Stms lore -> [Stm lore]
+stmsToList :: Stms rep -> [Stm rep]
 stmsToList = toList
 
 -- | The first statement in the sequence, if any.
-stmsHead :: Stms lore -> Maybe (Stm lore, Stms lore)
+stmsHead :: Stms rep -> Maybe (Stm rep, Stms rep)
 stmsHead stms = case Seq.viewl stms of
   stm Seq.:< stms' -> Just (stm, stms')
   Seq.EmptyL -> Nothing
@@ -288,17 +287,17 @@ type Result = [SubExp]
 
 -- | A body consists of a number of bindings, terminating in a result
 -- (essentially a tuple literal).
-data BodyT lore = Body
-  { bodyDec :: BodyDec lore,
-    bodyStms :: Stms lore,
+data BodyT rep = Body
+  { bodyDec :: BodyDec rep,
+    bodyStms :: Stms rep,
     bodyResult :: Result
   }
 
-deriving instance Decorations lore => Ord (BodyT lore)
+deriving instance RepTypes rep => Ord (BodyT rep)
 
-deriving instance Decorations lore => Show (BodyT lore)
+deriving instance RepTypes rep => Show (BodyT rep)
 
-deriving instance Decorations lore => Eq (BodyT lore)
+deriving instance RepTypes rep => Eq (BodyT rep)
 
 -- | Type alias for namespace reasons.
 type Body = BodyT
@@ -405,42 +404,42 @@ data BasicOp
   deriving (Eq, Ord, Show)
 
 -- | The root Futhark expression type.  The v'Op' constructor contains
--- a lore-specific operation.  Do-loops, branches and function calls
+-- a rep-specific operation.  Do-loops, branches and function calls
 -- are special.  Everything else is a simple t'BasicOp'.
-data ExpT lore
+data ExpT rep
   = -- | A simple (non-recursive) operation.
     BasicOp BasicOp
-  | Apply Name [(SubExp, Diet)] [RetType lore] (Safety, SrcLoc, [SrcLoc])
-  | If SubExp (BodyT lore) (BodyT lore) (IfDec (BranchType lore))
+  | Apply Name [(SubExp, Diet)] [RetType rep] (Safety, SrcLoc, [SrcLoc])
+  | If SubExp (BodyT rep) (BodyT rep) (IfDec (BranchType rep))
   | -- | @loop {a} = {v} (for i < n|while b) do b@.  The merge
     -- parameters are divided into context and value part.
-    DoLoop [(FParam lore, SubExp)] [(FParam lore, SubExp)] (LoopForm lore) (BodyT lore)
+    DoLoop [(FParam rep, SubExp)] [(FParam rep, SubExp)] (LoopForm rep) (BodyT rep)
   | -- | Create accumulators backed by the given arrays (which are
     -- consumed) and pass them to the lambda, which must return the
     -- updated accumulators and possibly some extra values.  The
     -- accumulators are turned back into arrays.  The 'Shape' is the
     -- write index space.  The corresponding arrays must all have this
     -- shape outermost.  This construct is not part of 'BasicOp'
-    -- because we need the @lore@ parameter.
-    WithAcc [(Shape, [VName], Maybe (Lambda lore, [SubExp]))] (Lambda lore)
-  | Op (Op lore)
+    -- because we need the @rep@ parameter.
+    WithAcc [(Shape, [VName], Maybe (Lambda rep, [SubExp]))] (Lambda rep)
+  | Op (Op rep)
 
-deriving instance Decorations lore => Eq (ExpT lore)
+deriving instance RepTypes rep => Eq (ExpT rep)
 
-deriving instance Decorations lore => Show (ExpT lore)
+deriving instance RepTypes rep => Show (ExpT rep)
 
-deriving instance Decorations lore => Ord (ExpT lore)
+deriving instance RepTypes rep => Ord (ExpT rep)
 
 -- | For-loop or while-loop?
-data LoopForm lore
-  = ForLoop VName IntType SubExp [(LParam lore, VName)]
+data LoopForm rep
+  = ForLoop VName IntType SubExp [(LParam rep, VName)]
   | WhileLoop VName
 
-deriving instance Decorations lore => Eq (LoopForm lore)
+deriving instance RepTypes rep => Eq (LoopForm rep)
 
-deriving instance Decorations lore => Show (LoopForm lore)
+deriving instance RepTypes rep => Show (LoopForm rep)
 
-deriving instance Decorations lore => Ord (LoopForm lore)
+deriving instance RepTypes rep => Ord (LoopForm rep)
 
 -- | Data associated with a branch.
 data IfDec rt = IfDec
@@ -472,44 +471,44 @@ data IfSort
 type Exp = ExpT
 
 -- | Anonymous function for use in a SOAC.
-data LambdaT lore = Lambda
-  { lambdaParams :: [LParam lore],
-    lambdaBody :: BodyT lore,
+data LambdaT rep = Lambda
+  { lambdaParams :: [LParam rep],
+    lambdaBody :: BodyT rep,
     lambdaReturnType :: [Type]
   }
 
-deriving instance Decorations lore => Eq (LambdaT lore)
+deriving instance RepTypes rep => Eq (LambdaT rep)
 
-deriving instance Decorations lore => Show (LambdaT lore)
+deriving instance RepTypes rep => Show (LambdaT rep)
 
-deriving instance Decorations lore => Ord (LambdaT lore)
+deriving instance RepTypes rep => Ord (LambdaT rep)
 
 -- | Type alias for namespacing reasons.
 type Lambda = LambdaT
 
 -- | A function and loop parameter.
-type FParam lore = Param (FParamInfo lore)
+type FParam rep = Param (FParamInfo rep)
 
 -- | A lambda parameter.
-type LParam lore = Param (LParamInfo lore)
+type LParam rep = Param (LParamInfo rep)
 
 -- | Function Declarations
-data FunDef lore = FunDef
+data FunDef rep = FunDef
   { -- | Contains a value if this function is
     -- an entry point.
     funDefEntryPoint :: Maybe EntryPoint,
     funDefAttrs :: Attrs,
     funDefName :: Name,
-    funDefRetType :: [RetType lore],
-    funDefParams :: [FParam lore],
-    funDefBody :: BodyT lore
+    funDefRetType :: [RetType rep],
+    funDefParams :: [FParam rep],
+    funDefBody :: BodyT rep
   }
 
-deriving instance Decorations lore => Eq (FunDef lore)
+deriving instance RepTypes rep => Eq (FunDef rep)
 
-deriving instance Decorations lore => Show (FunDef lore)
+deriving instance RepTypes rep => Show (FunDef rep)
 
-deriving instance Decorations lore => Ord (FunDef lore)
+deriving instance RepTypes rep => Ord (FunDef rep)
 
 -- | Information about the parameters and return value of an entry
 -- point.  The first element is for parameters, the second for return
@@ -531,14 +530,14 @@ data EntryPointType
   deriving (Eq, Show, Ord)
 
 -- | An entire Futhark program.
-data Prog lore = Prog
+data Prog rep = Prog
   { -- | Top-level constants that are computed at program startup, and
     -- which are in scope inside all functions.
-    progConsts :: Stms lore,
+    progConsts :: Stms rep,
     -- | The functions comprising the program.  All funtions are also
     -- available in scope in the definitions of the constants, so be
     -- careful not to introduce circular dependencies (not currently
     -- checked).
-    progFuns :: [FunDef lore]
+    progFuns :: [FunDef rep]
   }
   deriving (Eq, Ord, Show)

--- a/src/Futhark/IR/Syntax/Core.hs
+++ b/src/Futhark/IR/Syntax/Core.hs
@@ -5,7 +5,7 @@
 
 -- | The most primitive ("core") aspects of the AST.  Split out of
 -- "Futhark.IR.Syntax" in order for
--- "Futhark.IR.Decorations" to use these definitions.  This
+-- "Futhark.IR.Rep" to use these definitions.  This
 -- module is re-exported from "Futhark.IR.Syntax" and
 -- there should be no reason to include it explicitly.
 module Futhark.IR.Syntax.Core

--- a/src/Futhark/IR/Traversals.hs
+++ b/src/Futhark/IR/Traversals.hs
@@ -46,21 +46,21 @@ import Futhark.IR.Syntax
 -- | Express a monad mapping operation on a syntax node.  Each element
 -- of this structure expresses the operation to be performed on a
 -- given child.
-data Mapper flore tlore m = Mapper
+data Mapper frep trep m = Mapper
   { mapOnSubExp :: SubExp -> m SubExp,
     -- | Most bodies are enclosed in a scope, which is passed along
     -- for convenience.
-    mapOnBody :: Scope tlore -> Body flore -> m (Body tlore),
+    mapOnBody :: Scope trep -> Body frep -> m (Body trep),
     mapOnVName :: VName -> m VName,
-    mapOnRetType :: RetType flore -> m (RetType tlore),
-    mapOnBranchType :: BranchType flore -> m (BranchType tlore),
-    mapOnFParam :: FParam flore -> m (FParam tlore),
-    mapOnLParam :: LParam flore -> m (LParam tlore),
-    mapOnOp :: Op flore -> m (Op tlore)
+    mapOnRetType :: RetType frep -> m (RetType trep),
+    mapOnBranchType :: BranchType frep -> m (BranchType trep),
+    mapOnFParam :: FParam frep -> m (FParam trep),
+    mapOnLParam :: LParam frep -> m (LParam trep),
+    mapOnOp :: Op frep -> m (Op trep)
   }
 
 -- | A mapper that simply returns the tree verbatim.
-identityMapper :: Monad m => Mapper lore lore m
+identityMapper :: Monad m => Mapper rep rep m
 identityMapper =
   Mapper
     { mapOnSubExp = return,
@@ -78,9 +78,9 @@ identityMapper =
 -- into subexpressions.  The mapping is done left-to-right.
 mapExpM ::
   (Applicative m, Monad m) =>
-  Mapper flore tlore m ->
-  Exp flore ->
-  m (Exp tlore)
+  Mapper frep trep m ->
+  Exp frep ->
+  m (Exp trep)
 mapExpM tv (BasicOp (SubExp se)) =
   BasicOp <$> (SubExp <$> mapOnSubExp tv se)
 mapExpM tv (BasicOp (ArrayLit els rowt)) =
@@ -174,14 +174,14 @@ mapExpM tv (DoLoop ctxmerge valmerge form loopbody) = do
 mapExpM tv (Op op) =
   Op <$> mapOnOp tv op
 
-mapOnShape :: Monad m => Mapper flore tlore m -> Shape -> m Shape
+mapOnShape :: Monad m => Mapper frep trep m -> Shape -> m Shape
 mapOnShape tv (Shape ds) = Shape <$> mapM (mapOnSubExp tv) ds
 
 mapOnLoopForm ::
   Monad m =>
-  Mapper flore tlore m ->
-  LoopForm flore ->
-  m (LoopForm tlore)
+  Mapper frep trep m ->
+  LoopForm frep ->
+  m (LoopForm trep)
 mapOnLoopForm tv (ForLoop i it bound loop_vars) =
   ForLoop <$> mapOnVName tv i <*> pure it <*> mapOnSubExp tv bound
     <*> (zip <$> mapM (mapOnLParam tv) loop_lparams <*> mapM (mapOnVName tv) loop_arrs)
@@ -192,9 +192,9 @@ mapOnLoopForm tv (WhileLoop cond) =
 
 mapOnLambda ::
   Monad m =>
-  Mapper flore tlore m ->
-  Lambda flore ->
-  m (Lambda tlore)
+  Mapper frep trep m ->
+  Lambda frep ->
+  m (Lambda trep)
 mapOnLambda tv (Lambda params body ret) = do
   params' <- mapM (mapOnLParam tv) params
   Lambda params'
@@ -202,25 +202,25 @@ mapOnLambda tv (Lambda params body ret) = do
     <*> mapM (mapOnType (mapOnSubExp tv)) ret
 
 -- | Like 'mapExpM', but in the 'Identity' monad.
-mapExp :: Mapper flore tlore Identity -> Exp flore -> Exp tlore
+mapExp :: Mapper frep trep Identity -> Exp frep -> Exp trep
 mapExp m = runIdentity . mapExpM m
 
 -- | Express a monad expression on a syntax node.  Each element of
 -- this structure expresses the action to be performed on a given
 -- child.
-data Walker lore m = Walker
+data Walker rep m = Walker
   { walkOnSubExp :: SubExp -> m (),
-    walkOnBody :: Scope lore -> Body lore -> m (),
+    walkOnBody :: Scope rep -> Body rep -> m (),
     walkOnVName :: VName -> m (),
-    walkOnRetType :: RetType lore -> m (),
-    walkOnBranchType :: BranchType lore -> m (),
-    walkOnFParam :: FParam lore -> m (),
-    walkOnLParam :: LParam lore -> m (),
-    walkOnOp :: Op lore -> m ()
+    walkOnRetType :: RetType rep -> m (),
+    walkOnBranchType :: BranchType rep -> m (),
+    walkOnFParam :: FParam rep -> m (),
+    walkOnLParam :: LParam rep -> m (),
+    walkOnOp :: Op rep -> m ()
   }
 
 -- | A no-op traversal.
-identityWalker :: Monad m => Walker lore m
+identityWalker :: Monad m => Walker rep m
 identityWalker =
   Walker
     { walkOnSubExp = const $ return (),
@@ -233,10 +233,10 @@ identityWalker =
       walkOnOp = const $ return ()
     }
 
-walkOnShape :: Monad m => Walker lore m -> Shape -> m ()
+walkOnShape :: Monad m => Walker rep m -> Shape -> m ()
 walkOnShape tv (Shape ds) = mapM_ (walkOnSubExp tv) ds
 
-walkOnType :: Monad m => Walker lore m -> Type -> m ()
+walkOnType :: Monad m => Walker rep m -> Type -> m ()
 walkOnType _ Prim {} = return ()
 walkOnType tv (Acc acc ispace ts _) = do
   walkOnVName tv acc
@@ -245,7 +245,7 @@ walkOnType tv (Acc acc ispace ts _) = do
 walkOnType _ Mem {} = return ()
 walkOnType tv (Array _ shape _) = walkOnShape tv shape
 
-walkOnLoopForm :: Monad m => Walker lore m -> LoopForm lore -> m ()
+walkOnLoopForm :: Monad m => Walker rep m -> LoopForm rep -> m ()
 walkOnLoopForm tv (ForLoop i _ bound loop_vars) =
   walkOnVName tv i >> walkOnSubExp tv bound
     >> mapM_ (walkOnLParam tv) loop_lparams
@@ -255,14 +255,14 @@ walkOnLoopForm tv (ForLoop i _ bound loop_vars) =
 walkOnLoopForm tv (WhileLoop cond) =
   walkOnVName tv cond
 
-walkOnLambda :: Monad m => Walker lore m -> Lambda lore -> m ()
+walkOnLambda :: Monad m => Walker rep m -> Lambda rep -> m ()
 walkOnLambda tv (Lambda params body ret) = do
   mapM_ (walkOnLParam tv) params
   walkOnBody tv (scopeOfLParams params) body
   mapM_ (walkOnType tv) ret
 
 -- | As 'mapExpM', but do not construct a result AST.
-walkExpM :: Monad m => Walker lore m -> Exp lore -> m ()
+walkExpM :: Monad m => Walker rep m -> Exp rep -> m ()
 walkExpM tv (BasicOp (SubExp se)) =
   walkOnSubExp tv se
 walkExpM tv (BasicOp (ArrayLit els rowt)) =

--- a/src/Futhark/Internalise/Monad.hs
+++ b/src/Futhark/Internalise/Monad.hs
@@ -84,7 +84,7 @@ instance MonadFreshNames (State InternaliseState) where
   putNameSource src = modify $ \s -> s {stateNameSource = src}
 
 instance MonadBinder InternaliseM where
-  type Lore InternaliseM = SOACS
+  type Rep InternaliseM = SOACS
   mkExpDecM pat e = InternaliseM $ mkExpDecM pat e
   mkBodyM bnds res = InternaliseM $ mkBodyM bnds res
   mkLetNamesM pat e = InternaliseM $ mkLetNamesM pat e

--- a/src/Futhark/Optimise/BlkRegTiling.hs
+++ b/src/Futhark/Optimise/BlkRegTiling.hs
@@ -416,7 +416,7 @@ mmBlkRegTiling (Let pat aux (Op (SegOp (SegMap SegThread {} seg_space ts old_kbo
     return $ Just (host_stms, new_kernel)
 mmBlkRegTiling _ = return Nothing
 
-ceilDiv :: MonadBinder m => SubExp -> SubExp -> m (Exp (Lore m))
+ceilDiv :: MonadBinder m => SubExp -> SubExp -> m (Exp (Rep m))
 ceilDiv x y = pure $ BasicOp $ BinOp (SDivUp Int64 Unsafe) x y
 
 scratch :: MonadBinder m => String -> PrimType -> [SubExp] -> m VName

--- a/src/Futhark/Optimise/CSE.hs
+++ b/src/Futhark/Optimise/CSE.hs
@@ -46,7 +46,7 @@ import Futhark.IR.Aliases
     removeProgAliases,
     removeStmAliases,
   )
-import qualified Futhark.IR.Kernels.Kernel as Kernel
+import qualified Futhark.IR.GPU.Kernel as Kernel
 import qualified Futhark.IR.MC as MC
 import qualified Futhark.IR.Mem as Memory
 import Futhark.IR.Prop.Aliases

--- a/src/Futhark/Optimise/CSE.hs
+++ b/src/Futhark/Optimise/CSE.hs
@@ -54,22 +54,22 @@ import qualified Futhark.IR.SOACS.SOAC as SOAC
 import Futhark.Pass
 import Futhark.Transform.Substitute
 
-consumedInStms :: Aliased lore => Stms lore -> Names
+consumedInStms :: Aliased rep => Stms rep -> Names
 consumedInStms = snd . flip mkStmsAliases []
 
 -- | Perform CSE on every function in a program.
 --
 -- If the boolean argument is false, the pass will not perform CSE on
--- expressions producing arrays. This should be disabled when the lore has
+-- expressions producing arrays. This should be disabled when the rep has
 -- memory information, since at that point arrays have identity beyond their
 -- value.
 performCSE ::
-  ( ASTLore lore,
-    CanBeAliased (Op lore),
-    CSEInOp (OpWithAliases (Op lore))
+  ( ASTRep rep,
+    CanBeAliased (Op rep),
+    CSEInOp (OpWithAliases (Op rep))
   ) =>
   Bool ->
-  Pass lore lore
+  Pass rep rep
 performCSE cse_arrays =
   Pass "CSE" "Combine common subexpressions." $
     fmap removeProgAliases
@@ -87,34 +87,34 @@ performCSE cse_arrays =
 -- | Perform CSE on a single function.
 --
 -- If the boolean argument is false, the pass will not perform CSE on
--- expressions producing arrays. This should be disabled when the lore has
+-- expressions producing arrays. This should be disabled when the rep has
 -- memory information, since at that point arrays have identity beyond their
 -- value.
 performCSEOnFunDef ::
-  ( ASTLore lore,
-    CanBeAliased (Op lore),
-    CSEInOp (OpWithAliases (Op lore))
+  ( ASTRep rep,
+    CanBeAliased (Op rep),
+    CSEInOp (OpWithAliases (Op rep))
   ) =>
   Bool ->
-  FunDef lore ->
-  FunDef lore
+  FunDef rep ->
+  FunDef rep
 performCSEOnFunDef cse_arrays =
   removeFunDefAliases . cseInFunDef cse_arrays . analyseFun
 
 -- | Perform CSE on some statements.
 --
 -- If the boolean argument is false, the pass will not perform CSE on
--- expressions producing arrays. This should be disabled when the lore has
+-- expressions producing arrays. This should be disabled when the rep has
 -- memory information, since at that point arrays have identity beyond their
 -- value.
 performCSEOnStms ::
-  ( ASTLore lore,
-    CanBeAliased (Op lore),
-    CSEInOp (OpWithAliases (Op lore))
+  ( ASTRep rep,
+    CanBeAliased (Op rep),
+    CSEInOp (OpWithAliases (Op rep))
   ) =>
   Bool ->
-  Stms lore ->
-  Stms lore
+  Stms rep ->
+  Stms rep
 performCSEOnStms cse_arrays =
   fmap removeStmAliases . f . fst . analyseStms mempty
   where
@@ -129,10 +129,10 @@ performCSEOnStms cse_arrays =
           (newCSEState cse_arrays)
 
 cseInFunDef ::
-  (ASTLore lore, Aliased lore, CSEInOp (Op lore)) =>
+  (ASTRep rep, Aliased rep, CSEInOp (Op rep)) =>
   Bool ->
-  FunDef lore ->
-  FunDef lore
+  FunDef rep ->
+  FunDef rep
 cseInFunDef cse_arrays fundec =
   fundec
     { funDefBody =
@@ -150,13 +150,13 @@ cseInFunDef cse_arrays fundec =
       | primType $ declExtTypeOf t = Observe
       | otherwise = Consume
 
-type CSEM lore = Reader (CSEState lore)
+type CSEM rep = Reader (CSEState rep)
 
 cseInBody ::
-  (ASTLore lore, Aliased lore, CSEInOp (Op lore)) =>
+  (ASTRep rep, Aliased rep, CSEInOp (Op rep)) =>
   [Diet] ->
-  Body lore ->
-  CSEM lore (Body lore)
+  Body rep ->
+  CSEM rep (Body rep)
 cseInBody ds (Body bodydec stms res) = do
   (stms', res') <-
     cseInStms (res_cons <> stms_cons) (stmsToList stms) $ do
@@ -170,19 +170,19 @@ cseInBody ds (Body bodydec stms res) = do
     consumeResult _ _ = mempty
 
 cseInLambda ::
-  (ASTLore lore, Aliased lore, CSEInOp (Op lore)) =>
-  Lambda lore ->
-  CSEM lore (Lambda lore)
+  (ASTRep rep, Aliased rep, CSEInOp (Op rep)) =>
+  Lambda rep ->
+  CSEM rep (Lambda rep)
 cseInLambda lam = do
   body' <- cseInBody (map (const Observe) $ lambdaReturnType lam) $ lambdaBody lam
   return lam {lambdaBody = body'}
 
 cseInStms ::
-  (ASTLore lore, Aliased lore, CSEInOp (Op lore)) =>
+  (ASTRep rep, Aliased rep, CSEInOp (Op rep)) =>
   Names ->
-  [Stm lore] ->
-  CSEM lore a ->
-  CSEM lore (Stms lore, a)
+  [Stm rep] ->
+  CSEM rep a ->
+  CSEM rep (Stms rep, a)
 cseInStms _ [] m = do
   a <- m
   return (mempty, a)
@@ -208,11 +208,11 @@ cseInStms consumed (bnd : bnds) m =
       | otherwise = Observe
 
 cseInStm ::
-  ASTLore lore =>
+  ASTRep rep =>
   Names ->
-  Stm lore ->
-  ([Stm lore] -> CSEM lore a) ->
-  CSEM lore a
+  Stm rep ->
+  ([Stm rep] -> CSEM rep a) ->
+  CSEM rep a
 cseInStm consumed (Let pat (StmAux cs attrs edec) e) m = do
   CSEState (esubsts, nsubsts) cse_arrays <- ask
   let e' = substituteNames nsubsts e
@@ -239,70 +239,70 @@ cseInStm consumed (Let pat (StmAux cs attrs edec) e) m = do
       | patElemName pe `nameIn` consumed = True
       | otherwise = False
 
-type ExpressionSubstitutions lore =
+type ExpressionSubstitutions rep =
   M.Map
-    (ExpDec lore, Exp lore)
-    (Pattern lore)
+    (ExpDec rep, Exp rep)
+    (Pattern rep)
 
 type NameSubstitutions = M.Map VName VName
 
-data CSEState lore = CSEState
-  { _cseSubstitutions :: (ExpressionSubstitutions lore, NameSubstitutions),
+data CSEState rep = CSEState
+  { _cseSubstitutions :: (ExpressionSubstitutions rep, NameSubstitutions),
     _cseArrays :: Bool
   }
 
-newCSEState :: Bool -> CSEState lore
+newCSEState :: Bool -> CSEState rep
 newCSEState = CSEState (M.empty, M.empty)
 
 mkSubsts :: PatternT dec -> PatternT dec -> M.Map VName VName
 mkSubsts pat vs = M.fromList $ zip (patternNames pat) (patternNames vs)
 
-addNameSubst :: PatternT dec -> PatternT dec -> CSEState lore -> CSEState lore
+addNameSubst :: PatternT dec -> PatternT dec -> CSEState rep -> CSEState rep
 addNameSubst pat subpat (CSEState (esubsts, nsubsts) cse_arrays) =
   CSEState (esubsts, mkSubsts pat subpat `M.union` nsubsts) cse_arrays
 
 addExpSubst ::
-  ASTLore lore =>
-  Pattern lore ->
-  ExpDec lore ->
-  Exp lore ->
-  CSEState lore ->
-  CSEState lore
+  ASTRep rep =>
+  Pattern rep ->
+  ExpDec rep ->
+  Exp rep ->
+  CSEState rep ->
+  CSEState rep
 addExpSubst pat edec e (CSEState (esubsts, nsubsts) cse_arrays) =
   CSEState (M.insert (edec, e) pat esubsts, nsubsts) cse_arrays
 
 -- | The operations that permit CSE.
 class CSEInOp op where
   -- | Perform CSE within any nested expressions.
-  cseInOp :: op -> CSEM lore op
+  cseInOp :: op -> CSEM rep op
 
 instance CSEInOp () where
   cseInOp () = return ()
 
-subCSE :: CSEM lore r -> CSEM otherlore r
+subCSE :: CSEM rep r -> CSEM otherrep r
 subCSE m = do
   CSEState _ cse_arrays <- ask
   return $ runReader m $ newCSEState cse_arrays
 
 instance
-  ( ASTLore lore,
-    Aliased lore,
-    CSEInOp (Op lore),
+  ( ASTRep rep,
+    Aliased rep,
+    CSEInOp (Op rep),
     CSEInOp op
   ) =>
-  CSEInOp (Kernel.HostOp lore op)
+  CSEInOp (Kernel.HostOp rep op)
   where
   cseInOp (Kernel.SegOp op) = Kernel.SegOp <$> cseInOp op
   cseInOp (Kernel.OtherOp op) = Kernel.OtherOp <$> cseInOp op
   cseInOp x = return x
 
 instance
-  ( ASTLore lore,
-    Aliased lore,
-    CSEInOp (Op lore),
+  ( ASTRep rep,
+    Aliased rep,
+    CSEInOp (Op rep),
     CSEInOp op
   ) =>
-  CSEInOp (MC.MCOp lore op)
+  CSEInOp (MC.MCOp rep op)
   where
   cseInOp (MC.ParOp par_op op) =
     MC.ParOp <$> traverse cseInOp par_op <*> cseInOp op
@@ -310,8 +310,8 @@ instance
     MC.OtherOp <$> cseInOp op
 
 instance
-  (ASTLore lore, Aliased lore, CSEInOp (Op lore)) =>
-  CSEInOp (Kernel.SegOp lvl lore)
+  (ASTRep rep, Aliased rep, CSEInOp (Op rep)) =>
+  CSEInOp (Kernel.SegOp lvl rep)
   where
   cseInOp =
     subCSE
@@ -319,9 +319,9 @@ instance
         (Kernel.SegOpMapper return cseInLambda cseInKernelBody return return)
 
 cseInKernelBody ::
-  (ASTLore lore, Aliased lore, CSEInOp (Op lore)) =>
-  Kernel.KernelBody lore ->
-  CSEM lore (Kernel.KernelBody lore)
+  (ASTRep rep, Aliased rep, CSEInOp (Op rep)) =>
+  Kernel.KernelBody rep ->
+  CSEM rep (Kernel.KernelBody rep)
 cseInKernelBody (Kernel.KernelBody bodydec bnds res) = do
   Body _ bnds' _ <- cseInBody (map (const Observe) res) $ Body bodydec bnds []
   return $ Kernel.KernelBody bodydec bnds' res
@@ -331,10 +331,10 @@ instance CSEInOp op => CSEInOp (Memory.MemOp op) where
   cseInOp (Memory.Inner k) = Memory.Inner <$> subCSE (cseInOp k)
 
 instance
-  ( ASTLore lore,
-    CanBeAliased (Op lore),
-    CSEInOp (OpWithAliases (Op lore))
+  ( ASTRep rep,
+    CanBeAliased (Op rep),
+    CSEInOp (OpWithAliases (Op rep))
   ) =>
-  CSEInOp (SOAC.SOAC (Aliases lore))
+  CSEInOp (SOAC.SOAC (Aliases rep))
   where
   cseInOp = subCSE . SOAC.mapSOACM (SOAC.SOACMapper return cseInLambda return)

--- a/src/Futhark/Optimise/DoubleBuffer.hs
+++ b/src/Futhark/Optimise/DoubleBuffer.hs
@@ -48,7 +48,7 @@ doubleBufferMC :: Pass MCMem MCMem
 doubleBufferMC = doubleBuffer optimiseMCOp
 
 -- | The double buffering pass definition.
-doubleBuffer :: Mem lore => OptimiseOp lore -> Pass lore lore
+doubleBuffer :: Mem rep => OptimiseOp rep -> Pass rep rep
 doubleBuffer onOp =
   Pass
     { passName = "Double buffer",
@@ -66,51 +66,51 @@ doubleBuffer onOp =
     env = Env mempty doNotTouchLoop onOp
     doNotTouchLoop ctx val body = return (mempty, ctx, val, body)
 
-type OptimiseLoop lore =
-  [(FParam lore, SubExp)] ->
-  [(FParam lore, SubExp)] ->
-  Body lore ->
+type OptimiseLoop rep =
+  [(FParam rep, SubExp)] ->
+  [(FParam rep, SubExp)] ->
+  Body rep ->
   DoubleBufferM
-    lore
-    ( [Stm lore],
-      [(FParam lore, SubExp)],
-      [(FParam lore, SubExp)],
-      Body lore
+    rep
+    ( [Stm rep],
+      [(FParam rep, SubExp)],
+      [(FParam rep, SubExp)],
+      Body rep
     )
 
-type OptimiseOp lore =
-  Op lore -> DoubleBufferM lore (Op lore)
+type OptimiseOp rep =
+  Op rep -> DoubleBufferM rep (Op rep)
 
-data Env lore = Env
-  { envScope :: Scope lore,
-    envOptimiseLoop :: OptimiseLoop lore,
-    envOptimiseOp :: OptimiseOp lore
+data Env rep = Env
+  { envScope :: Scope rep,
+    envOptimiseLoop :: OptimiseLoop rep,
+    envOptimiseOp :: OptimiseOp rep
   }
 
-newtype DoubleBufferM lore a = DoubleBufferM
-  { runDoubleBufferM :: ReaderT (Env lore) (State VNameSource) a
+newtype DoubleBufferM rep a = DoubleBufferM
+  { runDoubleBufferM :: ReaderT (Env rep) (State VNameSource) a
   }
-  deriving (Functor, Applicative, Monad, MonadReader (Env lore), MonadFreshNames)
+  deriving (Functor, Applicative, Monad, MonadReader (Env rep), MonadFreshNames)
 
-instance ASTLore lore => HasScope lore (DoubleBufferM lore) where
+instance ASTRep rep => HasScope rep (DoubleBufferM rep) where
   askScope = asks envScope
 
-instance ASTLore lore => LocalScope lore (DoubleBufferM lore) where
+instance ASTRep rep => LocalScope rep (DoubleBufferM rep) where
   localScope scope = local $ \env -> env {envScope = envScope env <> scope}
 
-optimiseBody :: ASTLore lore => Body lore -> DoubleBufferM lore (Body lore)
+optimiseBody :: ASTRep rep => Body rep -> DoubleBufferM rep (Body rep)
 optimiseBody body = do
   bnds' <- optimiseStms $ stmsToList $ bodyStms body
   return $ body {bodyStms = stmsFromList bnds'}
 
-optimiseStms :: ASTLore lore => [Stm lore] -> DoubleBufferM lore [Stm lore]
+optimiseStms :: ASTRep rep => [Stm rep] -> DoubleBufferM rep [Stm rep]
 optimiseStms [] = return []
 optimiseStms (e : es) = do
   e_es <- optimiseStm e
   es' <- localScope (castScope $ scopeOf e_es) $ optimiseStms es
   return $ e_es ++ es'
 
-optimiseStm :: forall lore. ASTLore lore => Stm lore -> DoubleBufferM lore [Stm lore]
+optimiseStm :: forall rep. ASTRep rep => Stm rep -> DoubleBufferM rep [Stm rep]
 optimiseStm (Let pat aux (DoLoop ctx val form body)) = do
   body' <-
     localScope (scopeOf form <> scopeOfFParams (map fst $ ctx ++ val)) $
@@ -125,7 +125,7 @@ optimiseStm (Let pat aux e) = do
     optimise onOp =
       identityMapper
         { mapOnBody = \_ x ->
-            optimiseBody x :: DoubleBufferM lore (Body lore),
+            optimiseBody x :: DoubleBufferM rep (Body rep),
           mapOnOp = onOp
         }
 
@@ -156,34 +156,34 @@ optimiseMCOp (Inner (ParOp par_op op)) =
 optimiseMCOp op = return op
 
 optimiseKernelBody ::
-  ASTLore lore =>
-  KernelBody lore ->
-  DoubleBufferM lore (KernelBody lore)
+  ASTRep rep =>
+  KernelBody rep ->
+  DoubleBufferM rep (KernelBody rep)
 optimiseKernelBody kbody = do
   stms' <- optimiseStms $ stmsToList $ kernelBodyStms kbody
   return $ kbody {kernelBodyStms = stmsFromList stms'}
 
 optimiseLambda ::
-  ASTLore lore =>
-  Lambda lore ->
-  DoubleBufferM lore (Lambda lore)
+  ASTRep rep =>
+  Lambda rep ->
+  DoubleBufferM rep (Lambda rep)
 optimiseLambda lam = do
   body <- localScope (castScope $ scopeOf lam) $ optimiseBody $ lambdaBody lam
   return lam {lambdaBody = body}
 
-type Constraints lore =
-  ( ASTLore lore,
-    FParamInfo lore ~ FParamMem,
-    LParamInfo lore ~ LParamMem,
-    RetType lore ~ RetTypeMem,
-    LetDec lore ~ LetDecMem,
-    BranchType lore ~ BranchTypeMem,
-    ExpDec lore ~ (),
-    BodyDec lore ~ (),
-    OpReturns lore
+type Constraints rep =
+  ( ASTRep rep,
+    FParamInfo rep ~ FParamMem,
+    LParamInfo rep ~ LParamMem,
+    RetType rep ~ RetTypeMem,
+    LetDec rep ~ LetDecMem,
+    BranchType rep ~ BranchTypeMem,
+    ExpDec rep ~ (),
+    BodyDec rep ~ (),
+    OpReturns rep
   )
 
-optimiseLoop :: (Constraints lore, Op lore ~ MemOp inner, BinderOps lore) => OptimiseLoop lore
+optimiseLoop :: (Constraints rep, Op rep ~ MemOp inner, BinderOps rep) => OptimiseLoop rep
 optimiseLoop ctx val body = do
   -- We start out by figuring out which of the merge variables should
   -- be double-buffered.
@@ -273,10 +273,10 @@ doubleBufferMergeParams ctx_and_res val_params bound_in_loop =
       _ -> return NoBuffer
 
 allocStms ::
-  (Constraints lore, Op lore ~ MemOp inner, BinderOps lore) =>
-  [(FParam lore, SubExp)] ->
+  (Constraints rep, Op rep ~ MemOp inner, BinderOps rep) =>
+  [(FParam rep, SubExp)] ->
   [DoubleBuffer] ->
-  DoubleBufferM lore ([(FParam lore, SubExp)], [Stm lore])
+  DoubleBufferM rep ([(FParam rep, SubExp)], [Stm rep])
 allocStms merge = runWriterT . zipWithM allocation merge
   where
     allocation m@(Param pname _, _) (BufferAlloc name size space b) = do
@@ -310,11 +310,11 @@ allocStms merge = runWriterT . zipWithM allocation merge
       return (f, se)
 
 doubleBufferResult ::
-  (Constraints lore) =>
-  [FParam lore] ->
+  (Constraints rep) =>
+  [FParam rep] ->
   [DoubleBuffer] ->
-  Body lore ->
-  Body lore
+  Body rep ->
+  Body rep
 doubleBufferResult valparams buffered (Body _ bnds res) =
   let (ctx_res, val_res) = splitAt (length res - length valparams) res
       (copybnds, val_res') =

--- a/src/Futhark/Optimise/Fusion/Composing.hs
+++ b/src/Futhark/Optimise/Fusion/Composing.hs
@@ -44,11 +44,11 @@ import Futhark.Util (dropLast, splitAt3, takeLast)
 -- The result is the fused function, and a list of the array inputs
 -- expected by the SOAC containing the fused function.
 fuseMaps ::
-  Bindable lore =>
+  Bindable rep =>
   -- | The producer var names that still need to be returned
   Names ->
   -- | Function of SOAC to be fused.
-  Lambda lore ->
+  Lambda rep ->
   -- | Input of SOAC to be fused.
   [SOAC.Input] ->
   -- | Output of SOAC to be fused.  The
@@ -58,12 +58,12 @@ fuseMaps ::
   -- bind a single element of that output.
   [(VName, Ident)] ->
   -- | Function to be fused with.
-  Lambda lore ->
+  Lambda rep ->
   -- | Input of SOAC to be fused with.
   [SOAC.Input] ->
   -- | The fused lambda and the inputs of
   -- the resulting SOAC.
-  (Lambda lore, [SOAC.Input])
+  (Lambda rep, [SOAC.Input])
 fuseMaps unfus_nms lam1 inp1 out1 lam2 inp2 = (lam2', M.elems inputmap)
   where
     lam2' =
@@ -96,19 +96,19 @@ fuseMaps unfus_nms lam1 inp1 out1 lam2 inp2 = (lam2', M.elems inputmap)
 --(unfus_accpat, unfus_arrpat) = splitAt (length unfus_accs) unfus_pat
 
 fuseInputs ::
-  Bindable lore =>
+  Bindable rep =>
   Names ->
-  Lambda lore ->
+  Lambda rep ->
   [SOAC.Input] ->
   [(VName, Ident)] ->
-  Lambda lore ->
+  Lambda rep ->
   [SOAC.Input] ->
   ( [Ident],
     [Ident],
     [Ident],
     M.Map Ident SOAC.Input,
-    Body lore -> Body lore,
-    Body lore -> Body lore
+    Body rep -> Body rep,
+    Body rep -> Body rep
   )
 fuseInputs unfus_nms lam1 inp1 out1 lam2 inp2 =
   (lam2redparams, unfus_vars, outbnds, inputmap, makeCopies, makeCopiesInner)
@@ -172,9 +172,9 @@ filterOutParams out1 outins =
         _ -> (m, ra)
 
 removeDuplicateInputs ::
-  Bindable lore =>
+  Bindable rep =>
   M.Map Ident SOAC.Input ->
-  (M.Map Ident SOAC.Input, Body lore -> Body lore)
+  (M.Map Ident SOAC.Input, Body rep -> Body rep)
 removeDuplicateInputs = fst . M.foldlWithKey' comb ((M.empty, id), M.empty)
   where
     comb ((parmap, inner), arrmap) par arr =
@@ -192,19 +192,19 @@ removeDuplicateInputs = fst . M.foldlWithKey' comb ((M.empty, id), M.empty)
         `insertStm` b
 
 fuseRedomap ::
-  Bindable lore =>
+  Bindable rep =>
   Names ->
   [VName] ->
-  Lambda lore ->
+  Lambda rep ->
   [SubExp] ->
   [SubExp] ->
   [SOAC.Input] ->
   [(VName, Ident)] ->
-  Lambda lore ->
+  Lambda rep ->
   [SubExp] ->
   [SubExp] ->
   [SOAC.Input] ->
-  (Lambda lore, [SOAC.Input])
+  (Lambda rep, [SOAC.Input])
 fuseRedomap
   unfus_nms
   outVars
@@ -282,7 +282,7 @@ fuseRedomap
             }
      in (res_lam', new_inp)
 
-mergeReduceOps :: Lambda lore -> Lambda lore -> Lambda lore
+mergeReduceOps :: Lambda rep -> Lambda rep -> Lambda rep
 mergeReduceOps (Lambda par1 bdy1 rtp1) (Lambda par2 bdy2 rtp2) =
   let body' =
         Body

--- a/src/Futhark/Optimise/Fusion/LoopKernel.hs
+++ b/src/Futhark/Optimise/Fusion/LoopKernel.hs
@@ -429,7 +429,7 @@ fuseSOACwithKer unfus_set outVars soac_p soac_p_consumed ker = do
               (body_p, body_c) = (lambdaBody lam_p, lambdaBody lam_c)
               body' =
                 Body
-                  { bodyDec = bodyDec body_p, -- body_p and body_c have the same lores
+                  { bodyDec = bodyDec body_p, -- body_p and body_c have the same decorations
                     bodyStms = bodyStms body_p <> bodyStms body_c,
                     bodyResult =
                       take c_num_buckets (bodyResult body_c)
@@ -461,7 +461,7 @@ fuseSOACwithKer unfus_set outVars soac_p soac_p_consumed ker = do
           let (body_p, body_c) = (lambdaBody lam_p, lambdaBody lam_c)
           let body' =
                 Body
-                  { bodyDec = bodyDec body_p, -- body_p and body_c have the same lores
+                  { bodyDec = bodyDec body_p, -- body_p and body_c have the same decorations
                     bodyStms = bodyStms body_p <> bodyStms body_c,
                     bodyResult = zipW as_c (bodyResult body_c) as_p (bodyResult body_p)
                   }
@@ -547,7 +547,7 @@ fuseSOACwithKer unfus_set outVars soac_p soac_p_consumed ker = do
     ---------------------------------
     _ -> fail "Cannot fuse"
 
-getStreamOrder :: StreamForm lore -> StreamOrd
+getStreamOrder :: StreamForm rep -> StreamOrd
 getStreamOrder (Parallel o _ _) = o
 getStreamOrder Sequential = InOrder
 

--- a/src/Futhark/Optimise/InPlaceLowering.hs
+++ b/src/Futhark/Optimise/InPlaceLowering.hs
@@ -62,7 +62,7 @@
 -- FIXME: the implementation is not finished yet.  Specifically, not
 -- all of the above conditions are checked.
 module Futhark.Optimise.InPlaceLowering
-  ( inPlaceLoweringKernels,
+  ( inPlaceLoweringGPU,
     inPlaceLoweringSeq,
     inPlaceLoweringMC,
   )
@@ -73,15 +73,15 @@ import qualified Data.Map.Strict as M
 import Futhark.Analysis.Alias
 import Futhark.Binder
 import Futhark.IR.Aliases
-import Futhark.IR.Kernels
+import Futhark.IR.GPU
 import Futhark.IR.MC
 import Futhark.IR.Seq (Seq)
 import Futhark.Optimise.InPlaceLowering.LowerIntoStm
 import Futhark.Pass
 
 -- | Apply the in-place lowering optimisation to the given program.
-inPlaceLoweringKernels :: Pass Kernels Kernels
-inPlaceLoweringKernels = inPlaceLowering onKernelOp lowerUpdateKernels
+inPlaceLoweringGPU :: Pass GPU GPU
+inPlaceLoweringGPU = inPlaceLowering onKernelOp lowerUpdateGPU
 
 -- | Apply the in-place lowering optimisation to the given program.
 inPlaceLoweringSeq :: Pass Seq Seq
@@ -217,7 +217,7 @@ onMCOp :: OnOp MC
 onMCOp (ParOp par_op op) = ParOp <$> traverse onSegOp par_op <*> onSegOp op
 onMCOp op = return op
 
-onKernelOp :: OnOp Kernels
+onKernelOp :: OnOp GPU
 onKernelOp (SegOp op) = SegOp <$> onSegOp op
 onKernelOp op = return op
 

--- a/src/Futhark/Optimise/InPlaceLowering/LowerIntoStm.hs
+++ b/src/Futhark/Optimise/InPlaceLowering/LowerIntoStm.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Futhark.Optimise.InPlaceLowering.LowerIntoStm
-  ( lowerUpdateKernels,
+  ( lowerUpdateGPU,
     lowerUpdate,
     LowerUpdate,
     DesiredUpdate (..),
@@ -17,7 +17,7 @@ import Data.Maybe (isNothing, mapMaybe)
 import Futhark.Analysis.PrimExp.Convert
 import Futhark.Construct
 import Futhark.IR.Aliases
-import Futhark.IR.Kernels
+import Futhark.IR.GPU
 import Futhark.Optimise.InPlaceLowering.SubstituteIndices
 
 data DesiredUpdate dec = DesiredUpdate
@@ -76,8 +76,8 @@ lowerUpdate
 lowerUpdate _ _ _ =
   Nothing
 
-lowerUpdateKernels :: MonadFreshNames m => LowerUpdate Kernels m
-lowerUpdateKernels
+lowerUpdateGPU :: MonadFreshNames m => LowerUpdate GPU m
+lowerUpdateGPU
   scope
   (Let pat aux (Op (SegOp (SegMap lvl space ts kbody))))
   updates
@@ -99,20 +99,20 @@ lowerUpdateKernels
       source_used_in_kbody =
         mconcat (map (`lookupAliases` scope) (namesToList (freeIn kbody)))
           `namesIntersect` mconcat (map ((`lookupAliases` scope) . updateSource) updates)
-lowerUpdateKernels scope stm updates = lowerUpdate scope stm updates
+lowerUpdateGPU scope stm updates = lowerUpdate scope stm updates
 
 lowerUpdatesIntoSegMap ::
   MonadFreshNames m =>
-  Scope (Aliases Kernels) ->
-  Pattern (Aliases Kernels) ->
-  [DesiredUpdate (LetDec (Aliases Kernels))] ->
+  Scope (Aliases GPU) ->
+  Pattern (Aliases GPU) ->
+  [DesiredUpdate (LetDec (Aliases GPU))] ->
   SegSpace ->
-  KernelBody (Aliases Kernels) ->
+  KernelBody (Aliases GPU) ->
   Maybe
     ( m
-        ( Pattern (Aliases Kernels),
-          KernelBody (Aliases Kernels),
-          Stms (Aliases Kernels)
+        ( Pattern (Aliases GPU),
+          KernelBody (Aliases GPU),
+          Stms (Aliases GPU)
         )
     )
 lowerUpdatesIntoSegMap scope pat updates kspace kbody = do

--- a/src/Futhark/Optimise/InPlaceLowering/SubstituteIndices.hs
+++ b/src/Futhark/Optimise/InPlaceLowering/SubstituteIndices.hs
@@ -25,9 +25,9 @@ type IndexSubstitution dec = (Certificates, VName, dec, Slice SubExp)
 type IndexSubstitutions dec = [(VName, IndexSubstitution dec)]
 
 typeEnvFromSubstitutions ::
-  LetDec lore ~ dec =>
+  LetDec rep ~ dec =>
   IndexSubstitutions dec ->
-  Scope lore
+  Scope rep
 typeEnvFromSubstitutions = M.fromList . map (fromSubstitution . snd)
   where
     fromSubstitution (_, name, t, _) =
@@ -36,42 +36,42 @@ typeEnvFromSubstitutions = M.fromList . map (fromSubstitution . snd)
 -- | Perform the substitution.
 substituteIndices ::
   ( MonadFreshNames m,
-    BinderOps lore,
-    Bindable lore,
-    Aliased lore,
-    LetDec lore ~ dec
+    BinderOps rep,
+    Bindable rep,
+    Aliased rep,
+    LetDec rep ~ dec
   ) =>
   IndexSubstitutions dec ->
-  Stms lore ->
-  m (IndexSubstitutions dec, Stms lore)
+  Stms rep ->
+  m (IndexSubstitutions dec, Stms rep)
 substituteIndices substs bnds =
   runBinderT (substituteIndicesInStms substs bnds) types
   where
     types = typeEnvFromSubstitutions substs
 
 substituteIndicesInStms ::
-  (MonadBinder m, Bindable (Lore m), Aliased (Lore m)) =>
-  IndexSubstitutions (LetDec (Lore m)) ->
-  Stms (Lore m) ->
-  m (IndexSubstitutions (LetDec (Lore m)))
+  (MonadBinder m, Bindable (Rep m), Aliased (Rep m)) =>
+  IndexSubstitutions (LetDec (Rep m)) ->
+  Stms (Rep m) ->
+  m (IndexSubstitutions (LetDec (Rep m)))
 substituteIndicesInStms = foldM substituteIndicesInStm
 
 substituteIndicesInStm ::
-  (MonadBinder m, Bindable (Lore m), Aliased (Lore m)) =>
-  IndexSubstitutions (LetDec (Lore m)) ->
-  Stm (Lore m) ->
-  m (IndexSubstitutions (LetDec (Lore m)))
-substituteIndicesInStm substs (Let pat lore e) = do
+  (MonadBinder m, Bindable (Rep m), Aliased (Rep m)) =>
+  IndexSubstitutions (LetDec (Rep m)) ->
+  Stm (Rep m) ->
+  m (IndexSubstitutions (LetDec (Rep m)))
+substituteIndicesInStm substs (Let pat rep e) = do
   e' <- substituteIndicesInExp substs e
   (substs', pat') <- substituteIndicesInPattern substs pat
-  addStm $ Let pat' lore e'
+  addStm $ Let pat' rep e'
   return substs'
 
 substituteIndicesInPattern ::
-  (MonadBinder m, LetDec (Lore m) ~ dec) =>
-  IndexSubstitutions (LetDec (Lore m)) ->
+  (MonadBinder m, LetDec (Rep m) ~ dec) =>
+  IndexSubstitutions (LetDec (Rep m)) ->
   PatternT dec ->
-  m (IndexSubstitutions (LetDec (Lore m)), PatternT dec)
+  m (IndexSubstitutions (LetDec (Rep m)), PatternT dec)
 substituteIndicesInPattern substs pat = do
   (substs', context) <- mapAccumLM sub substs $ patternContextElements pat
   (substs'', values) <- mapAccumLM sub substs' $ patternValueElements pat
@@ -81,13 +81,13 @@ substituteIndicesInPattern substs pat = do
 
 substituteIndicesInExp ::
   ( MonadBinder m,
-    Bindable (Lore m),
-    Aliased (Lore m),
-    LetDec (Lore m) ~ dec
+    Bindable (Rep m),
+    Aliased (Rep m),
+    LetDec (Rep m) ~ dec
   ) =>
-  IndexSubstitutions (LetDec (Lore m)) ->
-  Exp (Lore m) ->
-  m (Exp (Lore m))
+  IndexSubstitutions (LetDec (Rep m)) ->
+  Exp (Rep m) ->
+  m (Exp (Rep m))
 substituteIndicesInExp substs (Op op) = do
   let used_in_op = filter ((`nameIn` freeIn op) . fst) substs
   var_substs <- fmap mconcat $
@@ -137,7 +137,7 @@ substituteIndicesInExp substs e = do
 
 substituteIndicesInSubExp ::
   MonadBinder m =>
-  IndexSubstitutions (LetDec (Lore m)) ->
+  IndexSubstitutions (LetDec (Rep m)) ->
   SubExp ->
   m SubExp
 substituteIndicesInSubExp substs (Var v) =
@@ -147,7 +147,7 @@ substituteIndicesInSubExp _ se =
 
 substituteIndicesInVar ::
   MonadBinder m =>
-  IndexSubstitutions (LetDec (Lore m)) ->
+  IndexSubstitutions (LetDec (Rep m)) ->
   VName ->
   m VName
 substituteIndicesInVar substs v
@@ -161,10 +161,10 @@ substituteIndicesInVar substs v
     return v
 
 substituteIndicesInBody ::
-  (MonadBinder m, Bindable (Lore m), Aliased (Lore m)) =>
-  IndexSubstitutions (LetDec (Lore m)) ->
-  Body (Lore m) ->
-  m (Body (Lore m))
+  (MonadBinder m, Bindable (Rep m), Aliased (Rep m)) =>
+  IndexSubstitutions (LetDec (Rep m)) ->
+  Body (Rep m) ->
+  m (Body (Rep m))
 substituteIndicesInBody substs (Body _ stms res) = do
   (substs', stms') <-
     inScopeOf stms $

--- a/src/Futhark/Optimise/InliningDeadFun.hs
+++ b/src/Futhark/Optimise/InliningDeadFun.hs
@@ -26,7 +26,7 @@ import Futhark.IR.SOACS.Simplify
     simplifyFun,
   )
 import Futhark.Optimise.CSE
-import Futhark.Optimise.Simplify.Lore (addScopeWisdom)
+import Futhark.Optimise.Simplify.Rep (addScopeWisdom)
 import Futhark.Pass
 import Futhark.Transform.CopyPropagate
   ( copyPropagateInFun,

--- a/src/Futhark/Optimise/ReuseAllocations.hs
+++ b/src/Futhark/Optimise/ReuseAllocations.hs
@@ -159,7 +159,7 @@ onKernelBodyStms (SegHist lvl space binops ts body) f = do
 -- replace allocations and references to memory blocks inside with a (hopefully)
 -- reduced number of allocations.
 optimiseKernel ::
-  (MonadBinder m, Lore m ~ KernelsMem) =>
+  (MonadBinder m, Rep m ~ KernelsMem) =>
   Interference.Graph VName ->
   SegOp lvl KernelsMem ->
   m (SegOp lvl KernelsMem)

--- a/src/Futhark/Optimise/Simplify.hs
+++ b/src/Futhark/Optimise/Simplify.hs
@@ -15,7 +15,7 @@ module Futhark.Optimise.Simplify
     Engine.bindableSimpleOps,
     Engine.noExtraHoistBlockers,
     Engine.neverHoist,
-    Engine.SimplifiableLore,
+    Engine.SimplifiableRep,
     Engine.HoistBlockers,
     RuleBook,
   )
@@ -27,7 +27,7 @@ import qualified Futhark.Analysis.UsageTable as UT
 import Futhark.IR
 import Futhark.MonadFreshNames
 import qualified Futhark.Optimise.Simplify.Engine as Engine
-import Futhark.Optimise.Simplify.Lore
+import Futhark.Optimise.Simplify.Rep
 import Futhark.Optimise.Simplify.Rule
 import Futhark.Pass
 
@@ -35,12 +35,12 @@ import Futhark.Pass
 -- output, meaningful simplification may not have taken place - the
 -- order of bindings may simply have been rearranged.
 simplifyProg ::
-  Engine.SimplifiableLore lore =>
-  Engine.SimpleOps lore ->
-  RuleBook (Engine.Wise lore) ->
-  Engine.HoistBlockers lore ->
-  Prog lore ->
-  PassM (Prog lore)
+  Engine.SimplifiableRep rep =>
+  Engine.SimpleOps rep ->
+  RuleBook (Engine.Wise rep) ->
+  Engine.HoistBlockers rep ->
+  Prog rep ->
+  PassM (Prog rep)
 simplifyProg simpl rules blockers (Prog consts funs) = do
   (consts_vtable, consts') <-
     simplifyConsts
@@ -84,13 +84,13 @@ simplifyProg simpl rules blockers (Prog consts funs) = do
 
 -- | Run a simplification operation to convergence.
 simplifySomething ::
-  (MonadFreshNames m, Engine.SimplifiableLore lore) =>
-  (a -> Engine.SimpleM lore b) ->
+  (MonadFreshNames m, Engine.SimplifiableRep rep) =>
+  (a -> Engine.SimpleM rep b) ->
   (b -> a) ->
-  Engine.SimpleOps lore ->
-  RuleBook (Wise lore) ->
-  Engine.HoistBlockers lore ->
-  ST.SymbolTable (Wise lore) ->
+  Engine.SimpleOps rep ->
+  RuleBook (Wise rep) ->
+  Engine.HoistBlockers rep ->
+  ST.SymbolTable (Wise rep) ->
   a ->
   m a
 simplifySomething f g simpl rules blockers vtable x = do
@@ -104,26 +104,26 @@ simplifySomething f g simpl rules blockers vtable x = do
 -- order of bindings may simply have been rearranged.  Runs in a loop
 -- until convergence.
 simplifyFun ::
-  (MonadFreshNames m, Engine.SimplifiableLore lore) =>
-  Engine.SimpleOps lore ->
-  RuleBook (Engine.Wise lore) ->
-  Engine.HoistBlockers lore ->
-  ST.SymbolTable (Wise lore) ->
-  FunDef lore ->
-  m (FunDef lore)
+  (MonadFreshNames m, Engine.SimplifiableRep rep) =>
+  Engine.SimpleOps rep ->
+  RuleBook (Engine.Wise rep) ->
+  Engine.HoistBlockers rep ->
+  ST.SymbolTable (Wise rep) ->
+  FunDef rep ->
+  m (FunDef rep)
 simplifyFun = simplifySomething Engine.simplifyFun removeFunDefWisdom
 
 -- | Simplify just a single t'Lambda'.
 simplifyLambda ::
   ( MonadFreshNames m,
-    HasScope lore m,
-    Engine.SimplifiableLore lore
+    HasScope rep m,
+    Engine.SimplifiableRep rep
   ) =>
-  Engine.SimpleOps lore ->
-  RuleBook (Engine.Wise lore) ->
-  Engine.HoistBlockers lore ->
-  Lambda lore ->
-  m (Lambda lore)
+  Engine.SimpleOps rep ->
+  RuleBook (Engine.Wise rep) ->
+  Engine.HoistBlockers rep ->
+  Lambda rep ->
+  m (Lambda rep)
 simplifyLambda simpl rules blockers orig_lam = do
   vtable <- ST.fromScope . addScopeWisdom <$> askScope
   simplifySomething
@@ -137,13 +137,13 @@ simplifyLambda simpl rules blockers orig_lam = do
 
 -- | Simplify a sequence of 'Stm's.
 simplifyStms ::
-  (MonadFreshNames m, Engine.SimplifiableLore lore) =>
-  Engine.SimpleOps lore ->
-  RuleBook (Engine.Wise lore) ->
-  Engine.HoistBlockers lore ->
-  Scope lore ->
-  Stms lore ->
-  m (ST.SymbolTable (Wise lore), Stms lore)
+  (MonadFreshNames m, Engine.SimplifiableRep rep) =>
+  Engine.SimpleOps rep ->
+  RuleBook (Engine.Wise rep) ->
+  Engine.HoistBlockers rep ->
+  Scope rep ->
+  Stms rep ->
+  m (ST.SymbolTable (Wise rep), Stms rep)
 simplifyStms simpl rules blockers scope =
   simplifySomething f g simpl rules blockers vtable . (mempty,)
   where
@@ -153,10 +153,10 @@ simplifyStms simpl rules blockers scope =
     g = second $ fmap removeStmWisdom
 
 loopUntilConvergence ::
-  (MonadFreshNames m, Engine.SimplifiableLore lore) =>
-  Engine.Env lore ->
-  Engine.SimpleOps lore ->
-  (a -> Engine.SimpleM lore b) ->
+  (MonadFreshNames m, Engine.SimplifiableRep rep) =>
+  Engine.Env rep ->
+  Engine.SimpleOps rep ->
+  (a -> Engine.SimpleM rep b) ->
   (b -> a) ->
   a ->
   m a

--- a/src/Futhark/Optimise/Simplify/Engine.hs
+++ b/src/Futhark/Optimise/Simplify/Engine.hs
@@ -48,7 +48,7 @@ module Futhark.Optimise.Simplify.Engine
     localVtable,
 
     -- * Building blocks
-    SimplifiableLore,
+    SimplifiableRep,
     Simplifiable (..),
     simplifyStms,
     simplifyFun,
@@ -61,7 +61,7 @@ module Futhark.Optimise.Simplify.Engine
     hoistStms,
     blockIf,
     enterLoop,
-    module Futhark.Optimise.Simplify.Lore,
+    module Futhark.Optimise.Simplify.Rep,
   )
 where
 
@@ -75,35 +75,35 @@ import qualified Futhark.Analysis.UsageTable as UT
 import Futhark.Construct
 import Futhark.IR
 import Futhark.IR.Prop.Aliases
-import Futhark.Optimise.Simplify.Lore
+import Futhark.Optimise.Simplify.Rep
 import Futhark.Optimise.Simplify.Rule
 import Futhark.Util (nubOrd, splitFromEnd)
 
-data HoistBlockers lore = HoistBlockers
+data HoistBlockers rep = HoistBlockers
   { -- | Blocker for hoisting out of parallel loops.
-    blockHoistPar :: BlockPred (Wise lore),
+    blockHoistPar :: BlockPred (Wise rep),
     -- | Blocker for hoisting out of sequential loops.
-    blockHoistSeq :: BlockPred (Wise lore),
+    blockHoistSeq :: BlockPred (Wise rep),
     -- | Blocker for hoisting out of branches.
-    blockHoistBranch :: BlockPred (Wise lore),
-    isAllocation :: Stm (Wise lore) -> Bool
+    blockHoistBranch :: BlockPred (Wise rep),
+    isAllocation :: Stm (Wise rep) -> Bool
   }
 
-noExtraHoistBlockers :: HoistBlockers lore
+noExtraHoistBlockers :: HoistBlockers rep
 noExtraHoistBlockers =
   HoistBlockers neverBlocks neverBlocks neverBlocks (const False)
 
-neverHoist :: HoistBlockers lore
+neverHoist :: HoistBlockers rep
 neverHoist =
   HoistBlockers alwaysBlocks alwaysBlocks alwaysBlocks (const False)
 
-data Env lore = Env
-  { envRules :: RuleBook (Wise lore),
-    envHoistBlockers :: HoistBlockers lore,
-    envVtable :: ST.SymbolTable (Wise lore)
+data Env rep = Env
+  { envRules :: RuleBook (Wise rep),
+    envHoistBlockers :: HoistBlockers rep,
+    envVtable :: ST.SymbolTable (Wise rep)
   }
 
-emptyEnv :: RuleBook (Wise lore) -> HoistBlockers lore -> Env lore
+emptyEnv :: RuleBook (Wise rep) -> HoistBlockers rep -> Env rep
 emptyEnv rules blockers =
   Env
     { envRules = rules,
@@ -111,33 +111,33 @@ emptyEnv rules blockers =
       envVtable = mempty
     }
 
-type Protect m = SubExp -> Pattern (Lore m) -> Op (Lore m) -> Maybe (m ())
+type Protect m = SubExp -> Pattern (Rep m) -> Op (Rep m) -> Maybe (m ())
 
-data SimpleOps lore = SimpleOps
+data SimpleOps rep = SimpleOps
   { mkExpDecS ::
-      ST.SymbolTable (Wise lore) ->
-      Pattern (Wise lore) ->
-      Exp (Wise lore) ->
-      SimpleM lore (ExpDec (Wise lore)),
+      ST.SymbolTable (Wise rep) ->
+      Pattern (Wise rep) ->
+      Exp (Wise rep) ->
+      SimpleM rep (ExpDec (Wise rep)),
     mkBodyS ::
-      ST.SymbolTable (Wise lore) ->
-      Stms (Wise lore) ->
+      ST.SymbolTable (Wise rep) ->
+      Stms (Wise rep) ->
       Result ->
-      SimpleM lore (Body (Wise lore)),
+      SimpleM rep (Body (Wise rep)),
     -- | Make a hoisted Op safe.  The SubExp is a boolean
     -- that is true when the value of the statement will
     -- actually be used.
-    protectHoistedOpS :: Protect (Binder (Wise lore)),
-    opUsageS :: Op (Wise lore) -> UT.UsageTable,
-    simplifyOpS :: SimplifyOp lore (Op lore)
+    protectHoistedOpS :: Protect (Binder (Wise rep)),
+    opUsageS :: Op (Wise rep) -> UT.UsageTable,
+    simplifyOpS :: SimplifyOp rep (Op rep)
   }
 
-type SimplifyOp lore op = op -> SimpleM lore (OpWithWisdom op, Stms (Wise lore))
+type SimplifyOp rep op = op -> SimpleM rep (OpWithWisdom op, Stms (Wise rep))
 
 bindableSimpleOps ::
-  (SimplifiableLore lore, Bindable lore) =>
-  SimplifyOp lore (Op lore) ->
-  SimpleOps lore
+  (SimplifiableRep rep, Bindable rep) =>
+  SimplifyOp rep (Op rep) ->
+  SimpleOps rep
 bindableSimpleOps =
   SimpleOps mkExpDecS' mkBodyS' protectHoistedOpS' (const mempty)
   where
@@ -145,10 +145,10 @@ bindableSimpleOps =
     mkBodyS' _ bnds res = return $ mkBody bnds res
     protectHoistedOpS' _ _ _ = Nothing
 
-newtype SimpleM lore a
+newtype SimpleM rep a
   = SimpleM
       ( ReaderT
-          (SimpleOps lore, Env lore)
+          (SimpleOps rep, Env rep)
           (State (VNameSource, Bool, Certificates))
           a
       )
@@ -156,15 +156,15 @@ newtype SimpleM lore a
     ( Applicative,
       Functor,
       Monad,
-      MonadReader (SimpleOps lore, Env lore),
+      MonadReader (SimpleOps rep, Env rep),
       MonadState (VNameSource, Bool, Certificates)
     )
 
-instance MonadFreshNames (SimpleM lore) where
+instance MonadFreshNames (SimpleM rep) where
   putNameSource src = modify $ \(_, b, c) -> (src, b, c)
   getNameSource = gets $ \(a, _, _) -> a
 
-instance SimplifiableLore lore => HasScope (Wise lore) (SimpleM lore) where
+instance SimplifiableRep rep => HasScope (Wise rep) (SimpleM rep) where
   askScope = ST.toScope <$> askVtable
   lookupType name = do
     vtable <- askVtable
@@ -177,37 +177,37 @@ instance SimplifiableLore lore => HasScope (Wise lore) (SimpleM lore) where
             ++ " in symbol table."
 
 instance
-  SimplifiableLore lore =>
-  LocalScope (Wise lore) (SimpleM lore)
+  SimplifiableRep rep =>
+  LocalScope (Wise rep) (SimpleM rep)
   where
   localScope types = localVtable (<> ST.fromScope types)
 
 runSimpleM ::
-  SimpleM lore a ->
-  SimpleOps lore ->
-  Env lore ->
+  SimpleM rep a ->
+  SimpleOps rep ->
+  Env rep ->
   VNameSource ->
   ((a, Bool), VNameSource)
 runSimpleM (SimpleM m) simpl env src =
   let (x, (src', b, _)) = runState (runReaderT m (simpl, env)) (src, False, mempty)
    in ((x, b), src')
 
-askEngineEnv :: SimpleM lore (Env lore)
+askEngineEnv :: SimpleM rep (Env rep)
 askEngineEnv = asks snd
 
-asksEngineEnv :: (Env lore -> a) -> SimpleM lore a
+asksEngineEnv :: (Env rep -> a) -> SimpleM rep a
 asksEngineEnv f = f <$> askEngineEnv
 
-askVtable :: SimpleM lore (ST.SymbolTable (Wise lore))
+askVtable :: SimpleM rep (ST.SymbolTable (Wise rep))
 askVtable = asksEngineEnv envVtable
 
 localVtable ::
-  (ST.SymbolTable (Wise lore) -> ST.SymbolTable (Wise lore)) ->
-  SimpleM lore a ->
-  SimpleM lore a
+  (ST.SymbolTable (Wise rep) -> ST.SymbolTable (Wise rep)) ->
+  SimpleM rep a ->
+  SimpleM rep a
 localVtable f = local $ \(ops, env) -> (ops, env {envVtable = f $ envVtable env})
 
-collectCerts :: SimpleM lore a -> SimpleM lore (a, Certificates)
+collectCerts :: SimpleM rep a -> SimpleM rep (a, Certificates)
 collectCerts m = do
   x <- m
   (a, b, cs) <- get
@@ -216,40 +216,40 @@ collectCerts m = do
 
 -- | Mark that we have changed something and it would be a good idea
 -- to re-run the simplifier.
-changed :: SimpleM lore ()
+changed :: SimpleM rep ()
 changed = modify $ \(src, _, cs) -> (src, True, cs)
 
-usedCerts :: Certificates -> SimpleM lore ()
+usedCerts :: Certificates -> SimpleM rep ()
 usedCerts cs = modify $ \(a, b, c) -> (a, b, cs <> c)
 
 -- | Indicate in the symbol table that we have descended into a loop.
-enterLoop :: SimpleM lore a -> SimpleM lore a
+enterLoop :: SimpleM rep a -> SimpleM rep a
 enterLoop = localVtable ST.deepen
 
-bindFParams :: SimplifiableLore lore => [FParam (Wise lore)] -> SimpleM lore a -> SimpleM lore a
+bindFParams :: SimplifiableRep rep => [FParam (Wise rep)] -> SimpleM rep a -> SimpleM rep a
 bindFParams params =
   localVtable $ ST.insertFParams params
 
-bindLParams :: SimplifiableLore lore => [LParam (Wise lore)] -> SimpleM lore a -> SimpleM lore a
+bindLParams :: SimplifiableRep rep => [LParam (Wise rep)] -> SimpleM rep a -> SimpleM rep a
 bindLParams params =
   localVtable $ \vtable -> foldr ST.insertLParam vtable params
 
 bindArrayLParams ::
-  SimplifiableLore lore =>
-  [LParam (Wise lore)] ->
-  SimpleM lore a ->
-  SimpleM lore a
+  SimplifiableRep rep =>
+  [LParam (Wise rep)] ->
+  SimpleM rep a ->
+  SimpleM rep a
 bindArrayLParams params =
   localVtable $ \vtable -> foldl' (flip ST.insertLParam) vtable params
 
 bindMerge ::
-  SimplifiableLore lore =>
-  [(FParam (Wise lore), SubExp, SubExp)] ->
-  SimpleM lore a ->
-  SimpleM lore a
+  SimplifiableRep rep =>
+  [(FParam (Wise rep), SubExp, SubExp)] ->
+  SimpleM rep a ->
+  SimpleM rep a
 bindMerge = localVtable . ST.insertLoopMerge
 
-bindLoopVar :: SimplifiableLore lore => VName -> IntType -> SubExp -> SimpleM lore a -> SimpleM lore a
+bindLoopVar :: SimplifiableRep rep => VName -> IntType -> SubExp -> SimpleM rep a -> SimpleM rep a
 bindLoopVar var it bound =
   localVtable $ ST.insertLoopVar var it bound
 
@@ -258,14 +258,14 @@ bindLoopVar var it bound =
 -- them.  (This means such hoisting is not worth it unless they are in
 -- turn hoisted out of a loop somewhere.)
 protectIfHoisted ::
-  SimplifiableLore lore =>
+  SimplifiableRep rep =>
   -- | Branch condition.
   SubExp ->
   -- | Which side of the branch are we
   -- protecting here?
   Bool ->
-  SimpleM lore (a, Stms (Wise lore)) ->
-  SimpleM lore (a, Stms (Wise lore))
+  SimpleM rep (a, Stms (Wise rep)) ->
+  SimpleM rep (a, Stms (Wise rep))
 protectIfHoisted cond side m = do
   (x, stms) <- m
   ops <- asks $ protectHoistedOpS . fst
@@ -286,12 +286,12 @@ protectIfHoisted cond side m = do
 -- loops, but they most be protected by adding a branch on top of
 -- them.
 protectLoopHoisted ::
-  SimplifiableLore lore =>
-  [(FParam (Wise lore), SubExp)] ->
-  [(FParam (Wise lore), SubExp)] ->
-  LoopForm (Wise lore) ->
-  SimpleM lore (a, Stms (Wise lore)) ->
-  SimpleM lore (a, Stms (Wise lore))
+  SimplifiableRep rep =>
+  [(FParam (Wise rep), SubExp)] ->
+  [(FParam (Wise rep), SubExp)] ->
+  LoopForm (Wise rep) ->
+  SimpleM rep (a, Stms (Wise rep)) ->
+  SimpleM rep (a, Stms (Wise rep))
 protectLoopHoisted ctx val form m = do
   (x, stms) <- m
   ops <- asks $ protectHoistedOpS . fst
@@ -317,9 +317,9 @@ protectLoopHoisted ctx val form m = do
 protectIf ::
   MonadBinder m =>
   Protect m ->
-  (Exp (Lore m) -> Bool) ->
+  (Exp (Rep m) -> Bool) ->
   SubExp ->
-  Stm (Lore m) ->
+  Stm (Rep m) ->
   m ()
 protectIf
   _
@@ -362,7 +362,7 @@ protectIf _ f taken (Let pat aux e)
 protectIf _ _ _ stm =
   addStm stm
 
-makeSafe :: Exp lore -> Maybe (Exp lore)
+makeSafe :: Exp rep -> Maybe (Exp rep)
 makeSafe (BasicOp (BinOp (SDiv t _) x y)) =
   Just $ BasicOp (BinOp (SDiv t Safe) x y)
 makeSafe (BasicOp (BinOp (SDivUp t _) x y)) =
@@ -382,7 +382,7 @@ makeSafe (BasicOp (BinOp (UMod t _) x y)) =
 makeSafe _ =
   Nothing
 
-emptyOfType :: MonadBinder m => [VName] -> Type -> m (Exp (Lore m))
+emptyOfType :: MonadBinder m => [VName] -> Type -> m (Exp (Rep m))
 emptyOfType _ Mem {} =
   error "emptyOfType: Cannot hoist non-existential memory."
 emptyOfType _ Acc {} =
@@ -399,21 +399,21 @@ emptyOfType ctx_names (Array et shape _) = do
 -- | Statements that are not worth hoisting out of loops, because they
 -- are unsafe, and added safety (by 'protectLoopHoisted') may inhibit
 -- further optimisation..
-notWorthHoisting :: ASTLore lore => BlockPred lore
+notWorthHoisting :: ASTRep rep => BlockPred rep
 notWorthHoisting _ _ (Let pat _ e) =
   not (safeExp e) && any ((> 0) . arrayRank) (patternTypes pat)
 
 hoistStms ::
-  SimplifiableLore lore =>
-  RuleBook (Wise lore) ->
-  BlockPred (Wise lore) ->
-  ST.SymbolTable (Wise lore) ->
+  SimplifiableRep rep =>
+  RuleBook (Wise rep) ->
+  BlockPred (Wise rep) ->
+  ST.SymbolTable (Wise rep) ->
   UT.UsageTable ->
-  Stms (Wise lore) ->
+  Stms (Wise rep) ->
   SimpleM
-    lore
-    ( Stms (Wise lore),
-      Stms (Wise lore)
+    rep
+    ( Stms (Wise rep),
+      Stms (Wise rep)
     )
 hoistStms rules block vtable uses orig_stms = do
   (blocked, hoisted) <- simplifyStmsBottomUp vtable uses orig_stms
@@ -465,9 +465,9 @@ hoistStms rules block vtable uses orig_stms = do
             return (uses'', stms' ++ stms)
 
 blockUnhoistedDeps ::
-  ASTLore lore =>
-  [Either (Stm lore) (Stm lore)] ->
-  [Either (Stm lore) (Stm lore)]
+  ASTRep rep =>
+  [Either (Stm rep) (Stm rep)] ->
+  [Either (Stm rep) (Stm rep)]
 blockUnhoistedDeps = snd . mapAccumL block mempty
   where
     block blocked (Left need) =
@@ -478,15 +478,15 @@ blockUnhoistedDeps = snd . mapAccumL block mempty
       | otherwise =
         (blocked, Right need)
 
-provides :: Stm lore -> [VName]
+provides :: Stm rep -> [VName]
 provides = patternNames . stmPattern
 
 expandUsage ::
-  (ASTLore lore, Aliased lore) =>
-  (Stm lore -> UT.UsageTable) ->
-  ST.SymbolTable lore ->
+  (ASTRep rep, Aliased rep) =>
+  (Stm rep -> UT.UsageTable) ->
+  ST.SymbolTable rep ->
   UT.UsageTable ->
-  Stm lore ->
+  Stm rep ->
   UT.UsageTable
 expandUsage usageInStm vtable utable stm@(Let pat _ e) =
   UT.expand (`ST.lookupAliases` vtable) (usageInStm stm <> usageThroughAliases)
@@ -504,47 +504,47 @@ expandUsage usageInStm vtable utable stm@(Let pat _ e) =
       uses <- UT.lookup name utable
       return $ mconcat $ map (`UT.usage` uses) $ namesToList aliases
 
-type BlockPred lore = ST.SymbolTable lore -> UT.UsageTable -> Stm lore -> Bool
+type BlockPred rep = ST.SymbolTable rep -> UT.UsageTable -> Stm rep -> Bool
 
-neverBlocks :: BlockPred lore
+neverBlocks :: BlockPred rep
 neverBlocks _ _ _ = False
 
-alwaysBlocks :: BlockPred lore
+alwaysBlocks :: BlockPred rep
 alwaysBlocks _ _ _ = True
 
-isFalse :: Bool -> BlockPred lore
+isFalse :: Bool -> BlockPred rep
 isFalse b _ _ _ = not b
 
-orIf :: BlockPred lore -> BlockPred lore -> BlockPred lore
+orIf :: BlockPred rep -> BlockPred rep -> BlockPred rep
 orIf p1 p2 body vtable need = p1 body vtable need || p2 body vtable need
 
-andAlso :: BlockPred lore -> BlockPred lore -> BlockPred lore
+andAlso :: BlockPred rep -> BlockPred rep -> BlockPred rep
 andAlso p1 p2 body vtable need = p1 body vtable need && p2 body vtable need
 
-isConsumed :: BlockPred lore
+isConsumed :: BlockPred rep
 isConsumed _ utable = any (`UT.isConsumed` utable) . patternNames . stmPattern
 
-isOp :: BlockPred lore
+isOp :: BlockPred rep
 isOp _ _ (Let _ _ Op {}) = True
 isOp _ _ _ = False
 
 constructBody ::
-  SimplifiableLore lore =>
-  Stms (Wise lore) ->
+  SimplifiableRep rep =>
+  Stms (Wise rep) ->
   Result ->
-  SimpleM lore (Body (Wise lore))
+  SimpleM rep (Body (Wise rep))
 constructBody stms res =
   fmap fst . runBinder . buildBody_ $ do
     addStms stms
     pure res
 
-type SimplifiedBody lore a = ((a, UT.UsageTable), Stms (Wise lore))
+type SimplifiedBody rep a = ((a, UT.UsageTable), Stms (Wise rep))
 
 blockIf ::
-  SimplifiableLore lore =>
-  BlockPred (Wise lore) ->
-  SimpleM lore (SimplifiedBody lore a) ->
-  SimpleM lore ((Stms (Wise lore), a), Stms (Wise lore))
+  SimplifiableRep rep =>
+  BlockPred (Wise rep) ->
+  SimpleM rep (SimplifiedBody rep a) ->
+  SimpleM rep ((Stms (Wise rep), a), Stms (Wise rep))
 blockIf block m = do
   ((x, usages), stms) <- m
   vtable <- askVtable
@@ -552,10 +552,10 @@ blockIf block m = do
   (blocked, hoisted) <- hoistStms rules block vtable usages stms
   return ((blocked, x), hoisted)
 
-hasFree :: ASTLore lore => Names -> BlockPred lore
+hasFree :: ASTRep rep => Names -> BlockPred rep
 hasFree ks _ _ need = ks `namesIntersect` freeIn need
 
-isNotSafe :: ASTLore lore => BlockPred lore
+isNotSafe :: ASTRep rep => BlockPred rep
 isNotSafe _ _ = not . safeExp . stmExp
 
 isInPlaceBound :: BlockPred m
@@ -564,13 +564,13 @@ isInPlaceBound _ _ = isUpdate . stmExp
     isUpdate (BasicOp Update {}) = True
     isUpdate _ = False
 
-isNotCheap :: ASTLore lore => BlockPred lore
+isNotCheap :: ASTRep rep => BlockPred rep
 isNotCheap _ _ = not . cheapStm
 
-cheapStm :: ASTLore lore => Stm lore -> Bool
+cheapStm :: ASTRep rep => Stm rep -> Bool
 cheapStm = cheapExp . stmExp
 
-cheapExp :: ASTLore lore => Exp lore -> Bool
+cheapExp :: ASTRep rep => Exp rep -> Bool
 cheapExp (BasicOp BinOp {}) = True
 cheapExp (BasicOp SubExp {}) = True
 cheapExp (BasicOp UnOp {}) = True
@@ -587,24 +587,24 @@ cheapExp (Op op) = cheapOp op
 cheapExp _ = True -- Used to be False, but
 -- let's try it out.
 
-stmIs :: (Stm lore -> Bool) -> BlockPred lore
+stmIs :: (Stm rep -> Bool) -> BlockPred rep
 stmIs f _ _ = f
 
-loopInvariantStm :: ASTLore lore => ST.SymbolTable lore -> Stm lore -> Bool
+loopInvariantStm :: ASTRep rep => ST.SymbolTable rep -> Stm rep -> Bool
 loopInvariantStm vtable =
   all (`nameIn` ST.availableAtClosestLoop vtable) . namesToList . freeIn
 
 hoistCommon ::
-  SimplifiableLore lore =>
+  SimplifiableRep rep =>
   SubExp ->
   IfSort ->
-  SimplifiedBody lore Result ->
-  SimplifiedBody lore Result ->
+  SimplifiedBody rep Result ->
+  SimplifiedBody rep Result ->
   SimpleM
-    lore
-    ( Body (Wise lore),
-      Body (Wise lore),
-      Stms (Wise lore)
+    rep
+    ( Body (Wise rep),
+      Body (Wise rep),
+      Stms (Wise rep)
     )
 hoistCommon cond ifsort ((res1, usages1), stms1) ((res2, usages2), stms2) = do
   is_alloc_fun <- asksEngineEnv $ isAllocation . envHoistBlockers
@@ -663,10 +663,10 @@ hoistCommon cond ifsort ((res1, usages1), stms1) ((res2, usages2), stms2) = do
 -- | Simplify a single body.  The @[Diet]@ only covers the value
 -- elements, because the context cannot be consumed.
 simplifyBody ::
-  SimplifiableLore lore =>
+  SimplifiableRep rep =>
   [Diet] ->
-  Body lore ->
-  SimpleM lore (SimplifiedBody lore Result)
+  Body rep ->
+  SimpleM rep (SimplifiedBody rep Result)
 simplifyBody ds (Body _ bnds res) =
   simplifyStms bnds $ do
     res' <- simplifyResult ds res
@@ -675,10 +675,10 @@ simplifyBody ds (Body _ bnds res) =
 -- | Simplify a single 'Result'.  The @[Diet]@ only covers the value
 -- elements, because the context cannot be consumed.
 simplifyResult ::
-  SimplifiableLore lore =>
+  SimplifiableRep rep =>
   [Diet] ->
   Result ->
-  SimpleM lore (Result, UT.UsageTable)
+  SimpleM rep (Result, UT.UsageTable)
 simplifyResult ds res = do
   let (ctx_res, val_res) = splitFromEnd (length ds) res
   -- Copy propagation is a little trickier here, because there is no
@@ -712,10 +712,10 @@ isDoLoopResult = mconcat . map checkForVar
     checkForVar _ = mempty
 
 simplifyStms ::
-  SimplifiableLore lore =>
-  Stms lore ->
-  SimpleM lore (a, Stms (Wise lore)) ->
-  SimpleM lore (a, Stms (Wise lore))
+  SimplifiableRep rep =>
+  Stms rep ->
+  SimpleM rep (a, Stms (Wise rep)) ->
+  SimpleM rep (a, Stms (Wise rep))
 simplifyStms stms m =
   case stmsHead stms of
     Nothing -> inspectStms mempty m
@@ -729,17 +729,17 @@ simplifyStms stms m =
           simplifyStms stms' m
 
 inspectStm ::
-  SimplifiableLore lore =>
-  Stm (Wise lore) ->
-  SimpleM lore (a, Stms (Wise lore)) ->
-  SimpleM lore (a, Stms (Wise lore))
+  SimplifiableRep rep =>
+  Stm (Wise rep) ->
+  SimpleM rep (a, Stms (Wise rep)) ->
+  SimpleM rep (a, Stms (Wise rep))
 inspectStm = inspectStms . oneStm
 
 inspectStms ::
-  SimplifiableLore lore =>
-  Stms (Wise lore) ->
-  SimpleM lore (a, Stms (Wise lore)) ->
-  SimpleM lore (a, Stms (Wise lore))
+  SimplifiableRep rep =>
+  Stms (Wise rep) ->
+  SimpleM rep (a, Stms (Wise rep)) ->
+  SimpleM rep (a, Stms (Wise rep))
 inspectStms stms m =
   case stmsHead stms of
     Nothing -> m
@@ -753,15 +753,15 @@ inspectStms stms m =
           (x, stms'') <- localVtable (ST.insertStm stm) $ inspectStms stms' m
           return (x, oneStm stm <> stms'')
 
-simplifyOp :: Op lore -> SimpleM lore (Op (Wise lore), Stms (Wise lore))
+simplifyOp :: Op rep -> SimpleM rep (Op (Wise rep), Stms (Wise rep))
 simplifyOp op = do
   f <- asks $ simplifyOpS . fst
   f op
 
 simplifyExp ::
-  SimplifiableLore lore =>
-  Exp lore ->
-  SimpleM lore (Exp (Wise lore), Stms (Wise lore))
+  SimplifiableRep rep =>
+  Exp rep ->
+  SimpleM rep (Exp (Wise rep), Stms (Wise rep))
 simplifyExp (If cond tbranch fbranch (IfDec ts ifsort)) = do
   -- Here, we have to check whether 'cond' puts a bound on some free
   -- variable, and if so, chomp it.  We should also try to do CSE
@@ -862,9 +862,9 @@ simplifyExp e = do
   return (e', mempty)
 
 simplifyExpBase ::
-  SimplifiableLore lore =>
-  Exp lore ->
-  SimpleM lore (Exp (Wise lore))
+  SimplifiableRep rep =>
+  Exp rep ->
+  SimpleM rep (Exp (Wise rep))
 simplifyExpBase = mapExpM hoist
   where
     hoist =
@@ -887,21 +887,21 @@ simplifyExpBase = mapExpM hoist
             error "Unhandled Op in simplification engine."
         }
 
-type SimplifiableLore lore =
-  ( ASTLore lore,
-    Simplifiable (LetDec lore),
-    Simplifiable (FParamInfo lore),
-    Simplifiable (LParamInfo lore),
-    Simplifiable (RetType lore),
-    Simplifiable (BranchType lore),
-    CanBeWise (Op lore),
-    ST.IndexOp (OpWithWisdom (Op lore)),
-    BinderOps (Wise lore),
-    IsOp (Op lore)
+type SimplifiableRep rep =
+  ( ASTRep rep,
+    Simplifiable (LetDec rep),
+    Simplifiable (FParamInfo rep),
+    Simplifiable (LParamInfo rep),
+    Simplifiable (RetType rep),
+    Simplifiable (BranchType rep),
+    CanBeWise (Op rep),
+    ST.IndexOp (OpWithWisdom (Op rep)),
+    BinderOps (Wise rep),
+    IsOp (Op rep)
   )
 
 class Simplifiable e where
-  simplify :: SimplifiableLore lore => e -> SimpleM lore e
+  simplify :: SimplifiableRep rep => e -> SimpleM rep e
 
 instance (Simplifiable a, Simplifiable b) => Simplifiable (a, b) where
   simplify (x, y) = (,) <$> simplify x <*> simplify y
@@ -940,15 +940,15 @@ instance Simplifiable SubExp where
     return $ Constant v
 
 simplifyPattern ::
-  (SimplifiableLore lore, Simplifiable dec) =>
+  (SimplifiableRep rep, Simplifiable dec) =>
   PatternT dec ->
-  SimpleM lore (PatternT dec)
+  SimpleM rep (PatternT dec)
 simplifyPattern pat =
   Pattern
     <$> mapM inspect (patternContextElements pat)
     <*> mapM inspect (patternValueElements pat)
   where
-    inspect (PatElem name lore) = PatElem name <$> simplify lore
+    inspect (PatElem name rep) = PatElem name <$> simplify rep
 
 instance Simplifiable () where
   simplify = pure
@@ -992,25 +992,25 @@ instance Simplifiable d => Simplifiable (DimIndex d) where
   simplify (DimSlice i n s) = DimSlice <$> simplify i <*> simplify n <*> simplify s
 
 simplifyLambda ::
-  SimplifiableLore lore =>
-  Lambda lore ->
-  SimpleM lore (Lambda (Wise lore), Stms (Wise lore))
+  SimplifiableRep rep =>
+  Lambda rep ->
+  SimpleM rep (Lambda (Wise rep), Stms (Wise rep))
 simplifyLambda lam = do
   par_blocker <- asksEngineEnv $ blockHoistPar . envHoistBlockers
   simplifyLambdaMaybeHoist par_blocker lam
 
 simplifyLambdaNoHoisting ::
-  SimplifiableLore lore =>
-  Lambda lore ->
-  SimpleM lore (Lambda (Wise lore))
+  SimplifiableRep rep =>
+  Lambda rep ->
+  SimpleM rep (Lambda (Wise rep))
 simplifyLambdaNoHoisting lam =
   fst <$> simplifyLambdaMaybeHoist (isFalse False) lam
 
 simplifyLambdaMaybeHoist ::
-  SimplifiableLore lore =>
-  BlockPred (Wise lore) ->
-  Lambda lore ->
-  SimpleM lore (Lambda (Wise lore), Stms (Wise lore))
+  SimplifiableRep rep =>
+  BlockPred (Wise rep) ->
+  Lambda rep ->
+  SimpleM rep (Lambda (Wise rep), Stms (Wise rep))
 simplifyLambdaMaybeHoist blocked lam@(Lambda params body rettype) = do
   params' <- mapM (traverse simplify) params
   let paramnames = namesFromList $ boundByLambda lam
@@ -1041,15 +1041,15 @@ instance Simplifiable Certificates where
           _ -> return [idd]
 
 insertAllStms ::
-  SimplifiableLore lore =>
-  SimpleM lore (SimplifiedBody lore Result) ->
-  SimpleM lore (Body (Wise lore))
+  SimplifiableRep rep =>
+  SimpleM rep (SimplifiedBody rep Result) ->
+  SimpleM rep (Body (Wise rep))
 insertAllStms = uncurry constructBody . fst <=< blockIf (isFalse False)
 
 simplifyFun ::
-  SimplifiableLore lore =>
-  FunDef lore ->
-  SimpleM lore (FunDef (Wise lore))
+  SimplifiableRep rep =>
+  FunDef rep ->
+  SimpleM rep (FunDef (Wise rep))
 simplifyFun (FunDef entry attrs fname rettype params body) = do
   rettype' <- simplify rettype
   params' <- mapM (traverse simplify) params

--- a/src/Futhark/Optimise/Simplify/Rep.hs
+++ b/src/Futhark/Optimise/Simplify/Rep.hs
@@ -1,11 +1,10 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
--- | Definition of the lore used by the simplification engine.
-module Futhark.Optimise.Simplify.Lore
+-- | Representation used by the simplification engine.
+module Futhark.Optimise.Simplify.Rep
   ( Wise,
     VarWisdom (..),
     ExpWisdom,
@@ -46,7 +45,7 @@ import Futhark.Transform.Substitute
 import Futhark.Util.Pretty
 import Prelude hiding (id, (.))
 
-data Wise lore
+data Wise rep
 
 -- | The wisdom of the let-bound variable.
 newtype VarWisdom = VarWisdom {varWisdomAliases :: VarAliases}
@@ -109,60 +108,55 @@ instance FreeIn BodyWisdom where
 instance FreeDec BodyWisdom where
   precomputed = const . fvNames . unAliases . bodyWisdomFree
 
-instance
-  ( Decorations lore,
-    CanBeWise (Op lore)
-  ) =>
-  Decorations (Wise lore)
-  where
-  type LetDec (Wise lore) = (VarWisdom, LetDec lore)
-  type ExpDec (Wise lore) = (ExpWisdom, ExpDec lore)
-  type BodyDec (Wise lore) = (BodyWisdom, BodyDec lore)
-  type FParamInfo (Wise lore) = FParamInfo lore
-  type LParamInfo (Wise lore) = LParamInfo lore
-  type RetType (Wise lore) = RetType lore
-  type BranchType (Wise lore) = BranchType lore
-  type Op (Wise lore) = OpWithWisdom (Op lore)
+instance (RepTypes rep, CanBeWise (Op rep)) => RepTypes (Wise rep) where
+  type LetDec (Wise rep) = (VarWisdom, LetDec rep)
+  type ExpDec (Wise rep) = (ExpWisdom, ExpDec rep)
+  type BodyDec (Wise rep) = (BodyWisdom, BodyDec rep)
+  type FParamInfo (Wise rep) = FParamInfo rep
+  type LParamInfo (Wise rep) = LParamInfo rep
+  type RetType (Wise rep) = RetType rep
+  type BranchType (Wise rep) = BranchType rep
+  type Op (Wise rep) = OpWithWisdom (Op rep)
 
 withoutWisdom ::
-  (HasScope (Wise lore) m, Monad m) =>
-  ReaderT (Scope lore) m a ->
+  (HasScope (Wise rep) m, Monad m) =>
+  ReaderT (Scope rep) m a ->
   m a
 withoutWisdom m = do
   scope <- asksScope removeScopeWisdom
   runReaderT m scope
 
-instance (ASTLore lore, CanBeWise (Op lore)) => ASTLore (Wise lore) where
+instance (ASTRep rep, CanBeWise (Op rep)) => ASTRep (Wise rep) where
   expTypesFromPattern =
     withoutWisdom . expTypesFromPattern . removePatternWisdom
 
 instance Pretty VarWisdom where
   ppr _ = ppr ()
 
-instance (PrettyLore lore, CanBeWise (Op lore)) => PrettyLore (Wise lore) where
-  ppExpLore (_, dec) = ppExpLore dec . removeExpWisdom
+instance (PrettyRep rep, CanBeWise (Op rep)) => PrettyRep (Wise rep) where
+  ppExpDec (_, dec) = ppExpDec dec . removeExpWisdom
 
 instance AliasesOf (VarWisdom, dec) where
   aliasesOf = unAliases . varWisdomAliases . fst
 
-instance (ASTLore lore, CanBeWise (Op lore)) => Aliased (Wise lore) where
+instance (ASTRep rep, CanBeWise (Op rep)) => Aliased (Wise rep) where
   bodyAliases = map unAliases . bodyWisdomAliases . fst . bodyDec
   consumedInBody = unAliases . bodyWisdomConsumed . fst . bodyDec
 
-removeWisdom :: CanBeWise (Op lore) => Rephraser Identity (Wise lore) lore
+removeWisdom :: CanBeWise (Op rep) => Rephraser Identity (Wise rep) rep
 removeWisdom =
   Rephraser
-    { rephraseExpLore = return . snd,
-      rephraseLetBoundLore = return . snd,
-      rephraseBodyLore = return . snd,
-      rephraseFParamLore = return,
-      rephraseLParamLore = return,
+    { rephraseExpDec = return . snd,
+      rephraseLetBoundDec = return . snd,
+      rephraseBodyDec = return . snd,
+      rephraseFParamDec = return,
+      rephraseLParamDec = return,
       rephraseRetType = return,
       rephraseBranchType = return,
       rephraseOp = return . removeOpWisdom
     }
 
-removeScopeWisdom :: Scope (Wise lore) -> Scope lore
+removeScopeWisdom :: Scope (Wise rep) -> Scope rep
 removeScopeWisdom = M.map unAlias
   where
     unAlias (LetName (_, dec)) = LetName dec
@@ -170,7 +164,7 @@ removeScopeWisdom = M.map unAlias
     unAlias (LParamName dec) = LParamName dec
     unAlias (IndexName it) = IndexName it
 
-addScopeWisdom :: Scope lore -> Scope (Wise lore)
+addScopeWisdom :: Scope rep -> Scope (Wise rep)
 addScopeWisdom = M.map alias
   where
     alias (LetName dec) = LetName (VarWisdom mempty, dec)
@@ -178,47 +172,47 @@ addScopeWisdom = M.map alias
     alias (LParamName dec) = LParamName dec
     alias (IndexName it) = IndexName it
 
-removeFunDefWisdom :: CanBeWise (Op lore) => FunDef (Wise lore) -> FunDef lore
+removeFunDefWisdom :: CanBeWise (Op rep) => FunDef (Wise rep) -> FunDef rep
 removeFunDefWisdom = runIdentity . rephraseFunDef removeWisdom
 
-removeStmWisdom :: CanBeWise (Op lore) => Stm (Wise lore) -> Stm lore
+removeStmWisdom :: CanBeWise (Op rep) => Stm (Wise rep) -> Stm rep
 removeStmWisdom = runIdentity . rephraseStm removeWisdom
 
-removeLambdaWisdom :: CanBeWise (Op lore) => Lambda (Wise lore) -> Lambda lore
+removeLambdaWisdom :: CanBeWise (Op rep) => Lambda (Wise rep) -> Lambda rep
 removeLambdaWisdom = runIdentity . rephraseLambda removeWisdom
 
-removeBodyWisdom :: CanBeWise (Op lore) => Body (Wise lore) -> Body lore
+removeBodyWisdom :: CanBeWise (Op rep) => Body (Wise rep) -> Body rep
 removeBodyWisdom = runIdentity . rephraseBody removeWisdom
 
-removeExpWisdom :: CanBeWise (Op lore) => Exp (Wise lore) -> Exp lore
+removeExpWisdom :: CanBeWise (Op rep) => Exp (Wise rep) -> Exp rep
 removeExpWisdom = runIdentity . rephraseExp removeWisdom
 
 removePatternWisdom :: PatternT (VarWisdom, a) -> PatternT a
 removePatternWisdom = runIdentity . rephrasePattern (return . snd)
 
 addWisdomToPattern ::
-  (ASTLore lore, CanBeWise (Op lore)) =>
-  Pattern lore ->
-  Exp (Wise lore) ->
-  Pattern (Wise lore)
+  (ASTRep rep, CanBeWise (Op rep)) =>
+  Pattern rep ->
+  Exp (Wise rep) ->
+  Pattern (Wise rep)
 addWisdomToPattern pat e =
   Pattern (map f ctx) (map f val)
   where
     (ctx, val) = Aliases.mkPatternAliases pat e
     f pe =
       let (als, dec) = patElemDec pe
-       in pe `setPatElemLore` (VarWisdom als, dec)
+       in pe `setPatElemDec` (VarWisdom als, dec)
 
 mkWiseBody ::
-  (ASTLore lore, CanBeWise (Op lore)) =>
-  BodyDec lore ->
-  Stms (Wise lore) ->
+  (ASTRep rep, CanBeWise (Op rep)) =>
+  BodyDec rep ->
+  Stms (Wise rep) ->
   Result ->
-  Body (Wise lore)
-mkWiseBody innerlore bnds res =
+  Body (Wise rep)
+mkWiseBody dec bnds res =
   Body
     ( BodyWisdom aliases consumed (AliasDec $ freeIn $ freeInStmsAndRes bnds res),
-      innerlore
+      dec
     )
     bnds
     res
@@ -226,33 +220,33 @@ mkWiseBody innerlore bnds res =
     (aliases, consumed) = Aliases.mkBodyAliases bnds res
 
 mkWiseLetStm ::
-  (ASTLore lore, CanBeWise (Op lore)) =>
-  Pattern lore ->
-  StmAux (ExpDec lore) ->
-  Exp (Wise lore) ->
-  Stm (Wise lore)
+  (ASTRep rep, CanBeWise (Op rep)) =>
+  Pattern rep ->
+  StmAux (ExpDec rep) ->
+  Exp (Wise rep) ->
+  Stm (Wise rep)
 mkWiseLetStm pat (StmAux cs attrs dec) e =
   let pat' = addWisdomToPattern pat e
    in Let pat' (StmAux cs attrs $ mkWiseExpDec pat' dec e) e
 
 mkWiseExpDec ::
-  (ASTLore lore, CanBeWise (Op lore)) =>
-  Pattern (Wise lore) ->
-  ExpDec lore ->
-  Exp (Wise lore) ->
-  ExpDec (Wise lore)
-mkWiseExpDec pat explore e =
+  (ASTRep rep, CanBeWise (Op rep)) =>
+  Pattern (Wise rep) ->
+  ExpDec rep ->
+  Exp (Wise rep) ->
+  ExpDec (Wise rep)
+mkWiseExpDec pat expdec e =
   ( ExpWisdom
       (AliasDec $ consumedInExp e)
-      (AliasDec $ freeIn pat <> freeIn explore <> freeIn e),
-    explore
+      (AliasDec $ freeIn pat <> freeIn expdec <> freeIn e),
+    expdec
   )
 
 instance
-  ( Bindable lore,
-    CanBeWise (Op lore)
+  ( Bindable rep,
+    CanBeWise (Op rep)
   ) =>
-  Bindable (Wise lore)
+  Bindable (Wise rep)
   where
   mkExpPat ctx val e =
     addWisdomToPattern (mkExpPat ctx val $ removeExpWisdom e) e
@@ -267,8 +261,8 @@ instance
       return $ mkWiseLetStm pat dec e
 
   mkBody bnds res =
-    let Body bodylore _ _ = mkBody (fmap removeStmWisdom bnds) res
-     in mkWiseBody bodylore bnds res
+    let Body bodyrep _ _ = mkBody (fmap removeStmWisdom bnds) res
+     in mkWiseBody bodyrep bnds res
 
 class
   ( AliasedOp (OpWithWisdom op),

--- a/src/Futhark/Optimise/Simplify/Rule.hs
+++ b/src/Futhark/Optimise/Simplify/Rule.hs
@@ -62,18 +62,18 @@ import Futhark.Binder
 import Futhark.IR
 
 -- | The monad in which simplification rules are evaluated.
-newtype RuleM lore a = RuleM (BinderT lore (StateT VNameSource Maybe) a)
+newtype RuleM rep a = RuleM (BinderT rep (StateT VNameSource Maybe) a)
   deriving
     ( Functor,
       Applicative,
       Monad,
       MonadFreshNames,
-      HasScope lore,
-      LocalScope lore
+      HasScope rep,
+      LocalScope rep
     )
 
-instance (ASTLore lore, BinderOps lore) => MonadBinder (RuleM lore) where
-  type Lore (RuleM lore) = lore
+instance (ASTRep rep, BinderOps rep) => MonadBinder (RuleM rep) where
+  type Rep (RuleM rep) = rep
   mkExpDecM pat e = RuleM $ mkExpDecM pat e
   mkBodyM bnds res = RuleM $ mkBodyM bnds res
   mkLetNamesM pat e = RuleM $ mkLetNamesM pat e
@@ -84,141 +84,141 @@ instance (ASTLore lore, BinderOps lore) => MonadBinder (RuleM lore) where
 -- | Execute a 'RuleM' action.  If succesful, returns the result and a
 -- list of new bindings.
 simplify ::
-  Scope lore ->
+  Scope rep ->
   VNameSource ->
-  Rule lore ->
-  Maybe (Stms lore, VNameSource)
+  Rule rep ->
+  Maybe (Stms rep, VNameSource)
 simplify _ _ Skip = Nothing
 simplify scope src (Simplify (RuleM m)) =
   runStateT (runBinderT_ m scope) src
 
-cannotSimplify :: RuleM lore a
+cannotSimplify :: RuleM rep a
 cannotSimplify = RuleM $ lift $ lift Nothing
 
-liftMaybe :: Maybe a -> RuleM lore a
+liftMaybe :: Maybe a -> RuleM rep a
 liftMaybe Nothing = cannotSimplify
 liftMaybe (Just x) = return x
 
 -- | An efficient way of encoding whether a simplification rule should even be attempted.
-data Rule lore
+data Rule rep
   = -- | Give it a shot.
-    Simplify (RuleM lore ())
+    Simplify (RuleM rep ())
   | -- | Don't bother.
     Skip
 
-type RuleGeneric lore a = a -> Stm lore -> Rule lore
+type RuleGeneric rep a = a -> Stm rep -> Rule rep
 
-type RuleBasicOp lore a =
+type RuleBasicOp rep a =
   ( a ->
-    Pattern lore ->
-    StmAux (ExpDec lore) ->
+    Pattern rep ->
+    StmAux (ExpDec rep) ->
     BasicOp ->
-    Rule lore
+    Rule rep
   )
 
-type RuleIf lore a =
+type RuleIf rep a =
   a ->
-  Pattern lore ->
-  StmAux (ExpDec lore) ->
+  Pattern rep ->
+  StmAux (ExpDec rep) ->
   ( SubExp,
-    BodyT lore,
-    BodyT lore,
-    IfDec (BranchType lore)
+    BodyT rep,
+    BodyT rep,
+    IfDec (BranchType rep)
   ) ->
-  Rule lore
+  Rule rep
 
-type RuleDoLoop lore a =
+type RuleDoLoop rep a =
   a ->
-  Pattern lore ->
-  StmAux (ExpDec lore) ->
-  ( [(FParam lore, SubExp)],
-    [(FParam lore, SubExp)],
-    LoopForm lore,
-    BodyT lore
+  Pattern rep ->
+  StmAux (ExpDec rep) ->
+  ( [(FParam rep, SubExp)],
+    [(FParam rep, SubExp)],
+    LoopForm rep,
+    BodyT rep
   ) ->
-  Rule lore
+  Rule rep
 
-type RuleOp lore a =
+type RuleOp rep a =
   a ->
-  Pattern lore ->
-  StmAux (ExpDec lore) ->
-  Op lore ->
-  Rule lore
+  Pattern rep ->
+  StmAux (ExpDec rep) ->
+  Op rep ->
+  Rule rep
 
 -- | A simplification rule takes some argument and a statement, and
 -- tries to simplify the statement.
-data SimplificationRule lore a
-  = RuleGeneric (RuleGeneric lore a)
-  | RuleBasicOp (RuleBasicOp lore a)
-  | RuleIf (RuleIf lore a)
-  | RuleDoLoop (RuleDoLoop lore a)
-  | RuleOp (RuleOp lore a)
+data SimplificationRule rep a
+  = RuleGeneric (RuleGeneric rep a)
+  | RuleBasicOp (RuleBasicOp rep a)
+  | RuleIf (RuleIf rep a)
+  | RuleDoLoop (RuleDoLoop rep a)
+  | RuleOp (RuleOp rep a)
 
 -- | A collection of rules grouped by which forms of statements they
 -- may apply to.
-data Rules lore a = Rules
-  { rulesAny :: [SimplificationRule lore a],
-    rulesBasicOp :: [SimplificationRule lore a],
-    rulesIf :: [SimplificationRule lore a],
-    rulesDoLoop :: [SimplificationRule lore a],
-    rulesOp :: [SimplificationRule lore a]
+data Rules rep a = Rules
+  { rulesAny :: [SimplificationRule rep a],
+    rulesBasicOp :: [SimplificationRule rep a],
+    rulesIf :: [SimplificationRule rep a],
+    rulesDoLoop :: [SimplificationRule rep a],
+    rulesOp :: [SimplificationRule rep a]
   }
 
-instance Semigroup (Rules lore a) where
+instance Semigroup (Rules rep a) where
   Rules as1 bs1 cs1 ds1 es1 <> Rules as2 bs2 cs2 ds2 es2 =
     Rules (as1 <> as2) (bs1 <> bs2) (cs1 <> cs2) (ds1 <> ds2) (es1 <> es2)
 
-instance Monoid (Rules lore a) where
+instance Monoid (Rules rep a) where
   mempty = Rules mempty mempty mempty mempty mempty
 
 -- | Context for a rule applied during top-down traversal of the
 -- program.  Takes a symbol table as argument.
-type TopDown lore = ST.SymbolTable lore
+type TopDown rep = ST.SymbolTable rep
 
-type TopDownRuleGeneric lore = RuleGeneric lore (TopDown lore)
+type TopDownRuleGeneric rep = RuleGeneric rep (TopDown rep)
 
-type TopDownRuleBasicOp lore = RuleBasicOp lore (TopDown lore)
+type TopDownRuleBasicOp rep = RuleBasicOp rep (TopDown rep)
 
-type TopDownRuleIf lore = RuleIf lore (TopDown lore)
+type TopDownRuleIf rep = RuleIf rep (TopDown rep)
 
-type TopDownRuleDoLoop lore = RuleDoLoop lore (TopDown lore)
+type TopDownRuleDoLoop rep = RuleDoLoop rep (TopDown rep)
 
-type TopDownRuleOp lore = RuleOp lore (TopDown lore)
+type TopDownRuleOp rep = RuleOp rep (TopDown rep)
 
-type TopDownRule lore = SimplificationRule lore (TopDown lore)
+type TopDownRule rep = SimplificationRule rep (TopDown rep)
 
 -- | Context for a rule applied during bottom-up traversal of the
 -- program.  Takes a symbol table and usage table as arguments.
-type BottomUp lore = (ST.SymbolTable lore, UT.UsageTable)
+type BottomUp rep = (ST.SymbolTable rep, UT.UsageTable)
 
-type BottomUpRuleGeneric lore = RuleGeneric lore (BottomUp lore)
+type BottomUpRuleGeneric rep = RuleGeneric rep (BottomUp rep)
 
-type BottomUpRuleBasicOp lore = RuleBasicOp lore (BottomUp lore)
+type BottomUpRuleBasicOp rep = RuleBasicOp rep (BottomUp rep)
 
-type BottomUpRuleIf lore = RuleIf lore (BottomUp lore)
+type BottomUpRuleIf rep = RuleIf rep (BottomUp rep)
 
-type BottomUpRuleDoLoop lore = RuleDoLoop lore (BottomUp lore)
+type BottomUpRuleDoLoop rep = RuleDoLoop rep (BottomUp rep)
 
-type BottomUpRuleOp lore = RuleOp lore (BottomUp lore)
+type BottomUpRuleOp rep = RuleOp rep (BottomUp rep)
 
-type BottomUpRule lore = SimplificationRule lore (BottomUp lore)
+type BottomUpRule rep = SimplificationRule rep (BottomUp rep)
 
 -- | A collection of top-down rules.
-type TopDownRules lore = Rules lore (TopDown lore)
+type TopDownRules rep = Rules rep (TopDown rep)
 
 -- | A collection of bottom-up rules.
-type BottomUpRules lore = Rules lore (BottomUp lore)
+type BottomUpRules rep = Rules rep (BottomUp rep)
 
 -- | A collection of both top-down and bottom-up rules.
-data RuleBook lore = RuleBook
-  { bookTopDownRules :: TopDownRules lore,
-    bookBottomUpRules :: BottomUpRules lore
+data RuleBook rep = RuleBook
+  { bookTopDownRules :: TopDownRules rep,
+    bookBottomUpRules :: BottomUpRules rep
   }
 
-instance Semigroup (RuleBook lore) where
+instance Semigroup (RuleBook rep) where
   RuleBook ts1 bs1 <> RuleBook ts2 bs2 = RuleBook (ts1 <> ts2) (bs1 <> bs2)
 
-instance Monoid (RuleBook lore) where
+instance Monoid (RuleBook rep) where
   mempty = RuleBook mempty mempty
 
 -- | Construct a rule book from a collection of rules.
@@ -259,11 +259,11 @@ ruleBook topdowns bottomups =
 -- of bindings is returned, that bind at least the same names as the
 -- original binding (and possibly more, for intermediate results).
 topDownSimplifyStm ::
-  (MonadFreshNames m, HasScope lore m) =>
-  RuleBook lore ->
-  ST.SymbolTable lore ->
-  Stm lore ->
-  m (Maybe (Stms lore))
+  (MonadFreshNames m, HasScope rep m) =>
+  RuleBook rep ->
+  ST.SymbolTable rep ->
+  Stm rep ->
+  m (Maybe (Stms rep))
 topDownSimplifyStm = applyRules . bookTopDownRules
 
 -- | @simplifyStm uses bnd@ performs simplification of the binding
@@ -272,14 +272,14 @@ topDownSimplifyStm = applyRules . bookTopDownRules
 -- original binding (and possibly more, for intermediate results).
 -- The first argument is the set of names used after this binding.
 bottomUpSimplifyStm ::
-  (MonadFreshNames m, HasScope lore m) =>
-  RuleBook lore ->
-  (ST.SymbolTable lore, UT.UsageTable) ->
-  Stm lore ->
-  m (Maybe (Stms lore))
+  (MonadFreshNames m, HasScope rep m) =>
+  RuleBook rep ->
+  (ST.SymbolTable rep, UT.UsageTable) ->
+  Stm rep ->
+  m (Maybe (Stms rep))
 bottomUpSimplifyStm = applyRules . bookBottomUpRules
 
-rulesForStm :: Stm lore -> Rules lore a -> [SimplificationRule lore a]
+rulesForStm :: Stm rep -> Rules rep a -> [SimplificationRule rep a]
 rulesForStm stm = case stmExp stm of
   BasicOp {} -> rulesBasicOp
   DoLoop {} -> rulesDoLoop
@@ -287,7 +287,7 @@ rulesForStm stm = case stmExp stm of
   If {} -> rulesIf
   _ -> rulesAny
 
-applyRule :: SimplificationRule lore a -> a -> Stm lore -> Rule lore
+applyRule :: SimplificationRule rep a -> a -> Stm rep -> Rule rep
 applyRule (RuleGeneric f) a stm = f a stm
 applyRule (RuleBasicOp f) a (Let pat aux (BasicOp e)) = f a pat aux e
 applyRule (RuleDoLoop f) a (Let pat aux (DoLoop ctx val form body)) =
@@ -300,11 +300,11 @@ applyRule _ _ _ =
   Skip
 
 applyRules ::
-  (MonadFreshNames m, HasScope lore m) =>
-  Rules lore a ->
+  (MonadFreshNames m, HasScope rep m) =>
+  Rules rep a ->
   a ->
-  Stm lore ->
-  m (Maybe (Stms lore))
+  Stm rep ->
+  m (Maybe (Stms rep))
 applyRules all_rules context stm = do
   scope <- askScope
 

--- a/src/Futhark/Optimise/Simplify/Rules.hs
+++ b/src/Futhark/Optimise/Simplify/Rules.hs
@@ -37,7 +37,7 @@ import Futhark.Optimise.Simplify.Rules.Index
 import Futhark.Optimise.Simplify.Rules.Loop
 import Futhark.Util
 
-topDownRules :: BinderOps lore => [TopDownRule lore]
+topDownRules :: BinderOps rep => [TopDownRule rep]
 topDownRules =
   [ RuleGeneric constantFoldPrimFun,
     RuleIf ruleIf,
@@ -45,7 +45,7 @@ topDownRules =
     RuleGeneric withAccTopDown
   ]
 
-bottomUpRules :: BinderOps lore => [BottomUpRule lore]
+bottomUpRules :: BinderOps rep => [BottomUpRule rep]
 bottomUpRules =
   [ RuleIf removeDeadBranchResult,
     RuleGeneric withAccBottomUp,
@@ -55,14 +55,14 @@ bottomUpRules =
 -- | A set of standard simplification rules.  These assume pure
 -- functional semantics, and so probably should not be applied after
 -- memory block merging.
-standardRules :: (BinderOps lore, Aliased lore) => RuleBook lore
+standardRules :: (BinderOps rep, Aliased rep) => RuleBook rep
 standardRules = ruleBook topDownRules bottomUpRules <> loopRules <> basicOpRules
 
 -- | Turn @copy(x)@ into @x@ iff @x@ is not used after this copy
 -- statement and it can be consumed.
 --
 -- This simplistic rule is only valid before we introduce memory.
-removeUnnecessaryCopy :: (BinderOps lore, Aliased lore) => BottomUpRuleBasicOp lore
+removeUnnecessaryCopy :: (BinderOps rep, Aliased rep) => BottomUpRuleBasicOp rep
 removeUnnecessaryCopy (vtable, used) (Pattern [] [d]) _ (Copy v)
   | not (v `UT.isConsumed` used),
     (not (v `UT.used` used) && consumable) || not (patElemName d `UT.isConsumed` used) =
@@ -84,7 +84,7 @@ removeUnnecessaryCopy (vtable, used) (Pattern [] [d]) _ (Copy v)
       pure True
 removeUnnecessaryCopy _ _ _ _ = Skip
 
-constantFoldPrimFun :: BinderOps lore => TopDownRuleGeneric lore
+constantFoldPrimFun :: BinderOps rep => TopDownRuleGeneric rep
 constantFoldPrimFun _ (Let pat (StmAux cs attrs _) (Apply fname args _ _))
   | Just args' <- mapM (isConst . fst) args,
     Just (_, _, fun) <- M.lookup (nameToString fname) primFuns,
@@ -98,7 +98,7 @@ constantFoldPrimFun _ (Let pat (StmAux cs attrs _) (Apply fname args _ _))
     isConst _ = Nothing
 constantFoldPrimFun _ _ = Skip
 
-simplifyIndex :: BinderOps lore => BottomUpRuleBasicOp lore
+simplifyIndex :: BinderOps rep => BottomUpRuleBasicOp rep
 simplifyIndex (vtable, used) pat@(Pattern [] [pe]) (StmAux cs attrs _) (Index idd inds)
   | Just m <- simplifyIndexing vtable seType idd inds consumed = Simplify $ do
     res <- m
@@ -115,7 +115,7 @@ simplifyIndex (vtable, used) pat@(Pattern [] [pe]) (StmAux cs attrs _) (Index id
     seType (Constant v) = Just $ Prim $ primValueType v
 simplifyIndex _ _ _ _ = Skip
 
-ruleIf :: BinderOps lore => TopDownRuleIf lore
+ruleIf :: BinderOps rep => TopDownRuleIf rep
 ruleIf _ pat _ (e1, tb, fb, IfDec _ ifsort)
   | Just branch <- checkBranch,
     ifsort /= IfFallback || isCt1 e1 = Simplify $ do
@@ -194,7 +194,7 @@ ruleIf _ _ _ _ = Skip
 -- | Move out results of a conditional expression whose computation is
 -- either invariant to the branches (only done for results in the
 -- context), or the same in both branches.
-hoistBranchInvariant :: BinderOps lore => TopDownRuleIf lore
+hoistBranchInvariant :: BinderOps rep => TopDownRuleIf rep
 hoistBranchInvariant _ pat _ (cond, tb, fb, IfDec ret ifsort) = Simplify $ do
   let tses = bodyResult tb
       fses = bodyResult fb
@@ -278,7 +278,7 @@ hoistBranchInvariant _ pat _ (cond, tb, fb, IfDec ret ifsort) = Simplify $ do
 -- after a branch.  Standard dead code removal can remove the branch
 -- if *none* of the return values are used, but this rule is more
 -- precise.
-removeDeadBranchResult :: BinderOps lore => BottomUpRuleIf lore
+removeDeadBranchResult :: BinderOps rep => BottomUpRuleIf rep
 removeDeadBranchResult (_, used) pat _ (e1, tb, fb, IfDec rettype ifsort)
   | -- Only if there is no existential context...
     patternSize pat == length rettype,
@@ -300,7 +300,7 @@ removeDeadBranchResult (_, used) pat _ (e1, tb, fb, IfDec rettype ifsort)
      in Simplify $ letBind (Pattern [] pat') $ If e1 tb' fb' $ IfDec rettype' ifsort
   | otherwise = Skip
 
-withAccTopDown :: BinderOps lore => TopDownRuleGeneric lore
+withAccTopDown :: BinderOps rep => TopDownRuleGeneric rep
 -- A WithAcc with no accumulators is sent to Valhalla.
 withAccTopDown _ (Let pat aux (WithAcc [] lam)) = Simplify . auxing aux $ do
   lam_res <- bodyBind $ lambdaBody lam
@@ -359,7 +359,7 @@ withAccTopDown vtable (Let pat aux (WithAcc inputs lam)) = Simplify . auxing aux
       pure $ Just x
 withAccTopDown _ _ = Skip
 
-withAccBottomUp :: BinderOps lore => BottomUpRuleGeneric lore
+withAccBottomUp :: BinderOps rep => BottomUpRuleGeneric rep
 -- Eliminate dead results.
 withAccBottomUp (_, utable) (Let pat aux (WithAcc inputs lam))
   | not $ all (`UT.used` utable) $ patternNames pat = Simplify $ do

--- a/src/Futhark/Optimise/Simplify/Rules/ClosedForm.hs
+++ b/src/Futhark/Optimise/Simplify/Rules/ClosedForm.hs
@@ -39,13 +39,13 @@ Motivation:
 -- | @foldClosedForm look foldfun accargs arrargs@ determines whether
 -- each of the results of @foldfun@ can be expressed in a closed form.
 foldClosedForm ::
-  (ASTLore lore, BinderOps lore) =>
-  VarLookup lore ->
-  Pattern lore ->
-  Lambda lore ->
+  (ASTRep rep, BinderOps rep) =>
+  VarLookup rep ->
+  Pattern rep ->
+  Lambda rep ->
   [SubExp] ->
   [VName] ->
-  RuleM lore ()
+  RuleM rep ()
 foldClosedForm look pat lam accs arrs = do
   inputsize <- arraysSize 0 <$> mapM lookupType arrs
 
@@ -78,14 +78,14 @@ foldClosedForm look pat lam accs arrs = do
 -- | @loopClosedForm pat respat merge bound bodys@ determines whether
 -- the do-loop can be expressed in a closed form.
 loopClosedForm ::
-  (ASTLore lore, BinderOps lore) =>
-  Pattern lore ->
-  [(FParam lore, SubExp)] ->
+  (ASTRep rep, BinderOps rep) =>
+  Pattern rep ->
+  [(FParam rep, SubExp)] ->
   Names ->
   IntType ->
   SubExp ->
-  Body lore ->
-  RuleM lore ()
+  Body rep ->
+  RuleM rep ()
 loopClosedForm pat merge i it bound body = do
   t <- case patternTypes pat of
     [Prim t] -> return t
@@ -118,7 +118,7 @@ loopClosedForm pat merge i it bound body = do
     knownBnds = M.fromList $ zip mergenames mergeexp
 
 checkResults ::
-  BinderOps lore =>
+  BinderOps rep =>
   [VName] ->
   SubExp ->
   Names ->
@@ -126,9 +126,9 @@ checkResults ::
   M.Map VName SubExp ->
   -- | Lambda-bound
   [VName] ->
-  Body lore ->
+  Body rep ->
   [SubExp] ->
-  RuleM lore (Body lore)
+  RuleM rep (Body rep)
 checkResults pat size untouchable it knownBnds params body accs = do
   ((), bnds) <-
     collectStms $
@@ -191,8 +191,8 @@ checkResults pat size untouchable it knownBnds params body accs = do
           BasicOp $ ConvOp (SIToFP it t) size
 
 determineKnownBindings ::
-  VarLookup lore ->
-  Lambda lore ->
+  VarLookup rep ->
+  Lambda rep ->
   [SubExp] ->
   [VName] ->
   M.Map VName SubExp
@@ -215,7 +215,7 @@ determineKnownBindings look lam accs arrs =
         Just (p, ve)
     isReplicate _ = Nothing
 
-makeBindMap :: Body lore -> M.Map VName (Exp lore)
+makeBindMap :: Body rep -> M.Map VName (Exp rep)
 makeBindMap = M.fromList . mapMaybe isSingletonStm . stmsToList . bodyStms
   where
     isSingletonStm (Let pat _ e) = case patternNames pat of

--- a/src/Futhark/Optimise/Simplify/Rules/Index.hs
+++ b/src/Futhark/Optimise/Simplify/Rules/Index.hs
@@ -33,7 +33,7 @@ data IndexResult
 -- | Try to simplify an index operation.
 simplifyIndexing ::
   MonadBinder m =>
-  ST.SymbolTable (Lore m) ->
+  ST.SymbolTable (Rep m) ->
   TypeLookup ->
   VName ->
   Slice SubExp ->

--- a/src/Futhark/Optimise/Simplify/Rules/Loop.hs
+++ b/src/Futhark/Optimise/Simplify/Rules/Loop.hs
@@ -25,7 +25,7 @@ import Futhark.Transform.Rename
 -- I do not claim that the current implementation of this rule is
 -- perfect, but it should suffice for many cases, and should never
 -- generate wrong code.
-removeRedundantMergeVariables :: BinderOps lore => BottomUpRuleDoLoop lore
+removeRedundantMergeVariables :: BinderOps rep => BottomUpRuleDoLoop rep
 removeRedundantMergeVariables (_, used) pat aux (ctx, val, form, body)
   | not $ all (usedAfterLoop . fst) val,
     null ctx -- FIXME: things get tricky if we can remove all vals
@@ -105,7 +105,7 @@ removeRedundantMergeVariables _ _ _ _ =
 
 -- We may change the type of the loop if we hoist out a shape
 -- annotation, in which case we also need to tweak the bound pattern.
-hoistLoopInvariantMergeVariables :: BinderOps lore => TopDownRuleDoLoop lore
+hoistLoopInvariantMergeVariables :: BinderOps rep => TopDownRuleDoLoop rep
 hoistLoopInvariantMergeVariables vtable pat aux (ctx, val, form, loopbody) =
   -- Figure out which of the elements of loopresult are
   -- loop-invariant, and hoist them out.
@@ -206,12 +206,12 @@ hoistLoopInvariantMergeVariables vtable pat aux (ctx, val, form, loopbody) =
       not (name `nameIn` namesOfMergeParams)
         || name `nameIn` namesOfInvariant
 
-simplifyClosedFormLoop :: BinderOps lore => TopDownRuleDoLoop lore
+simplifyClosedFormLoop :: BinderOps rep => TopDownRuleDoLoop rep
 simplifyClosedFormLoop _ pat _ ([], val, ForLoop i it bound [], body) =
   Simplify $ loopClosedForm pat val (oneName i) it bound body
 simplifyClosedFormLoop _ _ _ _ = Skip
 
-simplifyLoopVariables :: (BinderOps lore, Aliased lore) => TopDownRuleDoLoop lore
+simplifyLoopVariables :: (BinderOps rep, Aliased rep) => TopDownRuleDoLoop rep
 simplifyLoopVariables vtable pat aux (ctx, val, form@(ForLoop i it num_iters loop_vars), body)
   | simplifiable <- map checkIfSimplifiable loop_vars,
     not $ all isNothing simplifiable = Simplify $ do
@@ -290,7 +290,7 @@ simplifyLoopVariables _ _ _ _ = Skip
 -- instead.  We then move the sign extension inside the loop instead.
 -- This addresses loops of the form @for i in x..<y@ in the source
 -- language.
-narrowLoopType :: (BinderOps lore) => TopDownRuleDoLoop lore
+narrowLoopType :: (BinderOps rep) => TopDownRuleDoLoop rep
 narrowLoopType vtable pat aux (ctx, val, ForLoop i Int64 n [], body)
   | Just (n', it', cs) <- smallerType =
     Simplify $ do
@@ -315,13 +315,13 @@ narrowLoopType vtable pat aux (ctx, val, ForLoop i Int64 n [], body)
 narrowLoopType _ _ _ _ = Skip
 
 unroll ::
-  BinderOps lore =>
+  BinderOps rep =>
   Integer ->
-  [(FParam lore, SubExp)] ->
+  [(FParam rep, SubExp)] ->
   (VName, IntType, Integer) ->
-  [(LParam lore, VName)] ->
-  Body lore ->
-  RuleM lore [SubExp]
+  [(LParam rep, VName)] ->
+  Body rep ->
+  RuleM rep [SubExp]
 unroll n merge (iv, it, i) loop_vars body
   | i >= n =
     return $ map snd merge
@@ -348,7 +348,7 @@ unroll n merge (iv, it, i) loop_vars body
     let merge' = zip (map fst merge) $ bodyResult iter_body'
     unroll n merge' (iv, it, i + 1) loop_vars body
 
-simplifyKnownIterationLoop :: BinderOps lore => TopDownRuleDoLoop lore
+simplifyKnownIterationLoop :: BinderOps rep => TopDownRuleDoLoop rep
 simplifyKnownIterationLoop _ pat aux (ctx, val, ForLoop i it (Constant iters) loop_vars, body)
   | IntValue n <- iters,
     zeroIshInt n || oneIshInt n || "unroll" `inAttrs` stmAuxAttrs aux = Simplify $ do
@@ -358,7 +358,7 @@ simplifyKnownIterationLoop _ pat aux (ctx, val, ForLoop i it (Constant iters) lo
 simplifyKnownIterationLoop _ _ _ _ =
   Skip
 
-topDownRules :: (BinderOps lore, Aliased lore) => [TopDownRule lore]
+topDownRules :: (BinderOps rep, Aliased rep) => [TopDownRule rep]
 topDownRules =
   [ RuleDoLoop hoistLoopInvariantMergeVariables,
     RuleDoLoop simplifyClosedFormLoop,
@@ -367,11 +367,11 @@ topDownRules =
     RuleDoLoop narrowLoopType
   ]
 
-bottomUpRules :: BinderOps lore => [BottomUpRule lore]
+bottomUpRules :: BinderOps rep => [BottomUpRule rep]
 bottomUpRules =
   [ RuleDoLoop removeRedundantMergeVariables
   ]
 
 -- | Standard loop simplification rules.
-loopRules :: (BinderOps lore, Aliased lore) => RuleBook lore
+loopRules :: (BinderOps rep, Aliased rep) => RuleBook rep
 loopRules = ruleBook topDownRules bottomUpRules

--- a/src/Futhark/Optimise/Simplify/Rules/Simple.hs
+++ b/src/Futhark/Optimise/Simplify/Rules/Simple.hs
@@ -14,14 +14,14 @@ import Futhark.Analysis.PrimExp.Convert
 import Futhark.IR
 
 -- | A function that, given a variable name, returns its definition.
-type VarLookup lore = VName -> Maybe (Exp lore, Certificates)
+type VarLookup rep = VName -> Maybe (Exp rep, Certificates)
 
 -- | A function that, given a subexpression, returns its type.
 type TypeLookup = SubExp -> Maybe Type
 
 -- | A simple rule is a top-down rule that can be expressed as a pure
 -- function.
-type SimpleRule lore = VarLookup lore -> TypeLookup -> BasicOp -> Maybe (BasicOp, Certificates)
+type SimpleRule rep = VarLookup rep -> TypeLookup -> BasicOp -> Maybe (BasicOp, Certificates)
 
 isCt1 :: SubExp -> Bool
 isCt1 (Constant v) = oneIsh v
@@ -31,7 +31,7 @@ isCt0 :: SubExp -> Bool
 isCt0 (Constant v) = zeroIsh v
 isCt0 _ = False
 
-simplifyCmpOp :: SimpleRule lore
+simplifyCmpOp :: SimpleRule rep
 simplifyCmpOp _ _ (CmpOp cmp e1 e2)
   | e1 == e2 = constRes $
     BoolValue $
@@ -55,7 +55,7 @@ simplifyCmpOp look _ (CmpOp CmpEq {} (Constant (IntValue x)) (Var v))
       _ -> Just (SubExp (Constant (BoolValue False)), cs)
 simplifyCmpOp _ _ _ = Nothing
 
-simplifyBinOp :: SimpleRule lore
+simplifyBinOp :: SimpleRule rep
 simplifyBinOp _ _ (BinOp op (Constant v1) (Constant v2))
   | Just res <- doBinOp op v1 v2 =
     constRes res
@@ -204,7 +204,7 @@ constRes = Just . (,mempty) . SubExp . Constant
 subExpRes :: SubExp -> Maybe (BasicOp, Certificates)
 subExpRes = Just . (,mempty) . SubExp
 
-simplifyUnOp :: SimpleRule lore
+simplifyUnOp :: SimpleRule rep
 simplifyUnOp _ _ (UnOp op (Constant v)) =
   constRes =<< doUnOp op v
 simplifyUnOp defOf _ (UnOp Not (Var v))
@@ -213,7 +213,7 @@ simplifyUnOp defOf _ (UnOp Not (Var v))
 simplifyUnOp _ _ _ =
   Nothing
 
-simplifyConvOp :: SimpleRule lore
+simplifyConvOp :: SimpleRule rep
 simplifyConvOp _ _ (ConvOp op (Constant v)) =
   constRes =<< doConvOp op v
 simplifyConvOp _ _ (ConvOp op se)
@@ -244,13 +244,13 @@ simplifyConvOp _ _ _ =
   Nothing
 
 -- If expression is true then just replace assertion.
-simplifyAssert :: SimpleRule lore
+simplifyAssert :: SimpleRule rep
 simplifyAssert _ _ (Assert (Constant (BoolValue True)) _ _) =
   constRes UnitValue
 simplifyAssert _ _ _ =
   Nothing
 
-simplifyIdentityReshape :: SimpleRule lore
+simplifyIdentityReshape :: SimpleRule rep
 simplifyIdentityReshape _ seType (Reshape newshape v)
   | Just t <- seType $ Var v,
     newDims newshape == arrayDims t -- No-op reshape.
@@ -258,19 +258,19 @@ simplifyIdentityReshape _ seType (Reshape newshape v)
     subExpRes $ Var v
 simplifyIdentityReshape _ _ _ = Nothing
 
-simplifyReshapeReshape :: SimpleRule lore
+simplifyReshapeReshape :: SimpleRule rep
 simplifyReshapeReshape defOf _ (Reshape newshape v)
   | Just (BasicOp (Reshape oldshape v2), v_cs) <- defOf v =
     Just (Reshape (fuseReshape oldshape newshape) v2, v_cs)
 simplifyReshapeReshape _ _ _ = Nothing
 
-simplifyReshapeScratch :: SimpleRule lore
+simplifyReshapeScratch :: SimpleRule rep
 simplifyReshapeScratch defOf _ (Reshape newshape v)
   | Just (BasicOp (Scratch bt _), v_cs) <- defOf v =
     Just (Scratch bt $ newDims newshape, v_cs)
 simplifyReshapeScratch _ _ _ = Nothing
 
-simplifyReshapeReplicate :: SimpleRule lore
+simplifyReshapeReplicate :: SimpleRule rep
 simplifyReshapeReplicate defOf seType (Reshape newshape v)
   | Just (BasicOp (Replicate _ se), v_cs) <- defOf v,
     Just oldshape <- arrayShape <$> seType se,
@@ -281,7 +281,7 @@ simplifyReshapeReplicate defOf seType (Reshape newshape v)
      in Just (Replicate (Shape new) se, v_cs)
 simplifyReshapeReplicate _ _ _ = Nothing
 
-simplifyReshapeIota :: SimpleRule lore
+simplifyReshapeIota :: SimpleRule rep
 simplifyReshapeIota defOf _ (Reshape newshape v)
   | Just (BasicOp (Iota _ offset stride it), v_cs) <- defOf v,
     [n] <- newDims newshape =
@@ -297,7 +297,7 @@ reshapeSlice _ _ = []
 
 -- If we are size-coercing a slice, then we might as well just use a
 -- different slice instead.
-simplifyReshapeIndex :: SimpleRule lore
+simplifyReshapeIndex :: SimpleRule rep
 simplifyReshapeIndex defOf _ (Reshape newshape v)
   | Just ds <- shapeCoercion newshape,
     Just (BasicOp (Index v' slice), v_cs) <- defOf v,
@@ -308,7 +308,7 @@ simplifyReshapeIndex _ _ _ = Nothing
 
 -- If we are updating a slice with the result of a size coercion, we
 -- instead use the original array and update the slice dimensions.
-simplifyUpdateReshape :: SimpleRule lore
+simplifyUpdateReshape :: SimpleRule rep
 simplifyUpdateReshape defOf seType (Update dest slice (Var v))
   | Just (BasicOp (Reshape newshape v'), v_cs) <- defOf v,
     Just _ <- shapeCoercion newshape,
@@ -318,7 +318,7 @@ simplifyUpdateReshape defOf seType (Update dest slice (Var v))
     Just (Update dest slice' $ Var v', v_cs)
 simplifyUpdateReshape _ _ _ = Nothing
 
-improveReshape :: SimpleRule lore
+improveReshape :: SimpleRule rep
 improveReshape _ seType (Reshape newshape v)
   | Just t <- seType $ Var v,
     newshape' <- informReshape (arrayDims t) newshape,
@@ -328,7 +328,7 @@ improveReshape _ _ _ = Nothing
 
 -- | If we are copying a scratch array (possibly indirectly), just turn it into a scratch by
 -- itself.
-copyScratchToScratch :: SimpleRule lore
+copyScratchToScratch :: SimpleRule rep
 copyScratchToScratch defOf seType (Copy src) = do
   t <- seType $ Var src
   if isActuallyScratch src
@@ -344,7 +344,7 @@ copyScratchToScratch defOf seType (Copy src) = do
 copyScratchToScratch _ _ _ =
   Nothing
 
-simpleRules :: [SimpleRule lore]
+simpleRules :: [SimpleRule rep]
 simpleRules =
   [ simplifyBinOp,
     simplifyCmpOp,
@@ -366,7 +366,7 @@ simpleRules =
 -- and certificates that it must depend on.
 {-# NOINLINE applySimpleRules #-}
 applySimpleRules ::
-  VarLookup lore ->
+  VarLookup rep ->
   TypeLookup ->
   BasicOp ->
   Maybe (BasicOp, Certificates)

--- a/src/Futhark/Optimise/Sink.hs
+++ b/src/Futhark/Optimise/Sink.hs
@@ -56,24 +56,24 @@ import Futhark.IR.Kernels
 import Futhark.IR.MC
 import Futhark.Pass
 
-type SymbolTable lore = ST.SymbolTable lore
+type SymbolTable rep = ST.SymbolTable rep
 
-type Sinking lore = M.Map VName (Stm lore)
+type Sinking rep = M.Map VName (Stm rep)
 
 type Sunk = Names
 
-type Sinker lore a = SymbolTable lore -> Sinking lore -> a -> (a, Sunk)
+type Sinker rep a = SymbolTable rep -> Sinking rep -> a -> (a, Sunk)
 
-type Constraints lore =
-  ( ASTLore lore,
-    Aliased lore,
-    ST.IndexOp (Op lore)
+type Constraints rep =
+  ( ASTRep rep,
+    Aliased rep,
+    ST.IndexOp (Op rep)
   )
 
 -- | Given a statement, compute how often each of its free variables
 -- are used.  Not accurate: what we care about are only 1, and greater
 -- than 1.
-multiplicity :: Constraints lore => Stm lore -> M.Map VName Int
+multiplicity :: Constraints rep => Stm rep -> M.Map VName Int
 multiplicity stm =
   case stmExp stm of
     If cond tbranch fbranch _ ->
@@ -86,9 +86,9 @@ multiplicity stm =
     comb = M.unionWith (+)
 
 optimiseBranch ::
-  Constraints lore =>
-  Sinker lore (Op lore) ->
-  Sinker lore (Body lore)
+  Constraints rep =>
+  Sinker rep (Op rep) ->
+  Sinker rep (Body rep)
 optimiseBranch onOp vtable sinking (Body dec stms res) =
   let (stms', stms_sunk) = optimiseStms onOp vtable sinking' (sunk_stms <> stms) $ freeIn res
    in ( Body dec stms' res,
@@ -104,13 +104,13 @@ optimiseBranch onOp vtable sinking (Body dec stms res) =
     sunk = namesFromList $ foldMap (patternNames . stmPattern) sunk_stms
 
 optimiseStms ::
-  Constraints lore =>
-  Sinker lore (Op lore) ->
-  SymbolTable lore ->
-  Sinking lore ->
-  Stms lore ->
+  Constraints rep =>
+  Sinker rep (Op rep) ->
+  SymbolTable rep ->
+  Sinking rep ->
+  Stms rep ->
   Names ->
-  (Stms lore, Sunk)
+  (Stms rep, Sunk)
 optimiseStms onOp init_vtable init_sinking all_stms free_in_res =
   let (all_stms', sunk) =
         optimiseStms' init_vtable init_sinking $ stmsToList all_stms
@@ -168,25 +168,25 @@ optimiseStms onOp init_vtable init_sinking all_stms free_in_res =
             }
 
 optimiseBody ::
-  Constraints lore =>
-  Sinker lore (Op lore) ->
-  Sinker lore (Body lore)
+  Constraints rep =>
+  Sinker rep (Op rep) ->
+  Sinker rep (Body rep)
 optimiseBody onOp vtable sinking (Body attr stms res) =
   let (stms', sunk) = optimiseStms onOp vtable sinking stms $ freeIn res
    in (Body attr stms' res, sunk)
 
 optimiseKernelBody ::
-  Constraints lore =>
-  Sinker lore (Op lore) ->
-  Sinker lore (KernelBody lore)
+  Constraints rep =>
+  Sinker rep (Op rep) ->
+  Sinker rep (KernelBody rep)
 optimiseKernelBody onOp vtable sinking (KernelBody attr stms res) =
   let (stms', sunk) = optimiseStms onOp vtable sinking stms $ freeIn res
    in (KernelBody attr stms' res, sunk)
 
 optimiseSegOp ::
-  Constraints lore =>
-  Sinker lore (Op lore) ->
-  Sinker lore (SegOp lvl lore)
+  Constraints rep =>
+  Sinker rep (Op rep) ->
+  Sinker rep (SegOp lvl rep)
 optimiseSegOp onOp vtable sinking op =
   let scope = scopeOfSegSpace $ segSpace op
    in runState (mapSegOpM (opMapper scope) op) mempty
@@ -208,15 +208,15 @@ optimiseSegOp onOp vtable sinking op =
       where
         op_vtable = ST.fromScope scope <> vtable
 
-type SinkLore lore = Aliases lore
+type SinkRep rep = Aliases rep
 
 sink ::
-  ( ASTLore lore,
-    CanBeAliased (Op lore),
-    ST.IndexOp (OpWithAliases (Op lore))
+  ( ASTRep rep,
+    CanBeAliased (Op rep),
+    ST.IndexOp (OpWithAliases (Op rep))
   ) =>
-  Sinker (SinkLore lore) (Op (SinkLore lore)) ->
-  Pass lore lore
+  Sinker (SinkRep rep) (Op (SinkRep rep)) ->
+  Pass rep rep
 sink onOp =
   Pass "sink" "move memory loads closer to their uses" $
     fmap removeProgAliases
@@ -238,7 +238,7 @@ sink onOp =
 sinkKernels :: Pass Kernels Kernels
 sinkKernels = sink onHostOp
   where
-    onHostOp :: Sinker (SinkLore Kernels) (Op (SinkLore Kernels))
+    onHostOp :: Sinker (SinkRep Kernels) (Op (SinkRep Kernels))
     onHostOp vtable sinking (SegOp op) =
       first SegOp $ optimiseSegOp onHostOp vtable sinking op
     onHostOp _ _ op = (op, mempty)
@@ -247,7 +247,7 @@ sinkKernels = sink onHostOp
 sinkMC :: Pass MC MC
 sinkMC = sink onHostOp
   where
-    onHostOp :: Sinker (SinkLore MC) (Op (SinkLore MC))
+    onHostOp :: Sinker (SinkRep MC) (Op (SinkRep MC))
     onHostOp vtable sinking (ParOp par_op op) =
       let (par_op', par_sunk) =
             maybe

--- a/src/Futhark/Optimise/Sink.hs
+++ b/src/Futhark/Optimise/Sink.hs
@@ -40,10 +40,10 @@
 -- you ever see this pass as being a compilation speed bottleneck,
 -- start by caching that a bit.
 --
--- This pass is defined on the Kernels representation.  This is not
--- because we do anything kernel-specific here, but simply because
--- more explicit indexing is going on after SOACs are gone.
-module Futhark.Optimise.Sink (sinkKernels, sinkMC) where
+-- This pass is defined on post-SOACS representations.  This is not
+-- because we do anything GPU-specific here, but simply because more
+-- explicit indexing is going on after SOACs are gone.
+module Futhark.Optimise.Sink (sinkGPU, sinkMC) where
 
 import Control.Monad.State
 import Data.Bifunctor
@@ -52,7 +52,7 @@ import qualified Data.Map as M
 import qualified Futhark.Analysis.Alias as Alias
 import qualified Futhark.Analysis.SymbolTable as ST
 import Futhark.IR.Aliases
-import Futhark.IR.Kernels
+import Futhark.IR.GPU
 import Futhark.IR.MC
 import Futhark.Pass
 
@@ -235,10 +235,10 @@ sink onOp =
             namesFromList $ M.keys $ scopeOf consts
 
 -- | Sinking in GPU kernels.
-sinkKernels :: Pass Kernels Kernels
-sinkKernels = sink onHostOp
+sinkGPU :: Pass GPU GPU
+sinkGPU = sink onHostOp
   where
-    onHostOp :: Sinker (SinkRep Kernels) (Op (SinkRep Kernels))
+    onHostOp :: Sinker (SinkRep GPU) (Op (SinkRep GPU))
     onHostOp vtable sinking (SegOp op) =
       first SegOp $ optimiseSegOp onHostOp vtable sinking op
     onHostOp _ _ op = (op, mempty)

--- a/src/Futhark/Optimise/TileLoops.hs
+++ b/src/Futhark/Optimise/TileLoops.hs
@@ -12,7 +12,7 @@ import qualified Data.Map.Strict as M
 import Data.Maybe (mapMaybe)
 import qualified Data.Sequence as Seq
 import qualified Futhark.Analysis.Alias as Alias
-import Futhark.IR.Kernels
+import Futhark.IR.GPU
 import Futhark.IR.Prop.Aliases (consumedInStm)
 import Futhark.MonadFreshNames
 import Futhark.Optimise.BlkRegTiling
@@ -23,7 +23,7 @@ import Futhark.Transform.Rename
 import Prelude hiding (quot)
 
 -- | The pass definition.
-tileLoops :: Pass Kernels Kernels
+tileLoops :: Pass GPU GPU
 tileLoops =
   Pass "tile loops" "Tile stream loops inside kernels" $
     intraproceduralTransformation onStms
@@ -33,16 +33,16 @@ tileLoops =
         runState $
           runReaderT (optimiseStms stms) scope
 
-optimiseBody :: Body Kernels -> TileM (Body Kernels)
+optimiseBody :: Body GPU -> TileM (Body GPU)
 optimiseBody (Body () stms res) =
   Body () <$> optimiseStms stms <*> pure res
 
-optimiseStms :: Stms Kernels -> TileM (Stms Kernels)
+optimiseStms :: Stms GPU -> TileM (Stms GPU)
 optimiseStms stms =
   localScope (scopeOf stms) $
     mconcat <$> mapM optimiseStm (stmsToList stms)
 
-optimiseStm :: Stm Kernels -> TileM (Stms Kernels)
+optimiseStm :: Stm GPU -> TileM (Stms GPU)
 optimiseStm stm@(Let pat aux (Op (SegOp (SegMap lvl@SegThread {} space ts kbody)))) = do
   res3dtiling <- doRegTiling3D stm
   case res3dtiling of
@@ -67,8 +67,8 @@ tileInKernelBody ::
   SegLevel ->
   SegSpace ->
   [Type] ->
-  KernelBody Kernels ->
-  TileM (Stms Kernels, (SegLevel, SegSpace, KernelBody Kernels))
+  KernelBody GPU ->
+  TileM (Stms GPU, (SegLevel, SegSpace, KernelBody GPU))
 tileInKernelBody branch_variant initial_variance lvl initial_kspace ts kbody
   | Just kbody_res <- mapM isSimpleResult $ kernelBodyResult kbody = do
     maybe_tiled <-
@@ -99,8 +99,8 @@ tileInBody ::
   SegLevel ->
   SegSpace ->
   [Type] ->
-  Body Kernels ->
-  TileM (Maybe (Stms Kernels, Tiling, TiledBody))
+  Body GPU ->
+  TileM (Maybe (Stms GPU, Tiling, TiledBody))
 tileInBody branch_variant initial_variance initial_lvl initial_space res_ts (Body () initial_kstms stms_res) =
   descend mempty $ stmsToList initial_kstms
   where
@@ -207,10 +207,10 @@ tileInBody branch_variant initial_variance initial_lvl initial_space res_ts (Bod
 -- the tiled statement anyway.
 preludeToPostlude ::
   VarianceTable ->
-  Stms Kernels ->
-  Stm Kernels ->
-  Stms Kernels ->
-  (Stms Kernels, Stms Kernels)
+  Stms GPU ->
+  Stm GPU ->
+  Stms GPU ->
+  (Stms GPU, Stms GPU)
 preludeToPostlude variance prelude stm_to_tile postlude =
   (prelude_used, prelude_not_used <> postlude)
   where
@@ -247,10 +247,10 @@ preludeToPostlude variance prelude stm_to_tile postlude =
 -- in memory).
 partitionPrelude ::
   VarianceTable ->
-  Stms Kernels ->
+  Stms GPU ->
   Names ->
   Names ->
-  (Stms Kernels, Stms Kernels, Stms Kernels)
+  (Stms GPU, Stms GPU, Stms GPU)
 partitionPrelude variance prestms private used_after =
   (invariant_prestms, precomputed_variant_prestms, recomputed_variant_prestms)
   where
@@ -301,10 +301,10 @@ partitionPrelude variance prestms private used_after =
 injectPrelude ::
   SegSpace ->
   VarianceTable ->
-  Stms Kernels ->
+  Stms GPU ->
   Names ->
-  (Stms Kernels, Tiling, TiledBody) ->
-  (Stms Kernels, Tiling, TiledBody)
+  (Stms GPU, Tiling, TiledBody) ->
+  (Stms GPU, Tiling, TiledBody)
 injectPrelude initial_space variance prestms used (host_stms, tiling, tiledBody) =
   (host_stms, tiling, tiledBody')
   where
@@ -338,19 +338,19 @@ injectPrelude initial_space variance prestms used (host_stms, tiling, tiledBody)
 tileDoLoop ::
   SegSpace ->
   VarianceTable ->
-  Stms Kernels ->
+  Stms GPU ->
   Names ->
-  (Stms Kernels, Tiling, TiledBody) ->
+  (Stms GPU, Tiling, TiledBody) ->
   [Type] ->
-  Pattern Kernels ->
-  StmAux (ExpDec Kernels) ->
-  [(FParam Kernels, SubExp)] ->
+  Pattern GPU ->
+  StmAux (ExpDec GPU) ->
+  [(FParam GPU, SubExp)] ->
   VName ->
   IntType ->
   SubExp ->
-  Stms Kernels ->
+  Stms GPU ->
   Result ->
-  TileM (Stms Kernels, Tiling, TiledBody)
+  TileM (Stms GPU, Tiling, TiledBody)
 tileDoLoop initial_space variance prestms used_in_body (host_stms, tiling, tiledBody) res_ts pat aux merge i it bound poststms poststms_res = do
   let prestms_used = used_in_body <> freeIn poststms <> freeIn poststms_res
       ( invariant_prestms,
@@ -432,7 +432,7 @@ tileDoLoop initial_space variance prestms used_in_body (host_stms, tiling, tiled
           filter (`notElem` unSegSpace (tilingSpace tiling)) $
             unSegSpace initial_space
 
-doPrelude :: Tiling -> PrivStms -> Stms Kernels -> [VName] -> Binder Kernels [VName]
+doPrelude :: Tiling -> PrivStms -> Stms GPU -> [VName] -> Binder GPU [VName]
 doPrelude tiling privstms prestms prestms_live =
   -- Create a SegMap that takes care of the prelude for every thread.
   tilingSegMap tiling "prelude" (scalarLevel tiling) ResultPrivate $
@@ -449,17 +449,17 @@ doPrelude tiling privstms prestms prestms_live =
             )
             (eBody $ map eBlank ts)
 
-liveSet :: FreeIn a => Stms Kernels -> a -> Names
+liveSet :: FreeIn a => Stms GPU -> a -> Names
 liveSet stms after =
   namesFromList (concatMap (patternNames . stmPattern) stms)
     `namesIntersection` freeIn after
 
 tileable ::
-  Stm Kernels ->
+  Stm GPU ->
   Maybe
     ( SubExp,
       [VName],
-      (Commutativity, Lambda Kernels, [SubExp], Lambda Kernels)
+      (Commutativity, Lambda GPU, [SubExp], Lambda GPU)
     )
 tileable stm
   | Op (OtherOp (Screma w arrs form)) <- stmExp stm,
@@ -521,12 +521,12 @@ sliceUntiled arr tile_id full_tile_size this_tile_size = do
 -- SegMaps.  This is for things that cannot efficiently be computed
 -- once in advance in the prelude SegMap, primarily (exclusively?)
 -- array slicing operations.
-data PrivStms = PrivStms (Stms Kernels) ReadPrelude
+data PrivStms = PrivStms (Stms GPU) ReadPrelude
 
-privStms :: Stms Kernels -> PrivStms
+privStms :: Stms GPU -> PrivStms
 privStms stms = PrivStms stms $ const $ return ()
 
-addPrivStms :: Slice SubExp -> PrivStms -> Binder Kernels ()
+addPrivStms :: Slice SubExp -> PrivStms -> Binder GPU ()
 addPrivStms local_slice (PrivStms stms readPrelude) = do
   readPrelude local_slice
   addStms stms
@@ -541,13 +541,13 @@ instance Semigroup PrivStms where
 instance Monoid PrivStms where
   mempty = privStms mempty
 
-type ReadPrelude = Slice SubExp -> Binder Kernels ()
+type ReadPrelude = Slice SubExp -> Binder GPU ()
 
 data ProcessTileArgs = ProcessTileArgs
   { processPrivStms :: PrivStms,
     processComm :: Commutativity,
-    processRedLam :: Lambda Kernels,
-    processMapLam :: Lambda Kernels,
+    processRedLam :: Lambda GPU,
+    processMapLam :: Lambda GPU,
     processTiles :: [InputTile],
     processAcc :: [VName],
     processTileId :: SubExp
@@ -556,8 +556,8 @@ data ProcessTileArgs = ProcessTileArgs
 data ResidualTileArgs = ResidualTileArgs
   { residualPrivStms :: PrivStms,
     residualComm :: Commutativity,
-    residualRedLam :: Lambda Kernels,
-    residualMapLam :: Lambda Kernels,
+    residualRedLam :: Lambda GPU,
+    residualMapLam :: Lambda GPU,
     residualInput :: [InputArray],
     residualAcc :: [VName],
     residualInputSize :: SubExp,
@@ -572,8 +572,8 @@ data Tiling = Tiling
       String ->
       SegLevel ->
       ResultManifest ->
-      (PrimExp VName -> Slice SubExp -> Binder Kernels [SubExp]) ->
-      Binder Kernels [VName],
+      (PrimExp VName -> Slice SubExp -> Binder GPU [SubExp]) ->
+      Binder GPU [VName],
     -- The boolean PrimExp indicates whether they are in-bounds.
 
     tilingReadTile ::
@@ -581,22 +581,22 @@ data Tiling = Tiling
       PrivStms ->
       SubExp ->
       [InputArray] ->
-      Binder Kernels [InputTile],
+      Binder GPU [InputTile],
     tilingProcessTile ::
       ProcessTileArgs ->
-      Binder Kernels [VName],
+      Binder GPU [VName],
     tilingProcessResidualTile ::
       ResidualTileArgs ->
-      Binder Kernels [VName],
-    tilingTileReturns :: VName -> Binder Kernels KernelResult,
+      Binder GPU [VName],
+    tilingTileReturns :: VName -> Binder GPU KernelResult,
     tilingSpace :: SegSpace,
     tilingTileShape :: Shape,
     tilingLevel :: SegLevel,
-    tilingNumWholeTiles :: Binder Kernels SubExp
+    tilingNumWholeTiles :: Binder GPU SubExp
   }
 
 type DoTiling gtids kdims =
-  SegLevel -> gtids -> kdims -> SubExp -> Binder Kernels Tiling
+  SegLevel -> gtids -> kdims -> SubExp -> Binder GPU Tiling
 
 scalarLevel :: Tiling -> SegLevel
 scalarLevel tiling =
@@ -608,20 +608,20 @@ protectOutOfBounds ::
   String ->
   PrimExp VName ->
   [Type] ->
-  Binder Kernels [SubExp] ->
-  Binder Kernels [VName]
+  Binder GPU [SubExp] ->
+  Binder GPU [VName]
 protectOutOfBounds desc in_bounds ts m =
   letTupExp desc =<< eIf (toExp in_bounds) (resultBody <$> m) (eBody $ map eBlank ts)
 
 postludeGeneric ::
   Tiling ->
   PrivStms ->
-  Pattern Kernels ->
+  Pattern GPU ->
   [VName] ->
-  Stms Kernels ->
+  Stms GPU ->
   Result ->
   [Type] ->
-  Binder Kernels [VName]
+  Binder GPU [VName]
 postludeGeneric tiling privstms pat accs' poststms poststms_res res_ts =
   tilingSegMap tiling "thread_res" (scalarLevel tiling) ResultPrivate $ \in_bounds slice -> do
     -- Read our per-thread result from the tiled loop.
@@ -640,21 +640,21 @@ postludeGeneric tiling privstms pat accs' poststms poststms_res res_ts =
           addStms poststms
           return poststms_res
 
-type TiledBody = Names -> PrivStms -> Binder Kernels [VName]
+type TiledBody = Names -> PrivStms -> Binder GPU [VName]
 
 tileGeneric ::
   DoTiling gtids kdims ->
   SegLevel ->
   [Type] ->
-  Pattern Kernels ->
+  Pattern GPU ->
   gtids ->
   kdims ->
   SubExp ->
-  (Commutativity, Lambda Kernels, [SubExp], Lambda Kernels) ->
+  (Commutativity, Lambda GPU, [SubExp], Lambda GPU) ->
   [InputArray] ->
-  Stms Kernels ->
+  Stms GPU ->
   Result ->
-  TileM (Stms Kernels, Tiling, TiledBody)
+  TileM (Stms GPU, Tiling, TiledBody)
 tileGeneric doTiling initial_lvl res_ts pat gtids kdims w form inputs poststms poststms_res = do
   (tiling, tiling_stms) <- runBinder $ doTiling initial_lvl gtids kdims w
 
@@ -662,7 +662,7 @@ tileGeneric doTiling initial_lvl res_ts pat gtids kdims w form inputs poststms p
   where
     (red_comm, red_lam, red_nes, map_lam) = form
 
-    tiledBody :: Tiling -> Names -> PrivStms -> Binder Kernels [VName]
+    tiledBody :: Tiling -> Names -> PrivStms -> Binder GPU [VName]
     tiledBody tiling _private privstms = do
       let tile_shape = tilingTileShape tiling
 
@@ -723,7 +723,7 @@ mkReadPreludeValues prestms_live_arrs prestms_live slice =
       arr_t <- lookupType arr
       letBindNames [v] $ BasicOp $ Index arr $ fullSlice arr_t slice
 
-tileReturns :: [(VName, SubExp)] -> [(SubExp, SubExp)] -> VName -> Binder Kernels KernelResult
+tileReturns :: [(VName, SubExp)] -> [(SubExp, SubExp)] -> VName -> Binder GPU KernelResult
 tileReturns dims_on_top dims arr = do
   let unit_dims = replicate (length dims_on_top) (intConst Int64 1)
   arr' <-
@@ -747,8 +747,8 @@ segMap1D ::
   String ->
   SegLevel ->
   ResultManifest ->
-  (VName -> Binder Kernels [SubExp]) ->
-  Binder Kernels [VName]
+  (VName -> Binder GPU [SubExp]) ->
+  Binder GPU [VName]
 segMap1D desc lvl manifest f = do
   ltid <- newVName "ltid"
   ltid_flat <- newVName "ltid_flat"
@@ -770,7 +770,7 @@ reconstructGtids1D ::
   VName ->
   VName ->
   VName ->
-  Binder Kernels ()
+  Binder GPU ()
 reconstructGtids1D group_size gtid gid ltid =
   letBindNames [gtid]
     =<< toExp (le64 gid * pe64 (unCount group_size) + le64 ltid)
@@ -785,7 +785,7 @@ readTile1D ::
   PrivStms ->
   SubExp ->
   [InputArray] ->
-  Binder Kernels [InputTile]
+  Binder GPU [InputTile]
 readTile1D tile_size gid gtid num_groups group_size kind privstms tile_id inputs =
   fmap (inputsToTiles inputs)
     . segMap1D "full_tile" lvl ResultNoSimplify
@@ -826,7 +826,7 @@ processTile1D ::
   Count NumGroups SubExp ->
   Count GroupSize SubExp ->
   ProcessTileArgs ->
-  Binder Kernels [VName]
+  Binder GPU [VName]
 processTile1D gid gtid kdim tile_size num_groups group_size tile_args = do
   let red_comm = processComm tile_args
       privstms = processPrivStms tile_args
@@ -870,7 +870,7 @@ processResidualTile1D ::
   Count NumGroups SubExp ->
   Count GroupSize SubExp ->
   ResidualTileArgs ->
-  Binder Kernels [VName]
+  Binder GPU [VName]
 processResidualTile1D gid gtid kdim tile_size num_groups group_size args = do
   -- The number of residual elements that are not covered by
   -- the whole tiles.
@@ -1001,7 +1001,7 @@ reconstructGtids2D ::
   (VName, VName) ->
   (VName, VName) ->
   (VName, VName) ->
-  Binder Kernels ()
+  Binder GPU ()
 reconstructGtids2D tile_size (gtid_x, gtid_y) (gid_x, gid_y) (ltid_x, ltid_y) = do
   -- Reconstruct the original gtids from gid_x/gid_y and ltid_x/ltid_y.
   letBindNames [gtid_x]
@@ -1020,7 +1020,7 @@ readTile2D ::
   PrivStms ->
   SubExp ->
   [InputArray] ->
-  Binder Kernels [InputTile]
+  Binder GPU [InputTile]
 readTile2D (kdim_x, kdim_y) (gtid_x, gtid_y) (gid_x, gid_y) tile_size num_groups group_size kind privstms tile_id inputs =
   fmap (inputsToTiles inputs)
     . segMap2D
@@ -1092,7 +1092,7 @@ processTile2D ::
   Count NumGroups SubExp ->
   Count GroupSize SubExp ->
   ProcessTileArgs ->
-  Binder Kernels [VName]
+  Binder GPU [VName]
 processTile2D (gid_x, gid_y) (gtid_x, gtid_y) (kdim_x, kdim_y) tile_size num_groups group_size tile_args = do
   let privstms = processPrivStms tile_args
       red_comm = processComm tile_args
@@ -1148,7 +1148,7 @@ processResidualTile2D ::
   Count NumGroups SubExp ->
   Count GroupSize SubExp ->
   ResidualTileArgs ->
-  Binder Kernels [VName]
+  Binder GPU [VName]
 processResidualTile2D
   gids
   gtids

--- a/src/Futhark/Optimise/TileLoops.hs
+++ b/src/Futhark/Optimise/TileLoops.hs
@@ -1075,7 +1075,7 @@ readTile2D (kdim_x, kdim_y) (gtid_x, gtid_y) (gid_x, gid_y) tile_size num_groups
           TileFull ->
             mapM readTileElem arrs_and_perms
 
-findTileSize :: HasScope lore m => [InputTile] -> m SubExp
+findTileSize :: HasScope rep m => [InputTile] -> m SubExp
 findTileSize tiles =
   case mapMaybe isTiled tiles of
     v : _ -> arraySize 0 <$> lookupType v

--- a/src/Futhark/Optimise/TileLoops/Shared.hs
+++ b/src/Futhark/Optimise/TileLoops/Shared.hs
@@ -13,12 +13,12 @@ import Control.Monad.Reader
 import Control.Monad.State
 import Data.List (foldl', zip4)
 import qualified Data.Map as M
-import Futhark.IR.Kernels
+import Futhark.IR.GPU
 import Futhark.MonadFreshNames
 import Futhark.Tools
 import Futhark.Transform.Rename
 
-type TileM = ReaderT (Scope Kernels) (State VNameSource)
+type TileM = ReaderT (Scope GPU) (State VNameSource)
 
 segMap2D ::
   String -> -- desc
@@ -26,9 +26,9 @@ segMap2D ::
   ResultManifest -> -- manifest
   (SubExp, SubExp) -> -- (dim_x, dim_y)
   ( (VName, VName) -> -- f
-    Binder Kernels [SubExp]
+    Binder GPU [SubExp]
   ) ->
-  Binder Kernels [VName]
+  Binder GPU [VName]
 segMap2D desc lvl manifest (dim_y, dim_x) f = do
   ltid_xx <- newVName "ltid_x"
   ltid_flat <- newVName "ltid_flat"
@@ -51,9 +51,9 @@ segMap3D ::
   ResultManifest -> -- manifest
   (SubExp, SubExp, SubExp) -> -- (dim_z, dim_y, dim_x)
   ( (VName, VName, VName) -> -- f
-    Binder Kernels [SubExp]
+    Binder GPU [SubExp]
   ) ->
-  Binder Kernels [VName]
+  Binder GPU [VName]
 segMap3D desc lvl manifest (dim_z, dim_y, dim_x) f = do
   ltid_x <- newVName "ltid_x"
   ltid_flat <- newVName "ltid_flat"
@@ -77,8 +77,8 @@ segScatter2D ::
   VName ->
   SegLevel -> -- lvl
   (SubExp, SubExp) -> -- (dim_y, dim_x)
-  ((VName, VName) -> Binder Kernels (SubExp, SubExp)) -> -- f
-  Binder Kernels [VName]
+  ((VName, VName) -> Binder GPU (SubExp, SubExp)) -> -- f
+  Binder GPU [VName]
 segScatter2D desc arr_size updt_arr lvl (dim_x, dim_y) f = do
   ltid_x <- newVName "ltid_x"
   ltid_y <- newVName "ltid_y"
@@ -103,11 +103,11 @@ segScatter2D desc arr_size updt_arr lvl (dim_x, dim_y) f = do
 type VarianceTable = M.Map VName Names
 
 isTileableRedomap ::
-  Stm Kernels ->
+  Stm GPU ->
   Maybe
     ( SubExp,
       [VName],
-      (Commutativity, Lambda Kernels, [SubExp], Lambda Kernels)
+      (Commutativity, Lambda GPU, [SubExp], Lambda GPU)
     )
 isTileableRedomap stm
   | Op (OtherOp (Screma w arrs form)) <- stmExp stm,
@@ -123,7 +123,7 @@ isTileableRedomap stm
   | otherwise =
     Nothing
 
-defVarianceInStm :: VarianceTable -> Stm Kernels -> VarianceTable
+defVarianceInStm :: VarianceTable -> Stm GPU -> VarianceTable
 defVarianceInStm variance bnd =
   foldl' add variance $ patternNames $ stmPattern bnd
   where
@@ -133,7 +133,7 @@ defVarianceInStm variance bnd =
 
 -- just in case you need the Screma being treated differently than
 -- by default; previously Cosmin had to enhance it when dealing with stream.
-varianceInStm :: VarianceTable -> Stm Kernels -> VarianceTable
+varianceInStm :: VarianceTable -> Stm GPU -> VarianceTable
 varianceInStm v0 bnd@(Let _ _ (Op (OtherOp Screma {})))
   | Just (_, arrs, (_, red_lam, red_nes, map_lam)) <- isTileableRedomap bnd =
     let v = defVarianceInStm v0 bnd
@@ -156,5 +156,5 @@ varianceInStm v0 bnd@(Let _ _ (Op (OtherOp Screma {})))
      in varianceInStms v' stm_lam
 varianceInStm v0 bnd = defVarianceInStm v0 bnd
 
-varianceInStms :: VarianceTable -> Stms Kernels -> VarianceTable
+varianceInStms :: VarianceTable -> Stms GPU -> VarianceTable
 varianceInStms = foldl' varianceInStm

--- a/src/Futhark/Pass/ExpandAllocations.hs
+++ b/src/Futhark/Pass/ExpandAllocations.hs
@@ -20,7 +20,7 @@ import qualified Futhark.IR.Kernels.Simplify as Kernels
 import Futhark.IR.KernelsMem
 import qualified Futhark.IR.Mem.IxFun as IxFun
 import Futhark.MonadFreshNames
-import Futhark.Optimise.Simplify.Lore (addScopeWisdom)
+import Futhark.Optimise.Simplify.Rep (addScopeWisdom)
 import Futhark.Pass
 import Futhark.Pass.ExplicitAllocations.Kernels (explicitAllocationsInStms)
 import Futhark.Pass.ExtractKernels.BlockedKernel (nonSegRed)

--- a/src/Futhark/Pass/ExplicitAllocations.hs
+++ b/src/Futhark/Pass/ExplicitAllocations.hs
@@ -54,7 +54,7 @@ import qualified Futhark.IR.Mem.IxFun as IxFun
 import Futhark.MonadFreshNames
 import Futhark.Optimise.Simplify.Engine (SimpleOps (..))
 import qualified Futhark.Optimise.Simplify.Engine as Engine
-import Futhark.Optimise.Simplify.Lore (mkWiseBody)
+import Futhark.Optimise.Simplify.Rep (mkWiseBody)
 import Futhark.Pass
 import Futhark.Tools
 import Futhark.Util (splitAt3, splitFromEnd, takeLast)
@@ -66,7 +66,7 @@ data AllocStm
   deriving (Eq, Ord, Show)
 
 bindAllocStm ::
-  (MonadBinder m, Op (Lore m) ~ MemOp inner) =>
+  (MonadBinder m, Op (Rep m) ~ MemOp inner) =>
   AllocStm ->
   m ()
 bindAllocStm (SizeComputation name pe) =
@@ -77,15 +77,15 @@ bindAllocStm (ArrayCopy name src) =
   letBindNames [name] $ BasicOp $ Copy src
 
 class
-  (MonadFreshNames m, LocalScope lore m, Mem lore) =>
-  Allocator lore m
+  (MonadFreshNames m, LocalScope rep m, Mem rep) =>
+  Allocator rep m
   where
   addAllocStm :: AllocStm -> m ()
   askDefaultSpace :: m Space
 
   default addAllocStm ::
-    ( Allocable fromlore lore,
-      m ~ AllocM fromlore lore
+    ( Allocable fromrep rep,
+      m ~ AllocM fromrep rep
     ) =>
     AllocStm ->
     m ()
@@ -100,7 +100,7 @@ class
   -- allocate space for.  See 'ChunkMap' comment.
   dimAllocationSize :: SubExp -> m SubExp
   default dimAllocationSize ::
-    m ~ AllocM fromlore lore =>
+    m ~ AllocM fromrep rep =>
     SubExp ->
     m SubExp
   dimAllocationSize (Var v) =
@@ -113,11 +113,11 @@ class
   -- | Get those names that are known to be constants at run-time.
   askConsts :: m (S.Set VName)
 
-  expHints :: Exp lore -> m [ExpHint]
+  expHints :: Exp rep -> m [ExpHint]
   expHints = defaultExpHints
 
 allocateMemory ::
-  Allocator lore m =>
+  Allocator rep m =>
   String ->
   SubExp ->
   Space ->
@@ -128,7 +128,7 @@ allocateMemory desc size space = do
   return v
 
 computeSize ::
-  Allocator lore m =>
+  Allocator rep m =>
   String ->
   PrimExp VName ->
   m SubExp
@@ -137,19 +137,19 @@ computeSize desc se = do
   addAllocStm $ SizeComputation v se
   return $ Var v
 
-type Allocable fromlore tolore =
-  ( PrettyLore fromlore,
-    PrettyLore tolore,
-    Mem tolore,
-    FParamInfo fromlore ~ DeclType,
-    LParamInfo fromlore ~ Type,
-    BranchType fromlore ~ ExtType,
-    RetType fromlore ~ DeclExtType,
-    BodyDec fromlore ~ (),
-    BodyDec tolore ~ (),
-    ExpDec tolore ~ (),
-    SizeSubst (Op tolore),
-    BinderOps tolore
+type Allocable fromrep torep =
+  ( PrettyRep fromrep,
+    PrettyRep torep,
+    Mem torep,
+    FParamInfo fromrep ~ DeclType,
+    LParamInfo fromrep ~ Type,
+    BranchType fromrep ~ ExtType,
+    RetType fromrep ~ DeclExtType,
+    BodyDec fromrep ~ (),
+    BodyDec torep ~ (),
+    ExpDec torep ~ (),
+    SizeSubst (Op torep),
+    BinderOps torep
   )
 
 -- | A mapping from chunk names to their maximum size.  XXX FIXME
@@ -158,7 +158,7 @@ type Allocable fromlore tolore =
 -- analysis yet (it should).
 type ChunkMap = M.Map VName SubExp
 
-data AllocEnv fromlore tolore = AllocEnv
+data AllocEnv fromrep torep = AllocEnv
   { chunkMap :: ChunkMap,
     -- | Aggressively try to reuse memory in do-loops -
     -- should be True inside kernels, False outside.
@@ -170,28 +170,28 @@ data AllocEnv fromlore tolore = AllocEnv
     -- | The set of names that are known to be constants at
     -- kernel compile time.
     envConsts :: S.Set VName,
-    allocInOp :: Op fromlore -> AllocM fromlore tolore (Op tolore),
-    envExpHints :: Exp tolore -> AllocM fromlore tolore [ExpHint]
+    allocInOp :: Op fromrep -> AllocM fromrep torep (Op torep),
+    envExpHints :: Exp torep -> AllocM fromrep torep [ExpHint]
   }
 
 -- | Monad for adding allocations to an entire program.
-newtype AllocM fromlore tolore a
-  = AllocM (BinderT tolore (ReaderT (AllocEnv fromlore tolore) (State VNameSource)) a)
+newtype AllocM fromrep torep a
+  = AllocM (BinderT torep (ReaderT (AllocEnv fromrep torep) (State VNameSource)) a)
   deriving
     ( Applicative,
       Functor,
       Monad,
       MonadFreshNames,
-      HasScope tolore,
-      LocalScope tolore,
-      MonadReader (AllocEnv fromlore tolore)
+      HasScope torep,
+      LocalScope torep,
+      MonadReader (AllocEnv fromrep torep)
     )
 
 instance
-  (Allocable fromlore tolore, Allocator tolore (AllocM fromlore tolore)) =>
-  MonadBinder (AllocM fromlore tolore)
+  (Allocable fromrep torep, Allocator torep (AllocM fromrep torep)) =>
+  MonadBinder (AllocM fromrep torep)
   where
-  type Lore (AllocM fromlore tolore) = tolore
+  type Rep (AllocM fromrep torep) = torep
 
   mkExpDecM _ _ = return ()
 
@@ -205,8 +205,8 @@ instance
   collectStms (AllocM m) = AllocM $ collectStms m
 
 instance
-  (Allocable fromlore tolore) =>
-  Allocator tolore (AllocM fromlore tolore)
+  (Allocable fromrep torep) =>
+  Allocator torep (AllocM fromrep torep)
   where
   expHints e = do
     f <- asks envExpHints
@@ -217,9 +217,9 @@ instance
 
 runAllocM ::
   MonadFreshNames m =>
-  (Op fromlore -> AllocM fromlore tolore (Op tolore)) ->
-  (Exp tolore -> AllocM fromlore tolore [ExpHint]) ->
-  AllocM fromlore tolore a ->
+  (Op fromrep -> AllocM fromrep torep (Op torep)) ->
+  (Exp torep -> AllocM fromrep torep [ExpHint]) ->
+  AllocM fromrep torep a ->
   m a
 runAllocM handleOp hints (AllocM m) =
   fmap fst $ modifyNameSource $ runState $ runReaderT (runBinderT m mempty) env
@@ -235,10 +235,10 @@ runAllocM handleOp hints (AllocM m) =
         }
 
 -- | Monad for adding allocations to a single pattern.
-newtype PatAllocM lore a
+newtype PatAllocM rep a
   = PatAllocM
       ( RWS
-          (Scope lore)
+          (Scope rep)
           [AllocStm]
           VNameSource
           a
@@ -247,13 +247,13 @@ newtype PatAllocM lore a
     ( Applicative,
       Functor,
       Monad,
-      HasScope lore,
-      LocalScope lore,
+      HasScope rep,
+      LocalScope rep,
       MonadWriter [AllocStm],
       MonadFreshNames
     )
 
-instance Mem lore => Allocator lore (PatAllocM lore) where
+instance Mem rep => Allocator rep (PatAllocM rep) where
   addAllocStm = tell . pure
   dimAllocationSize = return
   askDefaultSpace = return DefaultSpace
@@ -261,8 +261,8 @@ instance Mem lore => Allocator lore (PatAllocM lore) where
 
 runPatAllocM ::
   MonadFreshNames m =>
-  PatAllocM lore a ->
-  Scope lore ->
+  PatAllocM rep a ->
+  Scope rep ->
   m (a, [AllocStm])
 runPatAllocM (PatAllocM m) mems =
   modifyNameSource $ frob . runRWS m mems
@@ -276,7 +276,7 @@ arraySizeInBytesExp :: Type -> PrimExp VName
 arraySizeInBytesExp t =
   untyped $ foldl' (*) (elemSize t) $ map pe64 (arrayDims t)
 
-arraySizeInBytesExpM :: Allocator lore m => Type -> m (PrimExp VName)
+arraySizeInBytesExpM :: Allocator rep m => Type -> m (PrimExp VName)
 arraySizeInBytesExpM t = do
   dims <- mapM dimAllocationSize (arrayDims t)
   let dim_prod_i64 = product $ map pe64 dims
@@ -286,12 +286,12 @@ arraySizeInBytesExpM t = do
       untyped $
         dim_prod_i64 * elm_size_i64
 
-arraySizeInBytes :: Allocator lore m => Type -> m SubExp
+arraySizeInBytes :: Allocator rep m => Type -> m SubExp
 arraySizeInBytes = computeSize "bytes" <=< arraySizeInBytesExpM
 
 -- | Allocate memory for a value of the given type.
 allocForArray ::
-  Allocator lore m =>
+  Allocator rep m =>
   Type ->
   Space ->
   m VName
@@ -300,11 +300,11 @@ allocForArray t space = do
   allocateMemory "mem" size space
 
 allocsForStm ::
-  (Allocator lore m, ExpDec lore ~ ()) =>
+  (Allocator rep m, ExpDec rep ~ ()) =>
   [Ident] ->
   [Ident] ->
-  Exp lore ->
-  m (Stm lore)
+  Exp rep ->
+  m (Stm rep)
 allocsForStm sizeidents validents e = do
   rts <- expReturns e
   hints <- expHints e
@@ -312,10 +312,10 @@ allocsForStm sizeidents validents e = do
   return $ Let (Pattern ctxElems valElems) (defAux ()) e
 
 patternWithAllocations ::
-  (Allocator lore m, ExpDec lore ~ ()) =>
+  (Allocator rep m, ExpDec rep ~ ()) =>
   [VName] ->
-  Exp lore ->
-  m (Pattern lore)
+  Exp rep ->
+  m (Pattern rep)
 patternWithAllocations names e = do
   (ts', sizes) <- instantiateShapes' =<< expExtType e
   let identForBindage name t =
@@ -324,14 +324,14 @@ patternWithAllocations names e = do
   stmPattern <$> allocsForStm sizes vals e
 
 allocsForPattern ::
-  Allocator lore m =>
+  Allocator rep m =>
   [Ident] ->
   [Ident] ->
   [ExpReturns] ->
   [ExpHint] ->
   m
-    ( [PatElem lore],
-      [PatElem lore]
+    ( [PatElem rep],
+      [PatElem rep]
     )
 allocsForPattern sizeidents validents rts hints = do
   let sizes' = [PatElem size $ MemPrim int64 | size <- map identName sizeidents]
@@ -435,7 +435,7 @@ instantiateIxFun = traverse $ traverse inst
     inst (Free x) = return x
 
 summaryForBindage ::
-  Allocator lore m =>
+  Allocator rep m =>
   Type ->
   ExpHint ->
   m (MemBound NoUniqueness)
@@ -459,7 +459,7 @@ summaryForBindage t@(Array pt _ _) (Hint ixfun space) = do
   m <- allocateMemory "mem" bytes space
   return $ MemArray pt (arrayShape t) NoUniqueness $ ArrayIn m ixfun
 
-lookupMemSpace :: (HasScope lore m, Monad m) => VName -> m Space
+lookupMemSpace :: (HasScope rep m, Monad m) => VName -> m Space
 lookupMemSpace v = do
   t <- lookupType v
   case t of
@@ -472,10 +472,10 @@ directIxFun bt shape u mem t =
    in MemArray bt shape u $ ArrayIn mem ixf
 
 allocInFParams ::
-  (Allocable fromlore tolore) =>
-  [(FParam fromlore, Space)] ->
-  ([FParam tolore] -> AllocM fromlore tolore a) ->
-  AllocM fromlore tolore a
+  (Allocable fromrep torep) =>
+  [(FParam fromrep, Space)] ->
+  ([FParam torep] -> AllocM fromrep torep a) ->
+  AllocM fromrep torep a
 allocInFParams params m = do
   (valparams, (ctxparams, memparams)) <-
     runWriterT $ mapM (uncurry allocInFParam) params
@@ -484,13 +484,13 @@ allocInFParams params m = do
   localScope summary $ m params'
 
 allocInFParam ::
-  (Allocable fromlore tolore) =>
-  FParam fromlore ->
+  (Allocable fromrep torep) =>
+  FParam fromrep ->
   Space ->
   WriterT
-    ([FParam tolore], [FParam tolore])
-    (AllocM fromlore tolore)
-    (FParam tolore)
+    ([FParam torep], [FParam torep])
+    (AllocM fromrep torep)
+    (FParam torep)
 allocInFParam param pspace =
   case paramDeclType param of
     Array pt shape u -> do
@@ -507,16 +507,16 @@ allocInFParam param pspace =
       return param {paramDec = MemAcc acc ispace ts u}
 
 allocInMergeParams ::
-  ( Allocable fromlore tolore,
-    Allocator tolore (AllocM fromlore tolore)
+  ( Allocable fromrep torep,
+    Allocator torep (AllocM fromrep torep)
   ) =>
-  [(FParam fromlore, SubExp)] ->
-  ( [FParam tolore] ->
-    [FParam tolore] ->
-    ([SubExp] -> AllocM fromlore tolore ([SubExp], [SubExp])) ->
-    AllocM fromlore tolore a
+  [(FParam fromrep, SubExp)] ->
+  ( [FParam torep] ->
+    [FParam torep] ->
+    ([SubExp] -> AllocM fromrep torep ([SubExp], [SubExp])) ->
+    AllocM fromrep torep a
   ) ->
-  AllocM fromlore tolore a
+  AllocM fromrep torep a
 allocInMergeParams merge m = do
   ((valparams, handle_loop_subexps), (ctx_params, mem_params)) <-
     runWriterT $ unzip <$> mapM allocInMergeParam merge
@@ -531,12 +531,12 @@ allocInMergeParams merge m = do
   localScope summary $ m (ctx_params <> mem_params) valparams mk_loop_res
   where
     allocInMergeParam ::
-      (Allocable fromlore tolore, Allocator tolore (AllocM fromlore tolore)) =>
+      (Allocable fromrep torep, Allocator torep (AllocM fromrep torep)) =>
       (Param DeclType, SubExp) ->
       WriterT
-        ([FParam tolore], [FParam tolore])
-        (AllocM fromlore tolore)
-        (FParam tolore, SubExp -> WriterT ([SubExp], [SubExp]) (AllocM fromlore tolore) SubExp)
+        ([FParam torep], [FParam torep])
+        (AllocM fromrep torep)
+        (FParam torep, SubExp -> WriterT ([SubExp], [SubExp]) (AllocM fromrep torep) SubExp)
     allocInMergeParam (mergeparam, Var v)
       | Array pt shape u <- paramDeclType mergeparam = do
         (mem', _) <- lift $ lookupArraySummary v
@@ -580,10 +580,10 @@ allocInMergeParams merge m = do
 
 -- Returns the existentialized index function, the list of substituted values and the memory location.
 existentializeArray ::
-  (Allocable fromlore tolore, Allocator tolore (AllocM fromlore tolore)) =>
+  (Allocable fromrep torep, Allocator torep (AllocM fromrep torep)) =>
   Space ->
   VName ->
-  AllocM fromlore tolore (SubExp, ExtIxFun, [TPrimExp Int64 VName], VName)
+  AllocM fromrep torep (SubExp, ExtIxFun, [TPrimExp Int64 VName], VName)
 existentializeArray ScalarSpace {} v = do
   (mem', ixfun) <- lookupArraySummary v
   return (Var v, fmap (fmap Free) ixfun, mempty, mem')
@@ -602,12 +602,12 @@ existentializeArray space v = do
       return (subexp, fromJust ext_ixfun, substs, mem)
 
 ensureArrayIn ::
-  ( Allocable fromlore tolore,
-    Allocator tolore (AllocM fromlore tolore)
+  ( Allocable fromrep torep,
+    Allocator torep (AllocM fromrep torep)
   ) =>
   Space ->
   SubExp ->
-  WriterT ([SubExp], [SubExp]) (AllocM fromlore tolore) SubExp
+  WriterT ([SubExp], [SubExp]) (AllocM fromrep torep) SubExp
 ensureArrayIn _ (Constant v) =
   error $ "ensureArrayIn: " ++ pretty v ++ " cannot be an array."
 ensureArrayIn space (Var v) = do
@@ -626,12 +626,12 @@ ensureArrayIn space (Var v) = do
   return sub_exp
 
 ensureDirectArray ::
-  ( Allocable fromlore tolore,
-    Allocator tolore (AllocM fromlore tolore)
+  ( Allocable fromrep torep,
+    Allocator torep (AllocM fromrep torep)
   ) =>
   Maybe Space ->
   VName ->
-  AllocM fromlore tolore (VName, SubExp)
+  AllocM fromrep torep (VName, SubExp)
 ensureDirectArray space_ok v = do
   (mem, ixfun) <- lookupArraySummary v
   mem_space <- lookupMemSpace mem
@@ -646,11 +646,11 @@ ensureDirectArray space_ok v = do
       allocLinearArray space (baseString v) v
 
 allocLinearArray ::
-  (Allocable fromlore tolore, Allocator tolore (AllocM fromlore tolore)) =>
+  (Allocable fromrep torep, Allocator torep (AllocM fromrep torep)) =>
   Space ->
   String ->
   VName ->
-  AllocM fromlore tolore (VName, SubExp)
+  AllocM fromrep torep (VName, SubExp)
 allocLinearArray space s v = do
   t <- lookupType v
   case t of
@@ -665,11 +665,11 @@ allocLinearArray space s v = do
       error $ "allocLinearArray: " ++ pretty t
 
 funcallArgs ::
-  ( Allocable fromlore tolore,
-    Allocator tolore (AllocM fromlore tolore)
+  ( Allocable fromrep torep,
+    Allocator torep (AllocM fromrep torep)
   ) =>
   [(SubExp, Diet)] ->
-  AllocM fromlore tolore [(SubExp, Diet)]
+  AllocM fromrep torep [(SubExp, Diet)]
 funcallArgs args = do
   (valargs, (ctx_args, mem_and_size_args)) <- runWriterT $
     forM args $ \(arg, d) -> do
@@ -680,13 +680,13 @@ funcallArgs args = do
   return $ map (,Observe) (ctx_args <> mem_and_size_args) <> valargs
 
 linearFuncallArg ::
-  ( Allocable fromlore tolore,
-    Allocator tolore (AllocM fromlore tolore)
+  ( Allocable fromrep torep,
+    Allocator torep (AllocM fromrep torep)
   ) =>
   Type ->
   Space ->
   SubExp ->
-  WriterT ([SubExp], [SubExp]) (AllocM fromlore tolore) SubExp
+  WriterT ([SubExp], [SubExp]) (AllocM fromrep torep) SubExp
 linearFuncallArg Array {} space (Var v) = do
   (mem, arg') <- lift $ ensureDirectArray (Just space) v
   tell ([], [Var mem])
@@ -695,12 +695,12 @@ linearFuncallArg _ _ arg =
   return arg
 
 explicitAllocationsGeneric ::
-  ( Allocable fromlore tolore,
-    Allocator tolore (AllocM fromlore tolore)
+  ( Allocable fromrep torep,
+    Allocator torep (AllocM fromrep torep)
   ) =>
-  (Op fromlore -> AllocM fromlore tolore (Op tolore)) ->
-  (Exp tolore -> AllocM fromlore tolore [ExpHint]) ->
-  Pass fromlore tolore
+  (Op fromrep -> AllocM fromrep torep (Op torep)) ->
+  (Exp torep -> AllocM fromrep torep [ExpHint]) ->
+  Pass fromrep torep
 explicitAllocationsGeneric handleOp hints =
   Pass "explicit allocations" "Transform program to explicit memory representation" $
     intraproceduralTransformationWithConsts onStms allocInFun
@@ -720,13 +720,13 @@ explicitAllocationsGeneric handleOp hints =
 
 explicitAllocationsInStmsGeneric ::
   ( MonadFreshNames m,
-    HasScope tolore m,
-    Allocable fromlore tolore
+    HasScope torep m,
+    Allocable fromrep torep
   ) =>
-  (Op fromlore -> AllocM fromlore tolore (Op tolore)) ->
-  (Exp tolore -> AllocM fromlore tolore [ExpHint]) ->
-  Stms fromlore ->
-  m (Stms tolore)
+  (Op fromrep -> AllocM fromrep torep (Op torep)) ->
+  (Exp torep -> AllocM fromrep torep [ExpHint]) ->
+  Stms fromrep ->
+  m (Stms torep)
 explicitAllocationsInStmsGeneric handleOp hints stms = do
   scope <- askScope
   runAllocM handleOp hints $
@@ -752,9 +752,9 @@ startOfFreeIDRange :: [TypeBase ExtShape u] -> Int
 startOfFreeIDRange = S.size . shapeContext
 
 bodyReturnMemCtx ::
-  (Allocable fromlore tolore, Allocator tolore (AllocM fromlore tolore)) =>
+  (Allocable fromrep torep, Allocator torep (AllocM fromrep torep)) =>
   SubExp ->
-  AllocM fromlore tolore [SubExp]
+  AllocM fromrep torep [SubExp]
 bodyReturnMemCtx Constant {} =
   return []
 bodyReturnMemCtx (Var v) = do
@@ -766,10 +766,10 @@ bodyReturnMemCtx (Var v) = do
     MemArray _ _ _ (ArrayIn mem _) -> return [Var mem]
 
 allocInFunBody ::
-  (Allocable fromlore tolore, Allocator tolore (AllocM fromlore tolore)) =>
+  (Allocable fromrep torep, Allocator torep (AllocM fromrep torep)) =>
   [Maybe Space] ->
-  Body fromlore ->
-  AllocM fromlore tolore (Body tolore)
+  Body fromrep ->
+  AllocM fromrep torep (Body torep)
 allocInFunBody space_oks (Body _ bnds res) =
   buildBody_ . allocInStms bnds $ do
     res' <- zipWithM ensureDirect space_oks' res
@@ -781,10 +781,10 @@ allocInFunBody space_oks (Body _ bnds res) =
     space_oks' = replicate (length res - num_vals) Nothing ++ space_oks
 
 ensureDirect ::
-  (Allocable fromlore tolore, Allocator tolore (AllocM fromlore tolore)) =>
+  (Allocable fromrep torep, Allocator torep (AllocM fromrep torep)) =>
   Maybe Space ->
   SubExp ->
-  AllocM fromlore tolore SubExp
+  AllocM fromrep torep SubExp
 ensureDirect space_ok se = do
   se_info <- subExpMemInfo se
   case (se_info, se) of
@@ -795,10 +795,10 @@ ensureDirect space_ok se = do
       return se
 
 allocInStms ::
-  (Allocable fromlore tolore) =>
-  Stms fromlore ->
-  AllocM fromlore tolore a ->
-  AllocM fromlore tolore a
+  (Allocable fromrep torep) =>
+  Stms fromrep ->
+  AllocM fromrep torep a ->
+  AllocM fromrep torep a
 allocInStms origstms m = allocInStms' $ stmsToList origstms
   where
     allocInStms' [] = m
@@ -815,9 +815,9 @@ allocInStms origstms m = allocInStms' $ stmsToList origstms
       local f $ allocInStms' stms
 
 allocInStm ::
-  (Allocable fromlore tolore, Allocator tolore (AllocM fromlore tolore)) =>
-  Stm fromlore ->
-  AllocM fromlore tolore ()
+  (Allocable fromrep torep, Allocator torep (AllocM fromrep torep)) =>
+  Stm fromrep ->
+  AllocM fromrep torep ()
 allocInStm (Let (Pattern sizeElems valElems) _ e) = do
   e' <- allocInExp e
   let sizeidents = map patElemIdent sizeElems
@@ -826,18 +826,18 @@ allocInStm (Let (Pattern sizeElems valElems) _ e) = do
   addStm bnd
 
 allocInLambda ::
-  Allocable fromlore tolore =>
-  [LParam tolore] ->
-  Body fromlore ->
-  AllocM fromlore tolore (Lambda tolore)
+  Allocable fromrep torep =>
+  [LParam torep] ->
+  Body fromrep ->
+  AllocM fromrep torep (Lambda torep)
 allocInLambda params body =
   mkLambda params . allocInStms (bodyStms body) $
     pure $ bodyResult body
 
 allocInExp ::
-  (Allocable fromlore tolore, Allocator tolore (AllocM fromlore tolore)) =>
-  Exp fromlore ->
-  AllocM fromlore tolore (Exp tolore)
+  (Allocable fromrep torep, Allocator torep (AllocM fromrep torep)) =>
+  Exp fromrep ->
+  AllocM fromrep torep (Exp torep)
 allocInExp (DoLoop ctx val form (Body () bodybnds bodyres)) =
   allocInMergeParams ctx $ \_ ctxparams' _ ->
     allocInMergeParams val $
@@ -923,10 +923,10 @@ allocInExp (If cond tbranch0 fbranch0 (IfDec rets ifsort)) = do
     selectSub f (Just (ixfn, m)) = Just (ixfn, map f m)
     selectSub _ Nothing = Nothing
     allocInIfBody ::
-      (Allocable fromlore tolore, Allocator tolore (AllocM fromlore tolore)) =>
+      (Allocable fromrep torep, Allocator torep (AllocM fromrep torep)) =>
       Int ->
-      Body fromlore ->
-      AllocM fromlore tolore (Body tolore, [Maybe IxFun])
+      Body fromrep ->
+      AllocM fromrep torep (Body torep, [Maybe IxFun])
     allocInIfBody num_vals (Body _ bnds res) =
       buildBody . allocInStms bnds $ do
         let (_, val_res) = splitFromEnd num_vals res
@@ -998,9 +998,9 @@ allocInExp e = mapExpM alloc e
         }
 
 subExpIxFun ::
-  (Allocable fromlore tolore, Allocator tolore (AllocM fromlore tolore)) =>
+  (Allocable fromrep torep, Allocator torep (AllocM fromrep torep)) =>
   SubExp ->
-  AllocM fromlore tolore (Maybe IxFun)
+  AllocM fromrep torep (Maybe IxFun)
 subExpIxFun Constant {} = return Nothing
 subExpIxFun (Var v) = do
   info <- lookupMemInfo v
@@ -1009,12 +1009,12 @@ subExpIxFun (Var v) = do
     _ -> return Nothing
 
 addResCtxInIfBody ::
-  (Allocable fromlore tolore, Allocator tolore (AllocM fromlore tolore)) =>
+  (Allocable fromrep torep, Allocator torep (AllocM fromrep torep)) =>
   [ExtType] ->
-  Body tolore ->
+  Body torep ->
   [Maybe Space] ->
   [Maybe (ExtIxFun, [TPrimExp Int64 VName])] ->
-  AllocM fromlore tolore (Body tolore, [BodyReturns])
+  AllocM fromrep torep (Body torep, [BodyReturns])
 addResCtxInIfBody ifrets (Body _ bnds res) spaces substs = do
   let num_vals = length ifrets
       (ctx_res, val_res) = splitFromEnd num_vals res
@@ -1093,9 +1093,9 @@ addResCtxInIfBody ifrets (Body _ bnds res) spaces substs = do
     adjustExtPE k = fmap (adjustExtV k)
 
 mkSpaceOks ::
-  (Mem tolore, LocalScope tolore m) =>
+  (Mem torep, LocalScope torep m) =>
   Int ->
-  Body tolore ->
+  Body torep ->
   m [Maybe Space]
 mkSpaceOks num_vals (Body _ stms res) =
   inScopeOf stms $
@@ -1113,11 +1113,11 @@ mkSpaceOks num_vals (Body _ stms res) =
     mkSpaceOK _ = return Nothing
 
 allocInLoopForm ::
-  ( Allocable fromlore tolore,
-    Allocator tolore (AllocM fromlore tolore)
+  ( Allocable fromrep torep,
+    Allocator torep (AllocM fromrep torep)
   ) =>
-  LoopForm fromlore ->
-  AllocM fromlore tolore (LoopForm tolore)
+  LoopForm fromrep ->
+  AllocM fromrep torep (LoopForm torep)
 allocInLoopForm (WhileLoop v) = return $ WhileLoop v
 allocInLoopForm (ForLoop i it n loopvars) =
   ForLoop i it n <$> mapM allocInLoopVar loopvars
@@ -1153,41 +1153,41 @@ instance SizeSubst op => SizeSubst (MemOp op) where
   opIsConst (Inner op) = opIsConst op
   opIsConst _ = False
 
-sizeSubst :: SizeSubst (Op lore) => Stm lore -> ChunkMap
+sizeSubst :: SizeSubst (Op rep) => Stm rep -> ChunkMap
 sizeSubst (Let pat _ (Op op)) = opSizeSubst pat op
 sizeSubst _ = mempty
 
-stmConsts :: SizeSubst (Op lore) => Stm lore -> S.Set VName
+stmConsts :: SizeSubst (Op rep) => Stm rep -> S.Set VName
 stmConsts (Let pat _ (Op op))
   | opIsConst op = S.fromList $ patternNames pat
 stmConsts _ = mempty
 
 mkLetNamesB' ::
-  ( Op (Lore m) ~ MemOp inner,
+  ( Op (Rep m) ~ MemOp inner,
     MonadBinder m,
-    ExpDec (Lore m) ~ (),
-    Allocator (Lore m) (PatAllocM (Lore m))
+    ExpDec (Rep m) ~ (),
+    Allocator (Rep m) (PatAllocM (Rep m))
   ) =>
-  ExpDec (Lore m) ->
+  ExpDec (Rep m) ->
   [VName] ->
-  Exp (Lore m) ->
-  m (Stm (Lore m))
+  Exp (Rep m) ->
+  m (Stm (Rep m))
 mkLetNamesB' dec names e = do
   scope <- askScope
   pat <- bindPatternWithAllocations scope names e
   return $ Let pat (defAux dec) e
 
 mkLetNamesB'' ::
-  ( Op (Lore m) ~ MemOp inner,
-    ExpDec lore ~ (),
-    HasScope (Engine.Wise lore) m,
-    Allocator lore (PatAllocM lore),
+  ( Op (Rep m) ~ MemOp inner,
+    ExpDec rep ~ (),
+    HasScope (Engine.Wise rep) m,
+    Allocator rep (PatAllocM rep),
     MonadBinder m,
-    Engine.CanBeWise (Op lore)
+    Engine.CanBeWise (Op rep)
   ) =>
   [VName] ->
-  Exp (Engine.Wise lore) ->
-  m (Stm (Engine.Wise lore))
+  Exp (Engine.Wise rep) ->
+  m (Stm (Engine.Wise rep))
 mkLetNamesB'' names e = do
   scope <- Engine.removeScopeWisdom <$> askScope
   (pat, prestms) <- runPatAllocM (patternWithAllocations names $ Engine.removeExpWisdom e) scope
@@ -1197,15 +1197,15 @@ mkLetNamesB'' names e = do
   return $ Let pat' (defAux dec) e
 
 simplifiable ::
-  ( Engine.SimplifiableLore lore,
-    ExpDec lore ~ (),
-    BodyDec lore ~ (),
-    Op lore ~ MemOp inner,
-    Allocator lore (PatAllocM lore)
+  ( Engine.SimplifiableRep rep,
+    ExpDec rep ~ (),
+    BodyDec rep ~ (),
+    Op rep ~ MemOp inner,
+    Allocator rep (PatAllocM rep)
   ) =>
   (Engine.OpWithWisdom inner -> UT.UsageTable) ->
-  (inner -> Engine.SimpleM lore (Engine.OpWithWisdom inner, Stms (Engine.Wise lore))) ->
-  SimpleOps lore
+  (inner -> Engine.SimpleM rep (Engine.OpWithWisdom inner, Stms (Engine.Wise rep))) ->
+  SimpleOps rep
 simplifiable innerUsage simplifyInnerOp =
   SimpleOps mkExpDecS' mkBodyS' protectOp opUsage simplifyOp
   where
@@ -1238,14 +1238,14 @@ simplifiable innerUsage simplifyInnerOp =
 
 bindPatternWithAllocations ::
   ( MonadBinder m,
-    ExpDec lore ~ (),
-    Op (Lore m) ~ MemOp inner,
-    Allocator lore (PatAllocM lore)
+    ExpDec rep ~ (),
+    Op (Rep m) ~ MemOp inner,
+    Allocator rep (PatAllocM rep)
   ) =>
-  Scope lore ->
+  Scope rep ->
   [VName] ->
-  Exp lore ->
-  m (Pattern lore)
+  Exp rep ->
+  m (Pattern rep)
 bindPatternWithAllocations types names e = do
   (pat, prebnds) <- runPatAllocM (patternWithAllocations names e) types
   mapM_ bindAllocStm prebnds
@@ -1255,5 +1255,5 @@ data ExpHint
   = NoHint
   | Hint IxFun Space
 
-defaultExpHints :: (Monad m, ASTLore lore) => Exp lore -> m [ExpHint]
+defaultExpHints :: (Monad m, ASTRep rep) => Exp rep -> m [ExpHint]
 defaultExpHints e = return $ replicate (expExtTypeSize e) NoHint

--- a/src/Futhark/Pass/ExplicitAllocations/GPU.hs
+++ b/src/Futhark/Pass/ExplicitAllocations/GPU.hs
@@ -3,8 +3,8 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
--- | Facilities for converting a 'Kernels' program to 'KernelsMem'.
-module Futhark.Pass.ExplicitAllocations.Kernels
+-- | Facilities for converting a 'GPU' program to 'GPUMem'.
+module Futhark.Pass.ExplicitAllocations.GPU
   ( explicitAllocations,
     explicitAllocationsInStms,
   )
@@ -12,8 +12,8 @@ where
 
 import qualified Data.Map as M
 import qualified Data.Set as S
-import Futhark.IR.Kernels
-import Futhark.IR.KernelsMem
+import Futhark.IR.GPU
+import Futhark.IR.GPUMem
 import qualified Futhark.IR.Mem.IxFun as IxFun
 import Futhark.Pass.ExplicitAllocations
 import Futhark.Pass.ExplicitAllocations.SegOp
@@ -39,8 +39,8 @@ allocAtLevel lvl = local $ \env ->
       SegGroup {} -> Space "local"
 
 handleSegOp ::
-  SegOp SegLevel Kernels ->
-  AllocM Kernels KernelsMem (SegOp SegLevel KernelsMem)
+  SegOp SegLevel GPU ->
+  AllocM GPU GPUMem (SegOp SegLevel GPUMem)
 handleSegOp op = do
   num_threads <-
     letSubExp "num_threads" $
@@ -68,8 +68,8 @@ handleSegOp op = do
     inGroup env = env {envExpHints = inGroupExpHints}
 
 handleHostOp ::
-  HostOp Kernels (SOAC Kernels) ->
-  AllocM Kernels KernelsMem (MemOp (HostOp KernelsMem ()))
+  HostOp GPU (SOAC GPU) ->
+  AllocM GPU GPUMem (MemOp (HostOp GPUMem ()))
 handleHostOp (SizeOp op) =
   return $ Inner $ SizeOp op
 handleHostOp (OtherOp op) =
@@ -77,7 +77,7 @@ handleHostOp (OtherOp op) =
 handleHostOp (SegOp op) =
   Inner . SegOp <$> handleSegOp op
 
-kernelExpHints :: Allocator KernelsMem m => Exp KernelsMem -> m [ExpHint]
+kernelExpHints :: Allocator GPUMem m => Exp GPUMem -> m [ExpHint]
 kernelExpHints (BasicOp (Manifest perm v)) = do
   dims <- arrayDims <$> lookupType v
   let perm_inv = rearrangeInverse perm
@@ -144,7 +144,7 @@ semiStatic :: S.Set VName -> SubExp -> Bool
 semiStatic _ Constant {} = True
 semiStatic consts (Var v) = v `S.member` consts
 
-inGroupExpHints :: Allocator KernelsMem m => Exp KernelsMem -> m [ExpHint]
+inGroupExpHints :: Allocator GPUMem m => Exp GPUMem -> m [ExpHint]
 inGroupExpHints (Op (Inner (SegOp (SegMap _ space ts body))))
   | any private $ kernelBodyResult body = do
     consts <- askConsts
@@ -167,7 +167,7 @@ inGroupExpHints (Op (Inner (SegOp (SegMap _ space ts body))))
     private _ = False
 inGroupExpHints e = return $ replicate (expExtTypeSize e) NoHint
 
-inThreadExpHints :: Allocator KernelsMem m => Exp KernelsMem -> m [ExpHint]
+inThreadExpHints :: Allocator GPUMem m => Exp GPUMem -> m [ExpHint]
 inThreadExpHints e = do
   consts <- askConsts
   mapM (maybePrivate consts) =<< expExtType e
@@ -180,13 +180,13 @@ inThreadExpHints e = do
       | otherwise =
         return NoHint
 
--- | The pass from 'Kernels' to 'KernelsMem'.
-explicitAllocations :: Pass Kernels KernelsMem
+-- | The pass from 'GPU' to 'GPUMem'.
+explicitAllocations :: Pass GPU GPUMem
 explicitAllocations = explicitAllocationsGeneric handleHostOp kernelExpHints
 
--- | Convert some 'Kernels' stms to 'KernelsMem'.
+-- | Convert some 'GPU' stms to 'GPUMem'.
 explicitAllocationsInStms ::
-  (MonadFreshNames m, HasScope KernelsMem m) =>
-  Stms Kernels ->
-  m (Stms KernelsMem)
+  (MonadFreshNames m, HasScope GPUMem m) =>
+  Stms GPU ->
+  m (Stms GPUMem)
 explicitAllocationsInStms = explicitAllocationsInStmsGeneric handleHostOp kernelExpHints

--- a/src/Futhark/Pass/ExplicitAllocations/Kernels.hs
+++ b/src/Futhark/Pass/ExplicitAllocations/Kernels.hs
@@ -18,7 +18,7 @@ import qualified Futhark.IR.Mem.IxFun as IxFun
 import Futhark.Pass.ExplicitAllocations
 import Futhark.Pass.ExplicitAllocations.SegOp
 
-instance SizeSubst (HostOp lore op) where
+instance SizeSubst (HostOp rep op) where
   opSizeSubst (Pattern _ [size]) (SizeOp (SplitSpace _ _ _ elems_per_thread)) =
     M.singleton (patElemName size) elems_per_thread
   opSizeSubst _ _ = mempty
@@ -27,7 +27,7 @@ instance SizeSubst (HostOp lore op) where
   opIsConst (SizeOp GetSizeMax {}) = True
   opIsConst _ = False
 
-allocAtLevel :: SegLevel -> AllocM fromlore tlore a -> AllocM fromlore tlore a
+allocAtLevel :: SegLevel -> AllocM fromrep trep a -> AllocM fromrep trep a
 allocAtLevel lvl = local $ \env ->
   env
     { allocSpace = space,
@@ -95,7 +95,7 @@ kernelExpHints e =
   return $ replicate (expExtTypeSize e) NoHint
 
 mapResultHint ::
-  Allocator lore m =>
+  Allocator rep m =>
   SegLevel ->
   SegSpace ->
   Type ->

--- a/src/Futhark/Pass/ExplicitAllocations/MC.hs
+++ b/src/Futhark/Pass/ExplicitAllocations/MC.hs
@@ -10,7 +10,7 @@ import Futhark.IR.MCMem
 import Futhark.Pass.ExplicitAllocations
 import Futhark.Pass.ExplicitAllocations.SegOp
 
-instance SizeSubst (MCOp lore op) where
+instance SizeSubst (MCOp rep op) where
   opSizeSubst _ _ = mempty
 
 handleSegOp :: SegOp () MC -> AllocM MC MCMem (SegOp () MCMem)

--- a/src/Futhark/Pass/ExplicitAllocations/SegOp.hs
+++ b/src/Futhark/Pass/ExplicitAllocations/SegOp.hs
@@ -9,7 +9,7 @@ module Futhark.Pass.ExplicitAllocations.SegOp
   )
 where
 
-import Futhark.IR.KernelsMem
+import Futhark.IR.GPUMem
 import qualified Futhark.IR.Mem.IxFun as IxFun
 import Futhark.Pass.ExplicitAllocations
 

--- a/src/Futhark/Pass/ExplicitAllocations/SegOp.hs
+++ b/src/Futhark/Pass/ExplicitAllocations/SegOp.hs
@@ -13,34 +13,34 @@ import Futhark.IR.KernelsMem
 import qualified Futhark.IR.Mem.IxFun as IxFun
 import Futhark.Pass.ExplicitAllocations
 
-instance SizeSubst (SegOp lvl lore) where
+instance SizeSubst (SegOp lvl rep) where
   opSizeSubst _ _ = mempty
 
 allocInKernelBody ::
-  Allocable fromlore tolore =>
-  KernelBody fromlore ->
-  AllocM fromlore tolore (KernelBody tolore)
+  Allocable fromrep torep =>
+  KernelBody fromrep ->
+  AllocM fromrep torep (KernelBody torep)
 allocInKernelBody (KernelBody () stms res) =
   uncurry (flip (KernelBody ()))
     <$> collectStms (allocInStms stms (pure res))
 
 allocInLambda ::
-  Allocable fromlore tolore =>
-  [LParam tolore] ->
-  Body fromlore ->
-  AllocM fromlore tolore (Lambda tolore)
+  Allocable fromrep torep =>
+  [LParam torep] ->
+  Body fromrep ->
+  AllocM fromrep torep (Lambda torep)
 allocInLambda params body =
   mkLambda params . allocInStms (bodyStms body) $
     pure $ bodyResult body
 
 allocInBinOpParams ::
-  Allocable fromlore tolore =>
+  Allocable fromrep torep =>
   SubExp ->
   TPrimExp Int64 VName ->
   TPrimExp Int64 VName ->
-  [LParam fromlore] ->
-  [LParam fromlore] ->
-  AllocM fromlore tolore ([LParam tolore], [LParam tolore])
+  [LParam fromrep] ->
+  [LParam fromrep] ->
+  AllocM fromrep torep ([LParam torep], [LParam torep])
 allocInBinOpParams num_threads my_id other_id xs ys = unzip <$> zipWithM alloc xs ys
   where
     alloc x y =
@@ -83,11 +83,11 @@ allocInBinOpParams num_threads my_id other_id xs ys = unzip <$> zipWithM alloc x
             )
 
 allocInBinOpLambda ::
-  Allocable fromlore tolore =>
+  Allocable fromrep torep =>
   SubExp ->
   SegSpace ->
-  Lambda fromlore ->
-  AllocM fromlore tolore (Lambda tolore)
+  Lambda fromrep ->
+  AllocM fromrep torep (Lambda torep)
 allocInBinOpLambda num_threads (SegSpace flat _) lam = do
   let (acc_params, arr_params) =
         splitAt (length (lambdaParams lam) `div` 2) $ lambdaParams lam

--- a/src/Futhark/Pass/ExtractKernels.hs
+++ b/src/Futhark/Pass/ExtractKernels.hs
@@ -165,8 +165,8 @@ import Control.Monad.RWS.Strict
 import Control.Monad.Reader
 import Data.Bifunctor (first)
 import Data.Maybe
-import qualified Futhark.IR.Kernels as Out
-import Futhark.IR.Kernels.Kernel
+import qualified Futhark.IR.GPU as Out
+import Futhark.IR.GPU.Kernel
 import Futhark.IR.SOACS
 import Futhark.IR.SOACS.Simplify (simplifyStms)
 import Futhark.MonadFreshNames
@@ -177,7 +177,7 @@ import Futhark.Pass.ExtractKernels.Distribution
 import Futhark.Pass.ExtractKernels.ISRWIM
 import Futhark.Pass.ExtractKernels.Intragroup
 import Futhark.Pass.ExtractKernels.StreamKernel
-import Futhark.Pass.ExtractKernels.ToKernels
+import Futhark.Pass.ExtractKernels.ToGPU
 import Futhark.Tools
 import qualified Futhark.Transform.FirstOrderTransform as FOT
 import Futhark.Transform.Rename
@@ -186,7 +186,7 @@ import Prelude hiding (log)
 
 -- | Transform a program using SOACs to a program using explicit
 -- kernels, using the kernel extraction transformation.
-extractKernels :: Pass SOACS Out.Kernels
+extractKernels :: Pass SOACS Out.GPU
 extractKernels =
   Pass
     { passName = "extract kernels",
@@ -194,7 +194,7 @@ extractKernels =
       passFunction = transformProg
     }
 
-transformProg :: Prog SOACS -> PassM (Prog Out.Kernels)
+transformProg :: Prog SOACS -> PassM (Prog Out.GPU)
 transformProg (Prog consts funs) = do
   consts' <- runDistribM $ transformStms mempty $ stmsToList consts
   funs' <- mapM (transformFunDef $ scopeOf consts') funs
@@ -208,13 +208,13 @@ data State = State
     stateThresholdCounter :: Int
   }
 
-newtype DistribM a = DistribM (RWS (Scope Out.Kernels) Log State a)
+newtype DistribM a = DistribM (RWS (Scope Out.GPU) Log State a)
   deriving
     ( Functor,
       Applicative,
       Monad,
-      HasScope Out.Kernels,
-      LocalScope Out.Kernels,
+      HasScope Out.GPU,
+      LocalScope Out.GPU,
       MonadState State,
       MonadLogger
     )
@@ -236,23 +236,23 @@ runDistribM (DistribM m) = do
 
 transformFunDef ::
   (MonadFreshNames m, MonadLogger m) =>
-  Scope Out.Kernels ->
+  Scope Out.GPU ->
   FunDef SOACS ->
-  m (Out.FunDef Out.Kernels)
+  m (Out.FunDef Out.GPU)
 transformFunDef scope (FunDef entry attrs name rettype params body) = runDistribM $ do
   body' <-
     localScope (scope <> scopeOfFParams params) $
       transformBody mempty body
   return $ FunDef entry attrs name rettype params body'
 
-type KernelsStms = Stms Out.Kernels
+type GPUStms = Stms Out.GPU
 
-transformBody :: KernelPath -> Body -> DistribM (Out.Body Out.Kernels)
+transformBody :: KernelPath -> Body -> DistribM (Out.Body Out.GPU)
 transformBody path body = do
   bnds <- transformStms path $ stmsToList $ bodyStms body
   return $ mkBody bnds $ bodyResult body
 
-transformStms :: KernelPath -> [Stm] -> DistribM KernelsStms
+transformStms :: KernelPath -> [Stm] -> DistribM GPUStms
 transformStms _ [] =
   return mempty
 transformStms path (bnd : bnds) =
@@ -308,7 +308,7 @@ cmpSizeLe ::
   String ->
   Out.SizeClass ->
   [SubExp] ->
-  DistribM ((SubExp, Name), Out.Stms Out.Kernels)
+  DistribM ((SubExp, Name), Out.Stms Out.GPU)
 cmpSizeLe desc size_class to_what = do
   x <- gets stateThresholdCounter
   modify $ \s -> s {stateThresholdCounter = x + 1}
@@ -321,11 +321,11 @@ cmpSizeLe desc size_class to_what = do
     return (cmp_res, size_key)
 
 kernelAlternatives ::
-  (MonadFreshNames m, HasScope Out.Kernels m) =>
-  Out.Pattern Out.Kernels ->
-  Out.Body Out.Kernels ->
-  [(SubExp, Out.Body Out.Kernels)] ->
-  m (Out.Stms Out.Kernels)
+  (MonadFreshNames m, HasScope Out.GPU m) =>
+  Out.Pattern Out.GPU ->
+  Out.Body Out.GPU ->
+  [(SubExp, Out.Body Out.GPU)] ->
+  m (Out.Stms Out.GPU)
 kernelAlternatives pat default_body [] = runBinder_ $ do
   ses <- bodyBind default_body
   forM_ (zip (patternNames pat) ses) $ \(name, se) ->
@@ -343,13 +343,13 @@ kernelAlternatives pat default_body ((cond, alt) : alts) = runBinder_ $ do
     If cond alt alt_body $
       IfDec (staticShapes (patternTypes pat)) IfEquiv
 
-transformLambda :: KernelPath -> Lambda -> DistribM (Out.Lambda Out.Kernels)
+transformLambda :: KernelPath -> Lambda -> DistribM (Out.Lambda Out.GPU)
 transformLambda path (Lambda params body ret) =
   Lambda params
     <$> localScope (scopeOfLParams params) (transformBody path body)
     <*> pure ret
 
-transformStm :: KernelPath -> Stm -> DistribM KernelsStms
+transformStm :: KernelPath -> Stm -> DistribM GPUStms
 transformStm _ stm
   | "sequential" `inAttrs` stmAuxAttrs (stmAux stm) =
     runBinder_ $ FOT.transformStmRecursively stm
@@ -366,7 +366,7 @@ transformStm path (Let pat aux (WithAcc inputs lam)) =
     <$> (WithAcc (map transformInput inputs) <$> transformLambda path lam)
   where
     transformInput (shape, arrs, op) =
-      (shape, arrs, fmap (first soacsLambdaToKernels) op)
+      (shape, arrs, fmap (first soacsLambdaToGPU) op)
 transformStm path (Let pat aux (DoLoop ctx val form body)) =
   localScope
     ( castScope (scopeOf form)
@@ -392,9 +392,9 @@ transformStm path (Let res_pat (StmAux cs _ _) (Op (Screma w arrs form)))
   | Just (scans, map_lam) <- isScanomapSOAC form = runBinder_ $ do
     scan_ops <- forM scans $ \(Scan scan_lam nes) -> do
       (scan_lam', nes', shape) <- determineReduceOp scan_lam nes
-      let scan_lam'' = soacsLambdaToKernels scan_lam'
+      let scan_lam'' = soacsLambdaToGPU scan_lam'
       return $ SegBinOp Noncommutative scan_lam'' nes' shape
-    let map_lam_sequential = soacsLambdaToKernels map_lam
+    let map_lam_sequential = soacsLambdaToGPU map_lam
     lvl <- segThreadCapped [w] "segscan" $ NoRecommendation SegNoVirt
     addStms . fmap (certify cs)
       =<< segScan lvl res_pat w scan_ops map_lam_sequential arrs [] []
@@ -415,9 +415,9 @@ transformStm path (Let pat aux@(StmAux cs _ _) (Op (Screma w arrs form)))
             let comm'
                   | commutativeLambda red_lam' = Commutative
                   | otherwise = comm
-                red_lam'' = soacsLambdaToKernels red_lam'
+                red_lam'' = soacsLambdaToGPU red_lam'
             return $ SegBinOp comm' red_lam'' nes' shape
-          let map_lam_sequential = soacsLambdaToKernels map_lam
+          let map_lam_sequential = soacsLambdaToGPU map_lam
           lvl <- segThreadCapped [w] "segred" $ NoRecommendation SegNoVirt
           addStms . fmap (certify cs)
             =<< nonSegRed lvl pat w red_ops map_lam_sequential arrs
@@ -482,7 +482,7 @@ transformStm path (Let pat aux@(StmAux cs _ _) (Op (Stream w arrs (Parallel o co
       | not $ all primType $ lambdaReturnType red_fun = do
         -- Split into a chunked map and a reduction, with the latter
         -- further transformed.
-        let fold_fun' = soacsLambdaToKernels fold_fun
+        let fold_fun' = soacsLambdaToGPU fold_fun
 
         let (red_pat_elems, concat_pat_elems) =
               splitAt (length nes) $ patternValueElements pat
@@ -509,8 +509,8 @@ transformStm path (Let pat aux@(StmAux cs _ _) (Op (Stream w arrs (Parallel o co
                   Op (Screma num_threads red_results reduce_soac)
             )
       | otherwise = do
-        let red_fun_sequential = soacsLambdaToKernels red_fun
-            fold_fun_sequential = soacsLambdaToKernels fold_fun
+        let red_fun_sequential = soacsLambdaToGPU red_fun
+            fold_fun_sequential = soacsLambdaToGPU fold_fun
         fmap (certify cs)
           <$> streamRed
             segThreadCapped
@@ -551,7 +551,7 @@ transformStm path (Let pat _ (Op (Stream w arrs Sequential nes fold_fun))) = do
   transformStms path . stmsToList . snd
     =<< runBinderT (sequentialStreamWholeArray pat w nes fold_fun arrs) types
 transformStm _ (Let pat (StmAux cs _ _) (Op (Scatter w lam ivs as))) = runBinder_ $ do
-  let lam' = soacsLambdaToKernels lam
+  let lam' = soacsLambdaToGPU lam
   write_i <- newVName "write_i"
   let (as_ws, _, _) = unzip3 as
       kstms = bodyStms $ lambdaBody lam'
@@ -574,7 +574,7 @@ transformStm _ (Let pat (StmAux cs _ _) (Op (Scatter w lam ivs as))) = runBinder
     addStms stms
     letBind pat $ Op $ SegOp kernel
 transformStm _ (Let orig_pat (StmAux cs _ _) (Op (Hist w ops bucket_fun imgs))) = do
-  let bfun' = soacsLambdaToKernels bucket_fun
+  let bfun' = soacsLambdaToGPU bucket_fun
 
   -- It is important not to launch unnecessarily many threads for
   -- histograms, because it may mean we unnecessarily need to reduce
@@ -583,7 +583,7 @@ transformStm _ (Let orig_pat (StmAux cs _ _) (Op (Hist w ops bucket_fun imgs))) 
     lvl <- segThreadCapped [w] "seghist" $ NoRecommendation SegNoVirt
     addStms =<< histKernel onLambda lvl orig_pat [] [] cs w ops bfun' imgs
   where
-    onLambda = pure . soacsLambdaToKernels
+    onLambda = pure . soacsLambdaToGPU
 transformStm _ bnd =
   runBinder_ $ FOT.transformStmRecursively bnd
 
@@ -592,7 +592,7 @@ sufficientParallelism ::
   [SubExp] ->
   KernelPath ->
   Maybe Int64 ->
-  DistribM ((SubExp, Name), Out.Stms Out.Kernels)
+  DistribM ((SubExp, Name), Out.Stms Out.GPU)
 sufficientParallelism desc ws path def =
   cmpSizeLe desc (Out.SizeThreshold path def) ws
 
@@ -672,11 +672,11 @@ worthSequentialising lam = bodyInterest (lambdaBody lam) > 1
 onTopLevelStms ::
   KernelPath ->
   Stms SOACS ->
-  DistNestT Out.Kernels DistribM KernelsStms
+  DistNestT Out.GPU DistribM GPUStms
 onTopLevelStms path stms =
   liftInner $ transformStms path $ stmsToList stms
 
-onMap :: KernelPath -> MapLoop -> DistribM KernelsStms
+onMap :: KernelPath -> MapLoop -> DistribM GPUStms
 onMap path (MapLoop pat aux w lam arrs) = do
   types <- askScope
   let loopnest = MapNesting pat aux w $ zip (lambdaParams lam) arrs
@@ -685,20 +685,20 @@ onMap path (MapLoop pat aux w lam arrs) = do
           { distNest = singleNesting (Nesting mempty loopnest),
             distScope =
               scopeOfPattern pat
-                <> scopeForKernels (scopeOf lam)
+                <> scopeForGPU (scopeOf lam)
                 <> types,
             distOnInnerMap = onInnerMap path',
             distOnTopLevelStms = onTopLevelStms path',
             distSegLevel = segThreadCapped,
-            distOnSOACSStms = pure . oneStm . soacsStmToKernels,
-            distOnSOACSLambda = pure . soacsLambdaToKernels
+            distOnSOACSStms = pure . oneStm . soacsStmToGPU,
+            distOnSOACSLambda = pure . soacsLambdaToGPU
           }
       exploitInnerParallelism path' =
         runDistNestT (env path') $
           distributeMapBodyStms acc (bodyStms $ lambdaBody lam)
 
   let exploitOuterParallelism path' = do
-        let lam' = soacsLambdaToKernels lam
+        let lam' = soacsLambdaToGPU lam
         runDistNestT (env path') $
           distribute $
             addStmsToAcc (bodyStms $ lambdaBody lam') acc
@@ -736,11 +736,11 @@ intraMinInnerPar = 32 -- One NVIDIA warp
 onMap' ::
   KernelNest ->
   KernelPath ->
-  (KernelPath -> DistribM (Out.Stms Out.Kernels)) ->
-  (KernelPath -> DistribM (Out.Stms Out.Kernels)) ->
+  (KernelPath -> DistribM (Out.Stms Out.GPU)) ->
+  (KernelPath -> DistribM (Out.Stms Out.GPU)) ->
   Pattern ->
   Lambda ->
-  DistribM (Out.Stms Out.Kernels)
+  DistribM (Out.Stms Out.GPU)
 onMap' loopnest path mk_seq_stms mk_par_stms pat lam = do
   -- Some of the control flow here looks a bit convoluted because we
   -- are trying to avoid generating unneeded threshold parameters,
@@ -865,8 +865,8 @@ onMap' loopnest path mk_seq_stms mk_par_stms pat lam = do
 onInnerMap ::
   KernelPath ->
   MapLoop ->
-  DistAcc Out.Kernels ->
-  DistNestT Out.Kernels DistribM (DistAcc Out.Kernels)
+  DistAcc Out.GPU ->
+  DistNestT Out.GPU DistribM (DistAcc Out.GPU)
 onInnerMap path maploop@(MapLoop pat aux w lam arrs) acc
   | unbalancedLambda lam,
     lambdaContainsParallelism lam =
@@ -920,7 +920,7 @@ onInnerMap path maploop@(MapLoop pat aux w lam arrs) acc
           -- versioning does not take place down that branch (it currently
           -- does not).
           (sequentialised_kernel, nestw_bnds) <- localScope extra_scope $ do
-            let sequentialised_lam = soacsLambdaToKernels lam'
+            let sequentialised_lam = soacsLambdaToGPU lam'
             constructKernel segThreadCapped nest' $ lambdaBody sequentialised_lam
 
           let outer_pat = loopNestingPattern $ fst nest

--- a/src/Futhark/Pass/ExtractKernels/DistributeNests.hs
+++ b/src/Futhark/Pass/ExtractKernels/DistributeNests.hs
@@ -62,7 +62,7 @@ import Futhark.Transform.Rename
 import Futhark.Util
 import Futhark.Util.Log
 
-scopeForSOACs :: SameScope lore SOACS => Scope lore -> Scope SOACS
+scopeForSOACs :: SameScope rep SOACS => Scope rep -> Scope SOACS
 scopeForSOACs = castScope
 
 data MapLoop = MapLoop SOACS.Pattern (StmAux ()) SubExp SOACS.Lambda [VName]
@@ -71,80 +71,80 @@ mapLoopStm :: MapLoop -> Stm SOACS
 mapLoopStm (MapLoop pat aux w lam arrs) =
   Let pat aux $ Op $ Screma w arrs $ mapSOAC lam
 
-data DistEnv lore m = DistEnv
+data DistEnv rep m = DistEnv
   { distNest :: Nestings,
-    distScope :: Scope lore,
-    distOnTopLevelStms :: Stms SOACS -> DistNestT lore m (Stms lore),
+    distScope :: Scope rep,
+    distOnTopLevelStms :: Stms SOACS -> DistNestT rep m (Stms rep),
     distOnInnerMap ::
       MapLoop ->
-      DistAcc lore ->
-      DistNestT lore m (DistAcc lore),
-    distOnSOACSStms :: Stm SOACS -> Binder lore (Stms lore),
-    distOnSOACSLambda :: Lambda SOACS -> Binder lore (Lambda lore),
-    distSegLevel :: MkSegLevel lore m
+      DistAcc rep ->
+      DistNestT rep m (DistAcc rep),
+    distOnSOACSStms :: Stm SOACS -> Binder rep (Stms rep),
+    distOnSOACSLambda :: Lambda SOACS -> Binder rep (Lambda rep),
+    distSegLevel :: MkSegLevel rep m
   }
 
-data DistAcc lore = DistAcc
+data DistAcc rep = DistAcc
   { distTargets :: Targets,
-    distStms :: Stms lore
+    distStms :: Stms rep
   }
 
-data DistRes lore = DistRes
-  { accPostStms :: PostStms lore,
+data DistRes rep = DistRes
+  { accPostStms :: PostStms rep,
     accLog :: Log
   }
 
-instance Semigroup (DistRes lore) where
+instance Semigroup (DistRes rep) where
   DistRes ks1 log1 <> DistRes ks2 log2 =
     DistRes (ks1 <> ks2) (log1 <> log2)
 
-instance Monoid (DistRes lore) where
+instance Monoid (DistRes rep) where
   mempty = DistRes mempty mempty
 
-newtype PostStms lore = PostStms {unPostStms :: Stms lore}
+newtype PostStms rep = PostStms {unPostStms :: Stms rep}
 
-instance Semigroup (PostStms lore) where
+instance Semigroup (PostStms rep) where
   PostStms xs <> PostStms ys = PostStms $ ys <> xs
 
-instance Monoid (PostStms lore) where
+instance Monoid (PostStms rep) where
   mempty = PostStms mempty
 
-typeEnvFromDistAcc :: DistLore lore => DistAcc lore -> Scope lore
+typeEnvFromDistAcc :: DistRep rep => DistAcc rep -> Scope rep
 typeEnvFromDistAcc = scopeOfPattern . fst . outerTarget . distTargets
 
-addStmsToAcc :: Stms lore -> DistAcc lore -> DistAcc lore
+addStmsToAcc :: Stms rep -> DistAcc rep -> DistAcc rep
 addStmsToAcc stms acc =
   acc {distStms = stms <> distStms acc}
 
 addStmToAcc ::
-  (MonadFreshNames m, DistLore lore) =>
+  (MonadFreshNames m, DistRep rep) =>
   Stm SOACS ->
-  DistAcc lore ->
-  DistNestT lore m (DistAcc lore)
+  DistAcc rep ->
+  DistNestT rep m (DistAcc rep)
 addStmToAcc stm acc = do
   onSoacs <- asks distOnSOACSStms
   (stm', _) <- runBinder $ onSoacs stm
   return acc {distStms = stm' <> distStms acc}
 
 soacsLambda ::
-  (MonadFreshNames m, DistLore lore) =>
+  (MonadFreshNames m, DistRep rep) =>
   Lambda SOACS ->
-  DistNestT lore m (Lambda lore)
+  DistNestT rep m (Lambda rep)
 soacsLambda lam = do
   onLambda <- asks distOnSOACSLambda
   fst <$> runBinder (onLambda lam)
 
-newtype DistNestT lore m a
-  = DistNestT (ReaderT (DistEnv lore m) (WriterT (DistRes lore) m) a)
+newtype DistNestT rep m a
+  = DistNestT (ReaderT (DistEnv rep m) (WriterT (DistRes rep) m) a)
   deriving
     ( Functor,
       Applicative,
       Monad,
-      MonadReader (DistEnv lore m),
-      MonadWriter (DistRes lore)
+      MonadReader (DistEnv rep m),
+      MonadWriter (DistRes rep)
     )
 
-liftInner :: (LocalScope lore m, DistLore lore) => m a -> DistNestT lore m a
+liftInner :: (LocalScope rep m, DistRep rep) => m a -> DistNestT rep m a
 liftInner m = do
   outer_scope <- askScope
   DistNestT $
@@ -153,25 +153,25 @@ liftInner m = do
         inner_scope <- askScope
         localScope (outer_scope `M.difference` inner_scope) m
 
-instance MonadFreshNames m => MonadFreshNames (DistNestT lore m) where
+instance MonadFreshNames m => MonadFreshNames (DistNestT rep m) where
   getNameSource = DistNestT $ lift getNameSource
   putNameSource = DistNestT . lift . putNameSource
 
-instance (Monad m, ASTLore lore) => HasScope lore (DistNestT lore m) where
+instance (Monad m, ASTRep rep) => HasScope rep (DistNestT rep m) where
   askScope = asks distScope
 
-instance (Monad m, ASTLore lore) => LocalScope lore (DistNestT lore m) where
+instance (Monad m, ASTRep rep) => LocalScope rep (DistNestT rep m) where
   localScope types = local $ \env ->
     env {distScope = types <> distScope env}
 
-instance Monad m => MonadLogger (DistNestT lore m) where
+instance Monad m => MonadLogger (DistNestT rep m) where
   addLog msgs = tell mempty {accLog = msgs}
 
 runDistNestT ::
-  (MonadLogger m, DistLore lore) =>
-  DistEnv lore m ->
-  DistNestT lore m (DistAcc lore) ->
-  m (Stms lore)
+  (MonadLogger m, DistRep rep) =>
+  DistEnv rep m ->
+  DistNestT rep m (DistAcc rep) ->
+  m (Stms rep)
 runDistNestT env (DistNestT m) = do
   (acc, res) <- runWriterT $ runReaderT m env
   addLog $ accLog res
@@ -200,17 +200,17 @@ runDistNestT env (DistNestT m) = do
         BasicOp $
           Replicate (Shape [loopNestingWidth outermost]) se
 
-addPostStms :: Monad m => PostStms lore -> DistNestT lore m ()
+addPostStms :: Monad m => PostStms rep -> DistNestT rep m ()
 addPostStms ks = tell $ mempty {accPostStms = ks}
 
-postStm :: Monad m => Stms lore -> DistNestT lore m ()
+postStm :: Monad m => Stms rep -> DistNestT rep m ()
 postStm stms = addPostStms $ PostStms stms
 
 withStm ::
-  (Monad m, DistLore lore) =>
+  (Monad m, DistRep rep) =>
   Stm SOACS ->
-  DistNestT lore m a ->
-  DistNestT lore m a
+  DistNestT rep m a ->
+  DistNestT rep m a
 withStm stm = local $ \env ->
   env
     { distScope =
@@ -223,9 +223,9 @@ withStm stm = local $ \env ->
     provided = namesFromList $ patternNames $ stmPattern stm
 
 leavingNesting ::
-  (MonadFreshNames m, DistLore lore) =>
-  DistAcc lore ->
-  DistNestT lore m (DistAcc lore)
+  (MonadFreshNames m, DistRep rep) =>
+  DistAcc rep ->
+  DistNestT rep m (DistAcc rep)
 leavingNesting acc =
   case popInnerTarget $ distTargets acc of
     Nothing ->
@@ -278,14 +278,14 @@ leavingNesting acc =
         return $ acc {distTargets = newtargets, distStms = stms}
 
 mapNesting ::
-  (MonadFreshNames m, DistLore lore) =>
+  (MonadFreshNames m, DistRep rep) =>
   PatternT Type ->
   StmAux () ->
   SubExp ->
   Lambda SOACS ->
   [VName] ->
-  DistNestT lore m (DistAcc lore) ->
-  DistNestT lore m (DistAcc lore)
+  DistNestT rep m (DistAcc rep) ->
+  DistNestT rep m (DistAcc rep)
 mapNesting pat aux w lam arrs m =
   local extend $ leavingNesting =<< m
   where
@@ -300,10 +300,10 @@ mapNesting pat aux w lam arrs m =
         }
 
 inNesting ::
-  (Monad m, DistLore lore) =>
+  (Monad m, DistRep rep) =>
   KernelNest ->
-  DistNestT lore m a ->
-  DistNestT lore m a
+  DistNestT rep m a ->
+  DistNestT rep m a
 inNesting (outer, nests) = local $ \env ->
   env
     { distNest = (inner, nests'),
@@ -334,10 +334,10 @@ lambdaContainsParallelism :: Lambda SOACS -> Bool
 lambdaContainsParallelism = bodyContainsParallelism . lambdaBody
 
 distributeMapBodyStms ::
-  (MonadFreshNames m, LocalScope lore m, DistLore lore) =>
-  DistAcc lore ->
+  (MonadFreshNames m, LocalScope rep m, DistRep rep) =>
+  DistAcc rep ->
   Stms SOACS ->
-  DistNestT lore m (DistAcc lore)
+  DistNestT rep m (DistAcc rep)
 distributeMapBodyStms orig_acc = distribute <=< onStms orig_acc . stmsToList
   where
     onStms acc [] = return acc
@@ -354,21 +354,21 @@ distributeMapBodyStms orig_acc = distribute <=< onStms orig_acc . stmsToList
       -- situation that stm is in scope of itself.
       withStm stm $ maybeDistributeStm stm =<< onStms acc stms
 
-onInnerMap :: Monad m => MapLoop -> DistAcc lore -> DistNestT lore m (DistAcc lore)
+onInnerMap :: Monad m => MapLoop -> DistAcc rep -> DistNestT rep m (DistAcc rep)
 onInnerMap loop acc = do
   f <- asks distOnInnerMap
   f loop acc
 
-onTopLevelStms :: Monad m => Stms SOACS -> DistNestT lore m ()
+onTopLevelStms :: Monad m => Stms SOACS -> DistNestT rep m ()
 onTopLevelStms stms = do
   f <- asks distOnTopLevelStms
   postStm =<< f stms
 
 maybeDistributeStm ::
-  (MonadFreshNames m, LocalScope lore m, DistLore lore) =>
+  (MonadFreshNames m, LocalScope rep m, DistRep rep) =>
   Stm SOACS ->
-  DistAcc lore ->
-  DistNestT lore m (DistAcc lore)
+  DistAcc rep ->
+  DistNestT rep m (DistAcc rep)
 maybeDistributeStm stm acc
   | "sequential" `inAttrs` stmAuxAttrs (stmAux stm) =
     addStmToAcc stm acc
@@ -650,12 +650,12 @@ maybeDistributeStm bnd acc =
   addStmToAcc bnd acc
 
 distributeSingleUnaryStm ::
-  (MonadFreshNames m, LocalScope lore m, DistLore lore) =>
-  DistAcc lore ->
+  (MonadFreshNames m, LocalScope rep m, DistRep rep) =>
+  DistAcc rep ->
   Stm SOACS ->
   VName ->
-  (KernelNest -> PatternT Type -> VName -> DistNestT lore m (Stms lore)) ->
-  DistNestT lore m (DistAcc lore)
+  (KernelNest -> PatternT Type -> VName -> DistNestT rep m (Stms rep)) ->
+  DistNestT rep m (DistAcc rep)
 distributeSingleUnaryStm acc stm stm_arr f =
   distributeSingleStm acc stm >>= \case
     Just (kernels, res, nest, acc')
@@ -682,15 +682,15 @@ distributeSingleUnaryStm acc stm stm_arr f =
         False
 
 distribute ::
-  (MonadFreshNames m, LocalScope lore m, DistLore lore) =>
-  DistAcc lore ->
-  DistNestT lore m (DistAcc lore)
+  (MonadFreshNames m, LocalScope rep m, DistRep rep) =>
+  DistAcc rep ->
+  DistNestT rep m (DistAcc rep)
 distribute acc =
   fromMaybe acc <$> distributeIfPossible acc
 
 mkSegLevel ::
-  (MonadFreshNames m, LocalScope lore m, DistLore lore) =>
-  DistNestT lore m (MkSegLevel lore (DistNestT lore m))
+  (MonadFreshNames m, LocalScope rep m, DistRep rep) =>
+  DistNestT rep m (MkSegLevel rep (DistNestT rep m))
 mkSegLevel = do
   mk_lvl <- asks distSegLevel
   return $ \w desc r -> do
@@ -699,9 +699,9 @@ mkSegLevel = do
     return lvl
 
 distributeIfPossible ::
-  (MonadFreshNames m, LocalScope lore m, DistLore lore) =>
-  DistAcc lore ->
-  DistNestT lore m (Maybe (DistAcc lore))
+  (MonadFreshNames m, LocalScope rep m, DistRep rep) =>
+  DistAcc rep ->
+  DistNestT rep m (Maybe (DistAcc rep))
 distributeIfPossible acc = do
   nest <- asks distNest
   mk_lvl <- mkSegLevel
@@ -717,17 +717,17 @@ distributeIfPossible acc = do
             }
 
 distributeSingleStm ::
-  (MonadFreshNames m, LocalScope lore m, DistLore lore) =>
-  DistAcc lore ->
+  (MonadFreshNames m, LocalScope rep m, DistRep rep) =>
+  DistAcc rep ->
   Stm SOACS ->
   DistNestT
-    lore
+    rep
     m
     ( Maybe
-        ( PostStms lore,
+        ( PostStms rep,
           Result,
           KernelNest,
-          DistAcc lore
+          DistAcc rep
         )
     )
 distributeSingleStm acc bnd = do
@@ -751,16 +751,16 @@ distributeSingleStm acc bnd = do
               )
 
 segmentedScatterKernel ::
-  (MonadFreshNames m, LocalScope lore m, DistLore lore) =>
+  (MonadFreshNames m, LocalScope rep m, DistRep rep) =>
   KernelNest ->
   [Int] ->
   PatternT Type ->
   Certificates ->
   SubExp ->
-  Lambda lore ->
+  Lambda rep ->
   [VName] ->
   [(Shape, Int, VName)] ->
-  DistNestT lore m (Stms lore)
+  DistNestT rep m (Stms rep)
 segmentedScatterKernel nest perm scatter_pat cs scatter_w lam ivs dests = do
   -- We replicate some of the checking done by 'isSegmentedOp', but
   -- things are different because a scatter is not a reduction or
@@ -833,14 +833,14 @@ segmentedScatterKernel nest perm scatter_pat cs scatter_w lam ivs dests = do
         (gtids, ws) = unzip ispace
 
 segmentedUpdateKernel ::
-  (MonadFreshNames m, LocalScope lore m, DistLore lore) =>
+  (MonadFreshNames m, LocalScope rep m, DistRep rep) =>
   KernelNest ->
   [Int] ->
   Certificates ->
   VName ->
   Slice SubExp ->
   VName ->
-  DistNestT lore m (Stms lore)
+  DistNestT rep m (Stms rep)
 segmentedUpdateKernel nest perm cs arr slice v = do
   (base_ispace, kernel_inps) <- flatKernel nest
   let slice_dims = sliceDims slice
@@ -889,12 +889,12 @@ segmentedUpdateKernel nest perm cs arr slice v = do
     letBind pat $ Op $ segOp k
 
 segmentedGatherKernel ::
-  (MonadFreshNames m, LocalScope lore m, DistLore lore) =>
+  (MonadFreshNames m, LocalScope rep m, DistRep rep) =>
   KernelNest ->
   Certificates ->
   VName ->
   Slice SubExp ->
-  DistNestT lore m (Stms lore)
+  DistNestT rep m (Stms rep)
 segmentedGatherKernel nest cs arr slice = do
   let slice_dims = sliceDims slice
   slice_gtids <- replicateM (length slice_dims) (newVName "gtid_slice")
@@ -925,15 +925,15 @@ segmentedGatherKernel nest cs arr slice = do
     letBind pat $ Op $ segOp k
 
 segmentedHistKernel ::
-  (MonadFreshNames m, LocalScope lore m, DistLore lore) =>
+  (MonadFreshNames m, LocalScope rep m, DistRep rep) =>
   KernelNest ->
   [Int] ->
   Certificates ->
   SubExp ->
   [SOACS.HistOp SOACS] ->
-  Lambda lore ->
+  Lambda rep ->
   [VName] ->
-  DistNestT lore m (Stms lore)
+  DistNestT rep m (Stms rep)
 segmentedHistKernel nest perm cs hist_w ops lam arrs = do
   -- We replicate some of the checking done by 'isSegmentedOp', but
   -- things are different because a Hist is not a reduction or
@@ -970,18 +970,18 @@ segmentedHistKernel nest perm cs hist_w ops lam arrs = do
     bad = error "Ill-typed nested Hist encountered."
 
 histKernel ::
-  (MonadBinder m, DistLore (Lore m)) =>
-  (Lambda SOACS -> m (Lambda (Lore m))) ->
-  SegOpLevel (Lore m) ->
+  (MonadBinder m, DistRep (Rep m)) =>
+  (Lambda SOACS -> m (Lambda (Rep m))) ->
+  SegOpLevel (Rep m) ->
   PatternT Type ->
   [(VName, SubExp)] ->
   [KernelInput] ->
   Certificates ->
   SubExp ->
   [SOACS.HistOp SOACS] ->
-  Lambda (Lore m) ->
+  Lambda (Rep m) ->
   [VName] ->
-  m (Stms (Lore m))
+  m (Stms (Rep m))
 histKernel onLambda lvl orig_pat ispace inputs cs hist_w ops lam arrs = runBinderT'_ $ do
   ops' <- forM ops $ \(SOACS.HistOp num_bins rf dests nes op) -> do
     (op', nes', shape) <- determineReduceOp op nes
@@ -1029,15 +1029,15 @@ isVectorMap lam
   | otherwise = (mempty, lam)
 
 segmentedScanomapKernel ::
-  (MonadFreshNames m, LocalScope lore m, DistLore lore) =>
+  (MonadFreshNames m, LocalScope rep m, DistRep rep) =>
   KernelNest ->
   [Int] ->
   SubExp ->
-  Lambda lore ->
-  Lambda lore ->
+  Lambda rep ->
+  Lambda rep ->
   [SubExp] ->
   [VName] ->
-  DistNestT lore m (Maybe (Stms lore))
+  DistNestT rep m (Maybe (Stms rep))
 segmentedScanomapKernel nest perm segment_size lam map_lam nes arrs = do
   mk_lvl <- asks distSegLevel
   isSegmentedOp nest perm (freeIn lam) (freeIn map_lam) nes [] $
@@ -1048,16 +1048,16 @@ segmentedScanomapKernel nest perm segment_size lam map_lam nes arrs = do
         =<< segScan lvl pat segment_size [scan_op] map_lam arrs ispace inps
 
 regularSegmentedRedomapKernel ::
-  (MonadFreshNames m, LocalScope lore m, DistLore lore) =>
+  (MonadFreshNames m, LocalScope rep m, DistRep rep) =>
   KernelNest ->
   [Int] ->
   SubExp ->
   Commutativity ->
-  Lambda lore ->
-  Lambda lore ->
+  Lambda rep ->
+  Lambda rep ->
   [SubExp] ->
   [VName] ->
-  DistNestT lore m (Maybe (Stms lore))
+  DistNestT rep m (Maybe (Stms rep))
 regularSegmentedRedomapKernel nest perm segment_size comm lam map_lam nes arrs = do
   mk_lvl <- asks distSegLevel
   isSegmentedOp nest perm (freeIn lam) (freeIn map_lam) nes [] $
@@ -1068,7 +1068,7 @@ regularSegmentedRedomapKernel nest perm segment_size comm lam map_lam nes arrs =
         =<< segRed lvl pat segment_size [red_op] map_lam arrs ispace inps
 
 isSegmentedOp ::
-  (MonadFreshNames m, LocalScope lore m, DistLore lore) =>
+  (MonadFreshNames m, LocalScope rep m, DistRep rep) =>
   KernelNest ->
   [Int] ->
   Names ->
@@ -1080,9 +1080,9 @@ isSegmentedOp ::
     [KernelInput] ->
     [SubExp] ->
     [VName] ->
-    BinderT lore m ()
+    BinderT rep m ()
   ) ->
-  DistNestT lore m (Maybe (Stms lore))
+  DistNestT rep m (Maybe (Stms rep))
 isSegmentedOp nest perm free_in_op _free_in_fold_op nes arrs m = runMaybeT $ do
   -- We must verify that array inputs to the operation are inputs to
   -- the outermost loop nesting or free in the loop nest.  Nothing
@@ -1181,14 +1181,14 @@ expandKernelNest pes (outer_nest, inner_nests) = do
           }
 
 kernelOrNot ::
-  (MonadFreshNames m, DistLore lore) =>
+  (MonadFreshNames m, DistRep rep) =>
   Certificates ->
   Stm SOACS ->
-  DistAcc lore ->
-  PostStms lore ->
-  DistAcc lore ->
-  Maybe (Stms lore) ->
-  DistNestT lore m (DistAcc lore)
+  DistAcc rep ->
+  PostStms rep ->
+  DistAcc rep ->
+  Maybe (Stms rep) ->
+  DistNestT rep m (DistAcc rep)
 kernelOrNot cs bnd acc _ _ Nothing =
   addStmToAcc (certify cs bnd) acc
 kernelOrNot cs _ _ kernels acc' (Just bnds) = do
@@ -1197,10 +1197,10 @@ kernelOrNot cs _ _ kernels acc' (Just bnds) = do
   return acc'
 
 distributeMap ::
-  (MonadFreshNames m, LocalScope lore m, DistLore lore) =>
+  (MonadFreshNames m, LocalScope rep m, DistRep rep) =>
   MapLoop ->
-  DistAcc lore ->
-  DistNestT lore m (DistAcc lore)
+  DistAcc rep ->
+  DistNestT rep m (DistAcc rep)
 distributeMap (MapLoop pat aux w lam arrs) acc =
   distribute
     =<< mapNesting

--- a/src/Futhark/Pass/ExtractKernels/ISRWIM.hs
+++ b/src/Futhark/Pass/ExtractKernels/ISRWIM.hs
@@ -18,7 +18,7 @@ import Futhark.Tools
 -- | Interchange Scan With Inner Map. Tries to turn a @scan(map)@ into a
 -- @map(scan)
 iswim ::
-  (MonadBinder m, Lore m ~ SOACS) =>
+  (MonadBinder m, Rep m ~ SOACS) =>
   Pattern ->
   SubExp ->
   Lambda ->
@@ -81,7 +81,7 @@ iswim res_pat w scan_fun scan_input
 -- | Interchange Reduce With Inner Map. Tries to turn a @reduce(map)@ into a
 -- @map(reduce)
 irwim ::
-  (MonadBinder m, Lore m ~ SOACS) =>
+  (MonadBinder m, Rep m ~ SOACS) =>
   Pattern ->
   SubExp ->
   Commutativity ->

--- a/src/Futhark/Pass/ExtractKernels/Interchange.hs
+++ b/src/Futhark/Pass/ExtractKernels/Interchange.hs
@@ -185,7 +185,7 @@ withAccStm (WithAccStm _ pat inputs lam) =
   Let pat (defAux ()) $ WithAcc inputs lam
 
 interchangeWithAcc1 ::
-  (MonadBinder m, Lore m ~ SOACS) =>
+  (MonadBinder m, Rep m ~ SOACS) =>
   WithAccStm ->
   LoopNesting ->
   m WithAccStm

--- a/src/Futhark/Pass/ExtractKernels/Intragroup.hs
+++ b/src/Futhark/Pass/ExtractKernels/Intragroup.hs
@@ -136,7 +136,7 @@ intraGroupParallelise knest lam = runMaybeT $ do
     aux = loopNestingAux first_nest
 
 readGroupKernelInput ::
-  (DistLore (Lore m), MonadBinder m) =>
+  (DistRep (Rep m), MonadBinder m) =>
   KernelInput ->
   m ()
 readGroupKernelInput inp

--- a/src/Futhark/Pass/ExtractKernels/Intragroup.hs
+++ b/src/Futhark/Pass/ExtractKernels/Intragroup.hs
@@ -13,14 +13,14 @@ import Control.Monad.Trans.Maybe
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Futhark.Analysis.PrimExp.Convert
-import qualified Futhark.IR.Kernels as Out
-import Futhark.IR.Kernels.Kernel hiding (HistOp)
+import qualified Futhark.IR.GPU as Out
+import Futhark.IR.GPU.Kernel hiding (HistOp)
 import Futhark.IR.SOACS
 import Futhark.MonadFreshNames
 import Futhark.Pass.ExtractKernels.BlockedKernel
 import Futhark.Pass.ExtractKernels.DistributeNests
 import Futhark.Pass.ExtractKernels.Distribution
-import Futhark.Pass.ExtractKernels.ToKernels
+import Futhark.Pass.ExtractKernels.ToGPU
 import Futhark.Tools
 import qualified Futhark.Transform.FirstOrderTransform as FOT
 import Futhark.Util.Log
@@ -39,7 +39,7 @@ import Prelude hiding (log)
 -- We distinguish between "minimum group size" and "maximum
 -- exploitable parallelism".
 intraGroupParallelise ::
-  (MonadFreshNames m, LocalScope Out.Kernels m) =>
+  (MonadFreshNames m, LocalScope Out.GPU m) =>
   KernelNest ->
   Lambda ->
   m
@@ -47,8 +47,8 @@ intraGroupParallelise ::
         ( (SubExp, SubExp),
           SubExp,
           Log,
-          Out.Stms Out.Kernels,
-          Out.Stms Out.Kernels
+          Out.Stms Out.GPU,
+          Out.Stms Out.GPU
         )
     )
 intraGroupParallelise knest lam = runMaybeT $ do
@@ -161,15 +161,15 @@ instance Monoid IntraAcc where
   mempty = IntraAcc mempty mempty mempty
 
 type IntraGroupM =
-  BinderT Out.Kernels (RWS () IntraAcc VNameSource)
+  BinderT Out.GPU (RWS () IntraAcc VNameSource)
 
 instance MonadLogger IntraGroupM where
   addLog log = tell mempty {accLog = log}
 
 runIntraGroupM ::
-  (MonadFreshNames m, HasScope Out.Kernels m) =>
+  (MonadFreshNames m, HasScope Out.GPU m) =>
   IntraGroupM () ->
-  m (IntraAcc, Out.Stms Out.Kernels)
+  m (IntraAcc, Out.Stms Out.GPU)
 runIntraGroupM m = do
   scope <- castScope <$> askScope
   modifyNameSource $ \src ->
@@ -184,7 +184,7 @@ parallelMin ws =
         accAvailPar = S.singleton ws
       }
 
-intraGroupBody :: SegLevel -> Body -> IntraGroupM (Out.Body Out.Kernels)
+intraGroupBody :: SegLevel -> Body -> IntraGroupM (Out.Body Out.GPU)
 intraGroupBody lvl body = do
   stms <- collectStms_ $ intraGroupStms lvl $ bodyStms body
   return $ mkBody stms $ bodyResult body
@@ -223,7 +223,7 @@ intraGroupStm lvl stm@(Let pat aux e) = do
                     singleNesting $ Nesting mempty loopnest,
                   distScope =
                     scopeOfPattern pat
-                      <> scopeForKernels (scopeOf lam)
+                      <> scopeForGPU (scopeOf lam)
                       <> scope,
                   distOnInnerMap =
                     distributeMap,
@@ -233,9 +233,9 @@ intraGroupStm lvl stm@(Let pat aux e) = do
                     lift $ parallelMin minw
                     return lvl,
                   distOnSOACSStms =
-                    pure . oneStm . soacsStmToKernels,
+                    pure . oneStm . soacsStmToGPU,
                   distOnSOACSLambda =
-                    pure . soacsLambdaToKernels
+                    pure . soacsLambdaToGPU
                 }
             acc =
               DistAcc
@@ -248,26 +248,26 @@ intraGroupStm lvl stm@(Let pat aux e) = do
     Op (Screma w arrs form)
       | Just (scans, mapfun) <- isScanomapSOAC form,
         Scan scanfun nes <- singleScan scans -> do
-        let scanfun' = soacsLambdaToKernels scanfun
-            mapfun' = soacsLambdaToKernels mapfun
+        let scanfun' = soacsLambdaToGPU scanfun
+            mapfun' = soacsLambdaToGPU mapfun
         certifying (stmAuxCerts aux) $
           addStms =<< segScan lvl' pat w [SegBinOp Noncommutative scanfun' nes mempty] mapfun' arrs [] []
         parallelMin [w]
     Op (Screma w arrs form)
       | Just (reds, map_lam) <- isRedomapSOAC form,
         Reduce comm red_lam nes <- singleReduce reds -> do
-        let red_lam' = soacsLambdaToKernels red_lam
-            map_lam' = soacsLambdaToKernels map_lam
+        let red_lam' = soacsLambdaToGPU red_lam
+            map_lam' = soacsLambdaToGPU map_lam
         certifying (stmAuxCerts aux) $
           addStms =<< segRed lvl' pat w [SegBinOp comm red_lam' nes mempty] map_lam' arrs [] []
         parallelMin [w]
     Op (Hist w ops bucket_fun arrs) -> do
       ops' <- forM ops $ \(HistOp num_bins rf dests nes op) -> do
         (op', nes', shape) <- determineReduceOp op nes
-        let op'' = soacsLambdaToKernels op'
+        let op'' = soacsLambdaToGPU op'
         return $ Out.HistOp num_bins rf dests nes' shape op''
 
-      let bucket_fun' = soacsLambdaToKernels bucket_fun
+      let bucket_fun' = soacsLambdaToGPU bucket_fun
       certifying (stmAuxCerts aux) $
         addStms =<< segHist lvl' pat w [] [] ops' bucket_fun' arrs
       parallelMin [w]
@@ -285,7 +285,7 @@ intraGroupStm lvl stm@(Let pat aux e) = do
       write_i <- newVName "write_i"
       space <- mkSegSpace [(write_i, w)]
 
-      let lam' = soacsLambdaToKernels lam
+      let lam' = soacsLambdaToGPU lam
           (dests_ws, _, _) = unzip3 dests
           krets = do
             (a_w, a, is_vs) <-
@@ -307,16 +307,16 @@ intraGroupStm lvl stm@(Let pat aux e) = do
 
       parallelMin [w]
     _ ->
-      addStm $ soacsStmToKernels stm
+      addStm $ soacsStmToGPU stm
 
 intraGroupStms :: SegLevel -> Stms SOACS -> IntraGroupM ()
 intraGroupStms lvl = mapM_ (intraGroupStm lvl)
 
 intraGroupParalleliseBody ::
-  (MonadFreshNames m, HasScope Out.Kernels m) =>
+  (MonadFreshNames m, HasScope Out.GPU m) =>
   SegLevel ->
   Body ->
-  m ([[SubExp]], [[SubExp]], Log, Out.KernelBody Out.Kernels)
+  m ([[SubExp]], [[SubExp]], Log, Out.KernelBody Out.GPU)
 intraGroupParalleliseBody lvl body = do
   (IntraAcc min_ws avail_ws log, kstms) <-
     runIntraGroupM $ intraGroupStms lvl $ bodyStms body

--- a/src/Futhark/Pass/ExtractKernels/StreamKernel.hs
+++ b/src/Futhark/Pass/ExtractKernels/StreamKernel.hs
@@ -14,7 +14,7 @@ import Control.Monad.Writer
 import Data.List ()
 import Futhark.Analysis.PrimExp
 import Futhark.IR
-import Futhark.IR.Kernels hiding
+import Futhark.IR.GPU hiding
   ( BasicOp,
     Body,
     Exp,
@@ -30,7 +30,7 @@ import Futhark.IR.Kernels hiding
   )
 import Futhark.MonadFreshNames
 import Futhark.Pass.ExtractKernels.BlockedKernel
-import Futhark.Pass.ExtractKernels.ToKernels
+import Futhark.Pass.ExtractKernels.ToGPU
 import Futhark.Tools
 import Prelude hiding (quot)
 
@@ -59,7 +59,7 @@ numberOfGroups desc w group_size = do
   return (num_groups, num_threads)
 
 blockedKernelSize ::
-  (MonadBinder m, Rep m ~ Kernels) =>
+  (MonadBinder m, Rep m ~ GPU) =>
   String ->
   SubExp ->
   m KernelSize
@@ -75,7 +75,7 @@ blockedKernelSize desc w = do
   return $ KernelSize per_thread_elements num_threads
 
 splitArrays ::
-  (MonadBinder m, Rep m ~ Kernels) =>
+  (MonadBinder m, Rep m ~ GPU) =>
   VName ->
   [VName] ->
   SplitOrdering ->
@@ -113,7 +113,7 @@ partitionChunkedKernelFoldParameters _ _ =
   error "partitionChunkedKernelFoldParameters: lambda takes too few parameters"
 
 blockedPerThread ::
-  (MonadBinder m, Rep m ~ Kernels) =>
+  (MonadBinder m, Rep m ~ GPU) =>
   VName ->
   SubExp ->
   KernelSize ->
@@ -172,8 +172,8 @@ blockedPerThread thread_gtid w kernel_size ordering lam num_nonconcat arrs = do
 kerneliseLambda ::
   MonadFreshNames m =>
   [SubExp] ->
-  Lambda Kernels ->
-  m (Lambda Kernels)
+  Lambda GPU ->
+  m (Lambda GPU)
 kerneliseLambda nes lam = do
   thread_index <- newVName "thread_index"
   let thread_index_param = Param thread_index $ Prim int64
@@ -197,15 +197,15 @@ kerneliseLambda nes lam = do
       }
 
 prepareStream ::
-  (MonadBinder m, Rep m ~ Kernels) =>
+  (MonadBinder m, Rep m ~ GPU) =>
   KernelSize ->
   [(VName, SubExp)] ->
   SubExp ->
   Commutativity ->
-  Lambda Kernels ->
+  Lambda GPU ->
   [SubExp] ->
   [VName] ->
-  m (SubExp, SegSpace, [Type], KernelBody Kernels)
+  m (SubExp, SegSpace, [Type], KernelBody GPU)
 prepareStream size ispace w comm fold_lam nes arrs = do
   let (KernelSize elems_per_thread num_threads) = size
   let (ordering, split_ordering) =
@@ -235,16 +235,16 @@ prepareStream size ispace w comm fold_lam nes arrs = do
   return (num_threads, space, ts, kbody)
 
 streamRed ::
-  (MonadFreshNames m, HasScope Kernels m) =>
-  MkSegLevel Kernels m ->
-  Pattern Kernels ->
+  (MonadFreshNames m, HasScope GPU m) =>
+  MkSegLevel GPU m ->
+  Pattern GPU ->
   SubExp ->
   Commutativity ->
-  Lambda Kernels ->
-  Lambda Kernels ->
+  Lambda GPU ->
+  Lambda GPU ->
   [SubExp] ->
   [VName] ->
-  m (Stms Kernels)
+  m (Stms GPU)
 streamRed mk_lvl pat w comm red_lam fold_lam nes arrs = runBinderT'_ $ do
   -- The strategy here is to rephrase the stream reduction as a
   -- non-segmented SegRed that does explicit chunking within its body.
@@ -272,16 +272,16 @@ streamRed mk_lvl pat w comm red_lam fold_lam nes arrs = runBinderT'_ $ do
 
 -- Similar to streamRed, but without the last reduction.
 streamMap ::
-  (MonadFreshNames m, HasScope Kernels m) =>
-  MkSegLevel Kernels m ->
+  (MonadFreshNames m, HasScope GPU m) =>
+  MkSegLevel GPU m ->
   [String] ->
-  [PatElem Kernels] ->
+  [PatElem GPU] ->
   SubExp ->
   Commutativity ->
-  Lambda Kernels ->
+  Lambda GPU ->
   [SubExp] ->
   [VName] ->
-  m ((SubExp, [VName]), Stms Kernels)
+  m ((SubExp, [VName]), Stms GPU)
 streamMap mk_lvl out_desc mapout_pes w comm fold_lam nes arrs = runBinderT' $ do
   size <- blockedKernelSize "stream_map" w
 
@@ -301,7 +301,7 @@ streamMap mk_lvl out_desc mapout_pes w comm fold_lam nes arrs = runBinderT' $ do
 -- | Like 'segThread', but cap the thread count to the input size.
 -- This is more efficient for small kernels, e.g. summing a small
 -- array.
-segThreadCapped :: MonadFreshNames m => MkSegLevel Kernels m
+segThreadCapped :: MonadFreshNames m => MkSegLevel GPU m
 segThreadCapped ws desc r = do
   w <-
     letSubExp "nest_size"

--- a/src/Futhark/Pass/ExtractKernels/StreamKernel.hs
+++ b/src/Futhark/Pass/ExtractKernels/StreamKernel.hs
@@ -43,7 +43,7 @@ data KernelSize = KernelSize
   deriving (Eq, Ord, Show)
 
 numberOfGroups ::
-  (MonadBinder m, Op (Lore m) ~ HostOp (Lore m) inner) =>
+  (MonadBinder m, Op (Rep m) ~ HostOp (Rep m) inner) =>
   String ->
   SubExp ->
   SubExp ->
@@ -59,7 +59,7 @@ numberOfGroups desc w group_size = do
   return (num_groups, num_threads)
 
 blockedKernelSize ::
-  (MonadBinder m, Lore m ~ Kernels) =>
+  (MonadBinder m, Rep m ~ Kernels) =>
   String ->
   SubExp ->
   m KernelSize
@@ -75,7 +75,7 @@ blockedKernelSize desc w = do
   return $ KernelSize per_thread_elements num_threads
 
 splitArrays ::
-  (MonadBinder m, Lore m ~ Kernels) =>
+  (MonadBinder m, Rep m ~ Kernels) =>
   VName ->
   [VName] ->
   SplitOrdering ->
@@ -113,12 +113,12 @@ partitionChunkedKernelFoldParameters _ _ =
   error "partitionChunkedKernelFoldParameters: lambda takes too few parameters"
 
 blockedPerThread ::
-  (MonadBinder m, Lore m ~ Kernels) =>
+  (MonadBinder m, Rep m ~ Kernels) =>
   VName ->
   SubExp ->
   KernelSize ->
   StreamOrd ->
-  Lambda (Lore m) ->
+  Lambda (Rep m) ->
   Int ->
   [VName] ->
   m ([PatElemT Type], [PatElemT Type])
@@ -197,7 +197,7 @@ kerneliseLambda nes lam = do
       }
 
 prepareStream ::
-  (MonadBinder m, Lore m ~ Kernels) =>
+  (MonadBinder m, Rep m ~ Kernels) =>
   KernelSize ->
   [(VName, SubExp)] ->
   SubExp ->

--- a/src/Futhark/Pass/ExtractKernels/ToGPU.hs
+++ b/src/Futhark/Pass/ExtractKernels/ToGPU.hs
@@ -2,12 +2,12 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeFamilies #-}
 
-module Futhark.Pass.ExtractKernels.ToKernels
+module Futhark.Pass.ExtractKernels.ToGPU
   ( getSize,
     segThread,
-    soacsLambdaToKernels,
-    soacsStmToKernels,
-    scopeForKernels,
+    soacsLambdaToGPU,
+    soacsStmToGPU,
+    scopeForGPU,
     scopeForSOACs,
     injectSOACS,
   )
@@ -17,7 +17,7 @@ import Control.Monad.Identity
 import Data.List ()
 import Futhark.Analysis.Rephrase
 import Futhark.IR
-import Futhark.IR.Kernels
+import Futhark.IR.GPU
 import Futhark.IR.SOACS (SOACS)
 import qualified Futhark.IR.SOACS.SOAC as SOAC
 import Futhark.Tools
@@ -72,14 +72,14 @@ injectSOACS f =
           SOAC.mapOnSOACLambda = rephraseLambda $ injectSOACS f
         }
 
-soacsStmToKernels :: Stm SOACS -> Stm Kernels
-soacsStmToKernels = runIdentity . rephraseStm (injectSOACS OtherOp)
+soacsStmToGPU :: Stm SOACS -> Stm GPU
+soacsStmToGPU = runIdentity . rephraseStm (injectSOACS OtherOp)
 
-soacsLambdaToKernels :: Lambda SOACS -> Lambda Kernels
-soacsLambdaToKernels = runIdentity . rephraseLambda (injectSOACS OtherOp)
+soacsLambdaToGPU :: Lambda SOACS -> Lambda GPU
+soacsLambdaToGPU = runIdentity . rephraseLambda (injectSOACS OtherOp)
 
-scopeForSOACs :: Scope Kernels -> Scope SOACS
+scopeForSOACs :: Scope GPU -> Scope SOACS
 scopeForSOACs = castScope
 
-scopeForKernels :: Scope SOACS -> Scope Kernels
-scopeForKernels = castScope
+scopeForGPU :: Scope SOACS -> Scope GPU
+scopeForGPU = castScope

--- a/src/Futhark/Pass/ExtractKernels/ToKernels.hs
+++ b/src/Futhark/Pass/ExtractKernels/ToKernels.hs
@@ -23,7 +23,7 @@ import qualified Futhark.IR.SOACS.SOAC as SOAC
 import Futhark.Tools
 
 getSize ::
-  (MonadBinder m, Op (Lore m) ~ HostOp (Lore m) inner) =>
+  (MonadBinder m, Op (Rep m) ~ HostOp (Rep m) inner) =>
   String ->
   SizeClass ->
   m SubExp
@@ -32,7 +32,7 @@ getSize desc size_class = do
   letSubExp desc $ Op $ SizeOp $ GetSize size_key size_class
 
 segThread ::
-  (MonadBinder m, Op (Lore m) ~ HostOp (Lore m) inner) =>
+  (MonadBinder m, Op (Rep m) ~ HostOp (Rep m) inner) =>
   String ->
   m SegLevel
 segThread desc =
@@ -54,11 +54,11 @@ injectSOACS ::
   Rephraser m from to
 injectSOACS f =
   Rephraser
-    { rephraseExpLore = return,
-      rephraseBodyLore = return,
-      rephraseLetBoundLore = return,
-      rephraseFParamLore = return,
-      rephraseLParamLore = return,
+    { rephraseExpDec = return,
+      rephraseBodyDec = return,
+      rephraseLetBoundDec = return,
+      rephraseFParamDec = return,
+      rephraseLParamDec = return,
       rephraseOp = fmap f . onSOAC,
       rephraseRetType = return,
       rephraseBranchType = return

--- a/src/Futhark/Pass/ExtractMulticore.hs
+++ b/src/Futhark/Pass/ExtractMulticore.hs
@@ -25,7 +25,7 @@ import qualified Futhark.IR.SOACS as SOACS
 import qualified Futhark.IR.SOACS.Simplify as SOACS
 import Futhark.Pass
 import Futhark.Pass.ExtractKernels.DistributeNests
-import Futhark.Pass.ExtractKernels.ToKernels (injectSOACS)
+import Futhark.Pass.ExtractKernels.ToGPU (injectSOACS)
 import Futhark.Tools
 import qualified Futhark.Transform.FirstOrderTransform as FOT
 import Futhark.Transform.Rename (Rename, renameSomething)

--- a/src/Futhark/Pass/FirstOrderTransform.hs
+++ b/src/Futhark/Pass/FirstOrderTransform.hs
@@ -24,10 +24,10 @@ module Futhark.Pass.FirstOrderTransform (firstOrderTransform) where
 
 import Futhark.IR.SOACS (SOACS, scopeOf)
 import Futhark.Pass
-import Futhark.Transform.FirstOrderTransform (FirstOrderLore, transformConsts, transformFunDef)
+import Futhark.Transform.FirstOrderTransform (FirstOrderRep, transformConsts, transformFunDef)
 
 -- | The first-order transformation pass.
-firstOrderTransform :: FirstOrderLore lore => Pass SOACS lore
+firstOrderTransform :: FirstOrderRep rep => Pass SOACS rep
 firstOrderTransform =
   Pass
     "first order transform"

--- a/src/Futhark/Pass/KernelBabysitting.hs
+++ b/src/Futhark/Pass/KernelBabysitting.hs
@@ -11,7 +11,7 @@ import Data.List (elemIndex, isPrefixOf, sort)
 import qualified Data.Map.Strict as M
 import Data.Maybe
 import Futhark.IR
-import Futhark.IR.Kernels hiding
+import Futhark.IR.GPU hiding
   ( BasicOp,
     Body,
     Exp,
@@ -31,7 +31,7 @@ import Futhark.Tools
 import Futhark.Util
 
 -- | The pass definition.
-babysitKernels :: Pass Kernels Kernels
+babysitKernels :: Pass GPU GPU
 babysitKernels =
   Pass
     "babysit kernels"
@@ -42,12 +42,12 @@ babysitKernels =
       let m = localScope scope $ transformStms mempty stms
       fmap fst $ modifyNameSource $ runState (runBinderT m M.empty)
 
-type BabysitM = Binder Kernels
+type BabysitM = Binder GPU
 
-transformStms :: ExpMap -> Stms Kernels -> BabysitM (Stms Kernels)
+transformStms :: ExpMap -> Stms GPU -> BabysitM (Stms GPU)
 transformStms expmap stms = collectStms_ $ foldM_ transformStm expmap stms
 
-transformBody :: ExpMap -> Body Kernels -> BabysitM (Body Kernels)
+transformBody :: ExpMap -> Body GPU -> BabysitM (Body GPU)
 transformBody expmap (Body () stms res) = do
   stms' <- transformStms expmap stms
   return $ Body () stms' res
@@ -57,7 +57,7 @@ transformBody expmap (Body () stms res) = do
 -- funky in memory (and we'd prefer it not to be).  If we cannot find
 -- it in the map, we just assume it's all good.  HACK and FIXME, I
 -- suppose.  We really should do this at the memory level.
-type ExpMap = M.Map VName (Stm Kernels)
+type ExpMap = M.Map VName (Stm GPU)
 
 nonlinearInMemory :: VName -> ExpMap -> Maybe (Maybe [Int])
 nonlinearInMemory name m =
@@ -80,7 +80,7 @@ nonlinearInMemory name m =
         return $ Just $ rearrangeInverse $ [inner_r .. inner_r + outer_r -1] ++ [0 .. inner_r -1]
       | otherwise = Nothing
 
-transformStm :: ExpMap -> Stm Kernels -> BabysitM ExpMap
+transformStm :: ExpMap -> Stm GPU -> BabysitM ExpMap
 transformStm expmap (Let pat aux (Op (SegOp op)))
   -- FIXME: We only make coalescing optimisations for SegThread
   -- SegOps, because that's what the analysis assumes.  For SegGroup
@@ -102,7 +102,7 @@ transformStm expmap (Let pat aux e) = do
   addStm bnd'
   return $ M.fromList [(name, bnd') | name <- patternNames pat] <> expmap
 
-transform :: ExpMap -> Mapper Kernels Kernels BabysitM
+transform :: ExpMap -> Mapper GPU GPU BabysitM
 transform expmap =
   identityMapper {mapOnBody = \scope -> localScope scope . transformBody expmap}
 
@@ -110,8 +110,8 @@ transformKernelBody ::
   ExpMap ->
   SegLevel ->
   SegSpace ->
-  KernelBody Kernels ->
-  BabysitM (KernelBody Kernels)
+  KernelBody GPU ->
+  BabysitM (KernelBody GPU)
 transformKernelBody expmap lvl space kbody = do
   -- Go spelunking for accesses to arrays that are defined outside the
   -- kernel body and where the indices are kernel thread indices.
@@ -143,7 +143,7 @@ type ArrayIndexTransform m =
   (VName -> Bool) -> -- thread local?
   (VName -> SubExp -> Bool) -> -- variant to a certain gid (given as first param)?
   (SubExp -> Maybe SubExp) -> -- split substitution?
-  Scope Kernels -> -- type environment
+  Scope GPU -> -- type environment
   VName ->
   Slice SubExp ->
   m (Maybe (VName, Slice SubExp))
@@ -152,10 +152,10 @@ traverseKernelBodyArrayIndexes ::
   (Applicative f, Monad f) =>
   Names ->
   Names ->
-  Scope Kernels ->
+  Scope GPU ->
   ArrayIndexTransform f ->
-  KernelBody Kernels ->
-  f (KernelBody Kernels)
+  KernelBody GPU ->
+  f (KernelBody GPU)
 traverseKernelBodyArrayIndexes free_ker_vars thread_variant outer_scope f (KernelBody () kstms kres) =
   KernelBody () . stmsFromList
     <$> mapM
@@ -513,10 +513,10 @@ paddedScanReduceInput w stride = do
 
 type VarianceTable = M.Map VName Names
 
-varianceInStms :: VarianceTable -> Stms Kernels -> VarianceTable
+varianceInStms :: VarianceTable -> Stms GPU -> VarianceTable
 varianceInStms t = foldl varianceInStm t . stmsToList
 
-varianceInStm :: VarianceTable -> Stm Kernels -> VarianceTable
+varianceInStm :: VarianceTable -> Stm GPU -> VarianceTable
 varianceInStm variance bnd =
   foldl' add variance $ patternNames $ stmPattern bnd
   where

--- a/src/Futhark/Pass/Simplify.hs
+++ b/src/Futhark/Pass/Simplify.hs
@@ -23,8 +23,8 @@ import Futhark.IR.Syntax
 import Futhark.Pass
 
 simplify ::
-  (Prog lore -> PassM (Prog lore)) ->
-  Pass lore lore
+  (Prog rep -> PassM (Prog rep)) ->
+  Pass rep rep
 simplify = Pass "simplify" "Perform simple enabling optimisations."
 
 simplifySOACS :: Pass SOACS.SOACS SOACS.SOACS

--- a/src/Futhark/Pass/Simplify.hs
+++ b/src/Futhark/Pass/Simplify.hs
@@ -5,15 +5,15 @@ module Futhark.Pass.Simplify
     simplifySOACS,
     simplifySeq,
     simplifyMC,
-    simplifyKernels,
-    simplifyKernelsMem,
+    simplifyGPU,
+    simplifyGPUMem,
     simplifySeqMem,
     simplifyMCMem,
   )
 where
 
-import qualified Futhark.IR.Kernels.Simplify as Kernels
-import qualified Futhark.IR.KernelsMem as KernelsMem
+import qualified Futhark.IR.GPU.Simplify as GPU
+import qualified Futhark.IR.GPUMem as GPUMem
 import qualified Futhark.IR.MC as MC
 import qualified Futhark.IR.MCMem as MCMem
 import qualified Futhark.IR.SOACS.Simplify as SOACS
@@ -30,8 +30,8 @@ simplify = Pass "simplify" "Perform simple enabling optimisations."
 simplifySOACS :: Pass SOACS.SOACS SOACS.SOACS
 simplifySOACS = simplify SOACS.simplifySOACS
 
-simplifyKernels :: Pass Kernels.Kernels Kernels.Kernels
-simplifyKernels = simplify Kernels.simplifyKernels
+simplifyGPU :: Pass GPU.GPU GPU.GPU
+simplifyGPU = simplify GPU.simplifyGPU
 
 simplifySeq :: Pass Seq.Seq Seq.Seq
 simplifySeq = simplify Seq.simplifyProg
@@ -39,8 +39,8 @@ simplifySeq = simplify Seq.simplifyProg
 simplifyMC :: Pass MC.MC MC.MC
 simplifyMC = simplify MC.simplifyProg
 
-simplifyKernelsMem :: Pass KernelsMem.KernelsMem KernelsMem.KernelsMem
-simplifyKernelsMem = simplify KernelsMem.simplifyProg
+simplifyGPUMem :: Pass GPUMem.GPUMem GPUMem.GPUMem
+simplifyGPUMem = simplify GPUMem.simplifyProg
 
 simplifySeqMem :: Pass SeqMem.SeqMem SeqMem.SeqMem
 simplifySeqMem = simplify SeqMem.simplifyProg

--- a/src/Futhark/Passes.hs
+++ b/src/Futhark/Passes.hs
@@ -13,8 +13,8 @@ module Futhark.Passes
 where
 
 import Control.Category ((>>>))
-import Futhark.IR.Kernels (Kernels)
-import Futhark.IR.KernelsMem (KernelsMem)
+import Futhark.IR.GPU (GPU)
+import Futhark.IR.GPUMem (GPUMem)
 import Futhark.IR.MC (MC)
 import Futhark.IR.MCMem (MCMem)
 import Futhark.IR.SOACS (SOACS)
@@ -30,7 +30,7 @@ import Futhark.Optimise.Sink
 import Futhark.Optimise.TileLoops
 import Futhark.Optimise.Unstream
 import Futhark.Pass.ExpandAllocations
-import qualified Futhark.Pass.ExplicitAllocations.Kernels as Kernels
+import qualified Futhark.Pass.ExplicitAllocations.GPU as GPU
 import qualified Futhark.Pass.ExplicitAllocations.MC as MC
 import qualified Futhark.Pass.ExplicitAllocations.Seq as Seq
 import Futhark.Pass.ExtractKernels
@@ -58,19 +58,19 @@ standardPipeline =
       removeDeadFunctions
     ]
 
-kernelsPipeline :: Pipeline SOACS Kernels
+kernelsPipeline :: Pipeline SOACS GPU
 kernelsPipeline =
   standardPipeline
     >>> onePass extractKernels
     >>> passes
-      [ simplifyKernels,
+      [ simplifyGPU,
         babysitKernels,
         tileLoops,
-        unstreamKernels,
+        unstreamGPU,
         performCSE True,
-        simplifyKernels,
-        sinkKernels,
-        inPlaceLoweringKernels
+        simplifyGPU,
+        sinkGPU,
+        inPlaceLoweringGPU
       ]
 
 sequentialPipeline :: Pipeline SOACS Seq
@@ -92,20 +92,20 @@ sequentialCpuPipeline =
         simplifySeqMem
       ]
 
-gpuPipeline :: Pipeline SOACS KernelsMem
+gpuPipeline :: Pipeline SOACS GPUMem
 gpuPipeline =
   kernelsPipeline
-    >>> onePass Kernels.explicitAllocations
+    >>> onePass GPU.explicitAllocations
     >>> passes
-      [ simplifyKernelsMem,
+      [ simplifyGPUMem,
         performCSE False,
-        simplifyKernelsMem,
-        doubleBufferKernels,
-        simplifyKernelsMem,
+        simplifyGPUMem,
+        doubleBufferGPU,
+        simplifyGPUMem,
         ReuseAllocations.optimise,
-        simplifyKernelsMem,
+        simplifyGPUMem,
         expandAllocations,
-        simplifyKernelsMem
+        simplifyGPUMem
       ]
 
 mcPipeline :: Pipeline SOACS MC

--- a/src/Futhark/Tools.hs
+++ b/src/Futhark/Tools.hs
@@ -31,19 +31,19 @@ import Futhark.Util
 -- Only handles a pattern with an empty 'patternContextElements'.
 redomapToMapAndReduce ::
   ( MonadFreshNames m,
-    Bindable lore,
-    ExpDec lore ~ (),
-    Op lore ~ SOAC lore
+    Bindable rep,
+    ExpDec rep ~ (),
+    Op rep ~ SOAC rep
   ) =>
-  Pattern lore ->
+  Pattern rep ->
   ( SubExp,
     Commutativity,
-    LambdaT lore,
-    LambdaT lore,
+    LambdaT rep,
+    LambdaT rep,
     [SubExp],
     [VName]
   ) ->
-  m (Stm lore, Stm lore)
+  m (Stm rep, Stm rep)
 redomapToMapAndReduce
   (Pattern [] patelems)
   (w, comm, redlam, map_lam, accs, arrs) = do
@@ -62,7 +62,7 @@ splitScanOrRedomap ::
   (Typed dec, MonadFreshNames m) =>
   [PatElemT dec] ->
   SubExp ->
-  LambdaT lore ->
+  LambdaT rep ->
   [SubExp] ->
   m ([Ident], PatternT dec, [(SubExp, VName)])
 splitScanOrRedomap patelems w map_lam accs = do
@@ -84,12 +84,12 @@ splitScanOrRedomap patelems w map_lam accs = do
 -- In essense, what happens is the opposite of horisontal fusion.
 dissectScrema ::
   ( MonadBinder m,
-    Op (Lore m) ~ SOAC (Lore m),
-    Bindable (Lore m)
+    Op (Rep m) ~ SOAC (Rep m),
+    Bindable (Rep m)
   ) =>
-  Pattern (Lore m) ->
+  Pattern (Rep m) ->
   SubExp ->
-  ScremaForm (Lore m) ->
+  ScremaForm (Rep m) ->
   [VName] ->
   m ()
 dissectScrema pat w (ScremaForm scans reds map_lam) arrs = do
@@ -110,11 +110,11 @@ dissectScrema pat w (ScremaForm scans reds map_lam) arrs = do
 -- | Turn a stream SOAC into statements that apply the stream lambda
 -- to the entire input.
 sequentialStreamWholeArray ::
-  (MonadBinder m, Bindable (Lore m)) =>
-  Pattern (Lore m) ->
+  (MonadBinder m, Bindable (Rep m)) =>
+  Pattern (Rep m) ->
   SubExp ->
   [SubExp] ->
-  LambdaT (Lore m) ->
+  LambdaT (Rep m) ->
   [VName] ->
   m ()
 sequentialStreamWholeArray pat w nes lam arrs = do

--- a/src/Futhark/Transform/CopyPropagate.hs
+++ b/src/Futhark/Transform/CopyPropagate.hs
@@ -15,31 +15,31 @@ import qualified Futhark.Analysis.SymbolTable as ST
 import Futhark.IR
 import Futhark.MonadFreshNames
 import Futhark.Optimise.Simplify
-import Futhark.Optimise.Simplify.Lore (Wise)
+import Futhark.Optimise.Simplify.Rep (Wise)
 import Futhark.Pass
 
 -- | Run copy propagation on an entire program.
 copyPropagateInProg ::
-  SimplifiableLore lore =>
-  SimpleOps lore ->
-  Prog lore ->
-  PassM (Prog lore)
+  SimplifiableRep rep =>
+  SimpleOps rep ->
+  Prog rep ->
+  PassM (Prog rep)
 copyPropagateInProg simpl = simplifyProg simpl mempty neverHoist
 
 -- | Run copy propagation on some statements.
 copyPropagateInStms ::
-  (MonadFreshNames m, SimplifiableLore lore) =>
-  SimpleOps lore ->
-  Scope lore ->
-  Stms lore ->
-  m (ST.SymbolTable (Wise lore), Stms lore)
+  (MonadFreshNames m, SimplifiableRep rep) =>
+  SimpleOps rep ->
+  Scope rep ->
+  Stms rep ->
+  m (ST.SymbolTable (Wise rep), Stms rep)
 copyPropagateInStms simpl = simplifyStms simpl mempty neverHoist
 
 -- | Run copy propagation on a function.
 copyPropagateInFun ::
-  (MonadFreshNames m, SimplifiableLore lore) =>
-  SimpleOps lore ->
-  ST.SymbolTable (Wise lore) ->
-  FunDef lore ->
-  m (FunDef lore)
+  (MonadFreshNames m, SimplifiableRep rep) =>
+  SimpleOps rep ->
+  ST.SymbolTable (Wise rep) ->
+  FunDef rep ->
+  m (FunDef rep)
 copyPropagateInFun simpl = simplifyFun simpl mempty neverHoist

--- a/src/Futhark/Transform/Substitute.hs
+++ b/src/Futhark/Transform/Substitute.hs
@@ -37,7 +37,7 @@ class Substitute a where
 instance Substitute a => Substitute [a] where
   substituteNames substs = map $ substituteNames substs
 
-instance Substitute (Stm lore) => Substitute (Stms lore) where
+instance Substitute (Stm rep) => Substitute (Stms rep) where
   substituteNames substs = fmap $ substituteNames substs
 
 instance (Substitute a, Substitute b) => Substitute (a, b) where
@@ -72,7 +72,7 @@ instance Substitute SubExp where
   substituteNames substs (Var v) = Var $ substituteNames substs v
   substituteNames _ (Constant v) = Constant v
 
-instance Substitutable lore => Substitute (Exp lore) where
+instance Substitutable rep => Substitute (Exp rep) where
   substituteNames substs = mapExp $ replace substs
 
 instance Substitute dec => Substitute (PatElemT dec) where
@@ -103,21 +103,21 @@ instance Substitute Certificates where
   substituteNames substs (Certificates cs) =
     Certificates $ substituteNames substs cs
 
-instance Substitutable lore => Substitute (Stm lore) where
+instance Substitutable rep => Substitute (Stm rep) where
   substituteNames substs (Let pat annot e) =
     Let
       (substituteNames substs pat)
       (substituteNames substs annot)
       (substituteNames substs e)
 
-instance Substitutable lore => Substitute (Body lore) where
+instance Substitutable rep => Substitute (Body rep) where
   substituteNames substs (Body dec stms res) =
     Body
       (substituteNames substs dec)
       (substituteNames substs stms)
       (substituteNames substs res)
 
-replace :: Substitutable lore => M.Map VName VName -> Mapper lore lore Identity
+replace :: Substitutable rep => M.Map VName VName -> Mapper rep rep Identity
 replace substs =
   Mapper
     { mapOnVName = return . substituteNames substs,
@@ -164,7 +164,7 @@ instance Substitute shape => Substitute (TypeBase shape u) where
   substituteNames _ (Mem space) =
     Mem space
 
-instance Substitutable lore => Substitute (Lambda lore) where
+instance Substitutable rep => Substitute (Lambda rep) where
   substituteNames substs (Lambda params body rettype) =
     Lambda
       (substituteNames substs params)
@@ -191,7 +191,7 @@ instance Substitute v => Substitute (TPrimExp t v) where
   substituteNames substs =
     TPrimExp . fmap (substituteNames substs) . untyped
 
-instance Substitutable lore => Substitute (NameInfo lore) where
+instance Substitutable rep => Substitute (NameInfo rep) where
   substituteNames subst (LetName dec) =
     LetName $ substituteNames subst dec
   substituteNames subst (FParamName dec) =
@@ -204,16 +204,16 @@ instance Substitutable lore => Substitute (NameInfo lore) where
 instance Substitute FV where
   substituteNames subst = fvNames . substituteNames subst . freeIn
 
--- | Lores in which all annotations support name
+-- | Representations in which all annotations support name
 -- substitution.
-type Substitutable lore =
-  ( Decorations lore,
-    Substitute (ExpDec lore),
-    Substitute (BodyDec lore),
-    Substitute (LetDec lore),
-    Substitute (FParamInfo lore),
-    Substitute (LParamInfo lore),
-    Substitute (RetType lore),
-    Substitute (BranchType lore),
-    Substitute (Op lore)
+type Substitutable rep =
+  ( RepTypes rep,
+    Substitute (ExpDec rep),
+    Substitute (BodyDec rep),
+    Substitute (LetDec rep),
+    Substitute (FParamInfo rep),
+    Substitute (LParamInfo rep),
+    Substitute (RetType rep),
+    Substitute (BranchType rep),
+    Substitute (Op rep)
   )

--- a/src/Futhark/TypeCheck.hs
+++ b/src/Futhark/TypeCheck.hs
@@ -70,14 +70,14 @@ import Futhark.Util.Pretty (Pretty, align, indent, ppr, prettyDoc, text, (<+>), 
 
 -- | Information about an error during type checking.  The 'Show'
 -- instance for this type produces a human-readable description.
-data ErrorCase lore
+data ErrorCase rep
   = TypeError String
-  | UnexpectedType (Exp lore) Type [Type]
+  | UnexpectedType (Exp rep) Type [Type]
   | ReturnTypeError Name [ExtType] [ExtType]
   | DupDefinitionError Name
   | DupParamError Name VName
   | DupPatternError VName
-  | InvalidPatternError (Pattern (Aliases lore)) [ExtType] (Maybe String)
+  | InvalidPatternError (Pattern (Aliases rep)) [ExtType] (Maybe String)
   | UnknownVariableError VName
   | UnknownFunctionError Name
   | ParameterMismatch (Maybe Name) [Type] [Type]
@@ -88,7 +88,7 @@ data ErrorCase lore
   | NotAnArray VName Type
   | PermutationError [Int] Int (Maybe VName)
 
-instance Checkable lore => Show (ErrorCase lore) where
+instance Checkable rep => Show (ErrorCase rep) where
   show (TypeError msg) =
     "Type error:\n" ++ msg
   show (UnexpectedType e _ []) =
@@ -177,9 +177,9 @@ instance Checkable lore => Show (ErrorCase lore) where
       name' = maybe "" ((++ " ") . pretty) name
 
 -- | A type error.
-data TypeError lore = Error [String] (ErrorCase lore)
+data TypeError rep = Error [String] (ErrorCase rep)
 
-instance Checkable lore => Show (TypeError lore) where
+instance Checkable rep => Show (TypeError rep) where
   show (Error [] err) =
     show err
   show (Error msgs err) =
@@ -187,9 +187,9 @@ instance Checkable lore => Show (TypeError lore) where
 
 -- | A tuple of a return type and a list of parameters, possibly
 -- named.
-type FunBinding lore = ([RetType (Aliases lore)], [FParam (Aliases lore)])
+type FunBinding rep = ([RetType (Aliases rep)], [FParam (Aliases rep)])
 
-type VarBinding lore = NameInfo (Aliases lore)
+type VarBinding rep = NameInfo (Aliases rep)
 
 data Usage
   = Consumed
@@ -271,10 +271,10 @@ instance Monoid Consumption where
 -- function table is only initialised at the very beginning, but the
 -- variable table will be extended during type-checking when
 -- let-expressions are encountered.
-data Env lore = Env
-  { envVtable :: M.Map VName (VarBinding lore),
-    envFtable :: M.Map Name (FunBinding lore),
-    envCheckOp :: OpWithAliases (Op lore) -> TypeM lore (),
+data Env rep = Env
+  { envVtable :: M.Map VName (VarBinding rep),
+    envFtable :: M.Map Name (FunBinding rep),
+    envCheckOp :: OpWithAliases (Op rep) -> TypeM rep (),
     envContext :: [String]
   }
 
@@ -284,24 +284,24 @@ data TState = TState
   }
 
 -- | The type checker runs in this monad.
-newtype TypeM lore a
+newtype TypeM rep a
   = TypeM
       ( ReaderT
-          (Env lore)
-          (StateT TState (Either (TypeError lore)))
+          (Env rep)
+          (StateT TState (Either (TypeError rep)))
           a
       )
   deriving
     ( Monad,
       Functor,
       Applicative,
-      MonadReader (Env lore),
+      MonadReader (Env rep),
       MonadState TState
     )
 
 instance
-  Checkable lore =>
-  HasScope (Aliases lore) (TypeM lore)
+  Checkable rep =>
+  HasScope (Aliases rep) (TypeM rep)
   where
   lookupType = fmap typeOf . lookupVar
   askScope = asks $ M.fromList . mapMaybe varType . M.toList . envVtable
@@ -309,18 +309,18 @@ instance
       varType (name, dec) = Just (name, dec)
 
 runTypeM ::
-  Env lore ->
-  TypeM lore a ->
-  Either (TypeError lore) (a, Consumption)
+  Env rep ->
+  TypeM rep a ->
+  Either (TypeError rep) (a, Consumption)
 runTypeM env (TypeM m) =
   second stateCons <$> runStateT (runReaderT m env) (TState mempty mempty)
 
-bad :: ErrorCase lore -> TypeM lore a
+bad :: ErrorCase rep -> TypeM rep a
 bad e = do
   messages <- asks envContext
   TypeM $ lift $ lift $ Left $ Error (reverse messages) e
 
-tell :: Consumption -> TypeM lore ()
+tell :: Consumption -> TypeM rep ()
 tell cons = modify $ \s -> s {stateCons = stateCons s <> cons}
 
 -- | Add information about what is being type-checked to the current
@@ -329,8 +329,8 @@ tell cons = modify $ \s -> s {stateCons = stateCons s <> cons}
 -- 'bad'.
 context ::
   String ->
-  TypeM lore a ->
-  TypeM lore a
+  TypeM rep a ->
+  TypeM rep a
 context s = local $ \env -> env {envContext = s : envContext env}
 
 message ::
@@ -344,35 +344,35 @@ message s x =
 
 -- | Mark a name as bound.  If the name has been bound previously in
 -- the program, report a type error.
-bound :: VName -> TypeM lore ()
+bound :: VName -> TypeM rep ()
 bound name = do
   already_seen <- gets $ nameIn name . stateNames
   when already_seen $
     bad $ TypeError $ "Name " ++ pretty name ++ " bound twice"
   modify $ \s -> s {stateNames = oneName name <> stateNames s}
 
-occur :: Occurences -> TypeM lore ()
+occur :: Occurences -> TypeM rep ()
 occur = tell . Consumption . filter (not . nullOccurence)
 
 -- | Proclaim that we have made read-only use of the given variable.
 -- No-op unless the variable is array-typed.
 observe ::
-  Checkable lore =>
+  Checkable rep =>
   VName ->
-  TypeM lore ()
+  TypeM rep ()
 observe name = do
   dec <- lookupVar name
   unless (primType $ typeOf dec) $
     occur [observation $ oneName name <> aliases dec]
 
 -- | Proclaim that we have written to the given variables.
-consume :: Checkable lore => Names -> TypeM lore ()
+consume :: Checkable rep => Names -> TypeM rep ()
 consume als = do
   scope <- askScope
   let isArray = maybe False (not . primType . typeOf) . (`M.lookup` scope)
   occur [consumption $ namesFromList $ filter isArray $ namesToList als]
 
-collectOccurences :: TypeM lore a -> TypeM lore (a, Occurences)
+collectOccurences :: TypeM rep a -> TypeM rep (a, Occurences)
 collectOccurences m = do
   old <- gets stateCons
   modify $ \s -> s {stateCons = mempty}
@@ -383,16 +383,16 @@ collectOccurences m = do
   pure (x, o)
 
 checkOpWith ::
-  (OpWithAliases (Op lore) -> TypeM lore ()) ->
-  TypeM lore a ->
-  TypeM lore a
+  (OpWithAliases (Op rep) -> TypeM rep ()) ->
+  TypeM rep a ->
+  TypeM rep a
 checkOpWith checker = local $ \env -> env {envCheckOp = checker}
 
-checkConsumption :: Consumption -> TypeM lore Occurences
+checkConsumption :: Consumption -> TypeM rep Occurences
 checkConsumption (ConsumptionError e) = bad $ TypeError e
 checkConsumption (Consumption os) = return os
 
-alternative :: TypeM lore a -> TypeM lore b -> TypeM lore (a, b)
+alternative :: TypeM rep a -> TypeM rep b -> TypeM rep (a, b)
 alternative m1 m2 = do
   (x, os1) <- collectOccurences m1
   (y, os2) <- collectOccurences m2
@@ -403,7 +403,7 @@ alternative m1 m2 = do
 -- names is consumed, the consumption will be rewritten to be a
 -- consumption of the corresponding alias set.  Consumption of
 -- anything else will result in a type error.
-consumeOnlyParams :: [(VName, Names)] -> TypeM lore a -> TypeM lore a
+consumeOnlyParams :: [(VName, Names)] -> TypeM rep a -> TypeM rep a
 consumeOnlyParams consumable m = do
   (x, os) <- collectOccurences m
   tell . Consumption =<< mapM inspect os
@@ -427,7 +427,7 @@ consumeOnlyParams consumable m = do
 
 -- | Given the immediate aliases, compute the full transitive alias
 -- set (including the immediate aliases).
-expandAliases :: Names -> Env lore -> Names
+expandAliases :: Names -> Env rep -> Names
 expandAliases names env = names <> aliasesOfAliases
   where
     aliasesOfAliases = mconcat . map look . namesToList $ names
@@ -436,10 +436,10 @@ expandAliases names env = names <> aliasesOfAliases
       _ -> mempty
 
 binding ::
-  Checkable lore =>
-  Scope (Aliases lore) ->
-  TypeM lore a ->
-  TypeM lore a
+  Checkable rep =>
+  Scope (Aliases rep) ->
+  TypeM rep a ->
+  TypeM rep a
 binding bnds = check . local (`bindVars` bnds)
   where
     bindVars = M.foldlWithKey' bindVar
@@ -464,14 +464,14 @@ binding bnds = check . local (`bindVars` bnds)
       tell $ Consumption $ unOccur (namesFromList boundnames) os
       return a
 
-lookupVar :: VName -> TypeM lore (NameInfo (Aliases lore))
+lookupVar :: VName -> TypeM rep (NameInfo (Aliases rep))
 lookupVar name = do
   bnd <- asks $ M.lookup name . envVtable
   case bnd of
     Nothing -> bad $ UnknownVariableError name
     Just dec -> return dec
 
-lookupAliases :: Checkable lore => VName -> TypeM lore Names
+lookupAliases :: Checkable rep => VName -> TypeM rep Names
 lookupAliases name = do
   info <- lookupVar name
   return $
@@ -479,19 +479,19 @@ lookupAliases name = do
       then mempty
       else oneName name <> aliases info
 
-aliases :: NameInfo (Aliases lore) -> Names
+aliases :: NameInfo (Aliases rep) -> Names
 aliases (LetName (als, _)) = unAliases als
 aliases _ = mempty
 
-subExpAliasesM :: Checkable lore => SubExp -> TypeM lore Names
+subExpAliasesM :: Checkable rep => SubExp -> TypeM rep Names
 subExpAliasesM Constant {} = return mempty
 subExpAliasesM (Var v) = lookupAliases v
 
 lookupFun ::
-  Checkable lore =>
+  Checkable rep =>
   Name ->
   [SubExp] ->
-  TypeM lore ([RetType lore], [DeclType])
+  TypeM rep ([RetType rep], [DeclType])
 lookupFun fname args = do
   bnd <- asks $ M.lookup fname . envFtable
   case bnd of
@@ -510,27 +510,27 @@ checkAnnotation ::
   String ->
   Type ->
   Type ->
-  TypeM lore ()
+  TypeM rep ()
 checkAnnotation desc t1 t2
   | t2 == t1 = return ()
   | otherwise = bad $ BadAnnotation desc t1 t2
 
 -- | @require ts se@ causes a '(TypeError vn)' if the type of @se@ is
 -- not a subtype of one of the types in @ts@.
-require :: Checkable lore => [Type] -> SubExp -> TypeM lore ()
+require :: Checkable rep => [Type] -> SubExp -> TypeM rep ()
 require ts se = do
   t <- checkSubExp se
   unless (t `elem` ts) $
     bad $ UnexpectedType (BasicOp $ SubExp se) t ts
 
 -- | Variant of 'require' working on variable names.
-requireI :: Checkable lore => [Type] -> VName -> TypeM lore ()
+requireI :: Checkable rep => [Type] -> VName -> TypeM rep ()
 requireI ts ident = require ts $ Var ident
 
 checkArrIdent ::
-  Checkable lore =>
+  Checkable rep =>
   VName ->
-  TypeM lore Type
+  TypeM rep Type
 checkArrIdent v = do
   t <- lookupType v
   case t of
@@ -538,9 +538,9 @@ checkArrIdent v = do
     _ -> bad $ NotAnArray v t
 
 checkAccIdent ::
-  Checkable lore =>
+  Checkable rep =>
   VName ->
-  TypeM lore (Shape, [Type])
+  TypeM rep (Shape, [Type])
 checkAccIdent v = do
   t <- lookupType v
   case t of
@@ -556,9 +556,9 @@ checkAccIdent v = do
 -- yielding either a type error or a program with complete type
 -- information.
 checkProg ::
-  Checkable lore =>
-  Prog (Aliases lore) ->
-  Either (TypeError lore) ()
+  Checkable rep =>
+  Prog (Aliases rep) ->
+  Either (TypeError rep) ()
 checkProg (Prog consts funs) = do
   let typeenv =
         Env
@@ -588,8 +588,8 @@ checkProg (Prog consts funs) = do
         return $ M.insert name (ret, params) ftable
 
 initialFtable ::
-  Checkable lore =>
-  TypeM lore (M.Map Name (FunBinding lore))
+  Checkable rep =>
+  TypeM rep (M.Map Name (FunBinding rep))
 initialFtable = fmap M.fromList $ mapM addBuiltin $ M.toList builtInFunctions
   where
     addBuiltin (fname, (t, ts)) = do
@@ -598,9 +598,9 @@ initialFtable = fmap M.fromList $ mapM addBuiltin $ M.toList builtInFunctions
     name = VName (nameFromString "x") 0
 
 checkFun ::
-  Checkable lore =>
-  FunDef (Aliases lore) ->
-  TypeM lore ()
+  Checkable rep =>
+  FunDef (Aliases rep) ->
+  TypeM rep ()
 checkFun (FunDef _ _ fname rettype params body) =
   context ("In function " ++ nameToString fname) $
     checkFun'
@@ -621,40 +621,40 @@ checkFun (FunDef _ _ fname rettype params body) =
       ]
 
 funParamsToNameInfos ::
-  [FParam lore] ->
-  [(VName, NameInfo (Aliases lore))]
-funParamsToNameInfos = map nameTypeAndLore
+  [FParam rep] ->
+  [(VName, NameInfo (Aliases rep))]
+funParamsToNameInfos = map nameTypeAndDec
   where
-    nameTypeAndLore fparam =
+    nameTypeAndDec fparam =
       ( paramName fparam,
         FParamName $ paramDec fparam
       )
 
 checkFunParams ::
-  Checkable lore =>
-  [FParam lore] ->
-  TypeM lore ()
+  Checkable rep =>
+  [FParam rep] ->
+  TypeM rep ()
 checkFunParams = mapM_ $ \param ->
   context ("In function parameter " ++ pretty param) $
-    checkFParamLore (paramName param) (paramDec param)
+    checkFParamDec (paramName param) (paramDec param)
 
 checkLambdaParams ::
-  Checkable lore =>
-  [LParam lore] ->
-  TypeM lore ()
+  Checkable rep =>
+  [LParam rep] ->
+  TypeM rep ()
 checkLambdaParams = mapM_ $ \param ->
   context ("In lambda parameter " ++ pretty param) $
-    checkLParamLore (paramName param) (paramDec param)
+    checkLParamDec (paramName param) (paramDec param)
 
 checkFun' ::
-  Checkable lore =>
+  Checkable rep =>
   ( Name,
     [DeclExtType],
-    [(VName, NameInfo (Aliases lore))]
+    [(VName, NameInfo (Aliases rep))]
   ) ->
   Maybe [(VName, Names)] ->
-  TypeM lore [Names] ->
-  TypeM lore ()
+  TypeM rep [Names] ->
+  TypeM rep ()
 checkFun' (fname, rettype, params) consumable check = do
   checkNoDuplicateParams
   binding (M.fromList params) $
@@ -698,7 +698,7 @@ checkFun' (fname, rettype, params) consumable check = do
         zip (reverse (map uniqueness expected) ++ repeat Nonunique) $
           reverse got
 
-checkSubExp :: Checkable lore => SubExp -> TypeM lore Type
+checkSubExp :: Checkable rep => SubExp -> TypeM rep Type
 checkSubExp (Constant val) =
   return $ Prim $ primValueType val
 checkSubExp (Var ident) = context ("In subexp " ++ pretty ident) $ do
@@ -706,10 +706,10 @@ checkSubExp (Var ident) = context ("In subexp " ++ pretty ident) $ do
   lookupType ident
 
 checkStms ::
-  Checkable lore =>
-  Stms (Aliases lore) ->
-  TypeM lore a ->
-  TypeM lore a
+  Checkable rep =>
+  Stms (Aliases rep) ->
+  TypeM rep a ->
+  TypeM rep a
 checkStms origbnds m = delve $ stmsToList origbnds
   where
     delve (stm@(Let pat _ e) : bnds) = do
@@ -721,18 +721,18 @@ checkStms origbnds m = delve $ stmsToList origbnds
       m
 
 checkResult ::
-  Checkable lore =>
+  Checkable rep =>
   Result ->
-  TypeM lore ()
+  TypeM rep ()
 checkResult = mapM_ checkSubExp
 
 checkFunBody ::
-  Checkable lore =>
-  [RetType lore] ->
-  Body (Aliases lore) ->
-  TypeM lore [Names]
-checkFunBody rt (Body (_, lore) bnds res) = do
-  checkBodyLore lore
+  Checkable rep =>
+  [RetType rep] ->
+  Body (Aliases rep) ->
+  TypeM rep [Names]
+checkFunBody rt (Body (_, rep) bnds res) = do
+  checkBodyDec rep
   checkStms bnds $ do
     context "When checking body result" $ checkResult res
     context "When matching declared return type to result of body" $
@@ -742,12 +742,12 @@ checkFunBody rt (Body (_, lore) bnds res) = do
     bound_here = namesFromList $ M.keys $ scopeOf bnds
 
 checkLambdaBody ::
-  Checkable lore =>
+  Checkable rep =>
   [Type] ->
-  Body (Aliases lore) ->
-  TypeM lore [Names]
-checkLambdaBody ret (Body (_, lore) bnds res) = do
-  checkBodyLore lore
+  Body (Aliases rep) ->
+  TypeM rep [Names]
+checkLambdaBody ret (Body (_, rep) bnds res) = do
+  checkBodyDec rep
   checkStms bnds $ do
     checkLambdaResult ret res
     map (`namesSubtract` bound_here) <$> mapM subExpAliasesM res
@@ -755,10 +755,10 @@ checkLambdaBody ret (Body (_, lore) bnds res) = do
     bound_here = namesFromList $ M.keys $ scopeOf bnds
 
 checkLambdaResult ::
-  Checkable lore =>
+  Checkable rep =>
   [Type] ->
   Result ->
-  TypeM lore ()
+  TypeM rep ()
 checkLambdaResult ts es
   | length ts /= length es =
     bad $
@@ -780,18 +780,18 @@ checkLambdaResult ts es
             ++ pretty t
 
 checkBody ::
-  Checkable lore =>
-  Body (Aliases lore) ->
-  TypeM lore [Names]
-checkBody (Body (_, lore) bnds res) = do
-  checkBodyLore lore
+  Checkable rep =>
+  Body (Aliases rep) ->
+  TypeM rep [Names]
+checkBody (Body (_, rep) bnds res) = do
+  checkBodyDec rep
   checkStms bnds $ do
     checkResult res
     map (`namesSubtract` bound_here) <$> mapM subExpAliasesM res
   where
     bound_here = namesFromList $ M.keys $ scopeOf bnds
 
-checkBasicOp :: Checkable lore => BasicOp -> TypeM lore ()
+checkBasicOp :: Checkable rep => BasicOp -> TypeM rep ()
 checkBasicOp (SubExp es) =
   void $ checkSubExp es
 checkBasicOp (Opaque es) =
@@ -934,11 +934,11 @@ checkBasicOp (UpdateAcc acc is ses) = do
   consume =<< lookupAliases acc
 
 matchLoopResultExt ::
-  Checkable lore =>
+  Checkable rep =>
   [Param DeclType] ->
   [Param DeclType] ->
   [SubExp] ->
-  TypeM lore ()
+  TypeM rep ()
 matchLoopResultExt ctx val loopres = do
   let rettype_ext =
         existentialiseExtTypes (map paramName ctx) $
@@ -962,9 +962,9 @@ matchLoopResultExt ctx val loopres = do
             (staticShapes bodyt)
 
 checkExp ::
-  Checkable lore =>
-  Exp (Aliases lore) ->
-  TypeM lore ()
+  Checkable rep =>
+  Exp (Aliases rep) ->
+  TypeM rep ()
 checkExp (BasicOp op) = checkBasicOp op
 checkExp (If e1 e2 e3 info) = do
   require [Prim Bool] e1
@@ -1016,7 +1016,7 @@ checkExp (DoLoop ctxmerge valmerge form loopbody) = do
         (Just consumable)
         $ do
           checkFunParams mergepat
-          checkBodyLore $ snd $ bodyDec loopbody
+          checkBodyDec $ snd $ bodyDec loopbody
 
           checkStms (bodyStms loopbody) $ do
             checkResult $ bodyResult loopbody
@@ -1037,7 +1037,7 @@ checkExp (DoLoop ctxmerge valmerge form loopbody) = do
       observe a
       case peelArray 1 a_t of
         Just a_t_r -> do
-          checkLParamLore (paramName p) $ paramDec p
+          checkLParamDec (paramName p) $ paramDec p
           unless (a_t_r `subtypeOf` typeOf (paramDec p)) $
             bad $
               TypeError $
@@ -1127,10 +1127,10 @@ checkExp (Op op) = do
   checker op
 
 checkSOACArrayArgs ::
-  Checkable lore =>
+  Checkable rep =>
   SubExp ->
   [VName] ->
-  TypeM lore [Arg]
+  TypeM rep [Arg]
 checkSOACArrayArgs width = mapM checkSOACArrayArg
   where
     checkSOACArrayArg v = do
@@ -1151,9 +1151,9 @@ checkSOACArrayArgs width = mapM checkSOACArrayArg
             "SOAC argument " ++ pretty v ++ " is not an array"
 
 checkType ::
-  Checkable lore =>
+  Checkable rep =>
   TypeBase Shape u ->
-  TypeM lore ()
+  TypeM rep ()
 checkType (Mem (ScalarSpace d _)) = mapM_ (require [Prim int64]) d
 checkType (Acc cert shape ts _) = do
   requireI [Prim Unit] cert
@@ -1162,20 +1162,20 @@ checkType (Acc cert shape ts _) = do
 checkType t = mapM_ checkSubExp $ arrayDims t
 
 checkExtType ::
-  Checkable lore =>
+  Checkable rep =>
   TypeBase ExtShape u ->
-  TypeM lore ()
+  TypeM rep ()
 checkExtType = mapM_ checkExtDim . shapeDims . arrayShape
   where
     checkExtDim (Free se) = void $ checkSubExp se
     checkExtDim (Ext _) = return ()
 
 checkCmpOp ::
-  Checkable lore =>
+  Checkable rep =>
   CmpOp ->
   SubExp ->
   SubExp ->
-  TypeM lore ()
+  TypeM rep ()
 checkCmpOp (CmpEq t) x y = do
   require [Prim t] x
   require [Prim t] y
@@ -1189,38 +1189,38 @@ checkCmpOp CmpLlt x y = checkBinOpArgs Bool x y
 checkCmpOp CmpLle x y = checkBinOpArgs Bool x y
 
 checkBinOpArgs ::
-  Checkable lore =>
+  Checkable rep =>
   PrimType ->
   SubExp ->
   SubExp ->
-  TypeM lore ()
+  TypeM rep ()
 checkBinOpArgs t e1 e2 = do
   require [Prim t] e1
   require [Prim t] e2
 
 checkPatElem ::
-  Checkable lore =>
-  PatElemT (LetDec lore) ->
-  TypeM lore ()
+  Checkable rep =>
+  PatElemT (LetDec rep) ->
+  TypeM rep ()
 checkPatElem (PatElem name dec) =
   context ("When checking pattern element " ++ pretty name) $
-    checkLetBoundLore name dec
+    checkLetBoundDec name dec
 
 checkDimIndex ::
-  Checkable lore =>
+  Checkable rep =>
   DimIndex SubExp ->
-  TypeM lore ()
+  TypeM rep ()
 checkDimIndex (DimFix i) = require [Prim int64] i
 checkDimIndex (DimSlice i n s) = mapM_ (require [Prim int64]) [i, n, s]
 
 checkStm ::
-  Checkable lore =>
-  Stm (Aliases lore) ->
-  TypeM lore a ->
-  TypeM lore a
+  Checkable rep =>
+  Stm (Aliases rep) ->
+  TypeM rep a ->
+  TypeM rep a
 checkStm stm@(Let pat (StmAux (Certificates cs) _ (_, dec)) e) m = do
   context "When checking certificates" $ mapM_ (requireI [Prim Unit]) cs
-  context "When checking expression annotation" $ checkExpLore dec
+  context "When checking expression annotation" $ checkExpDec dec
   context ("When matching\n" ++ message "  " pat ++ "\nwith\n" ++ message "  " e) $
     matchPattern pat e
   binding (maybeWithoutAliases $ scopeOf stm) $ do
@@ -1242,37 +1242,37 @@ checkStm stm@(Let pat (StmAux (Certificates cs) _ (_, dec)) e) m = do
     withoutAliases info = info
 
 matchExtPattern ::
-  Checkable lore =>
-  Pattern (Aliases lore) ->
+  Checkable rep =>
+  Pattern (Aliases rep) ->
   [ExtType] ->
-  TypeM lore ()
+  TypeM rep ()
 matchExtPattern pat ts =
   unless (expExtTypesFromPattern pat == ts) $
     bad $ InvalidPatternError pat ts Nothing
 
 matchExtReturnType ::
-  Checkable lore =>
+  Checkable rep =>
   [ExtType] ->
   Result ->
-  TypeM lore ()
+  TypeM rep ()
 matchExtReturnType rettype res = do
   ts <- mapM subExpType res
   matchExtReturns rettype res ts
 
 matchExtBranchType ::
-  Checkable lore =>
+  Checkable rep =>
   [ExtType] ->
-  Body (Aliases lore) ->
-  TypeM lore ()
+  Body (Aliases rep) ->
+  TypeM rep ()
 matchExtBranchType rettype (Body _ stms res) = do
   ts <- extendedScope (traverse subExpType res) stmscope
   matchExtReturns rettype res ts
   where
     stmscope = scopeOf stms
 
-matchExtReturns :: [ExtType] -> Result -> [Type] -> TypeM lore ()
+matchExtReturns :: [ExtType] -> Result -> [Type] -> TypeM rep ()
 matchExtReturns rettype res ts = do
-  let problem :: TypeM lore a
+  let problem :: TypeM rep a
       problem =
         bad $
           TypeError $
@@ -1337,9 +1337,9 @@ noArgAliases :: Arg -> Arg
 noArgAliases (t, _) = (t, mempty)
 
 checkArg ::
-  Checkable lore =>
+  Checkable rep =>
   SubExp ->
-  TypeM lore Arg
+  TypeM rep Arg
 checkArg arg = do
   argt <- checkSubExp arg
   als <- subExpAliasesM arg
@@ -1349,7 +1349,7 @@ checkFuncall ::
   Maybe Name ->
   [DeclType] ->
   [Arg] ->
-  TypeM lore ()
+  TypeM rep ()
 checkFuncall fname paramts args = do
   let argts = map argType args
   unless (validApply paramts argts) $
@@ -1359,7 +1359,7 @@ checkFuncall fname paramts args = do
 consumeArgs ::
   [DeclType] ->
   [Arg] ->
-  TypeM lore ()
+  TypeM rep ()
 consumeArgs paramts args =
   forM_ (zip (map diet paramts) args) $ \(d, (_, als)) ->
     occur [consumption (consumeArg als d)]
@@ -1370,7 +1370,7 @@ consumeArgs paramts args =
 -- The boolean indicates whether we only allow consumption of
 -- parameters.
 checkAnyLambda ::
-  Checkable lore => Bool -> Lambda (Aliases lore) -> [Arg] -> TypeM lore ()
+  Checkable rep => Bool -> Lambda (Aliases rep) -> [Arg] -> TypeM rep ()
 checkAnyLambda soac (Lambda params body rettype) args = do
   let fname = nameFromString "<anonymous>"
   if length params == length args
@@ -1407,10 +1407,10 @@ checkAnyLambda soac (Lambda params body rettype) args = do
             ++ show (length args)
             ++ " arguments."
 
-checkLambda :: Checkable lore => Lambda (Aliases lore) -> [Arg] -> TypeM lore ()
+checkLambda :: Checkable rep => Lambda (Aliases rep) -> [Arg] -> TypeM rep ()
 checkLambda = checkAnyLambda True
 
-checkPrimExp :: Checkable lore => PrimExp VName -> TypeM lore ()
+checkPrimExp :: Checkable rep => PrimExp VName -> TypeM rep ()
 checkPrimExp ValueExp {} = return ()
 checkPrimExp (LeafExp v pt) = requireI [Prim pt] v
 checkPrimExp (BinOpExp op x y) = do
@@ -1442,7 +1442,7 @@ checkPrimExp (FunExp h args t) = do
           ++ pretty h_ret
   zipWithM_ requirePrimExp h_ts args
 
-requirePrimExp :: Checkable lore => PrimType -> PrimExp VName -> TypeM lore ()
+requirePrimExp :: Checkable rep => PrimType -> PrimExp VName -> TypeM rep ()
 requirePrimExp t e = context ("in PrimExp " ++ pretty e) $ do
   checkPrimExp e
   unless (primExpType e == t) $
@@ -1450,62 +1450,62 @@ requirePrimExp t e = context ("in PrimExp " ++ pretty e) $ do
       TypeError $
         pretty e ++ " must have type " ++ pretty t
 
-class ASTLore lore => CheckableOp lore where
-  checkOp :: OpWithAliases (Op lore) -> TypeM lore ()
+class ASTRep rep => CheckableOp rep where
+  checkOp :: OpWithAliases (Op rep) -> TypeM rep ()
   -- ^ Used at top level; can be locally changed with 'checkOpWith'.
 
--- | The class of lores that can be type-checked.
-class (ASTLore lore, CanBeAliased (Op lore), CheckableOp lore) => Checkable lore where
-  checkExpLore :: ExpDec lore -> TypeM lore ()
-  checkBodyLore :: BodyDec lore -> TypeM lore ()
-  checkFParamLore :: VName -> FParamInfo lore -> TypeM lore ()
-  checkLParamLore :: VName -> LParamInfo lore -> TypeM lore ()
-  checkLetBoundLore :: VName -> LetDec lore -> TypeM lore ()
-  checkRetType :: [RetType lore] -> TypeM lore ()
-  matchPattern :: Pattern (Aliases lore) -> Exp (Aliases lore) -> TypeM lore ()
-  primFParam :: VName -> PrimType -> TypeM lore (FParam (Aliases lore))
-  matchReturnType :: [RetType lore] -> Result -> TypeM lore ()
-  matchBranchType :: [BranchType lore] -> Body (Aliases lore) -> TypeM lore ()
+-- | The class of representations that can be type-checked.
+class (ASTRep rep, CanBeAliased (Op rep), CheckableOp rep) => Checkable rep where
+  checkExpDec :: ExpDec rep -> TypeM rep ()
+  checkBodyDec :: BodyDec rep -> TypeM rep ()
+  checkFParamDec :: VName -> FParamInfo rep -> TypeM rep ()
+  checkLParamDec :: VName -> LParamInfo rep -> TypeM rep ()
+  checkLetBoundDec :: VName -> LetDec rep -> TypeM rep ()
+  checkRetType :: [RetType rep] -> TypeM rep ()
+  matchPattern :: Pattern (Aliases rep) -> Exp (Aliases rep) -> TypeM rep ()
+  primFParam :: VName -> PrimType -> TypeM rep (FParam (Aliases rep))
+  matchReturnType :: [RetType rep] -> Result -> TypeM rep ()
+  matchBranchType :: [BranchType rep] -> Body (Aliases rep) -> TypeM rep ()
   matchLoopResult ::
-    [FParam (Aliases lore)] ->
-    [FParam (Aliases lore)] ->
+    [FParam (Aliases rep)] ->
+    [FParam (Aliases rep)] ->
     [SubExp] ->
-    TypeM lore ()
+    TypeM rep ()
 
-  default checkExpLore :: ExpDec lore ~ () => ExpDec lore -> TypeM lore ()
-  checkExpLore = return
+  default checkExpDec :: ExpDec rep ~ () => ExpDec rep -> TypeM rep ()
+  checkExpDec = return
 
-  default checkBodyLore :: BodyDec lore ~ () => BodyDec lore -> TypeM lore ()
-  checkBodyLore = return
+  default checkBodyDec :: BodyDec rep ~ () => BodyDec rep -> TypeM rep ()
+  checkBodyDec = return
 
-  default checkFParamLore :: FParamInfo lore ~ DeclType => VName -> FParamInfo lore -> TypeM lore ()
-  checkFParamLore _ = checkType
+  default checkFParamDec :: FParamInfo rep ~ DeclType => VName -> FParamInfo rep -> TypeM rep ()
+  checkFParamDec _ = checkType
 
-  default checkLParamLore :: LParamInfo lore ~ Type => VName -> LParamInfo lore -> TypeM lore ()
-  checkLParamLore _ = checkType
+  default checkLParamDec :: LParamInfo rep ~ Type => VName -> LParamInfo rep -> TypeM rep ()
+  checkLParamDec _ = checkType
 
-  default checkLetBoundLore :: LetDec lore ~ Type => VName -> LetDec lore -> TypeM lore ()
-  checkLetBoundLore _ = checkType
+  default checkLetBoundDec :: LetDec rep ~ Type => VName -> LetDec rep -> TypeM rep ()
+  checkLetBoundDec _ = checkType
 
-  default checkRetType :: RetType lore ~ DeclExtType => [RetType lore] -> TypeM lore ()
+  default checkRetType :: RetType rep ~ DeclExtType => [RetType rep] -> TypeM rep ()
   checkRetType = mapM_ $ checkExtType . declExtTypeOf
 
-  default matchPattern :: Pattern (Aliases lore) -> Exp (Aliases lore) -> TypeM lore ()
+  default matchPattern :: Pattern (Aliases rep) -> Exp (Aliases rep) -> TypeM rep ()
   matchPattern pat = matchExtPattern pat <=< expExtType
 
-  default primFParam :: FParamInfo lore ~ DeclType => VName -> PrimType -> TypeM lore (FParam (Aliases lore))
+  default primFParam :: FParamInfo rep ~ DeclType => VName -> PrimType -> TypeM rep (FParam (Aliases rep))
   primFParam name t = return $ Param name (Prim t)
 
-  default matchReturnType :: RetType lore ~ DeclExtType => [RetType lore] -> Result -> TypeM lore ()
+  default matchReturnType :: RetType rep ~ DeclExtType => [RetType rep] -> Result -> TypeM rep ()
   matchReturnType = matchExtReturnType . map fromDecl
 
-  default matchBranchType :: BranchType lore ~ ExtType => [BranchType lore] -> Body (Aliases lore) -> TypeM lore ()
+  default matchBranchType :: BranchType rep ~ ExtType => [BranchType rep] -> Body (Aliases rep) -> TypeM rep ()
   matchBranchType = matchExtBranchType
 
   default matchLoopResult ::
-    FParamInfo lore ~ DeclType =>
-    [FParam (Aliases lore)] ->
-    [FParam (Aliases lore)] ->
+    FParamInfo rep ~ DeclType =>
+    [FParam (Aliases rep)] ->
+    [FParam (Aliases rep)] ->
     [SubExp] ->
-    TypeM lore ()
+    TypeM rep ()
   matchLoopResult = matchLoopResultExt


### PR DESCRIPTION
Specific changes:

* Decorations is now RepTypes.

* ASTLore is now ASTRep.

* The 'lore' type parameter is now generally named 'rep'.

Various other small follow-on renames.  In some cases, the "Lore"
suffix becomes "Dec" for "decoration".