### PR TITLE
Support scatter-like bounds checking for Update.

### DIFF
--- a/src/Futhark/Analysis/UsageTable.hs
+++ b/src/Futhark/Analysis/UsageTable.hs
@@ -181,7 +181,7 @@ usageInExp (WithAcc inputs lam) =
   foldMap inputUsage inputs <> usageInBody (lambdaBody lam)
   where
     inputUsage (_, arrs, _) = foldMap consumedUsage arrs
-usageInExp (BasicOp (Update src _ _)) =
+usageInExp (BasicOp (Update _ src _ _)) =
   consumedUsage src
 usageInExp (Op op) =
   mconcat $ map consumedUsage (namesToList $ consumedInOp op)

--- a/src/Futhark/IR/Mem.hs
+++ b/src/Futhark/IR/Mem.hs
@@ -1085,7 +1085,7 @@ expReturns (BasicOp (Index v slice)) = do
     MemPrim pt -> return [MemPrim pt]
     MemAcc acc ispace ts u -> return [MemAcc acc ispace ts u]
     MemMem space -> return [MemMem space]
-expReturns (BasicOp (Update v _ _)) =
+expReturns (BasicOp (Update _ v _ _)) =
   pure <$> varReturns v
 expReturns (BasicOp op) =
   extReturns . staticShapes <$> primOpType op

--- a/src/Futhark/IR/Parse.hs
+++ b/src/Futhark/IR/Parse.hs
@@ -283,8 +283,9 @@ pBasicOp =
           Concat d <$> pVName <*> many (pComma *> pVName) <*> pure w,
       pIota,
       try $
-        Update
+        flip Update
           <$> pVName <* keyword "with"
+          <*> choice [lexeme "?" $> Safe, pure Unsafe]
           <*> pSlice <* lexeme "="
           <*> pSubExp,
       ArrayLit

--- a/src/Futhark/IR/Pretty.hs
+++ b/src/Futhark/IR/Pretty.hs
@@ -177,10 +177,14 @@ instance Pretty BasicOp where
   ppr (UnOp op e) = ppr op <+> pprPrec 9 e
   ppr (Index v idxs) =
     ppr v <> brackets (commasep (map ppr idxs))
-  ppr (Update src idxs se) =
-    ppr src <+> text "with" <+> brackets (commasep (map ppr idxs))
+  ppr (Update safety src idxs se) =
+    ppr src <+> with <+> brackets (commasep (map ppr idxs))
       <+> text "="
       <+> ppr se
+    where
+      with = case safety of
+        Unsafe -> text "with"
+        Safe -> text "with?"
   ppr (Iota e x s et) = text "iota" <> et' <> apply [ppr e, ppr x, ppr s]
     where
       et' = text $ show $ primBitSize $ IntType et

--- a/src/Futhark/IR/Prop/Aliases.hs
+++ b/src/Futhark/IR/Prop/Aliases.hs
@@ -166,7 +166,7 @@ consumedInExp (WithAcc inputs lam) =
        )
   where
     inputConsumed (_, arrs, _) = namesFromList arrs
-consumedInExp (BasicOp (Update src _ _)) = oneName src
+consumedInExp (BasicOp (Update _ src _ _)) = oneName src
 consumedInExp (BasicOp (UpdateAcc acc _ _)) = oneName acc
 consumedInExp (BasicOp _) = mempty
 consumedInExp (Op op) = consumedInOp op

--- a/src/Futhark/IR/Prop/TypeOf.hs
+++ b/src/Futhark/IR/Prop/TypeOf.hs
@@ -82,7 +82,7 @@ primOpType (Index ident slice) =
     shape = Shape $ mapMaybe dimSize slice
     dimSize (DimSlice _ d _) = Just d
     dimSize DimFix {} = Nothing
-primOpType (Update src _ _) =
+primOpType (Update _ src _ _) =
   pure <$> lookupType src
 primOpType (Iota n _ _ et) =
   pure [arrayOf (Prim (IntType et)) (Shape [n]) NoUniqueness]

--- a/src/Futhark/IR/Syntax.hs
+++ b/src/Futhark/IR/Syntax.hs
@@ -367,8 +367,9 @@ data BasicOp
     -- | The certificates for bounds-checking are part of the 'Stm'.
     Index VName (Slice SubExp)
   | -- | An in-place update of the given array at the given position.
-    -- Consumes the array.
-    Update VName (Slice SubExp) SubExp
+    -- Consumes the array.  If 'Safe', perform a run-time bounds check
+    -- and ignore the write if out of bounds (like @Scatter@).
+    Update Safety VName (Slice SubExp) SubExp
   | -- | @concat@0([1],[2, 3, 4]) = [1, 2, 3, 4]@.
     Concat Int VName [VName] SubExp
   | -- | Copy the given array.  The result will not alias anything.

--- a/src/Futhark/IR/Traversals.hs
+++ b/src/Futhark/IR/Traversals.hs
@@ -108,9 +108,9 @@ mapExpM tv (BasicOp (Index arr slice)) =
     <$> ( Index <$> mapOnVName tv arr
             <*> mapM (traverse (mapOnSubExp tv)) slice
         )
-mapExpM tv (BasicOp (Update arr slice se)) =
+mapExpM tv (BasicOp (Update safety arr slice se)) =
   BasicOp
-    <$> ( Update <$> mapOnVName tv arr
+    <$> ( Update safety <$> mapOnVName tv arr
             <*> mapM (traverse (mapOnSubExp tv)) slice
             <*> mapOnSubExp tv se
         )
@@ -284,7 +284,7 @@ walkExpM tv (Apply _ args ret _) =
   mapM_ (walkOnSubExp tv . fst) args >> mapM_ (walkOnRetType tv) ret
 walkExpM tv (BasicOp (Index arr slice)) =
   walkOnVName tv arr >> mapM_ (traverse_ (walkOnSubExp tv)) slice
-walkExpM tv (BasicOp (Update arr slice se)) =
+walkExpM tv (BasicOp (Update _ arr slice se)) =
   walkOnVName tv arr
     >> mapM_ (traverse_ (walkOnSubExp tv)) slice
     >> walkOnSubExp tv se

--- a/src/Futhark/Optimise/BlkRegTiling.hs
+++ b/src/Futhark/Optimise/BlkRegTiling.hs
@@ -439,7 +439,7 @@ update se_desc arr indices new_elem = update' se_desc arr indices (Var new_elem)
 
 update' :: MonadBuilder m => String -> VName -> [VName] -> SubExp -> m VName
 update' se_desc arr indices new_elem =
-  letExp se_desc $ BasicOp $ Update arr (map (DimFix . Var) indices) new_elem
+  letExp se_desc $ BasicOp $ Update Unsafe arr (map (DimFix . Var) indices) new_elem
 
 forLoop' ::
   SubExp -> -- loop var
@@ -929,7 +929,7 @@ doRegTiling3D (Let pat aux (Op (SegOp old_kernel)))
                   forLoop rz [rss_init] $ \i [rss] -> do
                     let slice = [DimFix $ Var i, DimFix se0, DimFix se0]
                     thread_res <- index "thread_res" res [ltid_y, ltid_x, i]
-                    rss' <- letSubExp "rss" $ BasicOp $ Update rss slice $ Var thread_res
+                    rss' <- letSubExp "rss" $ BasicOp $ Update Unsafe rss slice $ Var thread_res
                     resultBodyM [rss']
             else segMap3D "rssss" segthd_lvl ResultPrivate (se1, ty, tx) $ \(_ltid_z, ltid_y, ltid_x) -> do
               letBindNames [gtid_y] =<< toExp (le64 jj1 + le64 ltid_y)
@@ -957,7 +957,7 @@ doRegTiling3D (Let pat aux (Op (SegOp old_kernel)))
                       (eBody $ map eBlank kertp)
                 rss' <- forM (zip res_els rss_merge) $ \(res_el, rs_merge) -> do
                   let slice = [DimFix $ Var i, DimFix se0, DimFix se0]
-                  letSubExp "rss" $ BasicOp $ Update rs_merge slice res_el
+                  letSubExp "rss" $ BasicOp $ Update Unsafe rs_merge slice res_el
                 resultBodyM rss'
               return $ map Var rss
 

--- a/src/Futhark/Optimise/Fusion.hs
+++ b/src/Futhark/Optimise/Fusion.hs
@@ -148,7 +148,7 @@ updateKerInPlaces res (ip_vs, other_infuse_vs) = do
   return res' {kernels = M.map inspectKer $ kernels res'}
 
 checkForUpdates :: FusedRes -> Exp -> FusionGM FusedRes
-checkForUpdates res (BasicOp (Update src is _)) = do
+checkForUpdates res (BasicOp (Update _ src is _)) = do
   let ifvs = namesToList $ mconcat $ map freeIn is
   updateKerInPlaces res ([src], ifvs)
 checkForUpdates res (Op (Futhark.Scatter _ _ _ written_info)) = do

--- a/src/Futhark/Optimise/InPlaceLowering.hs
+++ b/src/Futhark/Optimise/InPlaceLowering.hs
@@ -175,7 +175,7 @@ optimiseStms (bnd : bnds) m = do
 
     checkIfForwardableUpdate (Let pat (StmAux cs _ _) e)
       | Pattern [] [PatElem v dec] <- pat,
-        BasicOp (Update src slice (Var ve)) <- e =
+        BasicOp (Update Unsafe src slice (Var ve)) <- e =
         maybeForward ve v dec cs src slice
     checkIfForwardableUpdate _ = return ()
 

--- a/src/Futhark/Optimise/InPlaceLowering/LowerIntoStm.hs
+++ b/src/Futhark/Optimise/InPlaceLowering/LowerIntoStm.hs
@@ -71,7 +71,7 @@ lowerUpdate
             return
               [ certify (stmAuxCerts aux <> cs) $
                   mkLet [] [Ident bindee_nm $ typeOf bindee_dec] $
-                    BasicOp $ Update v is' $ Var val
+                    BasicOp $ Update Unsafe v is' $ Var val
               ]
 lowerUpdate _ _ _ =
   Nothing
@@ -256,18 +256,17 @@ lowerUpdateIntoLoop scope updates pat ctx val form body = do
                 (updateValue update)
                 (source_t `setArrayDims` sliceDims (updateIndices update))
         tell
-          ( [ mkLet [] [Ident source source_t] $
-                BasicOp $
-                  Update
-                    (updateSource update)
-                    (fullSlice source_t $ updateIndices update)
-                    $ snd $ mergeParam summary
+          ( [ mkLet [] [Ident source source_t] . BasicOp $
+                Update
+                  Unsafe
+                  (updateSource update)
+                  (fullSlice source_t $ updateIndices update)
+                  $ snd $ mergeParam summary
             ],
-            [ mkLet [] [elmident] $
-                BasicOp $
-                  Index
-                    (updateName update)
-                    (fullSlice source_t $ updateIndices update)
+            [ mkLet [] [elmident] . BasicOp $
+                Index
+                  (updateName update)
+                  (fullSlice source_t $ updateIndices update)
             ]
           )
         return $
@@ -373,9 +372,7 @@ manipulateResult summaries substs = do
     substRes res_se (_, (cs, nm, dec, is)) = do
       v' <- newIdent' (++ "_updated") $ Ident nm $ typeOf dec
       tell
-        [ certify cs $
-            mkLet [] [v'] $
-              BasicOp $
-                Update nm (fullSlice (typeOf dec) is) res_se
+        [ certify cs . mkLet [] [v'] . BasicOp $
+            Update Unsafe nm (fullSlice (typeOf dec) is) res_se
         ]
       return $ Var $ identName v'

--- a/src/Futhark/Optimise/Simplify/Rules/Simple.hs
+++ b/src/Futhark/Optimise/Simplify/Rules/Simple.hs
@@ -309,13 +309,13 @@ simplifyReshapeIndex _ _ _ = Nothing
 -- If we are updating a slice with the result of a size coercion, we
 -- instead use the original array and update the slice dimensions.
 simplifyUpdateReshape :: SimpleRule rep
-simplifyUpdateReshape defOf seType (Update dest slice (Var v))
+simplifyUpdateReshape defOf seType (Update safety dest slice (Var v))
   | Just (BasicOp (Reshape newshape v'), v_cs) <- defOf v,
     Just _ <- shapeCoercion newshape,
     Just ds <- arrayDims <$> seType (Var v'),
     slice' <- reshapeSlice slice ds,
     slice' /= slice =
-    Just (Update dest slice' $ Var v', v_cs)
+    Just (Update safety dest slice' $ Var v', v_cs)
 simplifyUpdateReshape _ _ _ = Nothing
 
 improveReshape :: SimpleRule rep

--- a/src/Futhark/Pass/ExtractKernels/DistributeNests.hs
+++ b/src/Futhark/Pass/ExtractKernels/DistributeNests.hs
@@ -619,7 +619,7 @@ maybeDistributeStm stm@(Let _ aux (BasicOp (Rotate rots stm_arr))) acc =
   distributeSingleUnaryStm acc stm stm_arr $ \nest outerpat arr -> do
     let rots' = map (const $ intConst Int64 0) (kernelNestWidths nest) ++ rots
     return $ oneStm $ Let outerpat aux $ BasicOp $ Rotate rots' arr
-maybeDistributeStm stm@(Let pat aux (BasicOp (Update arr slice (Var v)))) acc
+maybeDistributeStm stm@(Let pat aux (BasicOp (Update _ arr slice (Var v)))) acc
   | not $ null $ sliceDims slice =
     distributeSingleStm acc stm >>= \case
       Just (kernels, res, nest, acc')

--- a/src/Futhark/TypeCheck.hs
+++ b/src/Futhark/TypeCheck.hs
@@ -824,7 +824,7 @@ checkBasicOp (Index ident idxes) = do
   when (arrayRank vt /= length idxes) $
     bad $ SlicingError (arrayRank vt) (length idxes)
   mapM_ checkDimIndex idxes
-checkBasicOp (Update src idxes se) = do
+checkBasicOp (Update _ src idxes se) = do
   src_t <- checkArrIdent src
   when (arrayRank src_t /= length idxes) $
     bad $ SlicingError (arrayRank src_t) (length idxes)


### PR DESCRIPTION
Useful for AD and also makes sequentialisation of scatter nicer.  Not
exposed in source language for now.