### PR TITLE
Remove "context" part of patterns.

### DIFF
--- a/src/Futhark/Analysis/Metrics.hs
+++ b/src/Futhark/Analysis/Metrics.hs
@@ -101,9 +101,9 @@ stmMetrics = expMetrics . stmExp
 expMetrics :: OpMetrics (Op rep) => Exp rep -> MetricsM ()
 expMetrics (BasicOp op) =
   seen "BasicOp" >> primOpMetrics op
-expMetrics (DoLoop _ _ ForLoop {} body) =
+expMetrics (DoLoop _ ForLoop {} body) =
   inside "DoLoop" $ seen "ForLoop" >> bodyMetrics body
-expMetrics (DoLoop _ _ WhileLoop {} body) =
+expMetrics (DoLoop _ WhileLoop {} body) =
   inside "DoLoop" $ seen "WhileLoop" >> bodyMetrics body
 expMetrics (If _ tb fb _) =
   inside "If" $ do

--- a/src/Futhark/Analysis/SymbolTable.hs
+++ b/src/Futhark/Analysis/SymbolTable.hs
@@ -279,9 +279,8 @@ index' name is vtable = do
   case entryType entry of
     LetBound entry'
       | Just k <-
-          elemIndex name $
-            patternValueNames $
-              stmPattern $ letBoundStm entry' ->
+          elemIndex name . patternNames . stmPattern $
+            letBoundStm entry' ->
         letBoundIndex entry' k is
     FreeVar entry' ->
       freeVarIndex entry' name is

--- a/src/Futhark/Builder/Class.hs
+++ b/src/Futhark/Builder/Class.hs
@@ -42,7 +42,7 @@ class
   ) =>
   Buildable rep
   where
-  mkExpPat :: [Ident] -> [Ident] -> Exp rep -> Pattern rep
+  mkExpPat :: [Ident] -> Exp rep -> Pattern rep
   mkExpDec :: Pattern rep -> Exp rep -> ExpDec rep
   mkBody :: Stms rep -> Result -> Body rep
   mkLetNames ::
@@ -135,17 +135,17 @@ letBind pat e =
 
 -- | Construct a 'Stm' from identifiers for the context- and value
 -- part of the pattern, as well as the expression.
-mkLet :: Buildable rep => [Ident] -> [Ident] -> Exp rep -> Stm rep
-mkLet ctx val e =
-  let pat = mkExpPat ctx val e
+mkLet :: Buildable rep => [Ident] -> Exp rep -> Stm rep
+mkLet ids e =
+  let pat = mkExpPat ids e
       dec = mkExpDec pat e
    in Let pat (defAux dec) e
 
 -- | Like mkLet, but also take attributes and certificates from the
 -- given 'StmAux'.
-mkLet' :: Buildable rep => [Ident] -> [Ident] -> StmAux a -> Exp rep -> Stm rep
-mkLet' ctx val (StmAux cs attrs _) e =
-  let pat = mkExpPat ctx val e
+mkLet' :: Buildable rep => [Ident] -> StmAux a -> Exp rep -> Stm rep
+mkLet' ids (StmAux cs attrs _) e =
+  let pat = mkExpPat ids e
       dec = mkExpDec pat e
    in Let pat (StmAux cs attrs dec) e
 

--- a/src/Futhark/CodeGen/ImpGen/GPU.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU.hs
@@ -100,19 +100,19 @@ opCompiler ::
   CallKernelGen ()
 opCompiler dest (Alloc e space) =
   compileAlloc dest e space
-opCompiler (Pattern _ [pe]) (Inner (SizeOp (GetSize key size_class))) = do
+opCompiler (Pattern [pe]) (Inner (SizeOp (GetSize key size_class))) = do
   fname <- askFunction
   sOp $
     Imp.GetSize (patElemName pe) (keyWithEntryPoint fname key) $
       sizeClassWithEntryPoint fname size_class
-opCompiler (Pattern _ [pe]) (Inner (SizeOp (CmpSizeLe key size_class x))) = do
+opCompiler (Pattern [pe]) (Inner (SizeOp (CmpSizeLe key size_class x))) = do
   fname <- askFunction
   let size_class' = sizeClassWithEntryPoint fname size_class
   sOp . Imp.CmpSizeLe (patElemName pe) (keyWithEntryPoint fname key) size_class'
     =<< toExp x
-opCompiler (Pattern _ [pe]) (Inner (SizeOp (GetSizeMax size_class))) =
+opCompiler (Pattern [pe]) (Inner (SizeOp (GetSizeMax size_class))) =
   sOp $ Imp.GetSizeMax (patElemName pe) size_class
-opCompiler (Pattern _ [pe]) (Inner (SizeOp (CalcNumGroups w64 max_num_groups_key group_size))) = do
+opCompiler (Pattern [pe]) (Inner (SizeOp (CalcNumGroups w64 max_num_groups_key group_size))) = do
   fname <- askFunction
   max_num_groups :: TV Int32 <- dPrim "max_num_groups" int32
   sOp $
@@ -226,12 +226,12 @@ withAcc pat inputs lam = do
 
 expCompiler :: ExpCompiler GPUMem HostEnv Imp.HostOp
 -- We generate a simple kernel for itoa and replicate.
-expCompiler (Pattern _ [pe]) (BasicOp (Iota n x s et)) = do
+expCompiler (Pattern [pe]) (BasicOp (Iota n x s et)) = do
   x' <- toExp x
   s' <- toExp s
 
   sIota (patElemName pe) (toInt64Exp n) x' s' et
-expCompiler (Pattern _ [pe]) (BasicOp (Replicate _ se)) =
+expCompiler (Pattern [pe]) (BasicOp (Replicate _ se)) =
   sReplicate (patElemName pe) se
 -- Allocation in the "local" space is just a placeholder.
 expCompiler _ (Op (Alloc _ (Space "local"))) =

--- a/src/Futhark/CodeGen/ImpGen/GPU/SegHist.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/SegHist.hs
@@ -1030,7 +1030,7 @@ compileSegHist ::
   [HistOp GPUMem] ->
   KernelBody GPUMem ->
   CallKernelGen ()
-compileSegHist (Pattern _ pes) num_groups group_size space ops kbody = do
+compileSegHist (Pattern pes) num_groups group_size space ops kbody = do
   -- Most of this function is not the histogram part itself, but
   -- rather figuring out whether to use a local or global memory
   -- strategy, as well as collapsing the subhistograms produced (which
@@ -1138,7 +1138,7 @@ compileSegHist (Pattern _ pes) num_groups group_size space ops kbody = do
                   ++ [(subhistogram_id, Var $ tvVar num_histos)]
 
         let segred_op = SegBinOp Commutative (histOp op) (histNeutral op) mempty
-        compileSegRed' (Pattern [] red_pes) lvl segred_space [segred_op] $ \red_cont ->
+        compileSegRed' (Pattern red_pes) lvl segred_space [segred_op] $ \red_cont ->
           red_cont $
             flip map subhistos $ \subhisto ->
               ( Var subhisto,

--- a/src/Futhark/CodeGen/ImpGen/GPU/SegRed.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/SegRed.hs
@@ -262,7 +262,7 @@ smallSegmentsReduction ::
   [SegBinOp GPUMem] ->
   DoSegBody ->
   CallKernelGen ()
-smallSegmentsReduction (Pattern _ segred_pes) num_groups group_size space reds body = do
+smallSegmentsReduction (Pattern segred_pes) num_groups group_size space reds body = do
   let (gtids, dims) = unzip $ unSegSpace space
       dims' = map toInt64Exp dims
       segment_size = last dims'

--- a/src/Futhark/CodeGen/ImpGen/GPU/SegScan/SinglePass.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/SegScan/SinglePass.hs
@@ -110,7 +110,7 @@ compileSegScan ::
   KernelBody GPUMem ->
   CallKernelGen ()
 compileSegScan pat lvl space scanOp kbody = do
-  let Pattern _ all_pes = pat
+  let Pattern all_pes = pat
       group_size = toInt64Exp <$> segGroupSize lvl
       n = product $ map toInt64Exp $ segSpaceDims space
       num_groups = Count (n `divUp` (unCount group_size * m))

--- a/src/Futhark/CodeGen/ImpGen/GPU/SegScan/TwoPass.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/SegScan/TwoPass.hs
@@ -153,7 +153,7 @@ scanStage1 ::
   [SegBinOp GPUMem] ->
   KernelBody GPUMem ->
   CallKernelGen (TV Int32, Imp.TExp Int64, CrossesSegment)
-scanStage1 (Pattern _ all_pes) num_groups group_size space scans kbody = do
+scanStage1 (Pattern all_pes) num_groups group_size space scans kbody = do
   let num_groups' = fmap toInt64Exp num_groups
       group_size' = fmap toInt64Exp group_size
   num_threads <- dPrimV "num_threads" $ sExt32 $ unCount num_groups' * unCount group_size'
@@ -322,7 +322,7 @@ scanStage2 ::
   SegSpace ->
   [SegBinOp GPUMem] ->
   CallKernelGen ()
-scanStage2 (Pattern _ all_pes) stage1_num_threads elems_per_group num_groups crossesSegment space scans = do
+scanStage2 (Pattern all_pes) stage1_num_threads elems_per_group num_groups crossesSegment space scans = do
   let (gtids, dims) = unzip $ unSegSpace space
       dims' = map toInt64Exp dims
 
@@ -399,7 +399,7 @@ scanStage3 ::
   SegSpace ->
   [SegBinOp GPUMem] ->
   CallKernelGen ()
-scanStage3 (Pattern _ all_pes) num_groups group_size elems_per_group crossesSegment space scans = do
+scanStage3 (Pattern all_pes) num_groups group_size elems_per_group crossesSegment space scans = do
   let num_groups' = fmap toInt64Exp num_groups
       group_size' = fmap toInt64Exp group_size
       (gtids, dims) = unzip $ unSegSpace space

--- a/src/Futhark/CodeGen/ImpGen/Multicore/SegHist.hs
+++ b/src/Futhark/CodeGen/ImpGen/Multicore/SegHist.hs
@@ -101,7 +101,7 @@ atomicHistogram pat flat_idx space histops kbody = do
   let (is, ns) = unzip $ unSegSpace space
       ns_64 = map toInt64Exp ns
   let num_red_res = length histops + sum (map (length . histNeutral) histops)
-      (all_red_pes, map_pes) = splitAt num_red_res $ patternValueElements pat
+      (all_red_pes, map_pes) = splitAt num_red_res $ patternElements pat
 
   atomicOps <- mapM onOpAtomic histops
 
@@ -175,7 +175,7 @@ subHistogram pat flat_idx space histops num_histos kbody = do
   let pes = patternElements pat
       num_red_res = length histops + sum (map (length . histNeutral) histops)
       map_pes = drop num_red_res pes
-      per_red_pes = segHistOpChunks histops $ patternValueElements pat
+      per_red_pes = segHistOpChunks histops $ patternElements pat
 
   -- Allocate array of subhistograms in the calling thread.  Each
   -- tasks will work in its own private allocations (to avoid false
@@ -270,7 +270,7 @@ subHistogram pat flat_idx space histops num_histos kbody = do
         segred_op = SegBinOp Noncommutative (histOp op) (histNeutral op) (histShape op)
 
     nsubtasks_red <- dPrim "num_tasks" $ IntType Int32
-    red_code <- compileSegRed' (Pattern [] red_pes) segred_space [segred_op] nsubtasks_red $ \red_cont ->
+    red_code <- compileSegRed' (Pattern red_pes) segred_space [segred_op] nsubtasks_red $ \red_cont ->
       red_cont $
         flip map hists $ \subhisto ->
           ( Var subhisto,
@@ -318,8 +318,8 @@ compileSegHistBody idx pat space histops kbody = do
       ns_64 = map toInt64Exp ns
 
   let num_red_res = length histops + sum (map (length . histNeutral) histops)
-      map_pes = drop num_red_res $ patternValueElements pat
-      per_red_pes = segHistOpChunks histops $ patternValueElements pat
+      map_pes = drop num_red_res $ patternElements pat
+      per_red_pes = segHistOpChunks histops $ patternElements pat
 
   collect $ do
     let inner_bound = last ns_64

--- a/src/Futhark/CodeGen/ImpGen/Multicore/SegRed.hs
+++ b/src/Futhark/CodeGen/ImpGen/Multicore/SegRed.hs
@@ -169,7 +169,7 @@ reductionStage2 ::
   [SegBinOpSlug] ->
   MulticoreGen ()
 reductionStage2 pat space nsubtasks slugs = do
-  let per_red_pes = segBinOpChunks (map slugOp slugs) $ patternValueElements pat
+  let per_red_pes = segBinOpChunks (map slugOp slugs) $ patternElements pat
       phys_id = Imp.vi64 (segFlat space)
   sComment "neutral-initialise the output" $
     forM_ (zip (map slugOp slugs) per_red_pes) $ \(red, red_res) ->
@@ -226,7 +226,7 @@ compileSegRedBody n_segments pat space reds kbody = do
       inner_bound = last ns_64
       n_segments' = tvExp n_segments
 
-  let per_red_pes = segBinOpChunks reds $ patternValueElements pat
+  let per_red_pes = segBinOpChunks reds $ patternElements pat
   -- Perform sequential reduce on inner most dimension
   collect $ do
     flat_idx <- dPrimVE "flat_idx" $ n_segments' * inner_bound

--- a/src/Futhark/CodeGen/ImpGen/Multicore/SegScan.hs
+++ b/src/Futhark/CodeGen/ImpGen/Multicore/SegScan.hs
@@ -72,7 +72,7 @@ scanStage1 ::
 scanStage1 pat space scan_ops kbody = do
   let (all_scan_res, map_res) = splitAt (segBinOpResults scan_ops) $ kernelBodyResult kbody
       per_scan_res = segBinOpChunks scan_ops all_scan_res
-      per_scan_pes = segBinOpChunks scan_ops $ patternValueElements pat
+      per_scan_pes = segBinOpChunks scan_ops $ patternElements pat
   let (is, ns) = unzip $ unSegSpace space
       ns' = map toInt64Exp ns
   iter <- dPrim "iter" $ IntType Int64
@@ -138,7 +138,7 @@ scanStage2 pat nsubtasks space scan_ops kbody = do
   emit $ Imp.DebugPrint "nonsegmentedScan stage 2" Nothing
   let (is, ns) = unzip $ unSegSpace space
       ns_64 = map toInt64Exp ns
-      per_scan_pes = segBinOpChunks scan_ops $ patternValueElements pat
+      per_scan_pes = segBinOpChunks scan_ops $ patternElements pat
       nsubtasks' = tvExp nsubtasks
 
   dScope Nothing $ scopeOfLParams $ concatMap (lambdaParams . segBinOpLambda) scan_ops
@@ -195,7 +195,7 @@ scanStage3 pat space scan_ops kbody = do
   let (is, ns) = unzip $ unSegSpace space
       all_scan_res = take (segBinOpResults scan_ops) $ kernelBodyResult kbody
       per_scan_res = segBinOpChunks scan_ops all_scan_res
-      per_scan_pes = segBinOpChunks scan_ops $ patternValueElements pat
+      per_scan_pes = segBinOpChunks scan_ops $ patternElements pat
       ns' = map toInt64Exp ns
 
   iter <- dPrimV "iter" (0 :: Imp.TExp Int64)
@@ -276,7 +276,7 @@ compileSegScanBody segment_i pat space scan_ops kbody = do
   let (is, ns) = unzip $ unSegSpace space
       ns_64 = map toInt64Exp ns
 
-  let per_scan_pes = segBinOpChunks scan_ops $ patternValueElements pat
+  let per_scan_pes = segBinOpChunks scan_ops $ patternElements pat
   collect $
     forM_ (zip scan_ops per_scan_pes) $ \(scan_op, scan_pes) -> do
       dScope Nothing $ scopeOfLParams $ lambdaParams $ segBinOpLambda scan_op

--- a/src/Futhark/IR/GPU.hs
+++ b/src/Futhark/IR/GPU.hs
@@ -46,7 +46,7 @@ instance TypeCheck.Checkable GPU
 
 instance Buildable GPU where
   mkBody = Body ()
-  mkExpPat ctx val _ = basicPattern ctx val
+  mkExpPat idents _ = basicPattern idents
   mkExpDec _ _ = ()
   mkLetNames = simpleMkLetNames
 

--- a/src/Futhark/IR/GPUMem.hs
+++ b/src/Futhark/IR/GPUMem.hs
@@ -41,7 +41,7 @@ instance RepTypes GPUMem where
   type Op GPUMem = MemOp (HostOp GPUMem ())
 
 instance ASTRep GPUMem where
-  expTypesFromPattern = return . map snd . snd . bodyReturnsFromPattern
+  expTypesFromPattern = return . map snd . bodyReturnsFromPattern
 
 instance OpReturns GPUMem where
   opReturns (Alloc _ space) =

--- a/src/Futhark/IR/MC.hs
+++ b/src/Futhark/IR/MC.hs
@@ -51,7 +51,7 @@ instance TypeCheck.Checkable MC
 
 instance Buildable MC where
   mkBody = Body ()
-  mkExpPat ctx val _ = basicPattern ctx val
+  mkExpPat idents _ = basicPattern idents
   mkExpDec _ _ = ()
   mkLetNames = simpleMkLetNames
 

--- a/src/Futhark/IR/MCMem.hs
+++ b/src/Futhark/IR/MCMem.hs
@@ -38,7 +38,7 @@ instance RepTypes MCMem where
   type Op MCMem = MemOp (MCOp MCMem ())
 
 instance ASTRep MCMem where
-  expTypesFromPattern = return . map snd . snd . bodyReturnsFromPattern
+  expTypesFromPattern = return . map snd . bodyReturnsFromPattern
 
 instance OpReturns MCMem where
   opReturns (Alloc _ space) = return [MemMem space]

--- a/src/Futhark/IR/Mem.hs
+++ b/src/Futhark/IR/Mem.hs
@@ -106,11 +106,10 @@ import Control.Category
 import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.State
-import Data.Foldable (toList, traverse_)
+import Data.Foldable (traverse_)
 import Data.List (elemIndex, find)
 import qualified Data.Map.Strict as M
 import Data.Maybe
-import qualified Data.Set as S
 import Futhark.Analysis.Metrics
 import Futhark.Analysis.PrimExp.Convert
 import Futhark.Analysis.PrimExp.Simplify
@@ -571,19 +570,18 @@ matchFunctionReturnType rettype result = do
 matchLoopResultMem ::
   (Mem rep, TC.Checkable rep) =>
   [FParam (Aliases rep)] ->
-  [FParam (Aliases rep)] ->
   Result ->
   TC.TypeM rep ()
-matchLoopResultMem ctx val = matchRetTypeToResult rettype
+matchLoopResultMem params = matchRetTypeToResult rettype
   where
-    ctx_names = map paramName ctx
+    param_names = map paramName params
 
     -- Invent a ReturnType so we can pretend that the loop body is
     -- actually returning from a function.
-    rettype = map (toRet . paramDec) val
+    rettype = map (toRet . paramDec) params
 
     toExtV v
-      | Just i <- v `elemIndex` ctx_names = Ext i
+      | Just i <- v `elemIndex` param_names = Ext i
       | otherwise = Free v
 
     toExtSE (Var v) = Var <$> toExtV v
@@ -596,14 +594,14 @@ matchLoopResultMem ctx val = matchRetTypeToResult rettype
     toRet (MemAcc acc ispace ts u) =
       MemAcc acc ispace ts u
     toRet (MemArray pt shape u (ArrayIn mem ixfun))
-      | Just i <- mem `elemIndex` ctx_names,
-        Param _ (MemMem space) : _ <- drop i ctx =
+      | Just i <- mem `elemIndex` param_names,
+        Param _ (MemMem space) : _ <- drop i params =
         MemArray pt shape' u $ ReturnsNewBlock space i ixfun'
       | otherwise =
         MemArray pt shape' u $ ReturnsInBlock mem ixfun'
       where
         shape' = fmap toExtSE shape
-        ixfun' = existentialiseIxFun ctx_names ixfun
+        ixfun' = existentialiseIxFun param_names ixfun
 
 matchBranchReturnType ::
   (Mem rep, TC.Checkable rep) =>
@@ -650,19 +648,14 @@ matchReturnType ::
   [MemInfo SubExp NoUniqueness MemBind] ->
   TC.TypeM rep ()
 matchReturnType rettype res ts = do
-  let (ctx_ts, val_ts) = splitFromEnd (length rettype) ts
-      (ctx_res, _val_res) = splitFromEnd (length rettype) res
+  let (ctx_res, _val_res) = splitFromEnd (length rettype) res
 
       existentialiseIxFun0 :: IxFun -> ExtIxFun
       existentialiseIxFun0 = fmap $ fmap Free
 
-      fetchCtx i = case maybeNth i $ zip ctx_res ctx_ts of
+      fetchCtx i = case maybeNth i $ zip res ts of
         Nothing ->
-          throwError $
-            "Cannot find context variable "
-              ++ show i
-              ++ " in context results: "
-              ++ pretty ctx_res
+          throwError $ "Cannot find variable #" ++ show i ++ " in results: " ++ pretty res
         Just (se, t) -> return (se, t)
 
       checkReturn (MemPrim x) (MemPrim y)
@@ -685,88 +678,53 @@ matchReturnType rettype res ts = do
       checkDim (Free x) y
         | x == y = return ()
         | otherwise =
-          throwError $
-            unwords
-              [ "Expected dim",
-                pretty x,
-                "but got",
-                pretty y
-              ]
+          throwError $ unwords ["Expected dim", pretty x, "but got", pretty y]
       checkDim (Ext i) y = do
         (x, _) <- fetchCtx i
-        unless (x == y) $
-          throwError $
-            unwords
-              [ "Expected ext dim",
-                pretty i,
-                "=>",
-                pretty x,
-                "but got",
-                pretty y
-              ]
-
-      extsInMemInfo :: MemInfo ExtSize u MemReturn -> S.Set Int
-      extsInMemInfo (MemArray _ shp _ ret) =
-        extInShape shp <> extInMemReturn ret
-      extsInMemInfo _ = S.empty
+        unless (x == y) . throwError . unwords $
+          ["Expected ext dim", pretty i, "=>", pretty x, "but got", pretty y]
 
       checkMemReturn (ReturnsInBlock x_mem x_ixfun) (ArrayIn y_mem y_ixfun)
         | x_mem == y_mem =
           unless (IxFun.closeEnough x_ixfun $ existentialiseIxFun0 y_ixfun) $
-            throwError $
-              unwords
-                [ "Index function unification failed (ReturnsInBlock)",
-                  "\nixfun of body result: ",
-                  pretty y_ixfun,
-                  "\nixfun of return type: ",
-                  pretty x_ixfun,
-                  "\nand context elements: ",
-                  pretty ctx_res
-                ]
+            throwError . unwords $
+              [ "Index function unification failed (ReturnsInBlock)",
+                "\nixfun of body result: ",
+                pretty y_ixfun,
+                "\nixfun of return type: ",
+                pretty x_ixfun,
+                "\nand context elements: ",
+                pretty ctx_res
+              ]
       checkMemReturn
         (ReturnsNewBlock x_space x_ext x_ixfun)
         (ArrayIn y_mem y_ixfun) = do
           (x_mem, x_mem_type) <- fetchCtx x_ext
           unless (IxFun.closeEnough x_ixfun $ existentialiseIxFun0 y_ixfun) $
-            throwError $
-              pretty $
-                "Index function unification failed (ReturnsNewBlock)"
-                  </> "Ixfun of body result:"
-                  </> indent 2 (ppr y_ixfun)
-                  </> "Ixfun of return type:"
-                  </> indent 2 (ppr x_ixfun)
-                  </> "Context elements: "
-                  </> indent 2 (ppr ctx_res)
+            throwError . pretty $
+              "Index function unification failed (ReturnsNewBlock)"
+                </> "Ixfun of body result:"
+                </> indent 2 (ppr y_ixfun)
+                </> "Ixfun of return type:"
+                </> indent 2 (ppr x_ixfun)
+                </> "Context elements: "
+                </> indent 2 (ppr ctx_res)
           case x_mem_type of
             MemMem y_space ->
-              unless (x_space == y_space) $
-                throwError $
-                  unwords
-                    [ "Expected memory",
-                      pretty y_mem,
-                      "in space",
-                      pretty x_space,
-                      "but actually in space",
-                      pretty y_space
-                    ]
+              unless (x_space == y_space) . throwError . unwords $
+                [ "Expected memory",
+                  pretty y_mem,
+                  "in space",
+                  pretty x_space,
+                  "but actually in space",
+                  pretty y_space
+                ]
             t ->
-              throwError $
-                unwords
-                  [ "Expected memory",
-                    pretty x_ext,
-                    "=>",
-                    pretty x_mem,
-                    "but but has type",
-                    pretty t
-                  ]
+              throwError . unwords $
+                ["Expected memory", pretty x_ext, "=>", pretty x_mem, "but but has type", pretty t]
       checkMemReturn x y =
-        throwError $
-          unwords
-            [ "Expected array in",
-              pretty x,
-              "but array returned in",
-              pretty y
-            ]
+        throwError . unwords $
+          ["Expected array in", pretty x, "but array returned in", pretty y]
 
       bad :: String -> TC.TypeM rep a
       bad s =
@@ -779,16 +737,7 @@ matchReturnType rettype res ts = do
                 </> indent 2 (ppTuple' ts)
                 </> text s
 
-  unless (length (S.unions $ map extsInMemInfo rettype) == length ctx_res) $
-    TC.bad $
-      TC.TypeError $
-        "Too many context parameters for the number of "
-          ++ "existentials in the return type! type:\n  "
-          ++ prettyTuple rettype
-          ++ "\ncannot match context parameters:\n  "
-          ++ prettyTuple ctx_res
-
-  either bad return =<< runExceptT (zipWithM_ checkReturn rettype val_ts)
+  either bad return =<< runExceptT (zipWithM_ checkReturn rettype ts)
 
 matchPatternToExp ::
   (Mem rep, TC.Checkable rep) =>
@@ -799,26 +748,18 @@ matchPatternToExp pat e = do
   scope <- asksScope removeScopeAliases
   rt <- runReaderT (expReturns $ removeExpAliases e) scope
 
-  let (ctxs, vals) = bodyReturnsFromPattern $ removePatternAliases pat
-      (ctx_ids, _ctx_ts) = unzip ctxs
-      (_val_ids, val_ts) = unzip vals
-      (ctx_map_ids, ctx_map_exts) =
-        getExtMaps $ zip ctx_ids [0 .. length ctx_ids - 1]
-
-  let rt_exts = foldMap extInExpReturns rt
+  let (ctx_ids, val_ts) = unzip $ bodyReturnsFromPattern $ removePatternAliases pat
+      (ctx_map_ids, ctx_map_exts) = getExtMaps $ zip ctx_ids [0 .. 1]
 
   unless
     ( length val_ts == length rt
         && and (zipWith (matches ctx_map_ids ctx_map_exts) val_ts rt)
-        && M.keysSet ctx_map_exts `S.isSubsetOf` S.map Ext rt_exts
     )
     $ TC.bad $
       TC.TypeError $
         "Expression type:\n  " ++ prettyTuple rt
           ++ "\ncannot match pattern type:\n  "
           ++ prettyTuple val_ts
-          ++ "\nwith context elements: "
-          ++ pretty ctx_ids
   where
     matches _ _ (MemPrim x) (MemPrim y) = x == y
     matches _ _ (MemMem x_space) (MemMem y_space) =
@@ -847,22 +788,6 @@ matchPatternToExp pat e = do
           (_, Nothing) -> True
           _ -> False
     matches _ _ _ _ = False
-
-    extInExpReturns :: ExpReturns -> S.Set Int
-    extInExpReturns (MemArray _ shape _ mem_return) =
-      extInShape shape <> maybe S.empty extInMemReturn mem_return
-    extInExpReturns _ = mempty
-
-extInShape :: ShapeBase (Ext SubExp) -> S.Set Int
-extInShape shape = S.fromList $ mapMaybe isExt $ shapeDims shape
-
-extInMemReturn :: MemReturn -> S.Set Int
-extInMemReturn (ReturnsInBlock _ extixfn) = extInIxFn extixfn
-extInMemReturn (ReturnsNewBlock _ i extixfn) =
-  S.singleton i <> extInIxFn extixfn
-
-extInIxFn :: ExtIxFun -> S.Set Int
-extInIxFn ixfun = S.fromList $ concatMap (mapMaybe isExt . toList) ixfun
 
 varMemInfo ::
   Mem rep =>
@@ -908,7 +833,9 @@ lookupArraySummary name = do
     MemArray _ _ _ (ArrayIn mem ixfun) ->
       return (mem, ixfun)
     _ ->
-      error $ "Variable " ++ pretty name ++ " does not look like an array."
+      error $
+        "Expected " ++ pretty name ++ " to be array but bound to:\n"
+          ++ pretty summary
 
 checkMemInfo ::
   TC.Checkable rep =>
@@ -948,14 +875,11 @@ checkMemInfo name (MemArray _ shape _ (ArrayIn v ixfun)) = do
             ++ ")"
 
 bodyReturnsFromPattern ::
-  PatternT (MemBound NoUniqueness) ->
-  ([(VName, BodyReturns)], [(VName, BodyReturns)])
+  PatternT (MemBound NoUniqueness) -> [(VName, BodyReturns)]
 bodyReturnsFromPattern pat =
-  ( map asReturns $ patternContextElements pat,
-    map asReturns $ patternValueElements pat
-  )
+  map asReturns $ patternElements pat
   where
-    ctx = patternContextElements pat
+    ctx = patternElements pat
 
     ext (Var v)
       | Just (i, _) <- find ((== v) . patElemName . snd) $ zip [0 ..] ctx =
@@ -1089,9 +1013,9 @@ expReturns (BasicOp (Update _ v _ _)) =
   pure <$> varReturns v
 expReturns (BasicOp op) =
   extReturns . staticShapes <$> primOpType op
-expReturns e@(DoLoop ctx val _ _) = do
+expReturns e@(DoLoop merge _ _) = do
   t <- expExtType e
-  zipWithM typeWithDec t $ map fst val
+  zipWithM typeWithDec t $ map fst merge
   where
     typeWithDec t p =
       case (t, paramDec p) of
@@ -1102,10 +1026,7 @@ expReturns e@(DoLoop ctx val _ _) = do
               Mem space <- paramType mem_p ->
               return $ MemArray pt shape u $ Just $ ReturnsNewBlock space i ixfun'
             | otherwise ->
-              return
-                ( MemArray pt shape u $
-                    Just $ ReturnsInBlock mem ixfun'
-                )
+              return $ MemArray pt shape u $ Just $ ReturnsInBlock mem ixfun'
             where
               ixfun' = existentialiseIxFun (map paramName mergevars) ixfun
         (Array {}, _) ->
@@ -1114,10 +1035,10 @@ expReturns e@(DoLoop ctx val _ _) = do
           return $ MemAcc acc ispace ts u
         (Prim pt, _) ->
           return $ MemPrim pt
-        (Mem {}, _) ->
-          error "expReturns: loop returns memory block explicitly."
+        (Mem space, _) ->
+          pure $ MemMem space
     isMergeVar v = find ((== v) . paramName . snd) $ zip [0 ..] mergevars
-    mergevars = map fst $ ctx ++ val
+    mergevars = map fst merge
 expReturns (Apply _ _ ret _) =
   return $ map funReturnsToExpReturns ret
 expReturns (If _ _ _ (IfDec ret _)) =

--- a/src/Futhark/IR/Prop.hs
+++ b/src/Futhark/IR/Prop.hs
@@ -125,7 +125,7 @@ safeExp (BasicOp op) = safeBasicOp op
     safeBasicOp Replicate {} = True
     safeBasicOp Copy {} = True
     safeBasicOp _ = False
-safeExp (DoLoop _ _ _ body) = safeBody body
+safeExp (DoLoop _ _ body) = safeBody body
 safeExp (Apply fname _ _ _) =
   isBuiltInFunction fname
 safeExp (If _ tbranch fbranch _) =
@@ -160,7 +160,7 @@ commutativeLambda lam =
       okComponent c = isJust $ find (okBinOp c) $ bodyStms body
       okBinOp
         (xp, yp, SubExpRes _ (Var r))
-        (Let (Pattern [] [pe]) _ (BasicOp (BinOp op (Var x) (Var y)))) =
+        (Let (Pattern [pe]) _ (BasicOp (BinOp op (Var x) (Var y)))) =
           patElemName pe == r
             && commutativeBinOp op
             && ( (x == paramName xp && y == paramName yp)
@@ -239,8 +239,8 @@ class
 -- | Construct the type of an expression that would match the pattern.
 expExtTypesFromPattern :: Typed dec => PatternT dec -> [ExtType]
 expExtTypesFromPattern pat =
-  existentialiseExtTypes (patternContextNames pat) $
-    staticShapes $ map patElemType $ patternValueElements pat
+  existentialiseExtTypes (patternNames pat) $
+    staticShapes $ map patElemType $ patternElements pat
 
 -- | Keep only those attributes that are relevant for 'Assert'
 -- expressions.
@@ -257,7 +257,7 @@ lamIsBinOp lam = mapM splitStm $ bodyResult $ lambdaBody lam
     n = length $ lambdaReturnType lam
     splitStm (SubExpRes cs (Var res)) = do
       guard $ cs == mempty
-      Let (Pattern [] [pe]) _ (BasicOp (BinOp op (Var x) (Var y))) <-
+      Let (Pattern [pe]) _ (BasicOp (BinOp op (Var x) (Var y))) <-
         find (([res] ==) . patternNames . stmPattern) $
           stmsToList $ bodyStms $ lambdaBody lam
       i <- Var res `elemIndex` map resSubExp (bodyResult (lambdaBody lam))

--- a/src/Futhark/IR/Prop/Aliases.hs
+++ b/src/Futhark/IR/Prop/Aliases.hs
@@ -99,12 +99,11 @@ expAliases (If _ tb fb dec) =
         (bodyAliases tb, consumedInBody tb)
         (bodyAliases fb, consumedInBody fb)
 expAliases (BasicOp op) = basicOpAliases op
-expAliases (DoLoop ctxmerge valmerge _ loopbody) =
-  map (`namesSubtract` merge_names) val_aliases
+expAliases (DoLoop merge _ loopbody) =
+  map (`namesSubtract` merge_names) aliases
   where
-    (_ctx_aliases, val_aliases) =
-      splitAt (length ctxmerge) $ bodyAliases loopbody
-    merge_names = namesFromList $ map (paramName . fst) $ ctxmerge ++ valmerge
+    aliases = bodyAliases loopbody
+    merge_names = namesFromList $ map (paramName . fst) merge
 expAliases (Apply _ args t _) =
   funcallAliases args $ map declExtTypeOf t
 expAliases (WithAcc inputs lam) =
@@ -126,7 +125,7 @@ returnAliases rts args = map returnType' rts
     returnType' Acc {} =
       error "returnAliases Acc"
     returnType' Mem {} =
-      error "returnAliases Mem"
+      mconcat $ map (uncurry maskAliases) args
 
 maskAliases :: Names -> Diet -> Names
 maskAliases _ Consume = mempty
@@ -146,7 +145,7 @@ consumedInExp (Apply _ args _ _) =
     consumeArg _ = mempty
 consumedInExp (If _ tb fb _) =
   consumedInBody tb <> consumedInBody fb
-consumedInExp (DoLoop _ merge form body) =
+consumedInExp (DoLoop merge form body) =
   mconcat
     ( map (subExpAliases . snd) $
         filter (unique . paramDeclType . fst) merge

--- a/src/Futhark/IR/Prop/Patterns.hs
+++ b/src/Futhark/IR/Prop/Patterns.hs
@@ -15,13 +15,8 @@ module Futhark.IR.Prop.Patterns
     setPatElemDec,
     patternElements,
     patternIdents,
-    patternContextIdents,
-    patternValueIdents,
     patternNames,
-    patternValueNames,
-    patternContextNames,
     patternTypes,
-    patternValueTypes,
     patternSize,
 
     -- * Pattern construction
@@ -56,49 +51,25 @@ patElemType = typeOf
 setPatElemDec :: PatElemT oldattr -> newattr -> PatElemT newattr
 setPatElemDec pe x = fmap (const x) pe
 
--- | All pattern elements in the pattern - context first, then values.
-patternElements :: PatternT dec -> [PatElemT dec]
-patternElements pat = patternContextElements pat ++ patternValueElements pat
-
 -- | Return a list of the 'Ident's bound by the t'Pattern'.
 patternIdents :: Typed dec => PatternT dec -> [Ident]
-patternIdents pat = patternContextIdents pat ++ patternValueIdents pat
-
--- | Return a list of the context 'Ident's bound by the t'Pattern'.
-patternContextIdents :: Typed dec => PatternT dec -> [Ident]
-patternContextIdents = map patElemIdent . patternContextElements
-
--- | Return a list of the value 'Ident's bound by the t'Pattern'.
-patternValueIdents :: Typed dec => PatternT dec -> [Ident]
-patternValueIdents = map patElemIdent . patternValueElements
+patternIdents = map patElemIdent . patternElements
 
 -- | Return a list of the 'Name's bound by the t'Pattern'.
 patternNames :: PatternT dec -> [VName]
 patternNames = map patElemName . patternElements
 
--- | Return a list of the 'Name's bound by the context part of the t'Pattern'.
-patternContextNames :: PatternT dec -> [VName]
-patternContextNames = map patElemName . patternContextElements
-
--- | Return a list of the 'Name's bound by the value part of the t'Pattern'.
-patternValueNames :: PatternT dec -> [VName]
-patternValueNames = map patElemName . patternValueElements
-
 -- | Return a list of the typess bound by the pattern.
 patternTypes :: Typed dec => PatternT dec -> [Type]
 patternTypes = map identType . patternIdents
 
--- | Return a list of the typess bound by the value part of the pattern.
-patternValueTypes :: Typed dec => PatternT dec -> [Type]
-patternValueTypes = map identType . patternValueIdents
-
 -- | Return the number of names bound by the pattern.
 patternSize :: PatternT dec -> Int
-patternSize (Pattern context values) = length context + length values
+patternSize (Pattern xs) = length xs
 
 -- | Create a pattern using 'Type' as the attribute.
-basicPattern :: [Ident] -> [Ident] -> PatternT Type
-basicPattern context values =
-  Pattern (map patElem context) (map patElem values)
+basicPattern :: [Ident] -> PatternT Type
+basicPattern values =
+  Pattern $ map patElem values
   where
     patElem (Ident name t) = PatElem name t

--- a/src/Futhark/IR/Prop/Types.hs
+++ b/src/Futhark/IR/Prop/Types.hs
@@ -434,12 +434,9 @@ extractShapeContext ts shapes =
           return $ Just v
     extract' (Free _) _ = return Nothing
 
--- | The set of identifiers used for the shape context in the given
--- 'ExtType's.
+-- | The 'Ext' integers used for existential sizes in the given types.
 shapeContext :: [TypeBase ExtShape u] -> S.Set Int
-shapeContext =
-  S.fromList
-    . concatMap (mapMaybe ext . shapeDims . arrayShape)
+shapeContext = S.fromList . concatMap (mapMaybe ext . shapeDims . arrayShape)
   where
     ext (Ext x) = Just x
     ext (Free _) = Nothing
@@ -475,11 +472,7 @@ generaliseExtTypes rt1 rt2 =
         put (n + 1, m)
         return $ Ext n
     unifyExtDims (Ext x) (Ext y)
-      | x == y =
-        Ext
-          <$> ( maybe (new x) return
-                  =<< gets (M.lookup x . snd)
-              )
+      | x == y = Ext <$> (maybe (new x) return =<< gets (M.lookup x . snd))
     unifyExtDims (Ext x) _ = Ext <$> new x
     unifyExtDims _ (Ext x) = Ext <$> new x
     new x = do

--- a/src/Futhark/IR/RetType.hs
+++ b/src/Futhark/IR/RetType.hs
@@ -43,8 +43,8 @@ class (Show rt, Eq rt, Ord rt, DeclExtTyped rt) => IsRetType rt where
     [(SubExp, Type)] ->
     Maybe [rt]
 
--- | Given shape parameter names and value parameter types, produce the
--- types of arguments accepted.
+-- | Given shape parameter names and types, produce the types of
+-- arguments accepted.
 expectedTypes :: Typed t => [VName] -> [t] -> [SubExp] -> [Type]
 expectedTypes shapes value_ts args = map (correctDims . typeOf) value_ts
   where

--- a/src/Futhark/IR/SOACS.hs
+++ b/src/Futhark/IR/SOACS.hs
@@ -87,7 +87,7 @@ instance TypeCheck.Checkable SOACS
 
 instance Buildable SOACS where
   mkBody = AST.Body ()
-  mkExpPat ctx val _ = basicPattern ctx val
+  mkExpPat merge _ = basicPattern merge
   mkExpDec _ _ = ()
   mkLetNames = simpleMkLetNames
 

--- a/src/Futhark/IR/SegOp.hs
+++ b/src/Futhark/IR/SegOp.hs
@@ -1275,21 +1275,16 @@ topDownSegOp ::
   Rule rep
 -- If a SegOp produces something invariant to the SegOp, turn it
 -- into a replicate.
-topDownSegOp vtable (Pattern [] kpes) dec (SegMap lvl space ts (KernelBody _ kstms kres)) = Simplify $ do
+topDownSegOp vtable (Pattern kpes) dec (SegMap lvl space ts (KernelBody _ kstms kres)) = Simplify $ do
   (ts', kpes', kres') <-
     unzip3 <$> filterM checkForInvarianceResult (zip3 ts kpes kres)
 
   -- Check if we did anything at all.
-  when
-    (kres == kres')
-    cannotSimplify
+  when (kres == kres') cannotSimplify
 
   kbody <- mkKernelBodyM kstms kres'
   addStm $
-    Let (Pattern [] kpes') dec $
-      Op $
-        segOp $
-          SegMap lvl space ts' kbody
+    Let (Pattern kpes') dec $ Op $ segOp $ SegMap lvl space ts' kbody
   where
     isInvariant Constant {} = True
     isInvariant (Var v) = isJust $ ST.lookup v vtable
@@ -1307,7 +1302,7 @@ topDownSegOp vtable (Pattern [] kpes) dec (SegMap lvl space ts (KernelBody _ kst
 -- If a SegRed contains two reduction operations that have the same
 -- vector shape, merge them together.  This saves on communication
 -- overhead, but can in principle lead to more local memory usage.
-topDownSegOp _ (Pattern [] pes) _ (SegRed lvl space ops ts kbody)
+topDownSegOp _ (Pattern pes) _ (SegRed lvl space ops ts kbody)
   | length ops > 1,
     op_groupings <-
       groupBy sameShape $
@@ -1320,7 +1315,7 @@ topDownSegOp _ (Pattern [] pes) _ (SegRed lvl space ops ts kbody)
         pes' = red_pes' ++ map_pes
         ts' = red_ts' ++ map_ts
         kbody' = kbody {kernelBodyResult = red_res' ++ map_res}
-    letBind (Pattern [] pes') $ Op $ segOp $ SegRed lvl space ops' ts' kbody'
+    letBind (Pattern pes') $ Op $ segOp $ SegRed lvl space ops' ts' kbody'
   where
     (red_pes, map_pes) = splitAt (segBinOpResults ops) pes
     (red_ts, map_ts) = splitAt (segBinOpResults ops) ts
@@ -1386,7 +1381,7 @@ bottomUpSegOp ::
   Rule rep
 -- Some SegOp results can be moved outside the SegOp, which can
 -- simplify further analysis.
-bottomUpSegOp (vtable, used) (Pattern [] kpes) dec segop = Simplify $ do
+bottomUpSegOp (vtable, used) (Pattern kpes) dec segop = Simplify $ do
   -- Iterate through the bindings.  For each, we check whether it is
   -- in kres and can be moved outside.  If so, we remove it from kres
   -- and kpes and make it a binding outside.  We have to be careful
@@ -1405,7 +1400,7 @@ bottomUpSegOp (vtable, used) (Pattern [] kpes) dec segop = Simplify $ do
     localScope (scopeOfSegSpace space) $
       mkKernelBodyM kstms' kres'
 
-  addStm $ Let (Pattern [] kpes') dec $ Op $ segOp $ mk_segop kts' kbody
+  addStm $ Let (Pattern kpes') dec $ Op $ segOp $ mk_segop kts' kbody
   where
     (kts, KernelBody _ kstms kres, num_nonmap_results, mk_segop) =
       segOpGuts segop
@@ -1425,7 +1420,7 @@ bottomUpSegOp (vtable, used) (Pattern [] kpes) dec segop = Simplify $ do
         Nothing
 
     distribute (kpes', kts', kres', kstms') stm
-      | Let (Pattern [] [pe]) _ _ <- stm,
+      | Let (Pattern [pe]) _ _ <- stm,
         Just (remaining_slice, arr) <- sliceWithGtidsFixed stm,
         Just (kpe, kpes'', kts'', kres'') <- isResult kpes' kts' kres' pe = do
         let outer_slice =
@@ -1468,7 +1463,6 @@ bottomUpSegOp (vtable, used) (Pattern [] kpes) dec segop = Simplify $ do
       where
         matches (_, _, Returns _ _ (Var v)) = v == patElemName pe
         matches _ = False
-bottomUpSegOp _ _ _ _ = Skip
 
 --- Memory
 

--- a/src/Futhark/IR/Seq.hs
+++ b/src/Futhark/IR/Seq.hs
@@ -44,7 +44,7 @@ instance TypeCheck.Checkable Seq
 
 instance Buildable Seq where
   mkBody = Body ()
-  mkExpPat ctx val _ = basicPattern ctx val
+  mkExpPat idents _ = basicPattern idents
   mkExpDec _ _ = ()
   mkLetNames = simpleMkLetNames
 

--- a/src/Futhark/IR/SeqMem.hs
+++ b/src/Futhark/IR/SeqMem.hs
@@ -35,7 +35,7 @@ instance RepTypes SeqMem where
   type Op SeqMem = MemOp ()
 
 instance ASTRep SeqMem where
-  expTypesFromPattern = return . map snd . snd . bodyReturnsFromPattern
+  expTypesFromPattern = return . map snd . bodyReturnsFromPattern
 
 instance OpReturns SeqMem where
   opReturns (Alloc _ space) = return [MemMem space]

--- a/src/Futhark/Optimise/DoubleBuffer.hs
+++ b/src/Futhark/Optimise/DoubleBuffer.hs
@@ -64,16 +64,14 @@ doubleBuffer onOp =
        in runState (runReaderT m env) src
 
     env = Env mempty doNotTouchLoop onOp
-    doNotTouchLoop ctx val body = return (mempty, ctx, val, body)
+    doNotTouchLoop merge body = return (mempty, merge, body)
 
 type OptimiseLoop rep =
-  [(FParam rep, SubExp)] ->
   [(FParam rep, SubExp)] ->
   Body rep ->
   DoubleBufferM
     rep
     ( [Stm rep],
-      [(FParam rep, SubExp)],
       [(FParam rep, SubExp)],
       Body rep
     )
@@ -111,13 +109,13 @@ optimiseStms (e : es) = do
   return $ e_es ++ es'
 
 optimiseStm :: forall rep. ASTRep rep => Stm rep -> DoubleBufferM rep [Stm rep]
-optimiseStm (Let pat aux (DoLoop ctx val form body)) = do
+optimiseStm (Let pat aux (DoLoop merge form body)) = do
   body' <-
-    localScope (scopeOf form <> scopeOfFParams (map fst $ ctx ++ val)) $
+    localScope (scopeOf form <> scopeOfFParams (map fst merge)) $
       optimiseBody body
   opt_loop <- asks envOptimiseLoop
-  (bnds, ctx', val', body'') <- opt_loop ctx val body'
-  return $ bnds ++ [Let pat aux $ DoLoop ctx' val' form body'']
+  (bnds, merge', body'') <- opt_loop merge body'
+  return $ bnds ++ [Let pat aux $ DoLoop merge' form body'']
 optimiseStm (Let pat aux e) = do
   onOp <- asks envOptimiseOp
   pure . Let pat aux <$> mapExpM (optimise onOp) e
@@ -184,24 +182,19 @@ type Constraints rep =
   )
 
 optimiseLoop :: (Constraints rep, Op rep ~ MemOp inner, BuilderOps rep) => OptimiseLoop rep
-optimiseLoop ctx val body = do
+optimiseLoop merge body = do
   -- We start out by figuring out which of the merge variables should
   -- be double-buffered.
   buffered <-
     doubleBufferMergeParams
-      (zip (map fst ctx) (bodyResult body))
-      (map fst merge)
+      (zip (map fst merge) (bodyResult body))
       (boundInBody body)
   -- Then create the allocations of the buffers and copies of the
   -- initial values.
   (merge', allocs) <- allocStms merge buffered
   -- Modify the loop body to copy buffered result arrays.
   let body' = doubleBufferResult (map fst merge) buffered body
-      (ctx', val') = splitAt (length ctx) merge'
-  -- Modify the initial merge p
-  return (allocs, ctx', val', body')
-  where
-    merge = ctx ++ val
+  pure (allocs, merge', body')
 
 -- | The booleans indicate whether we should also play with the
 -- initial merge values.
@@ -216,12 +209,12 @@ data DoubleBuffer
 doubleBufferMergeParams ::
   MonadFreshNames m =>
   [(Param FParamMem, SubExpRes)] ->
-  [Param FParamMem] ->
   Names ->
   m [DoubleBuffer]
-doubleBufferMergeParams ctx_and_res val_params bound_in_loop =
+doubleBufferMergeParams ctx_and_res bound_in_loop =
   evalStateT (mapM buffer val_params) M.empty
   where
+    val_params = map fst ctx_and_res
     loopVariant v =
       v `nameIn` bound_in_loop
         || v `elem` map (paramName . fst) ctx_and_res
@@ -295,7 +288,7 @@ allocStms merge = runWriterT . zipWithM allocation merge
           shape = arrayShape $ paramType f
           bound = MemArray bt shape NoUniqueness $ ArrayIn mem v_ixfun
       tell
-        [ Let (Pattern [] [PatElem v_copy bound]) (defAux ()) $
+        [ Let (Pattern [PatElem v_copy bound]) (defAux ()) $
             BasicOp $ Copy v
         ]
       -- It is important that we treat this as a consumption, to
@@ -329,7 +322,7 @@ doubleBufferResult valparams buffered (Body _ bnds res) =
       let t = resultType $ paramType fparam
           summary = MemArray (elemType t) (arrayShape t) NoUniqueness $ ArrayIn bufname ixfun
           copybnd =
-            Let (Pattern [] [PatElem copyname summary]) (defAux ()) $
+            Let (Pattern [PatElem copyname summary]) (defAux ()) $
               BasicOp $ Copy v
        in (Just copybnd, SubExpRes cs (Var copyname))
     buffer _ _ se =

--- a/src/Futhark/Optimise/Fusion/Composing.hs
+++ b/src/Futhark/Optimise/Fusion/Composing.hs
@@ -76,7 +76,7 @@ fuseMaps unfus_nms lam1 inp1 out1 lam2 inp2 = (lam2', M.elems inputmap)
         }
     new_body2 =
       let bnds res =
-            [ certify cs $ mkLet [] [p] $ BasicOp $ SubExp e
+            [ certify cs $ mkLet [p] $ BasicOp $ SubExp e
               | (p, SubExpRes cs e) <- zip pat res
             ]
           bindLambda res =
@@ -184,8 +184,7 @@ removeDuplicateInputs = fst . M.foldlWithKey' comb ((M.empty, id), M.empty)
             arrmap
           )
     forward to from b =
-      mkLet [] [to] (BasicOp $ SubExp $ Var from)
-        `insertStm` b
+      mkLet [to] (BasicOp $ SubExp $ Var from) `insertStm` b
 
 fuseRedomap ::
   Buildable rep =>

--- a/src/Futhark/Optimise/Fusion/LoopKernel.hs
+++ b/src/Futhark/Optimise/Fusion/LoopKernel.hs
@@ -86,7 +86,7 @@ transformOutput ts names = descend ts
             letBindNames [k] $ BasicOp $ SubExp $ Var $ identName valident
         t SOAC.:< ts'' -> do
           let (es, css) = unzip $ map (applyTransform t) validents
-              mkPat (Ident nm tp) = Pattern [] [PatElem nm tp]
+              mkPat (Ident nm tp) = Pattern [PatElem nm tp]
           opts <- concat <$> mapM primOpType es
           newIds <- forM (zip names opts) $ \(k, opt) ->
             newIdent (baseString k) opt

--- a/src/Futhark/Optimise/InPlaceLowering.hs
+++ b/src/Futhark/Optimise/InPlaceLowering.hs
@@ -171,7 +171,7 @@ optimiseStms (bnd : bnds) m = do
     boundHere = patternNames $ stmPattern bnd
 
     checkIfForwardableUpdate (Let pat (StmAux cs _ _) e)
-      | Pattern [] [PatElem v dec] <- pat,
+      | Pattern [PatElem v dec] <- pat,
         BasicOp (Update Unsafe src slice (Var ve)) <- e =
         maybeForward ve v dec cs src slice
     checkIfForwardableUpdate _ = return ()
@@ -181,10 +181,9 @@ optimiseInStm (Let pat dec e) =
   Let pat dec <$> optimiseExp e
 
 optimiseExp :: Constraints rep => Exp (Aliases rep) -> ForwardingM rep (Exp (Aliases rep))
-optimiseExp (DoLoop ctx val form body) =
-  bindingScope (scopeOf form) $
-    bindingFParams (map fst $ ctx ++ val) $
-      DoLoop ctx val form <$> optimiseBody body
+optimiseExp (DoLoop merge form body) =
+  bindingScope (scopeOf form) . bindingFParams (map fst merge) $
+    DoLoop merge form <$> optimiseBody body
 optimiseExp (Op op) = do
   f <- asks topOnOp
   Op <$> f op

--- a/src/Futhark/Optimise/InPlaceLowering/SubstituteIndices.hs
+++ b/src/Futhark/Optimise/InPlaceLowering/SubstituteIndices.hs
@@ -73,9 +73,8 @@ substituteIndicesInPattern ::
   PatternT dec ->
   m (IndexSubstitutions (LetDec (Rep m)), PatternT dec)
 substituteIndicesInPattern substs pat = do
-  (substs', context) <- mapAccumLM sub substs $ patternContextElements pat
-  (substs'', values) <- mapAccumLM sub substs' $ patternValueElements pat
-  return (substs'', Pattern context values)
+  (substs', pes) <- mapAccumLM sub substs $ patternElements pat
+  return (substs', Pattern pes)
   where
     sub substs' patElem = return (substs', patElem)
 

--- a/src/Futhark/Optimise/InliningDeadFun.hs
+++ b/src/Futhark/Optimise/InliningDeadFun.hs
@@ -141,16 +141,11 @@ inlineFunction pat aux args (safety, loc, locs) fun = do
       mkBody
         (stmsFromList param_stms <> stmsFromList body_stms)
         (bodyResult (funDefBody fun))
-  let res_stms =
-        certify (stmAuxCerts aux)
-          <$> zipWith bindSubExpRes (patternIdents pat) res
-  pure $ stmsToList stms <> res_stms
+  pure $ stmsToList stms <> zipWith bindSubExpRes (patternIdents pat) res
   where
     param_stms =
-      zipWith
-        bindSubExp
-        (map paramIdent $ funDefParams fun)
-        (map fst args)
+      certify (stmAuxCerts aux)
+        <$> zipWith bindSubExp (map paramIdent $ funDefParams fun) (map fst args)
 
     body_stms =
       stmsToList $
@@ -161,7 +156,7 @@ inlineFunction pat aux args (safety, loc, locs) fun = do
     -- point - it is crucial that we run copy propagation before
     -- the type checker sees this!
     bindSubExp ident se =
-      mkLet [] [ident] $ BasicOp $ SubExp se
+      mkLet [ident] $ BasicOp $ SubExp se
 
     bindSubExpRes ident (SubExpRes cs se) =
       certify cs $ bindSubExp ident se

--- a/src/Futhark/Optimise/Simplify/Rep.hs
+++ b/src/Futhark/Optimise/Simplify/Rep.hs
@@ -196,9 +196,8 @@ addWisdomToPattern ::
   Exp (Wise rep) ->
   Pattern (Wise rep)
 addWisdomToPattern pat e =
-  Pattern (map f ctx) (map f val)
+  Pattern $ map f $ Aliases.mkPatternAliases pat e
   where
-    (ctx, val) = Aliases.mkPatternAliases pat e
     f pe =
       let (als, dec) = patElemDec pe
        in pe `setPatElemDec` (VarWisdom als, dec)
@@ -242,14 +241,9 @@ mkWiseExpDec pat expdec e =
     expdec
   )
 
-instance
-  ( Buildable rep,
-    CanBeWise (Op rep)
-  ) =>
-  Buildable (Wise rep)
-  where
-  mkExpPat ctx val e =
-    addWisdomToPattern (mkExpPat ctx val $ removeExpWisdom e) e
+instance (Buildable rep, CanBeWise (Op rep)) => Buildable (Wise rep) where
+  mkExpPat ids e =
+    addWisdomToPattern (mkExpPat ids $ removeExpWisdom e) e
 
   mkExpDec pat e =
     mkWiseExpDec pat (mkExpDec (removePatternWisdom pat) $ removeExpWisdom e) e

--- a/src/Futhark/Optimise/Simplify/Rule.hs
+++ b/src/Futhark/Optimise/Simplify/Rule.hs
@@ -132,7 +132,6 @@ type RuleDoLoop rep a =
   Pattern rep ->
   StmAux (ExpDec rep) ->
   ( [(FParam rep, SubExp)],
-    [(FParam rep, SubExp)],
     LoopForm rep,
     BodyT rep
   ) ->
@@ -290,8 +289,8 @@ rulesForStm stm = case stmExp stm of
 applyRule :: SimplificationRule rep a -> a -> Stm rep -> Rule rep
 applyRule (RuleGeneric f) a stm = f a stm
 applyRule (RuleBasicOp f) a (Let pat aux (BasicOp e)) = f a pat aux e
-applyRule (RuleDoLoop f) a (Let pat aux (DoLoop ctx val form body)) =
-  f a pat aux (ctx, val, form, body)
+applyRule (RuleDoLoop f) a (Let pat aux (DoLoop merge form body)) =
+  f a pat aux (merge, form, body)
 applyRule (RuleIf f) a (Let pat aux (If cond tbody fbody ifsort)) =
   f a pat aux (cond, tbody, fbody, ifsort)
 applyRule (RuleOp f) a (Let pat aux (Op op)) =

--- a/src/Futhark/Optimise/TileLoops.hs
+++ b/src/Futhark/Optimise/TileLoops.hs
@@ -156,7 +156,7 @@ tileInBody branch_variant initial_variance initial_lvl initial_space res_ts (Bod
             poststms'
             stms_res
       -- Tiling inside for-loop.
-      | DoLoop [] merge (ForLoop i it bound []) loopbody <- stmExp stm_to_tile,
+      | DoLoop merge (ForLoop i it bound []) loopbody <- stmExp stm_to_tile,
         (prestms', poststms') <-
           preludeToPostlude variance prestms stm_to_tile (stmsFromList poststms) = do
         let branch_variant' =
@@ -420,7 +420,7 @@ tileDoLoop initial_space variance prestms used_in_body (host_stms, tiling, tiled
               <$> tiledBody private' privstms'
         accs' <-
           letTupExp "tiled_inside_loop" $
-            DoLoop [] merge' (ForLoop i it bound []) loopbody'
+            DoLoop merge' (ForLoop i it bound []) loopbody'
 
         postludeGeneric tiling (privstms <> inloop_privstms) pat accs' poststms poststms_res res_ts
 
@@ -712,7 +712,7 @@ tileGeneric doTiling initial_lvl res_ts pat gtids kdims w form inputs poststms p
                   ProcessTileArgs privstms red_comm red_lam map_lam tile accs (Var tile_id)
             resultBody . map Var <$> tilingProcessTile tiling tile_args
 
-      accs <- letTupExp "accs" $ DoLoop [] merge loopform loopbody
+      accs <- letTupExp "accs" $ DoLoop merge loopform loopbody
 
       -- We possibly have to traverse a residual tile.
       red_lam' <- renameLambda red_lam

--- a/src/Futhark/Pass/ExplicitAllocations/GPU.hs
+++ b/src/Futhark/Pass/ExplicitAllocations/GPU.hs
@@ -19,7 +19,7 @@ import Futhark.Pass.ExplicitAllocations
 import Futhark.Pass.ExplicitAllocations.SegOp
 
 instance SizeSubst (HostOp rep op) where
-  opSizeSubst (Pattern _ [size]) (SizeOp (SplitSpace _ _ _ elems_per_thread)) =
+  opSizeSubst (Pattern [size]) (SizeOp (SplitSpace _ _ _ elems_per_thread)) =
     M.singleton (patElemName size) elems_per_thread
   opSizeSubst _ _ = mempty
 

--- a/src/Futhark/Pass/ExtractKernels/BlockedKernel.hs
+++ b/src/Futhark/Pass/ExtractKernels/BlockedKernel.hs
@@ -245,7 +245,7 @@ readKernelInput ::
   m ()
 readKernelInput inp = do
   let pe = PatElem (kernelInputName inp) $ kernelInputType inp
-  letBind (Pattern [] [pe]) . BasicOp $
+  letBind (Pattern [pe]) . BasicOp $
     case kernelInputType inp of
       Acc {} ->
         SubExp $ Var $ kernelInputArray inp

--- a/src/Futhark/Pass/ExtractKernels/ISRWIM.hs
+++ b/src/Futhark/Pass/ExtractKernels/ISRWIM.hs
@@ -58,24 +58,19 @@ iswim res_pat w scan_fun scan_input
         map_fun' = Lambda map_params map_body map_rettype
 
     res_pat' <-
-      fmap (basicPattern []) $
+      fmap basicPattern $
         mapM (newIdent' (<> "_transposed") . transposeIdentType) $
-          patternValueIdents res_pat
+          patternIdents res_pat
 
     addStm $
       Let res_pat' (StmAux map_cs mempty ()) $
         Op $ Screma map_w map_arrs' (mapSOAC map_fun')
 
-    forM_
-      ( zip
-          (patternValueIdents res_pat)
-          (patternValueIdents res_pat')
-      )
-      $ \(to, from) -> do
-        let perm = [1, 0] ++ [2 .. arrayRank (identType from) -1]
-        addStm $
-          Let (basicPattern [] [to]) (defAux ()) $
-            BasicOp $ Rearrange perm $ identName from
+    forM_ (zip (patternIdents res_pat) (patternIdents res_pat')) $ \(to, from) -> do
+      let perm = [1, 0] ++ [2 .. arrayRank (identType from) -1]
+      addStm $
+        Let (basicPattern [to]) (defAux ()) $
+          BasicOp $ Rearrange perm $ identName from
   | otherwise = Nothing
 
 -- | Interchange Reduce With Inner Map. Tries to turn a @reduce(map)@ into a
@@ -182,7 +177,7 @@ setOuterDimTo w t =
 
 setPatternOuterDimTo :: SubExp -> Pattern -> Pattern
 setPatternOuterDimTo w pat =
-  basicPattern [] $ map (setIdentOuterDimTo w) $ patternValueIdents pat
+  basicPattern $ map (setIdentOuterDimTo w) $ patternIdents pat
 
 transposeIdentType :: Ident -> Ident
 transposeIdentType ident =
@@ -194,4 +189,4 @@ stripIdentOuterDim ident =
 
 stripPatternOuterDim :: Pattern -> Pattern
 stripPatternOuterDim pat =
-  basicPattern [] $ map stripIdentOuterDim $ patternValueIdents pat
+  basicPattern $ map stripIdentOuterDim $ patternIdents pat

--- a/src/Futhark/Pass/ExtractKernels/Intragroup.hs
+++ b/src/Futhark/Pass/ExtractKernels/Intragroup.hs
@@ -195,12 +195,12 @@ intraGroupStm lvl stm@(Let pat aux e) = do
   let lvl' = SegThread (segNumGroups lvl) (segGroupSize lvl) SegNoVirt
 
   case e of
-    DoLoop ctx val form loopbody ->
+    DoLoop merge form loopbody ->
       localScope (scopeOf form') $
-        localScope (scopeOfFParams $ map fst $ ctx ++ val) $ do
+        localScope (scopeOfFParams $ map fst merge) $ do
           loopbody' <- intraGroupBody lvl loopbody
           certifying (stmAuxCerts aux) $
-            letBind pat $ DoLoop ctx val form' loopbody'
+            letBind pat $ DoLoop merge form' loopbody'
       where
         form' = case form of
           ForLoop i it bound inps -> ForLoop i it bound inps

--- a/src/Futhark/Pass/KernelBabysitting.hs
+++ b/src/Futhark/Pass/KernelBabysitting.hs
@@ -218,7 +218,7 @@ traverseKernelBodyArrayIndexes free_ker_vars thread_variant outer_scope f (Kerne
 
     mkSizeSubsts = foldMap mkStmSizeSubst
       where
-        mkStmSizeSubst (Let (Pattern [] [pe]) _ (Op (SizeOp (SplitSpace _ _ _ elems_per_i)))) =
+        mkStmSizeSubst (Let (Pattern [pe]) _ (Op (SizeOp (SplitSpace _ _ _ elems_per_i)))) =
           M.singleton (patElemName pe) elems_per_i
         mkStmSizeSubst _ = mempty
 

--- a/src/Futhark/Transform/FirstOrderTransform.hs
+++ b/src/Futhark/Transform/FirstOrderTransform.hs
@@ -221,7 +221,7 @@ transformSOAC pat (Screma w arrs form@(ScremaForm scans reds map_lam)) = do
   names <-
     (++ patternNames pat)
       <$> replicateM (length scanacc_params) (newVName "discard")
-  letBindNames names $ DoLoop [] merge loopform loop_body
+  letBindNames names $ DoLoop merge loopform loop_body
 transformSOAC pat (Stream w arrs _ nes lam) = do
   -- Create a loop that repeatedly applies the lambda body to a
   -- chunksize of 1.  Hopefully this will lead to this outer loop
@@ -273,7 +273,7 @@ transformSOAC pat (Stream w arrs _ nes lam) = do
 
       mkBodyM mempty $ res ++ subExpsRes mapout_res'
 
-  letBind pat $ DoLoop [] merge loop_form loop_body
+  letBind pat $ DoLoop merge loop_form loop_body
 transformSOAC pat (Scatter len lam ivs as) = do
   iter <- newVName "write_iter"
 
@@ -300,7 +300,7 @@ transformSOAC pat (Scatter len lam ivs as) = do
 
         foldM saveInArray arr indexes'
       return $ resultBody (map Var ress)
-  letBind pat $ DoLoop [] merge (ForLoop iter Int64 len []) loopBody
+  letBind pat $ DoLoop merge (ForLoop iter Int64 len []) loopBody
 transformSOAC pat (Hist len ops bucket_fun imgs) = do
   iter <- newVName "iter"
 
@@ -357,7 +357,7 @@ transformSOAC pat (Hist len ops bucket_fun imgs) = do
     return $ resultBody $ map Var $ concat hists_out''
 
   -- Wrap up the above into a for-loop.
-  letBind pat $ DoLoop [] merge (ForLoop iter Int64 len []) loopBody
+  letBind pat $ DoLoop merge (ForLoop iter Int64 len []) loopBody
 
 -- | Recursively first-order-transform a lambda.
 transformLambda ::

--- a/src/Futhark/Transform/Substitute.hs
+++ b/src/Futhark/Transform/Substitute.hs
@@ -100,8 +100,8 @@ instance Substitute SubExpRes where
     SubExpRes (substituteNames substs cs) (substituteNames substs se)
 
 instance Substitute dec => Substitute (PatternT dec) where
-  substituteNames substs (Pattern context values) =
-    Pattern (substituteNames substs context) (substituteNames substs values)
+  substituteNames substs (Pattern xs) =
+    Pattern (substituteNames substs xs)
 
 instance Substitute Certificates where
   substituteNames substs (Certificates cs) =


### PR DESCRIPTION
This is a significant simplification.  Now, if something returns N
values, its type list will have N entries, always. Probably we will be
chasing the dividends of this simplification for years, as the
context/value distinction was truly entrenched.

There are some programs that now crash the compiler.  The main ones I
noticed are related to being unable to copy-propagate
certificate-protected variables into Results.  This should be fixed
separately, and this commit rebased.

Entry points annotations (and some parts of the ExplicitAllocations
pass) still assume that the "context parts" (sizes) of a pattern are
first, but that is an easy property to maintain - and we might relax
it in the future.