### PR TITLE
Make 'futhark dev' use the correct representation names.

### DIFF
--- a/src/Futhark/CLI/Dev.hs
+++ b/src/Futhark/CLI/Dev.hs
@@ -543,7 +543,7 @@ commandLineOptions =
       "Run the default optimised kernels pipeline"
       kernelsPipeline
       []
-      ["kernels"],
+      ["gpu"],
     pipelineOption
       getSOACSProg
       "GPUMem"
@@ -551,15 +551,15 @@ commandLineOptions =
       "Run the full GPU compilation pipeline"
       gpuPipeline
       []
-      ["gpu"],
+      ["gpu-mem"],
     pipelineOption
       getSOACSProg
-      "GPUMem"
+      "SeqMem"
       SeqMem
       "Run the sequential CPU compilation pipeline"
       sequentialCpuPipeline
       []
-      ["cpu"],
+      ["seq-mem"],
     pipelineOption
       getSOACSProg
       "MCMem"
@@ -567,7 +567,7 @@ commandLineOptions =
       "Run the multicore compilation pipeline"
       multicorePipeline
       []
-      ["multicore"]
+      ["mc-mem"]
   ]
 
 incVerbosity :: Maybe FilePath -> FutharkConfig -> FutharkConfig
@@ -669,8 +669,8 @@ main = mainWithOptions newConfig commandLineOptions "options... program" compile
                   (".fut_soacs", readCore parseSOACS SOACS),
                   (".fut_seq", readCore parseSeq Seq),
                   (".fut_seq_mem", readCore parseSeqMem SeqMem),
-                  (".fut_kernels", readCore parseGPU GPU),
-                  (".fut_kernels_mem", readCore parseGPUMem GPUMem),
+                  (".fut_gpu", readCore parseGPU GPU),
+                  (".fut_gpu_mem", readCore parseGPUMem GPUMem),
                   (".fut_mc", readCore parseMC MC),
                   (".fut_mc_mem", readCore parseMCMem MCMem)
                 ]

--- a/src/Futhark/CLI/Test.hs
+++ b/src/Futhark/CLI/Test.hs
@@ -125,11 +125,11 @@ optimisedProgramMetrics programs pipeline program =
     SOACSPipeline ->
       check ["-s"]
     KernelsPipeline ->
-      check ["--kernels"]
-    SequentialCpuPipeline ->
-      check ["--cpu"]
-    GpuPipeline ->
       check ["--gpu"]
+    SequentialCpuPipeline ->
+      check ["--seq-mem"]
+    GpuPipeline ->
+      check ["--gpu-mem"]
     NoPipeline ->
       check []
   where

--- a/tools/testparser.sh
+++ b/tools/testparser.sh
@@ -30,10 +30,10 @@ if [ "$TESTPARSER_WORKER" ]; then
         if futhark check $f 2>/dev/null; then
             testwith $f soacs -s
             testwith $f mc -s --extract-multicore
-            testwith $f kernels --kernels
-            testwith $f mc_mem --cpu
+            testwith $f gpu --gpu
+            testwith $f mc_mem --mc-mem
             if ! grep -q no_opencl $f; then
-                testwith $f kernels_mem --gpu
+                testwith $f gpu_mem --gpu-mem
             fi
         fi
     done


### PR DESCRIPTION
So:

  * '--gpu' is what used to be '--kernels'
  * '--gpu-mem' is what used to be '--gpu'
  * '--mc-mem' is what used to be '--multicore'
  * '--seq-mem' is what used to be '--cpu'.

For input file names:

  * '.fut_gpu' is what used to be '_fut_kernels'
  * '.fut_gpu_mem' is what used to be '.fut_kernels_mem'

@munksgaard and @coancea: you will care about this.

Time to update years of muscle memory!