### PR TITLE
Add python lib tests to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -298,6 +298,7 @@ jobs:
 
     - run: |
         futhark test -c --no-terminal --no-tuning --backend=python --exclude=no_python --exclude=compiled tests examples
+        make -C tests_lib/python -j
 
   test-opencl:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
The Python library tests don't seem to be run by the CI. I'm not sure if this was an oversight or intentional. This PR adds them to the CI.