### PR TITLE
Remove implicit emcc flags.

### DIFF
--- a/src/Futhark/Actions.hs
+++ b/src/Futhark/Actions.hs
@@ -334,14 +334,7 @@ runEMCC cpath outpath classpath cflags_def ldflags expfuns lib = do
             ++ ["-lnodefs.js"]
             ++ ["-s", "--extern-post-js", classpath]
             ++ ( if lib
-                   then
-                     [ "-s",
-                       "EXPORT_NAME=loadWASM",
-                       "-s",
-                       "MODULARIZE=1",
-                       "-s",
-                       "EXPORT_ES6=1"
-                     ]
+                   then ["-s", "EXPORT_NAME=loadWASM"]
                    else []
                )
             ++ ["-s", "WASM_BIGINT"]


### PR DESCRIPTION
I'm pretty sure that deleting these lines is a good thing because they aren't needed.

Basically if the output file has a `.mjs` file extension it will automatically compile with `MODULARIZE` and `EXPORT_ES6`. The reason I didn't just commit is because I found out these lines weren't needed from reading Emscripten source code. Namely these [lines](https://github.com/emscripten-core/emscripten/blob/main/emcc.py#L1430-L1442). I can't find any reference to this in the documentation stating this is true. So its dependant on these lines not changing. But its unlikely it will change.

I thought I'd hand it over to you, to make the call.