### PR TITLE
Rename pipeline syntax for structure tests to match internal names

### DIFF
--- a/src/Futhark/CLI/Test.hs
+++ b/src/Futhark/CLI/Test.hs
@@ -125,11 +125,11 @@ optimisedProgramMetrics programs pipeline program =
   case pipeline of
     SOACSPipeline ->
       check ["-s"]
-    KernelsPipeline ->
-      check ["--gpu"]
-    SequentialCpuPipeline ->
-      check ["--seq-mem"]
     GpuPipeline ->
+      check ["--gpu"]
+    SeqMemPipeline ->
+      check ["--seq-mem"]
+    GpuMemPipeline ->
       check ["--gpu-mem"]
     NoPipeline ->
       check []
@@ -154,9 +154,9 @@ testMetrics programs program (StructureTest pipeline (AstMetrics expected)) =
   where
     maybePipeline :: StructurePipeline -> T.Text
     maybePipeline SOACSPipeline = "(soacs) "
-    maybePipeline KernelsPipeline = "(kernels) "
-    maybePipeline SequentialCpuPipeline = "(seq-mem) "
-    maybePipeline GpuPipeline = "(gpu-mem) "
+    maybePipeline GpuPipeline = "(kernels) "
+    maybePipeline SeqMemPipeline = "(seq-mem) "
+    maybePipeline GpuMemPipeline = "(gpu-mem) "
     maybePipeline NoPipeline = ""
 
     ok (AstMetrics metrics) (name, expected_occurences) =

--- a/src/Futhark/Test/Spec.hs
+++ b/src/Futhark/Test/Spec.hs
@@ -87,10 +87,10 @@ instance Show ExpectedError where
 
 -- | How a program can be transformed.
 data StructurePipeline
-  = KernelsPipeline
+  = GpuPipeline
   | SOACSPipeline
-  | SequentialCpuPipeline
-  | GpuPipeline
+  | SeqMemPipeline
+  | GpuMemPipeline
   | NoPipeline
   deriving (Show)
 
@@ -340,9 +340,9 @@ parseExpectedStructure sep =
 optimisePipeline :: Parser () -> Parser StructurePipeline
 optimisePipeline sep =
   choice
-    [ lexeme sep "distributed" $> KernelsPipeline,
+    [ lexeme sep "gpu-mem" $> GpuMemPipeline,
       lexeme sep "gpu" $> GpuPipeline,
-      lexeme sep "cpu" $> SequentialCpuPipeline,
+      lexeme sep "seq-mem" $> SeqMemPipeline,
       lexeme sep "internalised" $> NoPipeline,
       pure SOACSPipeline
     ]

--- a/tests/attributes/sequential0.fut
+++ b/tests/attributes/sequential0.fut
@@ -1,5 +1,5 @@
 -- ==
 -- random input { [10][10]i32 } auto output
--- structure distributed { SegMap 0 DoLoop 2 }
+-- structure gpu { SegMap 0 DoLoop 2 }
 
 let main xss = #[sequential] map i32.sum xss

--- a/tests/attributes/sequential1.fut
+++ b/tests/attributes/sequential1.fut
@@ -1,5 +1,5 @@
 -- ==
 -- random input { [10][10]i32 } auto output
--- structure distributed { /SegMap 1 /SegMap/DoLoop 1 }
+-- structure gpu { /SegMap 1 /SegMap/DoLoop 1 }
 
 let main xss = map (\xs -> #[sequential] i32.sum xs) xss

--- a/tests/attributes/sequential2.fut
+++ b/tests/attributes/sequential2.fut
@@ -1,7 +1,7 @@
 -- Test that attributes don't disappear after fusion.
 -- ==
 -- structure { Screma 1 }
--- structure distributed { /SegMap 0 /DoLoop 1 }
+-- structure gpu { /SegMap 0 /DoLoop 1 }
 
 let main (xs: []i32) =
   (#[sequential] map (+1) xs, map (*2) xs)

--- a/tests/attributes/sequential_inner0.fut
+++ b/tests/attributes/sequential_inner0.fut
@@ -1,5 +1,5 @@
 -- ==
 -- random input { [10][10]i32 } auto output
--- structure distributed { /SegMap 1 /SegMap/DoLoop 1 }
+-- structure gpu { /SegMap 1 /SegMap/DoLoop 1 }
 
 let main xss = #[sequential_inner] map i32.sum xss

--- a/tests/attributes/sequential_inner1.fut
+++ b/tests/attributes/sequential_inner1.fut
@@ -1,5 +1,5 @@
 -- ==
 -- random input { [10][10][10]i32 } auto output
--- structure distributed { /SegMap 1 /SegMap/DoLoop 1 }
+-- structure gpu { /SegMap 1 /SegMap/DoLoop 1 }
 
 let main = map (\xss -> #[sequential_inner] map i32.sum xss)

--- a/tests/attributes/sequential_inner2.fut
+++ b/tests/attributes/sequential_inner2.fut
@@ -1,5 +1,5 @@
 -- ==
 -- random input { [10][10]i32 } auto output
--- structure distributed { /SegRed 1 }
+-- structure gpu { /SegRed 1 }
 
 let main xsss = #[sequential_inner] map_stream (\k (xss: [k][]i32) -> map i32.sum xss) xsss

--- a/tests/attributes/sequential_outer0.fut
+++ b/tests/attributes/sequential_outer0.fut
@@ -1,5 +1,5 @@
 -- ==
 -- random input { [10][10]i32 } auto output
--- structure distributed { /DoLoop 1 /DoLoop/SegRed 1 }
+-- structure gpu { /DoLoop 1 /DoLoop/SegRed 1 }
 
 let main xss = #[sequential_outer] map i32.sum xss

--- a/tests/attributes/sequential_outer1.fut
+++ b/tests/attributes/sequential_outer1.fut
@@ -1,7 +1,7 @@
 -- Slightly odd result due to interchange.
 -- ==
 -- random input { [10][10][10]i32 } auto output
--- structure distributed {
+-- structure gpu {
 --   /DoLoop 1
 --   /DoLoop/SegRed 1
 --   /DoLoop/SegMap 1

--- a/tests/babysitter/no-manifest-1.fut
+++ b/tests/babysitter/no-manifest-1.fut
@@ -1,6 +1,6 @@
 -- this is a simplified version of batch matrix inversion: it should not introduce a transposition for A[i,j]
 -- ==
--- structure distributed {Manifest 0}
+-- structure gpu {Manifest 0}
 
 let gauss_jordan [nm] (n:i64) (m:i64) (A: *[nm]f32): [nm]f32 =
     loop A for i < n do

--- a/tests/babysitter/no-manifest-2.fut
+++ b/tests/babysitter/no-manifest-2.fut
@@ -1,6 +1,6 @@
 -- this is a code snippet from bfast; it should transpose `y_error`
 -- ==
--- structure distributed {Manifest 0}
+-- structure gpu {Manifest 0}
 
 let main [m][n] (nss: [m]i64) (hs: [m]i64) (y_errors: [m][n]f32) : [m]f32 =
   zip3 y_errors nss hs |>

--- a/tests/big0.fut
+++ b/tests/big0.fut
@@ -3,7 +3,7 @@
 -- tags { no_python no_pyopencl }
 -- no_python no_opencl no_cuda no_wasm compiled input { 2i64 1100000000i64 1 1073741823 } output { -2i8 }
 -- no_python no_opencl no_cuda no_wasm compiled input { 3i64 1073741824i64 2 1073741823 } output { -3i8 }
--- structure gpu { SegMap 1  }
+-- structure gpu-mem { SegMap 1  }
 
 let main (n: i64) (m: i64) (i: i32) (j: i32) =
   -- The opaque is just to force manifestation.

--- a/tests/bounds-elim1.fut
+++ b/tests/bounds-elim1.fut
@@ -1,6 +1,6 @@
 -- Optimise away another particularly simple case of bounds checking.
 -- ==
--- structure distributed { SegMap/Assert 0 }
+-- structure gpu { SegMap/Assert 0 }
 
 let main [n] (xs: [n]i32) =
   tabulate n (\i -> xs[i] + 2)

--- a/tests/coalescing/coalescing4.fut
+++ b/tests/coalescing/coalescing4.fut
@@ -1,5 +1,5 @@
 -- ==
--- structure distributed { Manifest 1 }
+-- structure gpu { Manifest 1 }
 
 
 let smoothen [n] (xs: [n]f32) =

--- a/tests/distribution/branch0.fut
+++ b/tests/distribution/branch0.fut
@@ -1,6 +1,6 @@
 -- Interchange map-invariant branches to exploit all parallelism.
 -- ==
--- structure distributed { Kernel/If 0 }
+-- structure gpu { Kernel/If 0 }
 
 let main (b: bool) (xs: []i32) (ys: []i32) =
   map (\x -> if b then map (+x) ys else ys) xs

--- a/tests/distribution/distribution0.fut
+++ b/tests/distribution/distribution0.fut
@@ -6,7 +6,7 @@
 --
 -- ==
 --
--- structure distributed { SegMap 1 DoLoop 2 }
+-- structure gpu { SegMap 1 DoLoop 2 }
 
 let fftmp (num_paths: i64) (md_c: [][]f64) (zi: []f64): [num_paths]f64 =
   #[incremental_flattening(only_outer)]

--- a/tests/distribution/distribution1.fut
+++ b/tests/distribution/distribution1.fut
@@ -12,7 +12,7 @@
 --     scan
 --
 -- ==
--- structure distributed { SegMap 1 }
+-- structure gpu { SegMap 1 }
 
 let combineVs [n] (n_row: [n]f64, vol_row: [n]f64, dr_row: [n]f64): [n]f64 =
     map2 (+) dr_row (map2 (*) n_row vol_row)

--- a/tests/distribution/distribution10.fut
+++ b/tests/distribution/distribution10.fut
@@ -4,7 +4,7 @@
 -- group-level stream.
 --
 -- ==
--- structure distributed { SegMap 2 SegMap/DoLoop 1 }
+-- structure gpu { SegMap 2 SegMap/DoLoop 1 }
 
 let indexOfMax8 ((x,i): (u8,i32)) ((y,j): (u8,i32)): (u8,i32) =
   if x < y then (y,j) else (x,i)

--- a/tests/distribution/distribution12.fut
+++ b/tests/distribution/distribution12.fut
@@ -1,5 +1,5 @@
 -- A triply nested map should not cause any multi-versioning.
 -- ==
--- structure distributed { SegMap 1 }
+-- structure gpu { SegMap 1 }
 
 let main (xsss: [][][]i32) = map (map (map (+1))) xsss

--- a/tests/distribution/distribution2.fut
+++ b/tests/distribution/distribution2.fut
@@ -2,7 +2,7 @@
 -- blackScholes computation from GenericPricing.
 --
 -- ==
--- structure distributed {
+-- structure gpu {
 --   SegMap 6
 --   DoLoop 10
 -- }

--- a/tests/distribution/distribution3.fut
+++ b/tests/distribution/distribution3.fut
@@ -1,7 +1,7 @@
 -- ==
 -- compiled random input { [10][16][16]i32 } auto output
 -- compiled random input { [10][8][32]i32 } auto output
--- structure distributed { SegScan 4 }
+-- structure gpu { SegScan 4 }
 
 let main [k][n][m] (a: [k][n][m]i32): [][][]i32 =
   map (\(a_row: [][]i32): [m][n]i32  ->

--- a/tests/distribution/distribution4.fut
+++ b/tests/distribution/distribution4.fut
@@ -6,7 +6,7 @@
 --   map
 --
 -- ==
--- structure distributed { SegMap 5 }
+-- structure gpu { SegMap 5 }
 
 let main [n][an] [bn] (a: [n][an]i32, b: [n][bn]i32): ([][]i32,[][]i32) =
   unzip(map2 (\(a_row: []i32) (b_row: []i32): ([an]i32,[bn]i32)  ->

--- a/tests/distribution/distribution5.fut
+++ b/tests/distribution/distribution5.fut
@@ -11,7 +11,7 @@
 --     reduce (which becomes a segmented reduction)
 --
 -- ==
--- structure distributed {
+-- structure gpu {
 --   SegMap 2 SegRed 1
 -- }
 

--- a/tests/distribution/distribution6.fut
+++ b/tests/distribution/distribution6.fut
@@ -1,5 +1,5 @@
 -- ==
--- structure distributed { SegMap 1 }
+-- structure gpu { SegMap 1 }
 --
 
 let main(outer_loop_count: i64, a: []i64): [][]i64 =

--- a/tests/distribution/distribution8.fut
+++ b/tests/distribution/distribution8.fut
@@ -13,7 +13,7 @@
 --     scan
 --
 -- ==
--- structure distributed { DoLoop/SegMap 1 DoLoop 2 }
+-- structure gpu { DoLoop/SegMap 1 DoLoop 2 }
 
 
 let combineVs [n] (n_row: [n]f64, vol_row: [n]f64, dr_row: [n]f64): [n]f64 =

--- a/tests/distribution/distribution9.fut
+++ b/tests/distribution/distribution9.fut
@@ -4,7 +4,7 @@
 -- be revised.
 --
 -- ==
--- structure distributed { If/Kernel 0 }
+-- structure gpu { If/Kernel 0 }
 
 let main(a: [][]i32): [][]i32 =
   map (\a_r  ->

--- a/tests/distribution/gather0.fut
+++ b/tests/distribution/gather0.fut
@@ -1,7 +1,7 @@
 -- Sometimes it is quite important that the parallelism in an array
 -- indexing result is exploited.
 -- ==
--- structure distributed { SegMap 2 }
+-- structure gpu { SegMap 2 }
 
 let main (is: []i32) (xss: [][]f32) =
   map (\i -> xss[i]) is

--- a/tests/distribution/icfp16-example.fut
+++ b/tests/distribution/icfp16-example.fut
@@ -19,7 +19,7 @@
 --    [276i32, 142i32, 92i32],
 --    [662i32, 1090i32, 1728i32]]
 -- }
--- structure distributed {
+-- structure gpu {
 --   DoLoop/SegMap 1
 --   SegMap 2
 --   SegRed 1

--- a/tests/distribution/inplace3.fut
+++ b/tests/distribution/inplace3.fut
@@ -2,7 +2,7 @@
 -- produce a sequential Update statement.
 -- ==
 -- random input { [2][12]i64 } auto output
--- structure distributed { SegMap/Update 0 }
+-- structure gpu { SegMap/Update 0 }
 
 let main [n][m] (xss: *[n][m]i64) =
   map (\xs -> copy xs with [0:10] = iota 10) xss

--- a/tests/distribution/inplace4.fut
+++ b/tests/distribution/inplace4.fut
@@ -2,7 +2,7 @@
 -- ==
 -- input { [[1,2,3],[4,5,6]] [0i64,1i64] [42,1337] }
 -- output { [[42,1337,3],[4,42,1337]] }
--- structure distributed { SegMap/Update 0 }
+-- structure gpu { SegMap/Update 0 }
 
 let main [n][m] (xss: *[n][m]i32) (is: [n]i64) (ys: [2]i32) =
   map2 (\xs i -> copy xs with [i:i+2] = ys) xss is

--- a/tests/distribution/inplace5.fut
+++ b/tests/distribution/inplace5.fut
@@ -1,7 +1,7 @@
 -- Distributed in-place update where slice is not final dimension.
 -- ==
 -- random input { 1i64 [2][12][2]i64 } auto output
--- structure distributed { SegMap/Update 0 }
+-- structure gpu { SegMap/Update 0 }
 
 let main [n][m] (l: i64) (xsss: *[n][m][2]i64) =
   map (\xss -> copy xss with [0:10,l] = iota 10) xsss

--- a/tests/distribution/inplace6.fut
+++ b/tests/distribution/inplace6.fut
@@ -1,7 +1,7 @@
 -- Distributed in-place update where slice is final dimension but there are more indexes.
 -- ==
 -- random input { 1i64 [2][2][12]i64 } auto output
--- structure distributed { SegMap/Update 0 }
+-- structure gpu { SegMap/Update 0 }
 
 let main [n][m] (l: i64) (xsss: *[n][2][m]i64) =
   map (\xss -> copy xss with [l, 0:10] = iota 10) xsss

--- a/tests/distribution/inplace7.fut
+++ b/tests/distribution/inplace7.fut
@@ -1,5 +1,5 @@
 -- ==
--- structure distributed { SegMap 1 }
+-- structure gpu { SegMap 1 }
 
 let main iss =
   map (\is ->

--- a/tests/distribution/irregular0.fut
+++ b/tests/distribution/irregular0.fut
@@ -4,7 +4,7 @@
 -- ==
 -- input { [1,2,3,4,5,6,7,8,9] }
 -- output { [1, 3, 6, 10, 15, 21, 28, 36, 45] }
--- structure distributed {
+-- structure gpu {
 --   SegMap 1
 -- }
 

--- a/tests/distribution/loop0.fut
+++ b/tests/distribution/loop0.fut
@@ -18,7 +18,7 @@
 --   [[18, 17], [8, 10]]
 -- }
 --
--- structure distributed { Map/DoLoop 0 }
+-- structure gpu { Map/DoLoop 0 }
 
 let main [n][m][k] (a: [n][m][k]i32): [n][k]i32 =
   let acc = replicate k 0 in

--- a/tests/distribution/loop1.fut
+++ b/tests/distribution/loop1.fut
@@ -12,7 +12,7 @@
 --   [8, 8]
 -- }
 --
--- structure distributed { Map/DoLoop 0 }
+-- structure gpu { Map/DoLoop 0 }
 
 let main [n][m][k] (a: [n][m][k]i32): ([n][k]i32,[n]i32) =
   let acc = replicate k 0

--- a/tests/distribution/loop2.fut
+++ b/tests/distribution/loop2.fut
@@ -12,7 +12,7 @@
 --    [9, 10]]
 -- }
 --
--- structure distributed { Map/Loop 0 }
+-- structure gpu { Map/Loop 0 }
 
 let main [n][m][k] (a: [n][m][k]i32): [n][k]i32 =
   map (\(a_r: [m][k]i32): [k]i32  ->

--- a/tests/distribution/loop3.fut
+++ b/tests/distribution/loop3.fut
@@ -2,7 +2,7 @@
 --
 -- ==
 --
--- structure distributed { Map/Loop 0 }
+-- structure gpu { Map/Loop 0 }
 
 let main [n][k] (m: i32, a: [n][k]i32): [n][k]i32 =
   map (\a_r ->

--- a/tests/distribution/loop4.fut
+++ b/tests/distribution/loop4.fut
@@ -2,7 +2,7 @@
 --
 -- ==
 --
--- structure distributed { Map/Loop 0 }
+-- structure gpu { Map/Loop 0 }
 
 
 let main [n][k] (m: i32) (a: [n][k]i32): [n][k]i32 =

--- a/tests/distribution/loop5.fut
+++ b/tests/distribution/loop5.fut
@@ -2,7 +2,7 @@
 --
 -- ==
 --
--- structure distributed { Map/Loop 0 }
+-- structure gpu { Map/Loop 0 }
 
 let main [n][m][k] (a: *[n][m][k]i32): [n][m][k]i32 =
   map (\(a_r: [m][k]i32): [m][k]i32  ->

--- a/tests/distribution/loop6.fut
+++ b/tests/distribution/loop6.fut
@@ -1,6 +1,6 @@
 -- Interchange of a loop where some parts are dead after the loop.
 -- ==
--- structure distributed { /SegMap 0 /DoLoop 1 /DoLoop/SegMap 1 }
+-- structure gpu { /SegMap 0 /DoLoop 1 /DoLoop/SegMap 1 }
 
 let main [m] [n] (xss: *[m][n]i64) =
   #[incremental_flattening(only_inner)]

--- a/tests/distribution/loop7.fut
+++ b/tests/distribution/loop7.fut
@@ -1,7 +1,7 @@
 -- Must realise that the 'take (i+1)' is invariant to the 'map' after
 -- interchange.
 -- ==
--- structure distributed { DoLoop/SegRed 1 }
+-- structure gpu { DoLoop/SegRed 1 }
 
 let main [n] (xs: [n]i32) =
   #[incremental_flattening(only_inner)]

--- a/tests/distribution/map-duplicate.fut
+++ b/tests/distribution/map-duplicate.fut
@@ -1,6 +1,6 @@
 -- A map with duplicate outputs should work.
 -- ==
--- structure distributed { SegMap 1 }
+-- structure gpu { SegMap 1 }
 
 let main (n: i64) (m: i64) =
   map (\i -> (replicate m i, replicate m i)) (iota n)

--- a/tests/distribution/map-replicate.fut
+++ b/tests/distribution/map-replicate.fut
@@ -4,7 +4,7 @@
 -- ==
 -- input { [1,2,3] 2i64 }
 -- output { [[1,1], [2,2], [3,3]] }
--- structure distributed { SegMap 1 }
+-- structure gpu { SegMap 1 }
 
 let main [n] (xs: [n]i32) (m: i64): [n][m]i32 =
   map (\(x: i32): [m]i32  ->

--- a/tests/distribution/redomap0.fut
+++ b/tests/distribution/redomap0.fut
@@ -1,6 +1,6 @@
 -- Distribute a redomap inside of a map.
 -- ==
--- structure distributed { SegRed 1 }
+-- structure gpu { SegRed 1 }
 
 let main(a: [][]i32): []i32 =
   map (\(a_r: []i32): i32  ->

--- a/tests/distribution/segconcat0.fut
+++ b/tests/distribution/segconcat0.fut
@@ -3,7 +3,7 @@
 -- input { [[1,2,3],[4,5,6]] [[3,2,1],[6,5,4]] }
 -- output { [[1,2,3,3,2,1],
 --           [4,5,6,6,5,4]] }
--- structure distributed { Kernel 0 }
+-- structure gpu { Kernel 0 }
 
 let main [n][m] (xss: [][n]i32) (yss: [][m]i32) =
   let k = n + m in

--- a/tests/distribution/segconcat1.fut
+++ b/tests/distribution/segconcat1.fut
@@ -2,7 +2,7 @@
 -- ==
 -- input { [[1,2],[3,4],[5,6]] [[1,2],[3,4],[5,6]] [[1,2],[3,4],[5,6]] }
 -- output { [[1,2,1,2,1,2], [3,4,3,4,3,4], [5,6,5,6,5,6]] }
--- structure distributed { Kernel 0 }
+-- structure gpu { Kernel 0 }
 
 let main [a][b][c] (xss: [][a]i32) (yss: [][b]i32) (zss: [][c]i32) =
   let n = a + b + c in

--- a/tests/distribution/segconcat2.fut
+++ b/tests/distribution/segconcat2.fut
@@ -2,7 +2,7 @@
 -- ==
 -- input { [[1,2],[3,4]] }
 -- output { [[1, 2, 2, 2], [3, 4, 2, 2]]}
--- structure distributed { Kernel 0 }
+-- structure gpu { Kernel 0 }
 
 let main [n] (xss: [n][]i32) =
   let m = n + 2 in

--- a/tests/existential-ifs/ixfun-antiunif-5.fut
+++ b/tests/existential-ifs/ixfun-antiunif-5.fut
@@ -3,7 +3,7 @@
 -- ==
 -- random input  { [30000]i32 }
 -- auto output
--- structure gpu { Copy 0 }
+-- structure gpu-mem { Copy 0 }
 let main (a: []i32) =
   let xs = if a[0] > 0
            then a[10:30:2]

--- a/tests/existential-ifs/no-ext.fut
+++ b/tests/existential-ifs/no-ext.fut
@@ -1,5 +1,5 @@
 -- ==
--- structure gpu { Copy 1 }
+-- structure gpu-mem { Copy 1 }
 entry ensure_pow_2 [n] [m] (xs: [n][m]i32): [][]i32 =
   if n == 2
      then xs[0:m/2, 0:n/2]

--- a/tests/existential-ifs/two-ixfuns.fut
+++ b/tests/existential-ifs/two-ixfuns.fut
@@ -1,7 +1,7 @@
 -- ==
 -- random input { [1001]i32 }
 -- auto output
--- structure gpu { Copy 0 }
+-- structure gpu-mem { Copy 0 }
 let main [n] (xs: [n]i32): i32 =
   let xs' = if n > 10
             then xs[1:5]

--- a/tests/existential-loop/rotate.fut
+++ b/tests/existential-loop/rotate.fut
@@ -2,7 +2,7 @@
 -- ==
 -- input { [2, 1000, 42, 1001, 50000] }
 -- output { [42, 1001, 50000, 2, 1000] }
--- structure gpu { Copy 2 }
+-- structure gpu-mem { Copy 2 }
 
 let main [n] (a: [n]i32): []i32 =
   loop xs = a for i < a[0] do

--- a/tests/existential-loop/slice.fut
+++ b/tests/existential-loop/slice.fut
@@ -2,7 +2,7 @@
 -- ==
 -- input { [0, 1000, 42, 1001, 50000] }
 -- output { 52043i32 }
--- structure gpu { Copy 0 }
+-- structure gpu-mem { Copy 0 }
 
 let main [n] (a: [n]i32): i32 =
   let b = loop xs = a[1:] for i < n / 2 - 2 do

--- a/tests/fusion/Vers2.0/histogram0.fut
+++ b/tests/fusion/Vers2.0/histogram0.fut
@@ -5,7 +5,7 @@
 -- output {
 --   [100.0f32, 100.0f32, 100.0f32]
 -- }
--- structure distributed {
+-- structure gpu {
 --   Iota 0
 -- }
 

--- a/tests/fusion/scanreduce0.fut
+++ b/tests/fusion/scanreduce0.fut
@@ -2,7 +2,7 @@
 -- ==
 -- input { [1,2,3,4] } output { [1, 3, 6, 10] 24 }
 -- structure { Screma 1 }
--- structure distributed { SegScan 1 }
+-- structure gpu { SegScan 1 }
 
 let main (xs: []i32) =
   (scan (+) 0 xs, reduce (*) 1 xs)

--- a/tests/fusion/scanreduce1.fut
+++ b/tests/fusion/scanreduce1.fut
@@ -3,7 +3,7 @@
 -- input { [1,2,-3,4,0,4] }
 -- output { 8i32 [false, false, false, false, false, false] 0i32 }
 -- structure { Screma 1 }
--- structure distributed { SegRed 1 SegScan 1 }
+-- structure gpu { SegRed 1 SegScan 1 }
 
 let main (xs: []i32) =
   (reduce (+) 0 xs,

--- a/tests/inplacelowering0.fut
+++ b/tests/inplacelowering0.fut
@@ -1,7 +1,7 @@
 -- ==
 -- random input { 10i64 [20]i32 } auto output
--- structure cpu { Update 1 }
--- structure gpu { Update 0 }
+-- structure seq-mem { Update 1 }
+-- structure gpu-mem { Update 0 }
 
 let main (n: i64) (xs: *[]i32) =
   #[unsafe]

--- a/tests/inplacelowering2.fut
+++ b/tests/inplacelowering2.fut
@@ -1,8 +1,8 @@
 -- ==
 -- input { [[0,0,0], [0,0,0]] }
 -- output { [[2,3,4], [0,0,0]] }
--- structure cpu { Update 1 }
--- structure gpu { Update 0 }
+-- structure seq-mem { Update 1 }
+-- structure gpu-mem { Update 0 }
 
 let main [n] (xs: *[][n]i32) =
   #[unsafe]

--- a/tests/inplacelowering3.fut
+++ b/tests/inplacelowering3.fut
@@ -1,7 +1,7 @@
 -- ==
 -- random input { [10][20][2]i32 } auto output
--- structure cpu { Update 1 }
--- structure gpu { Update 0 }
+-- structure seq-mem { Update 1 }
+-- structure gpu-mem { Update 0 }
 
 let main [n] (xs: *[n][][]i32) =
   #[unsafe]

--- a/tests/intragroup/if0.fut
+++ b/tests/intragroup/if0.fut
@@ -1,6 +1,6 @@
 -- ==
 -- compiled random input { [1023]bool [1023][256]i32 } auto output
--- structure distributed {
+-- structure gpu {
 --   /If/True/SegMap/If/True/SegMap 1
 --   /If/True/SegMap/If/False/SegMap 1
 -- }

--- a/tests/intragroup/inplace0.fut
+++ b/tests/intragroup/inplace0.fut
@@ -2,7 +2,7 @@
 -- be sure only one thread writes.
 -- ==
 -- random input { [1][256]f32 } auto output
--- structure distributed { SegMap/SegScan 2 SegMap/Update 1 }
+-- structure gpu { SegMap/SegScan 2 SegMap/Update 1 }
 
 let main (xss: [][]f32) =
   #[incremental_flattening(only_intra)]

--- a/tests/intragroup/reduce0.fut
+++ b/tests/intragroup/reduce0.fut
@@ -2,7 +2,7 @@
 -- ==
 -- random input { [1][256]i32 } auto output
 -- random input { [100][256]i32 } auto output
--- structure distributed { SegMap/SegRed 1 }
+-- structure gpu { SegMap/SegRed 1 }
 
 let main xs =
   #[incremental_flattening(only_intra)]

--- a/tests/intragroup/reduce1.fut
+++ b/tests/intragroup/reduce1.fut
@@ -2,7 +2,7 @@
 -- ==
 -- random input { [1][256]i32 } auto output
 -- compiled random input { [100][256]i32 } auto output
--- structure distributed { SegMap/SegRed 1 }
+-- structure gpu { SegMap/SegRed 1 }
 
 let main xs =
   #[incremental_flattening(only_intra)]

--- a/tests/intragroup/reduce2.fut
+++ b/tests/intragroup/reduce2.fut
@@ -2,7 +2,7 @@
 -- ==
 -- random input { [1][256]i32 } auto output
 -- random input { [100][256]i32 } auto output
--- structure distributed { SegMap/SegRed 1 }
+-- structure gpu { SegMap/SegRed 1 }
 
 let main xs =
   #[incremental_flattening(only_intra)]

--- a/tests/intragroup/scan0.fut
+++ b/tests/intragroup/scan0.fut
@@ -2,7 +2,7 @@
 -- ==
 -- random input { [1][256]i32 } auto output
 -- random input { [100][256]i32 } auto output
--- structure distributed { SegMap/SegScan 1 }
+-- structure gpu { SegMap/SegScan 1 }
 
 let main xs =
   #[incremental_flattening(only_intra)]

--- a/tests/intragroup/scan1.fut
+++ b/tests/intragroup/scan1.fut
@@ -2,7 +2,7 @@
 -- ==
 -- random input { [1][256]i32 } auto output
 -- compiled random input { [100][256]i32 } auto output
--- structure distributed { SegMap/SegScan 1 }
+-- structure gpu { SegMap/SegScan 1 }
 
 let main xss =
   #[incremental_flattening(only_intra)]

--- a/tests/intragroup/scan2.fut
+++ b/tests/intragroup/scan2.fut
@@ -2,7 +2,7 @@
 -- ==
 -- random input { [1][256]i32 } auto output
 -- random input { [100][256]i32 } auto output
--- structure distributed { SegMap/SegScan 1 }
+-- structure gpu { SegMap/SegScan 1 }
 
 let main xs =
   #[incremental_flattening(only_intra)]

--- a/tests/intragroup/segreduce0.fut
+++ b/tests/intragroup/segreduce0.fut
@@ -2,7 +2,7 @@
 -- ==
 -- random input { [1][1][256]i32 } auto output
 -- random input { [10][10][256]i32 } auto output
--- structure distributed { SegMap/SegRed 1 }
+-- structure gpu { SegMap/SegRed 1 }
 
 let main =
   map (\xs -> #[incremental_flattening(only_intra)] map i32.sum xs)

--- a/tests/intragroup/segreduce1.fut
+++ b/tests/intragroup/segreduce1.fut
@@ -2,7 +2,7 @@
 -- ==
 -- random input { [1][1][256]i32 } auto output
 -- compiled random input { [10][10][256]i32 } auto output
--- structure distributed { SegMap/SegRed 1 }
+-- structure gpu { SegMap/SegRed 1 }
 
 let main =
   map (\xss ->

--- a/tests/intragroup/segreduce2.fut
+++ b/tests/intragroup/segreduce2.fut
@@ -2,7 +2,7 @@
 -- ==
 -- random input { [1][1][256]i32 } auto output
 -- random input { [10][10][256]i32 } auto output
--- structure distributed { SegMap/SegRed 1 }
+-- structure gpu { SegMap/SegRed 1 }
 
 let main = map (\xss -> #[incremental_flattening(only_intra)]
                         map (map i32.abs >-> i32.sum) xss)

--- a/tests/issue1223.fut
+++ b/tests/issue1223.fut
@@ -1,6 +1,6 @@
 -- ==
 -- tags { no_opencl no_cuda no_pyopencl }
--- structure distributed { SegMap 3 }
+-- structure gpu { SegMap 3 }
 
 let foo [h][w] (seam_energy: [h][w]i64): [h]i64 =
   loop res = replicate h 0 for i < h do

--- a/tests/issue1424_tiny.fut
+++ b/tests/issue1424_tiny.fut
@@ -1,7 +1,7 @@
 -- Small program related to #1424.
 -- ==
 -- input { 2 [1,2,3] [42] } auto output
--- structure gpu {SegMap 1}
+-- structure gpu-mem {SegMap 1}
 
 let main n (xs: []i32) (unit: [1]i32) =
   #[sequential_inner]

--- a/tests/issue431.fut
+++ b/tests/issue431.fut
@@ -1,6 +1,6 @@
 -- Applying tiling inside of fused scanomaps.
 -- ==
--- structure distributed { SegScan 1 }
+-- structure gpu { SegScan 1 }
 
 let main (xs: []i32) =
   scan (+) 0 (map (\x -> reduce (+) 0 (map (+x) xs)) xs)

--- a/tests/issue456.fut
+++ b/tests/issue456.fut
@@ -3,7 +3,7 @@
 -- because the simplifier will have removed them, but they sometimes
 -- occur after loop interchange.
 -- ==
--- structure distributed { SegMap 1 }
+-- structure gpu { SegMap 1 }
 
 let main [n] (datas: *[][n]i32) (is: []i64) =
   #[incremental_flattening(only_inner)]

--- a/tests/issue921.fut
+++ b/tests/issue921.fut
@@ -1,5 +1,5 @@
 -- ==
--- structure distributed { SegMap 2 }
+-- structure gpu { SegMap 2 }
 
 let main (b1: bool) (b2: bool) (xs: [3]i32) (ys: [3]i32) =
   map (\x -> if b1

--- a/tests/mapslice.fut
+++ b/tests/mapslice.fut
@@ -1,7 +1,7 @@
 -- ==
 -- input { 2i64 [1,2,3,4,5,6,7,8,9] }
 -- output { [[1i32, 2i32, 3i32], [3i32, 4i32, 5i32]] }
--- structure distributed { SegMap 1 }
+-- structure gpu { SegMap 1 }
 
 let main (n: i64) (xs: []i32) =
   tabulate n (\i ->

--- a/tests/noinline/noinline0.fut
+++ b/tests/noinline/noinline0.fut
@@ -1,6 +1,6 @@
 -- ==
 -- input { [1,2,3] } output { [3,4,5] }
--- structure distributed { SegMap/Apply 1 }
+-- structure gpu { SegMap/Apply 1 }
 
 let f (x: i32) = x + 2
 

--- a/tests/noinline/noinline1.fut
+++ b/tests/noinline/noinline1.fut
@@ -1,6 +1,6 @@
 -- ==
 -- input { 3 [1,2,3] } output { [4,5,6] }
--- structure distributed { SegMap/Apply 1 }
+-- structure gpu { SegMap/Apply 1 }
 
 let f (x: i32) (y: i32) = x + y
 

--- a/tests/noinline/noinline2.fut
+++ b/tests/noinline/noinline2.fut
@@ -1,7 +1,7 @@
 -- ==
 -- input { 3 [1,2,3] } output { [0,0,1] }
 -- compiled input { 0 [1,2,3] } error: division by zero
--- structure distributed { SegMap/Apply 1 }
+-- structure gpu { SegMap/Apply 1 }
 
 let f (x: i32) (y: i32) = x / y
 

--- a/tests/noinline/noinline3.fut
+++ b/tests/noinline/noinline3.fut
@@ -1,7 +1,7 @@
 -- ==
 -- tags { no_opencl no_cuda no_pyopencl }
 -- input { [1,2,3] [0,0,1] } output { [1,1,2] }
--- structure distributed { SegMap/Apply 1 }
+-- structure gpu { SegMap/Apply 1 }
 
 let f (xs: []i32) i = xs[i]
 

--- a/tests/noinline/noinline4.fut
+++ b/tests/noinline/noinline4.fut
@@ -1,7 +1,7 @@
 -- ==
 -- input { 3 [1,2,3] } output { [0,0,1] }
 -- compiled input { 0 [1,2,3] } error: division by zero
--- structure distributed { SegMap/Apply 1 /Apply 1 }
+-- structure gpu { SegMap/Apply 1 /Apply 1 }
 
 let f (x: i32) (y: i32) = x / y
 

--- a/tests/psums.fut
+++ b/tests/psums.fut
@@ -1,7 +1,7 @@
 -- ==
 -- random input { [100][10]i32 }
 -- auto output
--- structure gpu { Alloc 3 }
+-- structure gpu-mem { Alloc 3 }
 
 let psum = scan (+) 0
 

--- a/tests/replicate1.fut
+++ b/tests/replicate1.fut
@@ -3,7 +3,7 @@
 -- ==
 -- input { 20i64 } output { 3810 }
 -- compiled no_python no_wasm input { 2000i64 } output { -296967286i32 }
--- structure distributed { Replicate 1 }
+-- structure gpu { Replicate 1 }
 let main(n: i64): i32 =
   let x  = iota n
   let y  = replicate n x

--- a/tests/simplify_primexp.fut
+++ b/tests/simplify_primexp.fut
@@ -1,7 +1,7 @@
 -- The map should be simplified away entirely, even though it is a
 -- call to a built-in function.
 -- ==
--- structure distributed { SegMap 1 }
+-- structure gpu { SegMap 1 }
 
 let main (n: i64) (accs: []i64) =
   let ys = map (2**) (iota n)

--- a/tests/sinking0.fut
+++ b/tests/sinking0.fut
@@ -1,5 +1,5 @@
 -- ==
--- structure distributed { /Index 1 }
+-- structure gpu { /Index 1 }
 
 let main (arr: [](i32, i32, i32, i32, i32)) =
   let (a,b,c,d,e) = arr[0]

--- a/tests/sinking1.fut
+++ b/tests/sinking1.fut
@@ -1,5 +1,5 @@
 -- ==
--- structure distributed { /SegMap/Index 1 }
+-- structure gpu { /SegMap/Index 1 }
 
 let main (as: []i32) (bs: []i32) (cs: []i32) (ds: []i32) (es: []i32) =
   map5 (\a b c d e -> if a == 0 then 0 else b + c + d + e) as bs cs ds es

--- a/tests/sinking2.fut
+++ b/tests/sinking2.fut
@@ -1,6 +1,6 @@
 -- Sinking can be safe even in the presence of in-place updates.
 -- ==
--- structure distributed { /SegMap/Index 1 }
+-- structure gpu { /SegMap/Index 1 }
 
 let main (n: i64) (as: []i32) (bs: []i32) (cs: []i32) (ds: []i32) (es: []i32) =
   map5 (\a b c d e ->

--- a/tests/sinking3.fut
+++ b/tests/sinking3.fut
@@ -1,6 +1,6 @@
 -- Careful; this one cannot be sunk.
 -- ==
--- structure distributed { /Index 5 }
+-- structure gpu { /Index 5 }
 
 let main (arr: *[](i32, i32, i32, i32, i32)) =
   let (a,b,c,d,e) = arr[0]

--- a/tests/sinking5.fut
+++ b/tests/sinking5.fut
@@ -1,6 +1,6 @@
 -- Sinking should be as deep as possible.
 -- ==
--- structure distributed {
+-- structure gpu {
 --   /Index 1
 --   /If/False/If/True/Index 1
 --   /If/False/If/False/If/True/Index 1

--- a/tests/slice2.fut
+++ b/tests/slice2.fut
@@ -29,7 +29,7 @@
 -- [[-0.15087804f32, -0.3175784f32],
 --  [-0.35215855f32, -0.17525783f32]]]
 -- }
--- structure distributed { SegMap 1 }
+-- structure gpu { SegMap 1 }
 
 let main [m][b] (mat: [m][m][b][b]f32): [m][b][b]f32 =
   let mat_rows = map (\(mat_row: [m][b][b]f32): [b][b]f32  ->

--- a/tests/soacs/map17.fut
+++ b/tests/soacs/map17.fut
@@ -9,7 +9,7 @@
 --  [[[0.000000]], [[0.674490]]]
 -- }
 -- output { [[[0.000000]], [[0.674490]]] }
--- structure cpu { Update 2 }
+-- structure seq-mem { Update 2 }
 
 let doInPlaceUpdate [num_dates]
                    (bb_inds: [3][num_dates]i32)

--- a/tests/soacs/mapreduce.fut
+++ b/tests/soacs/mapreduce.fut
@@ -5,7 +5,7 @@
 -- compiled input { 10i64 10i64 }
 -- output { [45i64, 145i64, 245i64, 345i64, 445i64, 545i64, 645i64, 745i64, 845i64, 945i64] }
 -- compiled input { 5i64 50i64 } auto output
--- structure distributed { SegRed 1 }
+-- structure gpu { SegRed 1 }
 
 let main (n: i64) (m: i64): [n]i64 =
   let a = unflatten n m (iota (n*m))

--- a/tests/soacs/reduce0.fut
+++ b/tests/soacs/reduce0.fut
@@ -10,7 +10,7 @@
 -- output { 704982704 }
 -- compiled input { 100000000 }
 -- output { 887459712 }
--- structure distributed { Iota 0 }
+-- structure gpu { Iota 0 }
 
 let main(n: i32): i32 =
   reduce (+) 0 (0..<n)

--- a/tests/soacs/scan0.fut
+++ b/tests/soacs/scan0.fut
@@ -6,7 +6,7 @@
 -- tags { no_python }
 -- input { 100i64 }       output { 4950 }
 -- compiled input { 1000000i64 } output { 1783293664i32 }
--- structure distributed { SegScan 1 Iota 0 }
+-- structure gpu { SegScan 1 Iota 0 }
 
 let main(n: i64): i32 =
   let a = scan (+) 0 (map i32.i64 (iota(n)))

--- a/tests/streamRed_interchange.fut
+++ b/tests/streamRed_interchange.fut
@@ -111,7 +111,7 @@
 -- -0.000443f32, 0.000283f32, -0.000084f32, 0.000129f32, 0.000419f32,
 -- -0.000178f32, -0.001124f32, -0.001211f32, 0.000297f32, 0.000291f32,
 -- 0.001163f32, 0.001455f32]]}
--- structure distributed { SegRed 1 SegMap 4 }
+-- structure gpu { SegRed 1 SegMap 4 }
 
 
 let main (nfeatures: i64) (npoints: i64) (nclusters: i64): [nclusters][nfeatures]f32 =

--- a/tests/tiling/seqloop_1d.fut
+++ b/tests/tiling/seqloop_1d.fut
@@ -2,7 +2,7 @@
 -- innermost one.
 -- ==
 -- input { [1,2,3] [[1,2,3],[4,5,6],[7,8,9]] [1,2,3] } auto output
--- structure distributed { SegMap/DoLoop/DoLoop/SegMap 2 }
+-- structure gpu { SegMap/DoLoop/DoLoop/SegMap 2 }
 
 let main (ns: []i32) (xs: [][]i32) (ys: []i32) =
   map (\n -> map (\y -> loop y for i < n do

--- a/tests/tiling/seqloop_1d_postlude.fut
+++ b/tests/tiling/seqloop_1d_postlude.fut
@@ -2,7 +2,7 @@
 -- postlude.
 -- ==
 -- random input { 3 [10][20]i32 [10]i32 } auto output
--- structure distributed { SegMap/DoLoop/DoLoop/SegMap 2 }
+-- structure gpu { SegMap/DoLoop/DoLoop/SegMap 2 }
 
 let main (n: i32) (xs: [][]i32) (ys: []i32) =
   map (\y ->

--- a/tests/tiling/seqloop_1d_variant.fut
+++ b/tests/tiling/seqloop_1d_variant.fut
@@ -2,7 +2,7 @@
 -- that this generates working code.
 -- ==
 -- random input { [1000][3][3]f32 }
--- structure distributed { SegMap/DoLoop/DoLoop/SegMap 2 }
+-- structure gpu { SegMap/DoLoop/DoLoop/SegMap 2 }
 
 let argmax (arr: []f32) =
   reduce_comm (\(a,i) (b,j) ->

--- a/tests/tiling/seqloop_2d.fut
+++ b/tests/tiling/seqloop_2d.fut
@@ -2,7 +2,7 @@
 -- is variant to an outermost dimension.
 -- ==
 -- input { [1,2,3] [[1,2,3],[4,5,6]] [[1,2,3],[4,5,6]] } auto output
--- structure distributed { SegMap/DoLoop/DoLoop/SegMap 2 }
+-- structure gpu { SegMap/DoLoop/DoLoop/SegMap 2 }
 
 let main [k] (ns: []i32) (xss: [][k]i32) (yss: [][k]i32) =
   map (\n -> map (\xs' -> map (\ys' -> loop z = 0 for _p < n do

--- a/tests/tiling/tiling2.fut
+++ b/tests/tiling/tiling2.fut
@@ -1,6 +1,6 @@
 -- Simple 2D tiling
 -- ==
--- structure distributed { SegMap/DoLoop/DoLoop/SegMap 4
+-- structure gpu { SegMap/DoLoop/DoLoop/SegMap 4
 -- SegMap/DoLoop/DoLoop/DoLoop/SegMap 2
 -- SegMap/SegMap 1
 -- SegMap/DoLoop/DoLoop/SegMap/DoLoop 3 }

--- a/tests/tiling/tiling_1d.fut
+++ b/tests/tiling/tiling_1d.fut
@@ -1,7 +1,7 @@
 -- Simple 1D tiling
 -- ==
 -- compiled random input { [100]i32 } auto output
--- structure distributed { SegMap/DoLoop/SegMap 2 }
+-- structure gpu { SegMap/DoLoop/SegMap 2 }
 
 let main (xs: []i32) =
   map (\x -> i32.sum (map (+x) xs)) xs

--- a/tests/tiling/tiling_1d_complex.fut
+++ b/tests/tiling/tiling_1d_complex.fut
@@ -2,7 +2,7 @@
 -- still just 1D tiling.
 -- ==
 -- compiled random input { [2000]f32 [2000]f32 } auto output
--- structure distributed { SegMap/DoLoop/SegMap 2 }
+-- structure gpu { SegMap/DoLoop/SegMap 2 }
 
 type point = (f32,f32)
 

--- a/tests/tiling/tiling_1d_partial.fut
+++ b/tests/tiling/tiling_1d_partial.fut
@@ -2,7 +2,7 @@
 -- ==
 -- compiled random input { [256][256]f32 [256]f32 } auto output
 -- compiled random input { [256][10]f32 [256]f32 } auto output
--- structure distributed { SegMap/DoLoop/SegMap 2 }
+-- structure gpu { SegMap/DoLoop/SegMap 2 }
 
 let dotprod [n] (xs: [n]f32) (ys: [n]f32): f32 =
   reduce (+) 0.0 (map2 (*) xs ys)

--- a/tests/tiling/tiling_2d.fut
+++ b/tests/tiling/tiling_2d.fut
@@ -1,6 +1,6 @@
 -- Simple 2D tiling
 -- ==
--- structure distributed { SegMap/DoLoop/DoLoop/SegMap 4
+-- structure gpu { SegMap/DoLoop/DoLoop/SegMap 4
 -- SegMap/DoLoop/DoLoop/DoLoop/SegMap 2
 -- SegMap/SegMap 1
 -- SegMap/DoLoop/DoLoop/SegMap/DoLoop 3 }

--- a/tests/tiling/tiling_2d_indirect.fut
+++ b/tests/tiling/tiling_2d_indirect.fut
@@ -1,6 +1,6 @@
 -- 2D tiling, but where the arrays are variant to an outermost third dimension.
 -- ==
--- structure distributed { SegMap/DoLoop/DoLoop/SegMap 4
+-- structure gpu { SegMap/DoLoop/DoLoop/SegMap 4
 -- SegMap/DoLoop/DoLoop/DoLoop/SegMap 2
 -- SegMap/SegMap 1
 -- SegMap/DoLoop/DoLoop/SegMap/DoLoop 3 }

--- a/tests/tiling/tiling_2d_inner.fut
+++ b/tests/tiling/tiling_2d_inner.fut
@@ -1,7 +1,7 @@
 -- 2D tiling with extra dimensions on top.
 -- ==
 -- compiled random input { [2][40][40]i32 [2][40][40]i32 } auto output
--- structure distributed { SegMap/DoLoop/DoLoop/SegMap 4
+-- structure gpu { SegMap/DoLoop/DoLoop/SegMap 4
 -- SegMap/DoLoop/DoLoop/DoLoop/SegMap 2
 -- SegMap/SegMap 1
 -- SegMap/DoLoop/DoLoop/SegMap/DoLoop 3 }

--- a/tests/tiling/tiling_2d_partial.fut
+++ b/tests/tiling/tiling_2d_partial.fut
@@ -12,7 +12,7 @@
 --   [256][10][256]i32
 --   [10]i32
 -- } auto output
--- structure distributed { SegMap/DoLoop/SegMap 2 }
+-- structure gpu { SegMap/DoLoop/SegMap 2 }
 
 let main [a][b][c] (xs: [a][c]i32) (ys: [c][b]i32) (zsss: [b][c][a]i32) (vs: [c]i32) =
   map2 (\xs' zss ->

--- a/tests/tiling/tricky_prelude0.fut
+++ b/tests/tiling/tricky_prelude0.fut
@@ -1,7 +1,7 @@
 -- A case of tiling with a complex dependency.
 -- ==
 -- compiled random input { [100]i32 } auto output
--- structure distributed { SegMap/DoLoop/SegMap 2 }
+-- structure gpu { SegMap/DoLoop/SegMap 2 }
 
 let main (xs: []i32) =
   map (\x ->

--- a/tests/uniqueness/uniqueness17.fut
+++ b/tests/uniqueness/uniqueness17.fut
@@ -4,7 +4,7 @@
 -- array).
 --
 -- ==
--- structure distributed { SegRed 2 }
+-- structure gpu { SegRed 2 }
 
 let max(a: f32) (b: f32): f32 = if(a < b) then b else a
 


### PR DESCRIPTION
From now on, to test the structure of generated programs, use `structure
seq-mem`, `structure gpu` and `structure gpu-mem` instead of `structure cpu`,
`structure kernels` and `structure gpu`. These new names match what the
different representations are called internally.

As discussed in #1493