### PR TITLE
Improve futhark literate output help message

### DIFF
--- a/src/Futhark/CLI/Literate.hs
+++ b/src/Futhark/CLI/Literate.hs
@@ -838,12 +838,12 @@ commandLineOptions =
       "v"
       ["verbose"]
       (NoArg $ Right $ \config -> config {scriptVerbose = scriptVerbose config + 1})
-      "Enable logging.  Pass multiple times for more.",
+      "Enable logging. Pass multiple times for more.",
     Option
       "o"
       ["output"]
       (ReqArg (\opt -> Right $ \config -> config {scriptOutput = Just opt}) "FILE")
-      "Enable logging.  Pass multiple times for more.",
+      "Override output file. Image directory is set to basename appended with -img/.",
     Option
       []
       ["stop-on-error"]


### PR DESCRIPTION
Previously the literate help message would display an incorrect help message for -o:
```
-o FILE  --output=FILE               Enable logging.  Pass multiple times for more.
```
