### PR TITLE
 Issue a warning if non-monotonicity is detected while autotuning. 

### DIFF
--- a/src/Futhark/CLI/Autotune.hs
+++ b/src/Futhark/CLI/Autotune.hs
@@ -312,8 +312,10 @@ tuneThreshold opts server datasets already_tuned (v, _v_path) = do
                 putStrLn $ unwords ("Got ePars: " : map show ePars)
 
               newMax <- binarySearch runner (t, tMax) ePars
-              let newMinIdx = pred <$> elemIndex newMax ePars
-              let newMin = maxinum $ catMaybes [Just tMin, newMinIdx]
+              let newMinIdx = do
+                    i <- pred <$> elemIndex newMax ePars
+                    if i < 0 then fail "Invalid lower index" else return i
+              let newMin = maxinum $ catMaybes [Just tMin, fmap (ePars !!) newMinIdx]
               return $ Just (newMin, newMax)
 
     bestPair :: [(Int, Int)] -> (Int, Int)

--- a/src/Futhark/CLI/Autotune.hs
+++ b/src/Futhark/CLI/Autotune.hs
@@ -8,6 +8,7 @@ import Control.Monad
 import qualified Data.ByteString.Char8 as SBS
 import Data.Function (on)
 import Data.List (elemIndex, intersect, isPrefixOf, minimumBy, sort, sortOn)
+import qualified Data.Map as M
 import Data.Maybe
 import qualified Data.Set as S
 import qualified Data.Text as T
@@ -240,31 +241,36 @@ thresholdForest prog = do
             return ((v, cmp), ancestors')
        in ((parent, parent_cmp), mapMaybe isChild thresholds)
 
+-- | The performance difference in percentage that triggers a non-monotonicity
+-- warning. This is to account for slight variantions in run-time.
+epsilon :: Double
+epsilon = 1.02
+
 --- Doing the atual tuning
 
 tuneThreshold ::
   AutotuneOptions ->
   Server ->
   [(DatasetName, RunDataset, T.Text)] ->
-  Path ->
+  (Path, M.Map DatasetName Int) ->
   (String, Path) ->
-  IO Path
-tuneThreshold opts server datasets already_tuned (v, _v_path) = do
-  tune_result <-
-    foldM tuneDataset Nothing datasets
+  IO (Path, M.Map DatasetName Int)
+tuneThreshold opts server datasets (already_tuned, best_runtimes0) (v, _v_path) = do
+  (tune_result, best_runtimes) <-
+    foldM tuneDataset (Nothing, best_runtimes0) datasets
   case tune_result of
     Nothing ->
-      return $ (v, thresholdMin) : already_tuned
+      return ((v, thresholdMin) : already_tuned, best_runtimes)
     Just (_, threshold) ->
-      return $ (v, threshold) : already_tuned
+      return ((v, threshold) : already_tuned, best_runtimes)
   where
-    tuneDataset :: Maybe (Int, Int) -> (DatasetName, RunDataset, T.Text) -> IO (Maybe (Int, Int))
-    tuneDataset thresholds (dataset_name, run, entry_point) =
+    tuneDataset :: (Maybe (Int, Int), M.Map DatasetName Int) -> (DatasetName, RunDataset, T.Text) -> IO (Maybe (Int, Int), M.Map DatasetName Int)
+    tuneDataset (thresholds, best_runtimes) (dataset_name, run, entry_point) =
       if not $ isPrefixOf (T.unpack entry_point ++ ".") v
         then do
           when (optVerbose opts > 0) $
             putStrLn $ unwords [v, "is irrelevant for", T.unpack entry_point]
-          return thresholds
+          return (thresholds, best_runtimes)
         else do
           putStrLn $
             unwords
@@ -290,7 +296,7 @@ tuneThreshold opts server datasets already_tuned (v, _v_path) = do
               when (optVerbose opts > 0) $
                 putStrLn $
                   "Sampling run failed:\n" ++ err
-              return thresholds
+              return (thresholds, best_runtimes)
             Right (cmps, t) -> do
               let (tMin, tMax) = fromMaybe (thresholdMin, thresholdMax) thresholds
               let ePars =
@@ -311,12 +317,30 @@ tuneThreshold opts server datasets already_tuned (v, _v_path) = do
               when (optVerbose opts > 1) $
                 putStrLn $ unwords ("Got ePars: " : map show ePars)
 
-              newMax <- binarySearch runner (t, tMax) ePars
+              (best_t, newMax) <- binarySearch runner (t, tMax) ePars
               let newMinIdx = do
                     i <- pred <$> elemIndex newMax ePars
                     if i < 0 then fail "Invalid lower index" else return i
               let newMin = maxinum $ catMaybes [Just tMin, fmap (ePars !!) newMinIdx]
-              return $ Just (newMin, newMax)
+              best_runtimes' <-
+                case dataset_name `M.lookup` best_runtimes of
+                  Just rt
+                    | fromIntegral rt * epsilon < fromIntegral best_t -> do
+                      putStrLn $
+                        unwords
+                          [ "WARNING! Possible non-monotonicity detected. Previous best run-time for dataset",
+                            dataset_name,
+                            " was",
+                            show rt,
+                            "but after tuning threshold",
+                            v,
+                            "it is",
+                            show best_t
+                          ]
+                      return best_runtimes
+                  _ ->
+                    return $ M.insertWith min dataset_name best_t best_runtimes
+              return (Just (newMin, newMax), best_runtimes')
 
     bestPair :: [(Int, Int)] -> (Int, Int)
     bestPair = minimumBy (compare `on` fst)
@@ -329,7 +353,7 @@ tuneThreshold opts server datasets already_tuned (v, _v_path) = do
     candidateEPar (tMin, tMax) (threshold, ePar) =
       ePar > tMin && ePar < tMax && threshold == v
 
-    binarySearch :: (Int -> Int -> IO (Maybe Int)) -> (Int, Int) -> [Int] -> IO Int
+    binarySearch :: (Int -> Int -> IO (Maybe Int)) -> (Int, Int) -> [Int] -> IO (Int, Int)
     binarySearch runner best@(best_t, best_e_par) xs =
       case splitAt (length xs `div` 2) xs of
         (lower, middle : middle' : upper) -> do
@@ -365,14 +389,14 @@ tuneThreshold opts server datasets already_tuned (v, _v_path) = do
                       "and",
                       show middle'
                     ]
-              return best_e_par
+              return (best_t, best_e_par)
         (_, _) -> do
           when (optVerbose opts > 0) $
             putStrLn $ unwords ["Trying e_pars", show xs]
           candidates <-
             catMaybes . zipWith (fmap . flip (,)) xs
               <$> mapM (runner $ timeout best_t) xs
-          return $ snd $ bestPair $ best : candidates
+          return $ bestPair $ best : candidates
 
 --- CLI
 
@@ -391,7 +415,9 @@ tune opts prog = do
   putStrLn $ "Running with options: " ++ unwords (serverOptions opts)
 
   withServer (futharkServerCfg progbin (serverOptions opts)) $ \server ->
-    foldM (tuneThreshold opts server datasets) [] $ tuningPaths forest
+    fmap fst $
+      foldM (tuneThreshold opts server datasets) ([], mempty) $
+        tuningPaths forest
 
 runAutotuner :: AutotuneOptions -> FilePath -> IO ()
 runAutotuner opts prog = do


### PR DESCRIPTION
Detects whether tuning a parameter decreases the performance on a given
dataset. Ideally, this should never happen and (excepting bugs in the autotuner)
is a sign of non-monotonicity in the generated Futhark program.

Fixes #1554.

