### PR TITLE
Adding DPP project enhancements to reverse-AD ('ad-genred-opt' branch)

### DIFF
--- a/src/Futhark/AD/Rev/Reduce.hs
+++ b/src/Futhark/AD/Rev/Reduce.hs
@@ -7,6 +7,7 @@
 module Futhark.AD.Rev.Reduce
   ( diffReduce,
     diffMinMaxReduce,
+    diffVecMinMaxOrMulReduce,
   )
 where
 
@@ -277,3 +278,15 @@ diffMinMaxReduce _ops x aux w minmax ne as m = do
     letSubExp "minmax_in_bounds" . BasicOp $
       CmpOp (CmpSlt Int64) (intConst Int64 0) w
   updateAdjIndex as (CheckBounds (Just in_bounds), Var x_ind) (Var x_adj)
+  
+--
+-- Special case of reduce with vectorised min/max:
+--    let x = reduce (map2 minmax) nes as
+-- Idea: 
+--    rewrite to
+--      let x = map2 (\as ne -> reduce minmax ne as) (transpose as) nes
+--    and diff
+diffVecMinMaxOrMulReduce ::
+  VjpOps -> Pat -> StmAux () -> SubExp -> SubExp -> BinOp -> VName -> VName -> ADM () -> ADM ()
+diffVecMinMaxOrMulReduce _ops x aux w n op ne as m =
+  error "todo"

--- a/src/Futhark/AD/Rev/SOAC.hs
+++ b/src/Futhark/AD/Rev/SOAC.hs
@@ -76,6 +76,13 @@ vjpSOAC ops pat aux soac@(Screma w as form) m
     Just [(op, _, _, _)] <- lamIsBinOp $ redLambda red,
     isMinMaxOp op =
     diffMinMaxReduce ops x aux w op ne a m
+  | Just [red] <- isReduceSOAC form,
+    [x] <- patNames pat,
+    [ne] <- redNeutral red,
+    [a] <- as,
+    Just [(op, _, _, _)] <- lamIsBinOp $ redLambda red,
+    isMulOp op =
+    diffMulReduce ops x aux w op ne a m
   | Just red <- singleReduce <$> isReduceSOAC form = do
     pat_adj <- mapM adjVal =<< commonSOAC pat aux soac m
     diffReduce ops pat_adj w as red

--- a/tests/ad/reduce-vec-minmax0.fut
+++ b/tests/ad/reduce-vec-minmax0.fut
@@ -1,0 +1,20 @@
+-- ==
+-- entry: main
+-- compiled random input { [50][66]f32 } output { true }
+-- compiled random input { [23][45]f32} output { true }
+
+let redmap [n][m] (arr: [m][n]f32) : [n]f32 = 
+  reduce (map2 f32.max) (replicate n f32.lowest) arr
+
+let forward [n][m] (arr: [m][n]f32) : [n][m][n]f32 =
+  tabulate_2d m n (\i j -> jvp redmap arr (replicate m (replicate n 0) with [i] = (replicate n 0 with [j] = 1)))
+  |> transpose
+
+let reverse [n][m] (arr: [m][n]f32) : [n][m][n]f32 =
+  tabulate n (\i -> vjp redmap arr (replicate n 0 with [i] = 1))
+
+let main [n][m] (arr : [m][n]f32) : bool =
+  let l  = n * m * n
+  let fs = forward arr |> flatten_3d :> [l]f32
+  let rs = reverse arr |> flatten_3d :> [l]f32
+   in reduce (&&) true (map2 (\i j -> f32.abs(i - j) < 0.0001f32) fs rs)

--- a/tests/ad/reducemul0.fut
+++ b/tests/ad/reducemul0.fut
@@ -1,0 +1,12 @@
+-- ==
+-- entry: rev fwd
+-- compiled input { [0.0f32, 2.0f32, 0.0f32, 4.0f32] } output { [0.0f32, 0.0f32, 0.0f32, 0.0f32] }
+
+def red_mult [n] (xs: [n]f32) : f32 =
+  reduce (*) 1 xs
+
+entry rev [n] (xs: [n]f32) =
+  vjp red_mult (xs) 1
+
+entry fwd [n] (xs: [n]f32) =
+  tabulate n (\i -> jvp red_mult xs (replicate n 0 with [i] = 1))

--- a/tests/ad/reducemul1.fut
+++ b/tests/ad/reducemul1.fut
@@ -1,0 +1,9 @@
+-- ==
+-- entry: rev 
+-- compiled input { [1f32, 0f32, 3f32, 4f32] 3.0f32 } output { [0f32, 36f32, 0f32, 0f32] 0f32 }
+
+def red_mult [n] (xs: [n]f32, c: f32) : f32 =
+  reduce (*) 1 xs * c
+
+entry rev [n] (xs: [n]f32) (c: f32) =
+  vjp red_mult (xs,c) 1

--- a/tests/ad/reducemul2.fut
+++ b/tests/ad/reducemul2.fut
@@ -1,0 +1,9 @@
+-- ==
+-- entry: rev 
+-- compiled input { [1f32, 0f32, 3f32, 0f32] 3.0f32 } output { [0f32, 0f32, 0f32, 0f32] 0f32 }
+
+def red_mult [n] (xs: [n]f32, c: f32) : f32 =
+  reduce (*) 1 xs * c
+
+entry rev [n] (xs: [n]f32) (c: f32) =
+  vjp red_mult (xs,c) 1

--- a/tests/ad/reducemul3.fut
+++ b/tests/ad/reducemul3.fut
@@ -1,0 +1,9 @@
+-- ==
+-- entry: rev 
+-- compiled input { [1f32, 2f32, 3f32, 4f32] 3.0f32 } output { [72f32, 36f32, 24f32, 18f32] 24f32 }
+
+def red_mult [n] (xs: [n]f32, c: f32) : f32 =
+  reduce (*) 1 xs * c
+
+entry rev [n] (xs: [n]f32) (c: f32) =
+  vjp red_mult (xs,c) 1

--- a/tests/ad/reducemul4.fut
+++ b/tests/ad/reducemul4.fut
@@ -1,0 +1,14 @@
+-- ==
+-- entry: fwd rev
+-- compiled input { [1f32, 2f32, 3f32, 4f32] } output { [[48f32, 12f32, 8f32, 6f32], [48f32, 48f32, 16f32, 12f32], [72f32, 36f32, 48f32, 18f32], [96f32, 48f32, 32f32, 48f32]] }
+
+def fun [n] (as: [n]f32) =
+  let x = reduce (*) 1 as 
+  in map (*x) as
+
+entry fwd [n] (as: [n]f32) =
+  tabulate n (\i -> jvp fun as (replicate n 0 with [i] = 1))
+  |> transpose
+
+entry rev [n] (as: [n]f32) =
+  tabulate n (\i -> vjp fun as (replicate n 0 with [i] = 1))

--- a/tests/ad/reducevecmul0.fut
+++ b/tests/ad/reducevecmul0.fut
@@ -1,0 +1,11 @@
+-- ==
+-- entry: rev
+-- compiled input { [[0.0f32, 2.0f32, 0.0f32, 4.0f32], [4.0f32, 2.0f32, 0.0f32, 0.0f32]] } output { [[4.000000f32, 0.000000f32, 0.000000f32, 0.000000f32], [0.000000f32, 0.000000f32, 0.000000f32, 0.000000f32]] }
+
+let red_mult [m][n] (xs: [m][n]f32) : [n]f32 =
+  reduce (map2 (*)) (replicate n 1) xs
+
+entry rev [m][n] (xs: [m][n]f32)  =
+  vjp red_mult xs (replicate n 0 with [0] = 1)
+
+let main = rev

--- a/tests/ad/reducevecmul1.fut
+++ b/tests/ad/reducevecmul1.fut
@@ -1,0 +1,11 @@
+-- ==
+-- entry: rev 
+-- compiled input { [[1f32, 0f32, 3f32, 4f32], [2f32,2f32,2f32,2f32]] 3.0f32 } output { [[0f32, 0f32, 0f32, 6f32], [0f32, 0f32, 0f32,12f32]] 8f32 }
+
+def red_mult [m][n] (xs: [m][n]f32, c: f32) =
+  reduce (map2 (*)) (replicate n 1) xs |> map (*c)
+
+entry rev [m][n] (xs: [m][n]f32) (c: f32) =
+  vjp red_mult (xs,c) (replicate n 0 with [3] = 1)
+
+let main = rev

--- a/tests/ad/reducevecmul2.fut
+++ b/tests/ad/reducevecmul2.fut
@@ -1,0 +1,11 @@
+-- ==
+-- entry: rev
+-- compiled input { [[1f32, 0f32, 3f32, 0f32], [1f32,2f32,3f32,4f32]] 3.0f32 } output { [[0f32, 0f32, 9f32, 0f32], [0f32, 0f32, 9f32, 0f32]] 9f32 }
+
+def red_mult [m][n] (xs: [m][n]f32, c: f32) =
+  reduce (map2 (*)) (replicate n 1) xs |> map (*c)
+
+entry rev [m][n] (xs: [m][n]f32) (c: f32) =
+  vjp red_mult (xs,c) (replicate n 0 with [2] = 1)
+
+let main = rev

--- a/tests/ad/reducevecmul3.fut
+++ b/tests/ad/reducevecmul3.fut
@@ -1,0 +1,11 @@
+-- ==
+-- entry: rev
+-- compiled input { [[1f32, 2f32, 3f32, 4f32], [1f32, 1f32, 1f32, 1f32]] 3.0f32 } output { [[0f32, 3f32, 0f32, 0f32],[0f32, 6f32, 0f32, 0f32]] 2f32 }
+
+def red_mult [m][n] (xs: [m][n]f32, c: f32) =
+  reduce (map2 (*)) (replicate n 1) xs |> map (*c)
+
+entry rev [m][n] (xs: [m][n]f32) (c: f32) =
+  vjp red_mult (xs,c) (replicate n 0 with [1] = 1)
+
+let main = rev


### PR DESCRIPTION
Includes enhancements for reverse-AD:
* reduce (*)
* reduce(map2(binop)) 2d_arr interchange 

After the oral part of the project we extended the interchange to work for all binops as suggested by you. 