### PR TITLE
Support partial sequentialisation of intra-group parallelism.

### DIFF
--- a/src/Futhark/IR/GPU/Op.hs
+++ b/src/Futhark/IR/GPU/Op.hs
@@ -74,7 +74,7 @@ instance PP.Pretty SegLevel where
         SegGroup {} -> "group"
       virt = case segVirt lvl of
         SegNoVirt -> mempty
-        SegNoVirtFull -> PP.semi <+> text "full"
+        SegNoVirtFull dims -> PP.semi <+> text "full" <+> ppr (segSeqDims dims)
         SegVirt -> PP.semi <+> text "virtualise"
 
 instance Engine.Simplifiable SegLevel where

--- a/src/Futhark/IR/Parse.hs
+++ b/src/Futhark/IR/Parse.hs
@@ -826,7 +826,8 @@ pSegLevel =
       <*> choice
         [ pSemi
             *> choice
-              [ keyword "full" $> SegOp.SegNoVirtFull,
+              [ keyword "full" $> SegOp.SegNoVirtFull
+                  <*> (SegOp.SegSeqDims <$> brackets (pInt `sepBy` pComma)),
                 keyword "virtualise" $> SegOp.SegVirt
               ],
           pure SegOp.SegNoVirt

--- a/src/Futhark/IR/SegOp.hs
+++ b/src/Futhark/IR/SegOp.hs
@@ -13,6 +13,7 @@
 module Futhark.IR.SegOp
   ( SegOp (..),
     SegVirt (..),
+    SegSeqDims (..),
     segLevel,
     segBody,
     segSpace,
@@ -494,6 +495,24 @@ instance Pretty KernelResult where
       onDim (dim, blk_tile, reg_tile) =
         ppr dim <+> "/" <+> parens (ppr blk_tile <+> "*" <+> ppr reg_tile)
 
+-- | These dimensions (indexed from 0, outermost) of the corresponding
+-- 'SegSpace' should not be parallelised, but instead iterated
+-- sequentially.  For example, with a 'SegSeqDims' of @[0]@ and a
+-- 'SegSpace' with dimensions @[n][m]@, there will be an outer loop
+-- with @n@ iterations, while the @m@ dimension will be parallelised.
+--
+-- Semantically, this has no effect, but it may allow reductions in
+-- memory usage or other low-level optimisations.  Operationally, the
+-- guarantee is that for a SegSeqDims of e.g. @[i,j,k]@, threads
+-- running at any given moment will always have the same indexes along
+-- the dimensions specified by @[i,j,k]@.
+--
+-- At the moment, this is only supported for 'SegNoVirtFull'
+-- intra-group parallelism in GPU code, as we have not yet found it
+-- useful anywhere else.
+newtype SegSeqDims = SegSeqDims {segSeqDims :: [Int]}
+  deriving (Eq, Ord, Show)
+
 -- | Do we need group-virtualisation when generating code for the
 -- segmented operation?  In most cases, we do, but for some simple
 -- kernels, we compute the full number of groups in advance, and then
@@ -507,7 +526,7 @@ data SegVirt
   | -- | Not only do we not need virtualisation, but we _guarantee_
     -- that all physical threads participate in the work.  This can
     -- save some checks in code generation.
-    SegNoVirtFull
+    SegNoVirtFull SegSeqDims
   deriving (Eq, Ord, Show)
 
 -- | Index space of a 'SegOp'.

--- a/src/Futhark/Optimise/BlkRegTiling.hs
+++ b/src/Futhark/Optimise/BlkRegTiling.hs
@@ -126,7 +126,7 @@ mmBlkRegTiling (Let pat aux (Op (SegOp (SegMap SegThread {} seg_space ts old_kbo
               map snd rem_outer_dims_rev
       grid_size <- letSubExp "grid_size" =<< toExp grid_pexp
       group_size <- letSubExp "group_size" =<< toExp (pe64 ty * pe64 tx)
-      let segthd_lvl = SegThread (Count grid_size) (Count group_size) SegNoVirtFull
+      let segthd_lvl = SegThread (Count grid_size) (Count group_size) (SegNoVirtFull (SegSeqDims []))
 
       gid_x <- newVName "gid_x"
       gid_y <- newVName "gid_y"
@@ -153,88 +153,88 @@ mmBlkRegTiling (Let pat aux (Op (SegOp (SegMap SegThread {} seg_space ts old_kbo
 
         let kkLoopBody tkind kk0 (thd_res_merge, a_loc_init', b_loc_init') epilogue = do
               kk <- letExp "kk" =<< toExp (le64 kk0 * pe64 tk)
-              a_loc <- forLoop ry [a_loc_init'] $ \i0 [a_loc_merge] -> do
-                loop_a_loc <- forLoop tk_div_tx [a_loc_merge] $ \k0 [a_loc_merge'] -> do
-                  scatter_a_loc <- segScatter2D "A_glb2loc" a_loc_sz a_loc_merge' segthd_lvl (ty, tx) $
-                    \(thd_y, thd_x) -> do
-                      k <- letExp "k" =<< toExp (le64 thd_x + le64 k0 * pe64 tx)
-                      i <- letExp "i" =<< toExp (le64 thd_y + le64 i0 * pe64 ty)
+              a_loc <- segScatter2D
+                "A_glb2loc"
+                a_loc_sz
+                a_loc_init'
+                segthd_lvl
+                [ry, tk_div_tx]
+                (ty, tx)
+                $ \[i0, k0] (thd_y, thd_x) -> do
+                  k <- letExp "k" =<< toExp (le64 thd_x + le64 k0 * pe64 tx)
+                  i <- letExp "i" =<< toExp (le64 thd_y + le64 i0 * pe64 ty)
 
-                      letBindNames [gtid_y] =<< toExp (le64 iii + le64 i)
-                      a_col_idx <- letExp "A_col_idx" =<< toExp (le64 kk + le64 k)
+                  letBindNames [gtid_y] =<< toExp (le64 iii + le64 i)
+                  a_col_idx <- letExp "A_col_idx" =<< toExp (le64 kk + le64 k)
 
-                      a_elem <-
-                        letSubExp "A_elem"
-                          =<< eIf
-                            ( toExp $
-                                le64 gtid_y .<. pe64 height_A
-                                  .&&. if epilogue
-                                    then le64 a_col_idx .<. pe64 common_dim
-                                    else true
-                            )
-                            ( do
-                                addStm load_A
-                                res <- index "A_elem" inp_A [a_col_idx]
-                                resultBodyM [Var res]
-                            )
-                            (eBody [eBlank $ Prim map_t1])
-                      a_loc_ind <-
-                        letSubExp "a_loc_ind"
-                          =<< eIf
-                            (toExp $ le64 k .<. pe64 tk)
-                            ( toExp (le64 k + le64 i * pe64 tk)
-                                >>= letTupExp' "loc_fi"
-                                >>= resultBodyM
-                            )
-                            (eBody [pure $ BasicOp $ SubExp $ intConst Int64 (-1)])
-                      return (a_elem, a_loc_ind)
-                  resultBodyM $ map Var scatter_a_loc
-                resultBodyM [Var loop_a_loc]
+                  a_elem <-
+                    letSubExp "A_elem"
+                      =<< eIf
+                        ( toExp $
+                            le64 gtid_y .<. pe64 height_A
+                              .&&. if epilogue
+                                then le64 a_col_idx .<. pe64 common_dim
+                                else true
+                        )
+                        ( do
+                            addStm load_A
+                            res <- index "A_elem" inp_A [a_col_idx]
+                            resultBodyM [Var res]
+                        )
+                        (eBody [eBlank $ Prim map_t1])
+                  a_loc_ind <-
+                    letSubExp "a_loc_ind"
+                      =<< eIf
+                        (toExp $ le64 k .<. pe64 tk)
+                        ( toExp (le64 k + le64 i * pe64 tk)
+                            >>= letTupExp' "loc_fi"
+                            >>= resultBodyM
+                        )
+                        (eBody [pure $ BasicOp $ SubExp $ intConst Int64 (-1)])
+                  return (a_elem, a_loc_ind)
 
               -- copy B from global to shared memory
-              b_loc <- forLoop tk_div_ty [b_loc_init'] $ \k0 [b_loc_merge] -> do
-                loop_b_loc <- forLoop rx [b_loc_merge] $ \j0 [b_loc_merge'] -> do
-                  scatter_b_loc <- segScatter2D
-                    "B_glb2loc"
-                    b_loc_sz
-                    b_loc_merge'
-                    segthd_lvl
-                    (ty, tx)
-                    $ \(thd_y, thd_x) -> do
-                      k <- letExp "k" =<< toExp (le64 thd_y + le64 k0 * pe64 ty)
-                      j <- letExp "j" =<< toExp (le64 thd_x + le64 j0 * pe64 tx)
+              b_loc <- segScatter2D
+                "B_glb2loc"
+                b_loc_sz
+                b_loc_init'
+                segthd_lvl
+                [tk_div_ty, rx]
+                (ty, tx)
+                $ \[k0, j0] (thd_y, thd_x) ->
+                  do
+                    k <- letExp "k" =<< toExp (le64 thd_y + le64 k0 * pe64 ty)
+                    j <- letExp "j" =<< toExp (le64 thd_x + le64 j0 * pe64 tx)
 
-                      letBindNames [gtid_x] =<< toExp (le64 jjj + le64 j)
-                      b_row_idx <- letExp "B_row_idx" =<< toExp (le64 kk + le64 k)
+                    letBindNames [gtid_x] =<< toExp (le64 jjj + le64 j)
+                    b_row_idx <- letExp "B_row_idx" =<< toExp (le64 kk + le64 k)
 
-                      b_elem <-
-                        letSubExp "B_elem"
-                          =<< eIf
-                            ( toExp $
-                                le64 gtid_x .<. pe64 width_B
-                                  .&&. if epilogue
-                                    then le64 b_row_idx .<. pe64 common_dim
-                                    else true
-                            )
-                            ( do
-                                addStm load_B
-                                res <- index "B_elem" inp_B [b_row_idx]
-                                resultBodyM [Var res]
-                            )
-                            (eBody [eBlank $ Prim map_t2])
+                    b_elem <-
+                      letSubExp "B_elem"
+                        =<< eIf
+                          ( toExp $
+                              le64 gtid_x .<. pe64 width_B
+                                .&&. if epilogue
+                                  then le64 b_row_idx .<. pe64 common_dim
+                                  else true
+                          )
+                          ( do
+                              addStm load_B
+                              res <- index "B_elem" inp_B [b_row_idx]
+                              resultBodyM [Var res]
+                          )
+                          (eBody [eBlank $ Prim map_t2])
 
-                      b_loc_ind <-
-                        letSubExp "b_loc_ind"
-                          =<< eIf
-                            (toExp $ le64 k .<. pe64 tk)
-                            ( toExp (le64 j + le64 k * pe64 tx_rx)
-                                >>= letTupExp' "loc_fi"
-                                >>= resultBodyM
-                            )
-                            (eBody [pure $ BasicOp $ SubExp $ intConst Int64 (-1)])
-                      return (b_elem, b_loc_ind)
-                  resultBodyM $ map Var scatter_b_loc
-                resultBodyM [Var loop_b_loc]
+                    b_loc_ind <-
+                      letSubExp "b_loc_ind"
+                        =<< eIf
+                          (toExp $ le64 k .<. pe64 tk)
+                          ( toExp (le64 j + le64 k * pe64 tx_rx)
+                              >>= letTupExp' "loc_fi"
+                              >>= resultBodyM
+                          )
+                          (eBody [pure $ BasicOp $ SubExp $ intConst Int64 (-1)])
+                    return (b_elem, b_loc_ind)
 
               -- inner loop updating this thread's accumulator (loop k in mmm_kernels).
               thd_acc <- forLoop tk [thd_res_merge] $ \k [acc_merge] ->
@@ -782,7 +782,7 @@ doRegTiling3D (Let pat aux (Op (SegOp old_kernel)))
       let grid_pexp = product $ gridxyz_pexp : map (pe64 . snd) rem_outer_dims_rev
       grid_size <- letSubExp "grid_size_tile3d" =<< toExp grid_pexp
       group_size <- letSubExp "group_size_tile3d" =<< toExp (pe64 ty * pe64 tx)
-      let segthd_lvl = SegThread (Count grid_size) (Count group_size) SegNoVirtFull
+      let segthd_lvl = SegThread (Count grid_size) (Count group_size) (SegNoVirtFull (SegSeqDims []))
 
       count_shmem <- letSubExp "count_shmem" =<< ceilDiv rz group_size
 

--- a/src/Futhark/Optimise/TileLoops.hs
+++ b/src/Futhark/Optimise/TileLoops.hs
@@ -1010,7 +1010,7 @@ readTile2D (kdim_x, kdim_y) (gtid_x, gtid_y) (gid_x, gid_y) tile_size num_groups
   fmap (inputsToTiles inputs)
     . segMap2D
       "full_tile"
-      (SegThread num_groups group_size SegNoVirtFull)
+      (SegThread num_groups group_size (SegNoVirtFull (SegSeqDims [])))
       ResultNoSimplify
       (tile_size, tile_size)
     $ \(ltid_x, ltid_y) -> do
@@ -1090,7 +1090,7 @@ processTile2D (gid_x, gid_y) (gtid_x, gtid_y) (kdim_x, kdim_y) tile_size num_gro
 
   segMap2D
     "acc"
-    (SegThread num_groups group_size SegNoVirtFull)
+    (SegThread num_groups group_size (SegNoVirtFull (SegSeqDims [])))
     ResultPrivate
     (tile_size, tile_size)
     $ \(ltid_x, ltid_y) -> do
@@ -1225,7 +1225,7 @@ tiling2d dims_on_top _initial_lvl (gtid_x, gtid_y) (kdim_x, kdim_y) w = do
         (num_groups_y : map snd dims_on_top)
 
   gid_flat <- newVName "gid_flat"
-  let lvl = SegGroup (Count num_groups) (Count group_size) SegNoVirtFull
+  let lvl = SegGroup (Count num_groups) (Count group_size) (SegNoVirtFull (SegSeqDims []))
       space =
         SegSpace gid_flat $
           dims_on_top ++ [(gid_x, num_groups_x), (gid_y, num_groups_y)]

--- a/src/Futhark/Optimise/TileLoops/Shared.hs
+++ b/src/Futhark/Optimise/TileLoops/Shared.hs
@@ -100,24 +100,36 @@ segScatter2D ::
   SubExp -> -- arr_size
   VName ->
   SegLevel -> -- lvl
+  [SubExp] -> -- dims of sequential loop on top
   (SubExp, SubExp) -> -- (dim_y, dim_x)
-  ((VName, VName) -> Builder GPU (SubExp, SubExp)) -> -- f
-  Builder GPU [VName]
-segScatter2D desc arr_size updt_arr lvl (dim_x, dim_y) f = do
+  ([VName] -> (VName, VName) -> Builder GPU (SubExp, SubExp)) -> -- f
+  Builder GPU VName
+segScatter2D desc arr_size updt_arr lvl seq_dims (dim_x, dim_y) f = do
   ltid_x <- newVName "ltid_x"
   ltid_y <- newVName "ltid_y"
   ltid_flat <- newVName "ltid_flat"
-  let segspace = SegSpace ltid_flat [(ltid_x, dim_x), (ltid_y, dim_y)]
+
+  seq_is <- replicateM (length seq_dims) (newVName "ltid_seq")
+  let seq_space = zip seq_is seq_dims
+
+  let segspace = SegSpace ltid_flat $ seq_space ++ [(ltid_x, dim_x), (ltid_y, dim_y)]
+      lvl' =
+        SegThread
+          (segNumGroups lvl)
+          (segGroupSize lvl)
+          (SegNoVirtFull (SegSeqDims [0 .. length seq_dims -1]))
 
   ((t_v, res_v, res_i), stms) <- runBuilder $ do
-    (res_v, res_i) <- f (ltid_x, ltid_y)
+    (res_v, res_i) <-
+      localScope (scopeOfSegSpace segspace) $
+        f seq_is (ltid_x, ltid_y)
     t_v <- subExpType res_v
     return (t_v, res_v, res_i)
 
   let ret = WriteReturns mempty (Shape [arr_size]) updt_arr [(Slice [DimFix res_i], res_v)]
   let body = KernelBody () stms [ret]
 
-  letTupExp desc <=< renameExp $ Op $ SegOp $ SegMap lvl segspace [t_v] body
+  letExp desc <=< renameExp $ Op $ SegOp $ SegMap lvl' segspace [t_v] body
 
 -- | The variance table keeps a mapping from a variable name
 -- (something produced by a 'Stm') to the kernel thread indices

--- a/tests/tiling/tiling2.fut
+++ b/tests/tiling/tiling2.fut
@@ -1,8 +1,8 @@
 -- Simple 2D tiling
 -- ==
--- structure gpu { SegMap/DoLoop/DoLoop/SegMap 4
--- SegMap/DoLoop/DoLoop/DoLoop/SegMap 2
--- SegMap/SegMap 1
+-- structure gpu { SegMap/SegMap 4
+-- SegMap/DoLoop/SegMap 2
+-- SegMap/SegMap 3
 -- SegMap/DoLoop/DoLoop/SegMap/DoLoop 3 }
 
 def main (xs: [][]i32) (ys: [][]i32) =

--- a/tests/tiling/tiling_2d.fut
+++ b/tests/tiling/tiling_2d.fut
@@ -1,8 +1,8 @@
 -- Simple 2D tiling
 -- ==
--- structure gpu { SegMap/DoLoop/DoLoop/SegMap 4
--- SegMap/DoLoop/DoLoop/DoLoop/SegMap 2
--- SegMap/SegMap 1
+-- structure gpu { SegMap/SegMap 4
+-- SegMap/DoLoop/SegMap 2
+-- SegMap/SegMap 3
 -- SegMap/DoLoop/DoLoop/SegMap/DoLoop 3 }
 
 def main (xs: [][]i32) (ys: [][]i32) =

--- a/tests/tiling/tiling_2d_indirect.fut
+++ b/tests/tiling/tiling_2d_indirect.fut
@@ -1,8 +1,8 @@
 -- 2D tiling, but where the arrays are variant to an outermost third dimension.
 -- ==
--- structure gpu { SegMap/DoLoop/DoLoop/SegMap 4
--- SegMap/DoLoop/DoLoop/DoLoop/SegMap 2
--- SegMap/SegMap 1
+-- structure gpu { SegMap/SegMap 4
+-- SegMap/DoLoop/SegMap 2
+-- SegMap/SegMap 3
 -- SegMap/DoLoop/DoLoop/SegMap/DoLoop 3 }
 
 

--- a/tests/tiling/tiling_2d_inner.fut
+++ b/tests/tiling/tiling_2d_inner.fut
@@ -1,9 +1,9 @@
 -- 2D tiling with extra dimensions on top.
 -- ==
 -- compiled random input { [2][40][40]i32 [2][40][40]i32 } auto output
--- structure gpu { SegMap/DoLoop/DoLoop/SegMap 4
--- SegMap/DoLoop/DoLoop/DoLoop/SegMap 2
--- SegMap/SegMap 1
+-- structure gpu { SegMap/SegMap 4
+-- SegMap/DoLoop/SegMap 2
+-- SegMap/SegMap 3
 -- SegMap/DoLoop/DoLoop/SegMap/DoLoop 3 }
 
 def main [a][b][c] (xss: [a][b][c]i32) (yss: [a][b][c]i32) =


### PR DESCRIPTION
This is used to simplify register tiling slightly, and might even
result in a performance improvement as there will be fewer barriers.