### PR TITLE
Simplify ParLoop in multicore representation.

### DIFF
--- a/src/Futhark/CodeGen/ImpGen.hs
+++ b/src/Futhark/CodeGen/ImpGen.hs
@@ -85,6 +85,7 @@ module Futhark.CodeGen.ImpGen
     -- * Constructing code.
     dLParams,
     dFParams,
+    addLoopVar,
     dScope,
     dArray,
     dPrim,

--- a/src/Futhark/CodeGen/ImpGen/Multicore/Base.hs
+++ b/src/Futhark/CodeGen/ImpGen/Multicore/Base.hs
@@ -15,9 +15,11 @@ module Futhark.CodeGen.ImpGen.Multicore.Base
     AtomicUpdate (..),
     Locking (..),
     getSpace,
+    getLoopBounds,
     getIterationDomain,
     getReturnParams,
     segOpString,
+    generateChunkLoop,
   )
 where
 
@@ -29,6 +31,7 @@ import qualified Futhark.CodeGen.ImpCode.Multicore as Imp
 import Futhark.CodeGen.ImpGen
 import Futhark.Error
 import Futhark.IR.MCMem
+import Futhark.MonadFreshNames
 import Futhark.Transform.Rename
 import Prelude hiding (quot, rem)
 
@@ -75,6 +78,13 @@ getSpace (SegHist _ space _ _ _) = space
 getSpace (SegRed _ space _ _ _) = space
 getSpace (SegScan _ space _ _ _) = space
 getSpace (SegMap _ space _ _) = space
+
+getLoopBounds :: MulticoreGen (Imp.TExp Int64, Imp.TExp Int64)
+getLoopBounds = do
+  start <- dPrim "start" int64
+  end <- dPrim "end" int64
+  emit $ Imp.Op $ Imp.GetLoopBounds (tvVar start) (tvVar end)
+  pure (tvExp start, tvExp end)
 
 getIterationDomain :: SegOp () MCMem -> SegSpace -> MulticoreGen (Imp.TExp Int64)
 getIterationDomain SegMap {} space = do
@@ -156,7 +166,7 @@ isLoadBalanced (Imp.For _ _ a) = isLoadBalanced a
 isLoadBalanced (Imp.If _ a b) = isLoadBalanced a && isLoadBalanced b
 isLoadBalanced (Imp.Comment _ a) = isLoadBalanced a
 isLoadBalanced Imp.While {} = False
-isLoadBalanced (Imp.Op (Imp.ParLoop _ _ _ code _ _ _)) = isLoadBalanced code
+isLoadBalanced (Imp.Op (Imp.ParLoop _ code _ _)) = isLoadBalanced code
 isLoadBalanced _ = True
 
 segBinOpComm' :: [SegBinOp rep] -> Commutativity
@@ -203,7 +213,7 @@ extractAllocations segop_code = f segop_code
       let (ta, tcode') = f tcode
           (fa, fcode') = f fcode
        in (ta <> fa, Imp.If cond tcode' fcode')
-    f (Imp.Op (Imp.ParLoop s i prebody body postbody free info)) =
+    f (Imp.Op (Imp.ParLoop s body free info)) =
       let (body_allocs, body') = extractAllocations body
           (free_allocs, here_allocs) = f body_allocs
           free' =
@@ -214,11 +224,31 @@ extractAllocations segop_code = f segop_code
               )
               free
        in ( free_allocs,
-            here_allocs
-              <> Imp.Op (Imp.ParLoop s i prebody body' postbody free' info)
+            here_allocs <> Imp.Op (Imp.ParLoop s body' free' info)
           )
     f code =
       (mempty, code)
+
+-- | Emit code for the chunk loop, given an action that generates code
+-- for a single iteration.
+--
+-- The action is called with the (symbolic) index of the current
+-- iteration.
+generateChunkLoop ::
+  String ->
+  (Imp.TExp Int64 -> MulticoreGen ()) ->
+  MulticoreGen ()
+generateChunkLoop desc m = do
+  emit $ Imp.DebugPrint (desc <> " " <> "fbody") Nothing
+  (start, end) <- getLoopBounds
+  n <- dPrimVE "n" $ end - start
+  i <- newVName (desc <> "_i")
+  (body_allocs, body) <- fmap extractAllocations $
+    collect $ do
+      addLoopVar i Int64
+      m $ start + Imp.le64 i
+  emit body_allocs
+  emit $ Imp.For i (untyped n) body
 
 -------------------------------
 ------- SegHist helpers -------

--- a/src/Futhark/CodeGen/ImpGen/Multicore/SegHist.hs
+++ b/src/Futhark/CodeGen/ImpGen/Multicore/SegHist.hs
@@ -55,11 +55,10 @@ nonsegmentedHist pat space histops kbody num_histos = do
   -- Only do something if there is actually input.
   collect $
     sUnless (product ns_64 .==. 0) $ do
-      flat_idx <- dPrim "iter" int64
       sIf
         use_subhistogram
-        (subHistogram pat flat_idx space histops num_histos kbody)
-        (atomicHistogram pat flat_idx space histops' kbody)
+        (subHistogram pat space histops num_histos kbody)
+        (atomicHistogram pat space histops' kbody)
 
 -- |
 -- Atomic Histogram approach
@@ -93,12 +92,11 @@ onOpAtomic op = do
 
 atomicHistogram ::
   Pat MCMem ->
-  TV Int64 ->
   SegSpace ->
   [HistOp MCMem] ->
   KernelBody MCMem ->
   MulticoreGen ()
-atomicHistogram pat flat_idx space histops kbody = do
+atomicHistogram pat space histops kbody = do
   let (is, ns) = unzip $ unSegSpace space
       ns_64 = map toInt64Exp ns
   let num_red_res = length histops + sum (map (length . histNeutral) histops)
@@ -106,8 +104,8 @@ atomicHistogram pat flat_idx space histops kbody = do
 
   atomicOps <- mapM onOpAtomic histops
 
-  body <- collect $ do
-    zipWithM_ dPrimV_ is $ unflattenIndex ns_64 $ tvExp flat_idx
+  body <- collect . generateChunkLoop "SegHist" $ \flat_idx -> do
+    zipWithM_ dPrimV_ is $ unflattenIndex ns_64 flat_idx
     compileStms mempty (kernelBodyStms kbody) $ do
       let (red_res, map_res) =
             splitFromEnd (length map_pes) $ kernelBodyResult kbody
@@ -134,8 +132,8 @@ atomicHistogram pat flat_idx space histops kbody = do
                   copyDWIMFix (paramName p) [] res is'
                 do_op (map patElemName dest_res) (bucket_is ++ is')
 
-  free_params <- freeParams body (segFlat space : [tvVar flat_idx])
-  emit $ Imp.Op $ Imp.ParLoop "atomic_seg_hist" (tvVar flat_idx) mempty body mempty free_params $ segFlat space
+  free_params <- freeParams body [segFlat space]
+  emit $ Imp.Op $ Imp.ParLoop "atomic_seg_hist" body free_params $ segFlat space
 
 updateHisto :: HistOp MCMem -> [VName] -> [Imp.TExp Int64] -> MulticoreGen ()
 updateHisto op arrs bucket = do
@@ -161,13 +159,12 @@ updateHisto op arrs bucket = do
 -- This is expected to be fast if len(histDest) is small
 subHistogram ::
   Pat MCMem ->
-  TV Int64 ->
   SegSpace ->
   [HistOp MCMem] ->
   TV Int32 ->
   KernelBody MCMem ->
   MulticoreGen ()
-subHistogram pat flat_idx space histops num_histos kbody = do
+subHistogram pat space histops num_histos kbody = do
   emit $ Imp.DebugPrint "subHistogram segHist" Nothing
 
   let (is, ns) = unzip $ unSegSpace space
@@ -188,12 +185,10 @@ subHistogram pat flat_idx space histops num_histos kbody = do
       sAllocArray "subhistogram" (elemType t) shape DefaultSpace
 
   let tid' = Imp.le64 $ segFlat space
-      flat_idx' = tvExp flat_idx
 
-  (local_subhistograms, prebody) <- collect' $ do
-    zipWithM_ dPrimV_ is $ unflattenIndex ns_64 $ sExt64 flat_idx'
-
-    forM (zip per_red_pes histops) $ \(pes', histop) -> do
+  -- Generate loop body of parallel function
+  body <- collect $ do
+    local_subhistograms <- forM (zip per_red_pes histops) $ \(pes', histop) -> do
       op_local_subhistograms <- forM (histType histop) $ \t ->
         sAllocArray "subhistogram" (elemType t) (arrayShape t) DefaultSpace
 
@@ -208,48 +203,45 @@ subHistogram pat flat_idx space histops num_histos kbody = do
                 copyDWIMFix hist (shape_is <> vec_is) ne []
           )
 
-      return op_local_subhistograms
+      pure op_local_subhistograms
 
-  -- Generate loop body of parallel function
-  body <- collect $ do
-    zipWithM_ dPrimV_ is $ unflattenIndex ns_64 $ sExt64 flat_idx'
-    compileStms mempty (kernelBodyStms kbody) $ do
-      let (red_res, map_res) =
-            splitFromEnd (length map_pes) $
-              map kernelResultSubExp $ kernelBodyResult kbody
+    generateChunkLoop "SegRed" $ \i -> do
+      zipWithM_ dPrimV_ is $ unflattenIndex ns_64 i
+      compileStms mempty (kernelBodyStms kbody) $ do
+        let (red_res, map_res) =
+              splitFromEnd (length map_pes) $
+                map kernelResultSubExp $ kernelBodyResult kbody
 
-      sComment "save map-out results" $
-        forM_ (zip map_pes map_res) $ \(pe, res) ->
-          copyDWIMFix (patElemName pe) (map Imp.le64 is) res []
+        sComment "save map-out results" $
+          forM_ (zip map_pes map_res) $ \(pe, res) ->
+            copyDWIMFix (patElemName pe) (map Imp.le64 is) res []
 
-      forM_ (zip3 histops local_subhistograms (splitHistResults histops red_res)) $
-        \( histop@(HistOp dest_shape _ _ _ shape lam),
-           histop_subhistograms,
-           (bucket, vs')
-           ) -> do
-            let bucket' = map toInt64Exp bucket
-                dest_shape' = map toInt64Exp $ shapeDims dest_shape
-                bucket_in_bounds =
-                  inBounds (Slice (map DimFix bucket')) dest_shape'
-                vs_params = takeLast (length vs') $ lambdaParams lam
+        forM_ (zip3 histops local_subhistograms (splitHistResults histops red_res)) $
+          \( histop@(HistOp dest_shape _ _ _ shape lam),
+             histop_subhistograms,
+             (bucket, vs')
+             ) -> do
+              let bucket' = map toInt64Exp bucket
+                  dest_shape' = map toInt64Exp $ shapeDims dest_shape
+                  bucket_in_bounds =
+                    inBounds (Slice (map DimFix bucket')) dest_shape'
+                  vs_params = takeLast (length vs') $ lambdaParams lam
 
-            sComment "perform updates" $
-              sWhen bucket_in_bounds $ do
-                dLParams $ lambdaParams lam
-                sLoopNest shape $ \is' -> do
-                  forM_ (zip vs_params vs') $ \(p, res) ->
-                    copyDWIMFix (paramName p) [] res is'
-                  updateHisto histop histop_subhistograms (bucket' ++ is')
+              sComment "perform updates" $
+                sWhen bucket_in_bounds $ do
+                  dLParams $ lambdaParams lam
+                  sLoopNest shape $ \is' -> do
+                    forM_ (zip vs_params vs') $ \(p, res) ->
+                      copyDWIMFix (paramName p) [] res is'
+                    updateHisto histop histop_subhistograms (bucket' ++ is')
 
-  -- Copy the task-local subhistograms to the global subhistograms,
-  -- where they will be combined.
-  postbody <- collect $
+    -- Copy the task-local subhistograms to the global subhistograms,
+    -- where they will be combined.
     forM_ (zip (concat global_subhistograms) (concat local_subhistograms)) $
       \(global, local) -> copyDWIMFix global [tid'] (Var local) []
 
-  free_params <- freeParams (prebody <> body <> postbody) (segFlat space : [tvVar flat_idx])
-  let (body_allocs, body') = extractAllocations body
-  emit $ Imp.Op $ Imp.ParLoop "seghist_stage_1" (tvVar flat_idx) (body_allocs <> prebody) body' postbody free_params $ segFlat space
+  free_params <- freeParams body [segFlat space]
+  emit $ Imp.Op $ Imp.ParLoop "seghist_stage_1" body free_params $ segFlat space
 
   -- Perform a segmented reduction over the subhistograms
   forM_ (zip3 per_red_pes global_subhistograms histops) $ \(red_pes, hists, op) -> do
@@ -294,22 +286,18 @@ segmentedHist ::
   MulticoreGen Imp.Code
 segmentedHist pat space histops kbody = do
   emit $ Imp.DebugPrint "Segmented segHist" Nothing
-  -- Iteration variable over the segments
-  segments_i <- dPrim "segment_iter" $ IntType Int64
   collect $ do
-    par_body <- compileSegHistBody (tvExp segments_i) pat space histops kbody
-    free_params <- freeParams par_body [segFlat space, tvVar segments_i]
-    let (body_allocs, body') = extractAllocations par_body
-    emit $ Imp.Op $ Imp.ParLoop "segmented_hist" (tvVar segments_i) body_allocs body' mempty free_params $ segFlat space
+    body <- compileSegHistBody pat space histops kbody
+    free_params <- freeParams body [segFlat space]
+    emit $ Imp.Op $ Imp.ParLoop "segmented_hist" body free_params $ segFlat space
 
 compileSegHistBody ::
-  Imp.TExp Int64 ->
   Pat MCMem ->
   SegSpace ->
   [HistOp MCMem] ->
   KernelBody MCMem ->
   MulticoreGen Imp.Code
-compileSegHistBody idx pat space histops kbody = do
+compileSegHistBody pat space histops kbody = do
   let (is, ns) = unzip $ unSegSpace space
       ns_64 = map toInt64Exp ns
 
@@ -317,7 +305,7 @@ compileSegHistBody idx pat space histops kbody = do
       map_pes = drop num_red_res $ patElems pat
       per_red_pes = segHistOpChunks histops $ patElems pat
 
-  collect $ do
+  collect . generateChunkLoop "SegHist" $ \idx -> do
     let inner_bound = last ns_64
     sFor "i" inner_bound $ \i -> do
       zipWithM_ dPrimV_ (init is) $ unflattenIndex (init ns_64) idx

--- a/src/Futhark/CodeGen/ImpGen/Multicore/SegMap.hs
+++ b/src/Futhark/CodeGen/ImpGen/Multicore/SegMap.hs
@@ -23,24 +23,22 @@ writeResult _ pe (WriteReturns _ (Shape rws) _ idx_vals) = do
       rws' = map toInt64Exp rws
   forM_ (zip iss vs) $ \(slice, v) -> do
     let slice' = fmap toInt64Exp slice
-        when_in_bounds = copyDWIM (patElemName pe) (unSlice slice') v []
-    sWhen (inBounds slice' rws') when_in_bounds
+    sWhen (inBounds slice' rws') $
+      copyDWIM (patElemName pe) (unSlice slice') v []
 writeResult _ _ res =
   error $ "writeResult: cannot handle " ++ pretty res
 
 compileSegMapBody ::
-  TV Int64 ->
   Pat MCMem ->
   SegSpace ->
   KernelBody MCMem ->
   MulticoreGen Imp.Code
-compileSegMapBody flat_idx pat space (KernelBody _ kstms kres) = do
+compileSegMapBody pat space (KernelBody _ kstms kres) = collect $ do
   let (is, ns) = unzip $ unSegSpace space
       ns' = map toInt64Exp ns
   kstms' <- mapM renameStm kstms
-  collect $ do
-    emit $ Imp.DebugPrint "SegMap fbody" Nothing
-    dIndexSpace (zip is ns') $ tvExp flat_idx
+  generateChunkLoop "SegMap" $ \i -> do
+    dIndexSpace (zip is ns') i
     compileStms (freeIn kres) kstms' $
       zipWithM_ (writeResult is) (patElems pat) kres
 
@@ -49,10 +47,7 @@ compileSegMap ::
   SegSpace ->
   KernelBody MCMem ->
   MulticoreGen Imp.Code
-compileSegMap pat space kbody =
-  collect $ do
-    flat_par_idx <- dPrim "iter" int64
-    body <- compileSegMapBody flat_par_idx pat space kbody
-    free_params <- freeParams body [segFlat space, tvVar flat_par_idx]
-    let (body_allocs, body') = extractAllocations body
-    emit $ Imp.Op $ Imp.ParLoop "segmap" (tvVar flat_par_idx) body_allocs body' mempty free_params $ segFlat space
+compileSegMap pat space kbody = collect $ do
+  body <- compileSegMapBody pat space kbody
+  free_params <- freeParams body [segFlat space]
+  emit $ Imp.Op $ Imp.ParLoop "segmap" body free_params $ segFlat space

--- a/src/Futhark/CodeGen/ImpGen/Multicore/SegRed.hs
+++ b/src/Futhark/CodeGen/ImpGen/Multicore/SegRed.hs
@@ -96,8 +96,6 @@ reductionStage1 ::
 reductionStage1 space slugs kbody = do
   let (is, ns) = unzip $ unSegSpace space
       ns' = map toInt64Exp ns
-  flat_idx <- dPrim "iter" int64
-
   -- Create local accumulator variables in which we carry out the
   -- sequential reduction of this function.  If we are dealing with
   -- vectorised operators, then this implies a private allocation.  If
@@ -105,62 +103,61 @@ reductionStage1 space slugs kbody = do
   -- then our hands are unfortunately tied, and we have to use exactly
   -- that memory.  This is likely to be slow.
 
-  (slug_local_accs, prebody) <- collect' $ do
-    dScope Nothing $ scopeOfLParams $ concatMap slugParams slugs
-
-    forM slugs $ \slug -> do
-      let shape = segBinOpShape $ slugOp slug
-
-      forM (zip (accParams slug) (slugNeutral slug)) $ \(p, ne) -> do
-        -- Declare accumulator variable.
-        acc <-
-          case paramType p of
-            Prim pt
-              | shape == mempty ->
-                tvVar <$> dPrim "local_acc" pt
-              | otherwise ->
-                sAllocArray "local_acc" pt shape DefaultSpace
-            _ ->
-              pure $ paramName p
-
-        -- Now neutral-initialise the accumulator.
-        sLoopNest (slugShape slug) $ \vec_is ->
-          copyDWIMFix acc vec_is ne []
-
-        pure acc
-
   fbody <- collect $ do
-    zipWithM_ dPrimV_ is $ unflattenIndex ns' $ tvExp flat_idx
-    kbody $ \all_red_res -> do
-      let all_red_res' = segBinOpChunks (map slugOp slugs) all_red_res
-      forM_ (zip3 all_red_res' slugs slug_local_accs) $ \(red_res, slug, local_accs) ->
-        sLoopNest (slugShape slug) $ \vec_is -> do
-          let lamtypes = lambdaReturnType $ segBinOpLambda $ slugOp slug
-          -- Load accum params
-          sComment "Load accum params" $
-            forM_ (zip3 (accParams slug) local_accs lamtypes) $
-              \(p, local_acc, t) ->
-                when (primType t) $
-                  copyDWIMFix (paramName p) [] (Var local_acc) vec_is
+    slug_local_accs <- do
+      dScope Nothing $ scopeOfLParams $ concatMap slugParams slugs
 
-          sComment "Load next params" $
-            forM_ (zip (nextParams slug) red_res) $ \(p, (res, res_is)) ->
-              copyDWIMFix (paramName p) [] res (res_is ++ vec_is)
+      forM slugs $ \slug -> do
+        let shape = segBinOpShape $ slugOp slug
 
-          sComment "Red body" $
-            compileStms mempty (bodyStms $ slugBody slug) $
-              forM_ (zip local_accs $ map resSubExp $ bodyResult $ slugBody slug) $
-                \(local_acc, se) ->
-                  copyDWIMFix local_acc vec_is se []
+        forM (zip (accParams slug) (slugNeutral slug)) $ \(p, ne) -> do
+          -- Declare accumulator variable.
+          acc <-
+            case paramType p of
+              Prim pt
+                | shape == mempty ->
+                  tvVar <$> dPrim "local_acc" pt
+                | otherwise ->
+                  sAllocArray "local_acc" pt shape DefaultSpace
+              _ ->
+                pure $ paramName p
 
-  postbody <- collect $
+          -- Now neutral-initialise the accumulator.
+          sLoopNest (slugShape slug) $ \vec_is ->
+            copyDWIMFix acc vec_is ne []
+
+          pure acc
+
+    generateChunkLoop "SegRed" $ \i -> do
+      zipWithM_ dPrimV_ is $ unflattenIndex ns' i
+      kbody $ \all_red_res -> do
+        let all_red_res' = segBinOpChunks (map slugOp slugs) all_red_res
+        forM_ (zip3 all_red_res' slugs slug_local_accs) $ \(red_res, slug, local_accs) ->
+          sLoopNest (slugShape slug) $ \vec_is -> do
+            let lamtypes = lambdaReturnType $ segBinOpLambda $ slugOp slug
+            -- Load accum params
+            sComment "Load accum params" $
+              forM_ (zip3 (accParams slug) local_accs lamtypes) $
+                \(p, local_acc, t) ->
+                  when (primType t) $
+                    copyDWIMFix (paramName p) [] (Var local_acc) vec_is
+
+            sComment "Load next params" $
+              forM_ (zip (nextParams slug) red_res) $ \(p, (res, res_is)) ->
+                copyDWIMFix (paramName p) [] res (res_is ++ vec_is)
+
+            sComment "SegRed body" $
+              compileStms mempty (bodyStms $ slugBody slug) $
+                forM_ (zip local_accs $ map resSubExp $ bodyResult $ slugBody slug) $
+                  \(local_acc, se) ->
+                    copyDWIMFix local_acc vec_is se []
+
     forM_ (zip slugs slug_local_accs) $ \(slug, local_accs) ->
       forM (zip (slugResArrs slug) local_accs) $ \(acc, local_acc) ->
         copyDWIMFix acc [Imp.le64 $ segFlat space] (Var local_acc) []
 
-  free_params <- freeParams (prebody <> fbody <> postbody) (segFlat space : [tvVar flat_idx])
-  let (body_allocs, fbody') = extractAllocations fbody
-  emit $ Imp.Op $ Imp.ParLoop "segred_stage_1" (tvVar flat_idx) (body_allocs <> prebody) fbody' postbody free_params $ segFlat space
+  free_params <- freeParams fbody [segFlat space]
+  emit $ Imp.Op $ Imp.ParLoop "segred_stage_1" fbody free_params $ segFlat space
 
 reductionStage2 ::
   Pat MCMem ->
@@ -207,29 +204,25 @@ segmentedReduction ::
   MulticoreGen Imp.Code
 segmentedReduction pat space reds kbody =
   collect $ do
-    n_par_segments <- dPrim "segment_iter" $ IntType Int64
-    body <- compileSegRedBody n_par_segments pat space reds kbody
-    free_params <- freeParams body (segFlat space : [tvVar n_par_segments])
-    let (body_allocs, body') = extractAllocations body
-    emit $ Imp.Op $ Imp.ParLoop "segmented_segred" (tvVar n_par_segments) body_allocs body' mempty free_params $ segFlat space
+    body <- compileSegRedBody pat space reds kbody
+    free_params <- freeParams body [segFlat space]
+    emit $ Imp.Op $ Imp.ParLoop "segmented_segred" body free_params $ segFlat space
 
 compileSegRedBody ::
-  TV Int64 ->
   Pat MCMem ->
   SegSpace ->
   [SegBinOp MCMem] ->
   DoSegBody ->
   MulticoreGen Imp.Code
-compileSegRedBody n_segments pat space reds kbody = do
+compileSegRedBody pat space reds kbody = do
   let (is, ns) = unzip $ unSegSpace space
       ns_64 = map toInt64Exp ns
       inner_bound = last ns_64
-      n_segments' = tvExp n_segments
 
   let per_red_pes = segBinOpChunks reds $ patElems pat
   -- Perform sequential reduce on inner most dimension
-  collect $ do
-    flat_idx <- dPrimVE "flat_idx" $ n_segments' * inner_bound
+  collect . generateChunkLoop "SegRed" $ \n_segments -> do
+    flat_idx <- dPrimVE "flat_idx" $ n_segments * inner_bound
     zipWithM_ dPrimV_ is $ unflattenIndex ns_64 flat_idx
     sComment "neutral-initialise the accumulators" $
       forM_ (zip per_red_pes reds) $ \(pes, red) ->
@@ -243,7 +236,7 @@ compileSegRedBody n_segments pat space reds kbody = do
         zipWithM_
           (<--)
           (map (`mkTV` int64) $ init is)
-          (unflattenIndex (init ns_64) (sExt64 n_segments'))
+          (unflattenIndex (init ns_64) (sExt64 n_segments))
         dPrimV_ (last is) i
         kbody $ \all_red_res -> do
           let red_res' = chunks (map (length . segBinOpNeutral) reds) all_red_res


### PR DESCRIPTION
The actual loop is now explicit in the ImpCode, rather than being
inserted during C code generation.  This should give us a little more
flexibility.