### PR TITLE
Don't perform memory block merging on ScalarSpace values

### DIFF
--- a/src/Futhark/Optimise/MemoryBlockMerging.hs
+++ b/src/Futhark/Optimise/MemoryBlockMerging.hs
@@ -197,7 +197,7 @@ onKernels f stms = inScopeOf stms $ mapM helper stms
 -- | Perform the reuse-allocations optimization.
 optimise :: Pass GPUMem GPUMem
 optimise =
-  Pass "reuse allocations" "reuse allocations" $ \prog ->
+  Pass "memory block merging" "memory block merging allocations" $ \prog ->
     let graph = Interference.analyseProgGPU prog
      in Pass.intraproceduralTransformation (onStms graph) prog
   where


### PR DESCRIPTION
This turned out to negatively affect performance. Also, I have renamed the `futhark dev` flag for memory block merging from `--reuse-allocations` to `--memory-block-merging`.