### PR TITLE
Prohibit newlines in string literals

### DIFF
--- a/docs/language-reference.rst
+++ b/docs/language-reference.rst
@@ -197,8 +197,9 @@ first class.  See :ref:`hofs` for the details.
 
 .. productionlist::
    stringlit: '"' `stringchar`* '"'
-   charlit: "'" `stringchar` "'"
-   stringchar: <any source character except "\" or newline or quotes>
+   stringchar: <any source character except "\" or newline or double quotes>
+   charlit: "'" `char` "'"
+   char: <any source character except "\" or newline or single quotes>
 
 String literals are supported, but only as syntactic sugar for UTF-8
 encoded arrays of ``u8`` values.  There is no character type in

--- a/src/Language/Futhark/Parser/Lexer.x
+++ b/src/Language/Futhark/Parser/Lexer.x
@@ -37,7 +37,7 @@ import Futhark.Util.Loc hiding (L)
 %wrapper "monad-bytestring"
 
 @charlit = ($printable#['\\]|\\($printable|[0-9]+))
-@stringcharlit = ($printable#[\"\\]|\\($printable|[0-9]+)|\n)
+@stringcharlit = ($printable#[\"\\]|\\($printable|[0-9]+))
 @hexlit = 0[xX][0-9a-fA-F][0-9a-fA-F_]*
 @declit = [0-9][0-9_]*
 @binlit = 0[bB][01][01_]*


### PR DESCRIPTION
As per the reference, newlines in string literals should not be allowed.