### PR TITLE
Support program reload cache.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Parsing multi-file programs is now parallelised, making it
   *slightly* faster.
 
+* Reloading a large program in `futhark repl` is now faster, as long
+  as not too many of its files have been modified (#1597).
+
 ### Removed
 
 ### Changed

--- a/src/Futhark/CLI/Defs.hs
+++ b/src/Futhark/CLI/Defs.hs
@@ -13,7 +13,7 @@ import Futhark.Util.Options
 import Language.Futhark
 
 isBuiltin :: String -> Bool
-isBuiltin = ("prelude/" `isPrefixOf`)
+isBuiltin = ("/prelude/" `isPrefixOf`)
 
 data DefKind = Value | Module | ModuleType | Type
 

--- a/src/Futhark/CLI/Misc.hs
+++ b/src/Futhark/CLI/Misc.hs
@@ -25,7 +25,7 @@ import System.FilePath
 import System.IO
 
 isBuiltin :: String -> Bool
-isBuiltin = ("prelude/" `isPrefixOf`)
+isBuiltin = ("/prelude/" `isPrefixOf`)
 
 -- | @futhark imports@
 mainImports :: String -> [String] -> IO ()

--- a/src/Futhark/CLI/REPL.hs
+++ b/src/Futhark/CLI/REPL.hs
@@ -15,14 +15,14 @@ import Control.Monad.State
 import Data.Char
 import Data.List (intercalate, intersperse)
 import qualified Data.List.NonEmpty as NE
+import qualified Data.Map as M
 import Data.Maybe
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import Data.Version
 import Futhark.Compiler
 import Futhark.MonadFreshNames
-import Futhark.Pipeline
-import Futhark.Util (fancyTerminal, toPOSIX)
+import Futhark.Util (fancyTerminal)
 import Futhark.Util.Options
 import Futhark.Version
 import Language.Futhark
@@ -81,30 +81,30 @@ repl maybe_prog = do
           Left (Load file) -> do
             liftIO $ T.putStrLn $ "Loading " <> T.pack file
             maybe_new_state <-
-              liftIO $ newFutharkiState (futharkiCount s) $ Just file
+              liftIO $ newFutharkiState (futharkiCount s) (futharkiProg s) $ Just file
             case maybe_new_state of
               Right new_state -> toploop new_state
               Left err -> do
                 liftIO $ putStrLn err
                 toploop s'
-          Right _ -> return ()
+          Right _ -> pure ()
 
       finish s = do
         quit <- if fancyTerminal then confirmQuit else pure True
-        if quit then return () else toploop s
+        if quit then pure () else toploop s
 
-  maybe_init_state <- liftIO $ newFutharkiState 0 maybe_prog
+  maybe_init_state <- liftIO $ newFutharkiState 0 noLoadedProg maybe_prog
   s <- case maybe_init_state of
     Left prog_err -> do
-      noprog_init_state <- liftIO $ newFutharkiState 0 Nothing
+      noprog_init_state <- liftIO $ newFutharkiState 0 noLoadedProg Nothing
       case noprog_init_state of
         Left err ->
           error $ "Failed to initialise interpreter state: " ++ err
         Right s -> do
           liftIO $ putStrLn prog_err
-          return s {futharkiLoaded = maybe_prog}
+          pure s {futharkiLoaded = maybe_prog}
     Right s ->
-      return s
+      pure s
   Haskeline.runInputT Haskeline.defaultSettings $ toploop s
 
   putStrLn "Leaving 'futhark repl'."
@@ -113,9 +113,9 @@ confirmQuit :: Haskeline.InputT IO Bool
 confirmQuit = do
   c <- Haskeline.getInputChar "Quit REPL? (y/n) "
   case c of
-    Nothing -> return True -- EOF
-    Just 'y' -> return True
-    Just 'n' -> return False
+    Nothing -> pure True -- EOF
+    Just 'y' -> pure True
+    Just 'n' -> pure False
     _ -> confirmQuit
 
 -- | Representation of breaking at a breakpoint, to allow for
@@ -128,8 +128,7 @@ data Breaking = Breaking
   }
 
 data FutharkiState = FutharkiState
-  { futharkiImports :: Imports,
-    futharkiNameSource :: VNameSource,
+  { futharkiProg :: LoadedProg,
     futharkiCount :: Int,
     futharkiEnv :: (T.Env, I.Ctx),
     -- | Are we currently stopped at a breakpoint?
@@ -141,55 +140,49 @@ data FutharkiState = FutharkiState
     futharkiLoaded :: Maybe FilePath
   }
 
-newFutharkiState :: Int -> Maybe FilePath -> IO (Either String FutharkiState)
-newFutharkiState count maybe_file = runExceptT $ do
-  (imports, src, tenv, ienv) <- case maybe_file of
+extendEnvs :: LoadedProg -> (T.Env, I.Ctx) -> [String] -> (T.Env, I.Ctx)
+extendEnvs prog (tenv, ictx) opens = (tenv', ictx')
+  where
+    tenv' = T.envWithImports t_imports tenv
+    ictx' = I.ctxWithImports i_envs ictx
+    t_imports = filter ((`elem` opens) . fst) $ lpImports prog
+    i_envs = map snd $ filter ((`elem` opens) . fst) $ M.toList $ I.ctxImports ictx
+
+newFutharkiState :: Int -> LoadedProg -> Maybe FilePath -> IO (Either String FutharkiState)
+newFutharkiState count prev_prog maybe_file = runExceptT $ do
+  (prog, tenv, ienv) <- case maybe_file of
     Nothing -> do
       -- Load the builtins through the type checker.
-      (_, imports, src) <- badOnLeft show =<< runExceptT (readLibrary [] [])
+      (_, prog) <- badOnLeft show =<< runExceptT (reloadProg prev_prog [])
       -- Then into the interpreter.
       ienv <-
         foldM
           (\ctx -> badOnLeft show <=< runInterpreter' . I.interpretImport ctx)
           I.initialCtx
-          $ map (fmap fileProg) imports
+          $ map (fmap fileProg) (lpImports prog)
 
-      -- Then make the prelude available in the type checker.
-      (tenv, d, src') <-
-        badOnLeft pretty . snd $
-          T.checkDec imports src T.initialEnv (T.mkInitialImport ".") $
-            mkOpen "/prelude/prelude"
-      -- Then in the interpreter.
-      ienv' <- badOnLeft show =<< runInterpreter' (I.interpretDec ienv d)
-      return (imports, src', tenv, ienv')
+      let (tenv, ienv') =
+            extendEnvs prog (T.initialEnv, ienv) ["/prelude/prelude"]
+
+      pure (prog, tenv, ienv')
     Just file -> do
-      (ws, imports, src) <-
-        badOnLeft show
-          =<< liftIO
-            ( runExceptT (readProgram [] file)
-                `catch` \(err :: IOException) ->
-                  return (externalErrorS (show err))
-            )
+      (ws, prog) <- badOnLeft show =<< runExceptT (reloadProg prev_prog [file])
       liftIO $ putStrLn $ pretty ws
 
-      let imp = T.mkInitialImport "."
-      ienv1 <-
-        foldM (\ctx -> badOnLeft show <=< runInterpreter' . I.interpretImport ctx) I.initialCtx $
-          map (fmap fileProg) imports
-      (tenv1, d1, src') <-
-        badOnLeft pretty . snd . T.checkDec imports src T.initialEnv imp $
-          mkOpen "/prelude/prelude"
-      (tenv2, d2, src'') <-
-        badOnLeft pretty . snd . T.checkDec imports src' tenv1 imp $
-          mkOpen $ toPOSIX $ dropExtension file
-      ienv2 <- badOnLeft show =<< runInterpreter' (I.interpretDec ienv1 d1)
-      ienv3 <- badOnLeft show =<< runInterpreter' (I.interpretDec ienv2 d2)
-      return (imports, src'', tenv2, ienv3)
+      ienv <-
+        foldM
+          (\ctx -> badOnLeft show <=< runInterpreter' . I.interpretImport ctx)
+          I.initialCtx
+          $ map (fmap fileProg) (lpImports prog)
+
+      let (tenv, ienv') =
+            extendEnvs prog (T.initialEnv, ienv) ["/prelude/prelude", dropExtension file]
+
+      pure (prog, tenv, ienv')
 
   return
     FutharkiState
-      { futharkiImports = imports,
-        futharkiNameSource = src,
+      { futharkiProg = prog,
         futharkiCount = count,
         futharkiEnv = (tenv, ienv),
         futharkiBreaking = Nothing,
@@ -199,16 +192,13 @@ newFutharkiState count maybe_file = runExceptT $ do
       }
   where
     badOnLeft :: (err -> String) -> Either err a -> ExceptT String IO a
-    badOnLeft _ (Right x) = return x
+    badOnLeft _ (Right x) = pure x
     badOnLeft p (Left err) = throwError $ p err
 
 getPrompt :: FutharkiM String
 getPrompt = do
   i <- gets futharkiCount
-  return $ "[" ++ show i ++ "]> "
-
-mkOpen :: FilePath -> UncheckedDec
-mkOpen f = OpenDec (ModImport f NoInfo mempty) mempty
+  pure $ "[" ++ show i ++ "]> "
 
 -- The ExceptT part is more of a continuation, really.
 newtype FutharkiM a = FutharkiM {runFutharkiM :: ExceptT StopReason (StateT FutharkiState (Haskeline.InputT IO)) a}
@@ -229,7 +219,7 @@ readEvalPrint = do
   case T.uncons line of
     Nothing
       | isJust breaking -> throwError Stop
-      | otherwise -> return ()
+      | otherwise -> pure ()
     Just (':', command) -> do
       let (cmdname, rest) = T.break isSpace command
           arg = T.dropWhileEnd isSpace $ T.dropWhile isSpace rest
@@ -253,42 +243,50 @@ readEvalPrint = do
     inputLine prompt = do
       inp <- FutharkiM $ lift $ lift $ Haskeline.getInputLine prompt
       case inp of
-        Just s -> return $ T.pack s
+        Just s -> pure $ T.pack s
         Nothing -> throwError EOF
 
 getIt :: FutharkiM (Imports, VNameSource, T.Env, I.Ctx)
 getIt = do
-  imports <- gets futharkiImports
-  src <- gets futharkiNameSource
+  imports <- gets $ lpImports . futharkiProg
+  src <- gets $ lpNameSource . futharkiProg
   (tenv, ienv) <- gets futharkiEnv
-  return (imports, src, tenv, ienv)
+  pure (imports, src, tenv, ienv)
 
 onDec :: UncheckedDec -> FutharkiM ()
-onDec d
-  | not $ null $ decImports d = liftIO $ do
-    putStrLn "'import' is not allowed in 'futhark repl'."
-    putStrLn "Use :load instead."
-  | otherwise = do
-    (imports, src, tenv, ienv) <- getIt
-    cur_import <- gets $ T.mkInitialImport . fromMaybe "." . futharkiLoaded
+onDec d = do
+  old_imports <- gets $ lpImports . futharkiProg
+  cur_import <- gets $ T.mkInitialImport . fromMaybe "." . futharkiLoaded
+  let mkImport = uncurry $ T.mkImportFrom cur_import
+      files = map (T.includeToFilePath . mkImport) $ decImports d
 
-    case T.checkDec imports src tenv cur_import d of
-      (_, Left e) -> liftIO $ putStrLn $ pretty e
-      (_, Right (tenv', d', src')) -> do
-        let new_imports = filter ((`notElem` map fst imports) . fst) imports
-        int_r <- runInterpreter $ do
-          let onImport ienv' (s, imp) =
-                I.interpretImport ienv' (s, T.fileProg imp)
-          ienv' <- foldM onImport ienv new_imports
-          I.interpretDec ienv' d'
-        case int_r of
-          Left err -> liftIO $ print err
-          Right ienv' -> modify $ \s ->
-            s
-              { futharkiEnv = (tenv', ienv'),
-                futharkiImports = imports,
-                futharkiNameSource = src'
-              }
+  imp_r <- runExceptT $ do
+    prog <- lift $ gets futharkiProg
+    extendProg prog files
+
+  case imp_r of
+    Left e -> liftIO $ print e
+    Right (_ws, prog) -> do
+      env <- gets futharkiEnv
+      let (tenv, ienv) = extendEnvs prog env (map fst $ decImports d)
+          imports = lpImports prog
+          src = lpNameSource prog
+      case T.checkDec imports src tenv cur_import d of
+        (_, Left e) -> liftIO $ putStrLn $ pretty e
+        (_, Right (tenv', d', src')) -> do
+          let new_imports = filter ((`notElem` map fst old_imports) . fst) imports
+          int_r <- runInterpreter $ do
+            let onImport ienv' (s, imp) =
+                  I.interpretImport ienv' (s, T.fileProg imp)
+            ienv' <- foldM onImport ienv new_imports
+            I.interpretDec ienv' d'
+          case int_r of
+            Left err -> liftIO $ print err
+            Right ienv' -> modify $ \s ->
+              s
+                { futharkiEnv = (tenv', ienv'),
+                  futharkiProg = prog {lpNameSource = src'}
+                }
 
 onExp :: UncheckedExp -> FutharkiM ()
 onExp e = do
@@ -325,7 +323,7 @@ runInterpreter :: F I.ExtOp a -> FutharkiM (Either I.InterpreterError a)
 runInterpreter m = runF m (return . Right) intOp
   where
     intOp (I.ExtOpError err) =
-      return $ Left err
+      pure $ Left err
     intOp (I.ExtOpTrace w v c) = do
       liftIO $ putStrLn $ w ++ ": " ++ v
       c
@@ -377,7 +375,7 @@ runInterpreter m = runF m (return . Right) intOp
 runInterpreter' :: MonadIO m => F I.ExtOp a -> m (Either I.InterpreterError a)
 runInterpreter' m = runF m (return . Right) intOp
   where
-    intOp (I.ExtOpError err) = return $ Left err
+    intOp (I.ExtOpError err) = pure $ Left err
     intOp (I.ExtOpTrace w v c) = do
       liftIO $ putStrLn $ w ++ ": " ++ v
       c
@@ -404,9 +402,7 @@ genTypeCommand f g h e = do
   case f prompt e of
     Left err -> liftIO $ print err
     Right e' -> do
-      imports <- gets futharkiImports
-      src <- gets futharkiNameSource
-      (tenv, _) <- gets futharkiEnv
+      (imports, src, tenv, _) <- getIt
       case snd $ g imports src tenv e' of
         Left err -> liftIO $ putStrLn $ pretty err
         Right x -> liftIO $ putStrLn $ h x

--- a/src/Futhark/Compiler/Program.hs
+++ b/src/Futhark/Compiler/Program.hs
@@ -10,6 +10,11 @@ module Futhark.Compiler.Program
     Imports,
     FileModule (..),
     E.Warnings,
+    LoadedProg (lpNameSource),
+    noLoadedProg,
+    lpImports,
+    reloadProg,
+    extendProg,
   )
 where
 
@@ -25,12 +30,16 @@ import Control.Concurrent.MVar
 import Control.Monad
 import Control.Monad.Except
 import Control.Monad.State (execStateT, gets, modify)
-import Data.List (intercalate, isPrefixOf)
+import Data.Bifunctor (first)
+import Data.List (intercalate, isPrefixOf, sort)
 import qualified Data.Map as M
+import Data.Maybe (mapMaybe)
 import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import Data.Time.Clock (UTCTime)
 import Futhark.Error
 import Futhark.FreshNames
-import Futhark.Util (readFileSafely)
+import Futhark.Util (interactWithFileSafely, nubOrd, startupTime)
 import Futhark.Util.Pretty (line, ppr, text, (</>))
 import qualified Language.Futhark as E
 import Language.Futhark.Parser
@@ -38,23 +47,35 @@ import Language.Futhark.Prelude
 import Language.Futhark.Semantic
 import qualified Language.Futhark.TypeChecker as E
 import Language.Futhark.Warnings
+import System.Directory (getModificationTime)
 import System.FilePath (normalise)
 import qualified System.FilePath.Posix as Posix
 
+data LoadedFile fm = LoadedFile
+  { lfPath :: FilePath,
+    lfImportName :: ImportName,
+    lfMod :: fm,
+    -- | Modification time of the underlying file.
+    lfModTime :: UTCTime
+  }
+  deriving (Eq, Ord, Show)
+
 newtype UncheckedImport = UncheckedImport
   { unChecked ::
-      Either CompilerError (E.UncheckedProg, [(ImportName, MVar UncheckedImport)])
+      Either CompilerError (LoadedFile E.UncheckedProg, [(ImportName, MVar UncheckedImport)])
   }
 
-type ReaderState = MVar (M.Map ImportName (MVar UncheckedImport))
+-- | If mapped to Nothing, treat it as present.  This is used when
+-- reloading programs.
+type ReaderState = MVar (M.Map ImportName (Maybe (MVar UncheckedImport)))
 
-newState :: IO ReaderState
-newState = newMVar mempty
+newState :: [ImportName] -> IO ReaderState
+newState known = newMVar $ M.fromList $ zip known $ repeat Nothing
 
 orderedImports ::
   (MonadError CompilerError m, MonadIO m) =>
   [(ImportName, MVar UncheckedImport)] ->
-  m [(ImportName, E.UncheckedProg)]
+  m [(ImportName, LoadedFile E.UncheckedProg)]
 orderedImports = fmap reverse . flip execStateT [] . mapM_ (spelunk [])
   where
     spelunk steps (include, mvar)
@@ -69,31 +90,46 @@ orderedImports = fmap reverse . flip execStateT [] . mapM_ (spelunk [])
         case prev of
           Just _ -> pure ()
           Nothing -> do
-            (prog, more_imports) <-
+            (file, more_imports) <-
               either throwError pure . unChecked =<< liftIO (readMVar mvar)
             mapM_ (spelunk (include : steps)) more_imports
-            modify ((include, prog) :)
+            modify ((include, file) :)
 
-newImportMVar :: IO UncheckedImport -> IO (MVar UncheckedImport)
+newImportMVar :: IO UncheckedImport -> IO (Maybe (MVar UncheckedImport))
 newImportMVar m = do
   mvar <- newEmptyMVar
   void $ forkIO $ putMVar mvar =<< m
-  pure mvar
+  pure $ Just mvar
 
-readImportFile :: ImportName -> IO (Either CompilerError (T.Text, FilePath))
+contentsAndModTime :: FilePath -> IO (Maybe (Either String (T.Text, UTCTime)))
+contentsAndModTime filepath =
+  interactWithFileSafely $
+    (,) <$> T.readFile filepath <*> getModificationTime filepath
+
+readImportFile :: ImportName -> IO (Either CompilerError (LoadedFile T.Text))
 readImportFile include = do
   -- First we try to find a file of the given name in the search path,
   -- then we look at the builtin library if we have to.  For the
   -- builtins, we don't use the search path.
   let filepath = includeToFilePath include
-  r <- readFileSafely filepath
+  r <- contentsAndModTime filepath
   case (r, lookup prelude_str prelude) of
-    (Just (Right s), _) -> pure $ Right (s, filepath)
+    (Just (Right (s, mod_time)), _) ->
+      pure $ Right $ loaded filepath s mod_time
     (Just (Left e), _) -> pure $ Left $ ExternalError $ text e
-    (Nothing, Just t) -> pure $ Right (t, prelude_str)
+    (Nothing, Just s) ->
+      pure $ Right $ loaded prelude_str s startupTime
     (Nothing, Nothing) -> pure $ Left $ ExternalError $ text not_found
   where
     prelude_str = "/" Posix.</> includeToString include Posix.<.> "fut"
+
+    loaded path s mod_time =
+      LoadedFile
+        { lfImportName = include,
+          lfPath = path,
+          lfMod = s,
+          lfModTime = mod_time
+        }
 
     not_found =
       "Error at " ++ E.locStr (E.srclocOf include)
@@ -102,52 +138,66 @@ readImportFile include = do
         ++ "'."
 
 handleFile ::
-  ReaderState -> [ImportName] -> ImportName -> T.Text -> FilePath -> IO UncheckedImport
-handleFile state_mvar steps import_name file_contents file_name = do
+  ReaderState -> LoadedFile T.Text -> IO UncheckedImport
+handleFile state_mvar (LoadedFile file_name import_name file_contents mod_time) = do
   case parseFuthark file_name file_contents of
     Left err -> pure $ UncheckedImport $ Left $ ExternalError $ text $ show err
     Right prog -> do
-      let steps' = import_name : steps
-          imports = map (uncurry (mkImportFrom import_name)) $ E.progImports prog
+      let imports = map (uncurry (mkImportFrom import_name)) $ E.progImports prog
       mvars <-
-        mapM (readImport state_mvar steps') imports
-      pure $ UncheckedImport $ Right (prog, zip imports mvars)
+        mapMaybe sequenceA . zip imports
+          <$> mapM (readImport state_mvar) imports
+      let file =
+            LoadedFile
+              { lfPath = file_name,
+                lfImportName = import_name,
+                lfModTime = mod_time,
+                lfMod = prog
+              }
+      pure $ UncheckedImport $ Right (file, mvars)
 
-readImport :: ReaderState -> [ImportName] -> ImportName -> IO (MVar UncheckedImport)
-readImport state_mvar steps include =
+readImport :: ReaderState -> ImportName -> IO (Maybe (MVar UncheckedImport))
+readImport state_mvar include =
   modifyMVar state_mvar $ \state ->
     case M.lookup include state of
-      Just prog_mvar -> pure (state, prog_mvar)
+      Just x -> pure (state, x)
       Nothing -> do
         prog_mvar <- newImportMVar $ do
           readImportFile include >>= \case
             Left e -> pure $ UncheckedImport $ Left e
-            Right (x, y) -> handleFile state_mvar steps include x y
+            Right file -> handleFile state_mvar file
         pure (M.insert include prog_mvar state, prog_mvar)
 
--- | Read (and parse) all source files (including the builtin prelude)
--- corresponding to a set of root files.
-readUntypedLibrary ::
+readUntypedLibraryExceptKnown ::
   (MonadIO m, MonadError CompilerError m) =>
+  [ImportName] ->
   [FilePath] ->
-  m [(ImportName, E.UncheckedProg)]
-readUntypedLibrary fps = do
-  state_mvar <- liftIO newState
+  m [LoadedFile E.UncheckedProg]
+readUntypedLibraryExceptKnown known fps = do
+  state_mvar <- liftIO $ newState known
   let prelude_import = mkInitialImport "/prelude/prelude"
-  prelude_mvar <- liftIO $ readImport state_mvar [] prelude_import
+  prelude_mvar <- liftIO $ readImport state_mvar prelude_import
   fps_mvars <- liftIO (mapM (onFile state_mvar) fps)
-  orderedImports $ (prelude_import, prelude_mvar) : fps_mvars
+  let unknown_mvars = onlyUnknown ((prelude_import, prelude_mvar) : fps_mvars)
+  map snd <$> orderedImports unknown_mvars
   where
+    onlyUnknown = mapMaybe sequenceA
     onFile state_mvar fp =
       modifyMVar state_mvar $ \state -> do
         case M.lookup include state of
           Just prog_mvar -> pure (state, (include, prog_mvar))
           Nothing -> do
             prog_mvar <- newImportMVar $ do
-              r <- readFileSafely fp
+              r <- contentsAndModTime fp
               case r of
-                Just (Right fs) -> do
-                  handleFile state_mvar [] include fs fp
+                Just (Right (fs, mod_time)) -> do
+                  handleFile state_mvar $
+                    LoadedFile
+                      { lfImportName = include,
+                        lfMod = fs,
+                        lfModTime = mod_time,
+                        lfPath = fp
+                      }
                 Just (Left e) ->
                   pure $ UncheckedImport $ Left $ ExternalError $ text $ show e
                 Nothing ->
@@ -157,38 +207,27 @@ readUntypedLibrary fps = do
         include = mkInitialImport fp_name
         (fp_name, _) = Posix.splitExtension fp
 
--- | Pre-typechecked imports, including a starting point for the name source.
-data Basis = Basis
-  { basisImports :: Imports,
-    basisNameSource :: VNameSource
-  }
-
--- | A basis that contains no imports, and has a properly initialised
--- name source.
-emptyBasis :: Basis
-emptyBasis =
-  Basis
-    { basisImports = mempty,
-      basisNameSource = src
-    }
+asImports :: [LoadedFile (VNameSource, FileModule)] -> Imports
+asImports = map f
   where
-    src = newNameSource $ E.maxIntrinsicTag + 1
+    f lf = (includeToString (lfImportName lf), snd $ lfMod lf)
 
-typeCheckProgram ::
+typeCheckProg ::
   MonadError CompilerError m =>
-  Basis ->
-  [(ImportName, E.UncheckedProg)] ->
-  m (E.Warnings, Imports, VNameSource)
-typeCheckProgram basis =
-  foldM f (mempty, basisImports basis, basisNameSource basis)
+  [LoadedFile (VNameSource, FileModule)] ->
+  VNameSource ->
+  [LoadedFile E.UncheckedProg] ->
+  m (E.Warnings, [LoadedFile (VNameSource, FileModule)], VNameSource)
+typeCheckProg orig_imports orig_src =
+  foldM f (mempty, orig_imports, orig_src)
   where
     roots = ["/prelude/prelude"]
 
-    f (ws, imports, src) (import_name, prog) = do
+    f (ws, imports, src) (LoadedFile path import_name prog mod_time) = do
       let prog'
             | "/prelude" `isPrefixOf` includeToFilePath import_name = prog
             | otherwise = prependRoots roots prog
-      case E.checkProg imports src import_name prog' of
+      case E.checkProg (asImports imports) src import_name prog' of
         (prog_ws, Left err) -> do
           let ws' = ws <> prog_ws
           externalError $
@@ -198,28 +237,117 @@ typeCheckProgram basis =
         (prog_ws, Right (m, src')) ->
           pure
             ( ws <> prog_ws,
-              imports ++ [(includeToString import_name, m)],
+              imports ++ [LoadedFile path import_name (src, m) mod_time],
               src'
             )
 
 setEntryPoints ::
   [E.Name] ->
   [FilePath] ->
-  [(ImportName, E.UncheckedProg)] ->
-  [(ImportName, E.UncheckedProg)]
-setEntryPoints extra_eps fps = map onProg
+  [LoadedFile E.UncheckedProg] ->
+  [LoadedFile E.UncheckedProg]
+setEntryPoints extra_eps fps = map onFile
   where
     fps' = map normalise fps
-    onProg (name, prog)
-      | includeToFilePath name `elem` fps' =
-        (name, prog {E.progDecs = map onDec (E.progDecs prog)})
+    onFile lf
+      | includeToFilePath (lfImportName lf) `elem` fps' =
+        lf {lfMod = prog {E.progDecs = map onDec (E.progDecs prog)}}
       | otherwise =
-        (name, prog)
+        lf
+      where
+        prog = lfMod lf
 
     onDec (E.ValDec vb)
       | E.valBindName vb `elem` extra_eps =
         E.ValDec vb {E.valBindEntryPoint = Just E.NoInfo}
     onDec dec = dec
+
+prependRoots :: [FilePath] -> E.UncheckedProg -> E.UncheckedProg
+prependRoots roots (E.Prog doc ds) =
+  E.Prog doc $ map mkImport roots ++ ds
+  where
+    mkImport fp =
+      -- We do not use ImportDec here, because we do not want the
+      -- type checker to issue a warning about a redundant import.
+      E.LocalDec (E.OpenDec (E.ModImport fp E.NoInfo mempty) mempty) mempty
+
+data LoadedProg = LoadedProg
+  { lpRoots :: [FilePath],
+    -- | The 'VNameSource' is the name source just *before* the module
+    -- was type checked.
+    lpFiles :: [LoadedFile (VNameSource, FileModule)],
+    -- | Final name source.
+    lpNameSource :: VNameSource
+  }
+
+-- | The 'Imports' of a 'LoadedProg', as expected by e.g. type
+-- checking functions.
+lpImports :: LoadedProg -> Imports
+lpImports = map f . lpFiles
+  where
+    f lf = (includeToString (lfImportName lf), snd $ lfMod lf)
+
+unchangedImports ::
+  MonadIO m =>
+  VNameSource ->
+  [LoadedFile (VNameSource, FileModule)] ->
+  m ([LoadedFile (VNameSource, FileModule)], VNameSource)
+unchangedImports src [] = pure ([], src)
+unchangedImports src (f : fs)
+  | "/prelude" `isPrefixOf` includeToFilePath (lfImportName f) =
+    first (f :) <$> unchangedImports src fs
+  | otherwise = do
+    changed <-
+      maybe True (either (const True) (> lfModTime f))
+        <$> liftIO (interactWithFileSafely (getModificationTime $ lfPath f))
+    if changed
+      then pure ([], fst $ lfMod f)
+      else first (f :) <$> unchangedImports src fs
+
+noLoadedProg :: LoadedProg
+noLoadedProg =
+  LoadedProg
+    { lpRoots = [],
+      lpFiles = mempty,
+      lpNameSource = newNameSource $ E.maxIntrinsicTag + 1
+    }
+
+-- | Find out how many of the old imports can be used.  Here we are
+-- forced to be overly conservative, because our type checker
+-- enforces a linear ordering.
+usableLoadedProg :: MonadIO m => LoadedProg -> [FilePath] -> m LoadedProg
+usableLoadedProg (LoadedProg roots imports src) new_roots
+  | sort roots == sort new_roots = do
+    (imports', src') <- unchangedImports src imports
+    pure $ LoadedProg [] imports' src'
+  | otherwise =
+    pure noLoadedProg
+
+-- | Extend a loaded program with (possibly new) files.
+extendProg ::
+  (MonadError CompilerError m, MonadIO m) =>
+  LoadedProg ->
+  [FilePath] ->
+  m (E.Warnings, LoadedProg)
+extendProg lp new_roots = do
+  new_imports_untyped <-
+    readUntypedLibraryExceptKnown (map lfImportName $ lpFiles lp) new_roots
+  (ws, imports, src') <-
+    typeCheckProg (lpFiles lp) (lpNameSource lp) new_imports_untyped
+  pure (ws, LoadedProg (nubOrd (lpRoots lp ++ new_roots)) imports src')
+
+-- | Load some new files, reusing as much of the previously loaded
+-- program as possible.  This does not *extend* the currently loaded
+-- program the way 'extendProg' does it, so it is always correct (if
+-- less efficient) to pass 'noLoadedProg'.
+reloadProg ::
+  (MonadError CompilerError m, MonadIO m) =>
+  LoadedProg ->
+  [FilePath] ->
+  m (E.Warnings, LoadedProg)
+reloadProg lp new_roots = do
+  lp' <- usableLoadedProg lp new_roots
+  extendProg lp' new_roots
 
 -- | Read and type-check some Futhark files.
 readLibrary ::
@@ -231,14 +359,19 @@ readLibrary ::
   [FilePath] ->
   m (E.Warnings, Imports, VNameSource)
 readLibrary extra_eps fps =
-  typeCheckProgram emptyBasis . setEntryPoints (E.defaultEntryPoint : extra_eps) fps
-    =<< readUntypedLibrary fps
-
-prependRoots :: [FilePath] -> E.UncheckedProg -> E.UncheckedProg
-prependRoots roots (E.Prog doc ds) =
-  E.Prog doc $ map mkImport roots ++ ds
+  fmap frob
+    . typeCheckProg mempty (lpNameSource noLoadedProg)
+    . setEntryPoints (E.defaultEntryPoint : extra_eps) fps
+    =<< readUntypedLibraryExceptKnown [] fps
   where
-    mkImport fp =
-      -- We do not use ImportDec here, because we do not want the
-      -- type checker to issue a warning about a redundant import.
-      E.LocalDec (E.OpenDec (E.ModImport fp E.NoInfo mempty) mempty) mempty
+    frob (x, y, z) = (x, asImports y, z)
+
+-- | Read (and parse) all source files (including the builtin prelude)
+-- corresponding to a set of root files.
+readUntypedLibrary ::
+  (MonadIO m, MonadError CompilerError m) =>
+  [FilePath] ->
+  m [(ImportName, E.UncheckedProg)]
+readUntypedLibrary = fmap (map f) . readUntypedLibraryExceptKnown []
+  where
+    f lf = (lfImportName lf, lfMod lf)

--- a/src/Futhark/Util.hs
+++ b/src/Futhark/Util.hs
@@ -27,6 +27,7 @@ module Futhark.Util
     hashText,
     unixEnvironment,
     isEnvVarAtLeast,
+    startupTime,
     fancyTerminal,
     runProgramWithExitCode,
     directoryContents,
@@ -46,6 +47,7 @@ module Futhark.Util
     toPOSIX,
     trim,
     pmapIO,
+    interactWithFileSafely,
     readFileSafely,
     convFloat,
     UserString,
@@ -76,6 +78,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Text.Encoding.Error as T
 import qualified Data.Text.IO as T
+import Data.Time.Clock (UTCTime, getCurrentTime)
 import Data.Tuple (swap)
 import Numeric
 import qualified System.Directory.Tree as Dir
@@ -199,6 +202,13 @@ isEnvVarAtLeast s x =
   case readMaybe =<< lookup s unixEnvironment of
     Just y -> y >= x
     _ -> False
+
+{-# NOINLINE startupTime #-}
+
+-- | The time at which the process started - or more accurately, the
+-- first time this binding was forced.
+startupTime :: UTCTime
+startupTime = unsafePerformIO getCurrentTime
 
 {-# NOINLINE fancyTerminal #-}
 
@@ -355,17 +365,23 @@ pmapIO concurrency f elems = do
         Left err -> throw (err :: SomeException)
         Right v -> pure v
 
--- | Read a file, returning 'Nothing' if the file does not exist, and
--- 'Left' if some other error occurs.
-readFileSafely :: FilePath -> IO (Maybe (Either String T.Text))
-readFileSafely filepath =
-  (Just . Right <$> T.readFile filepath) `catch` couldNotRead
+-- | Do some operation on a file, returning 'Nothing' if the file does
+-- not exist, and 'Left' if some other error occurs.
+interactWithFileSafely :: IO a -> IO (Maybe (Either String a))
+interactWithFileSafely m =
+  (Just . Right <$> m) `catch` couldNotRead
   where
     couldNotRead e
       | isDoesNotExistError e =
         return Nothing
       | otherwise =
         return $ Just $ Left $ show e
+
+-- | Read a file, returning 'Nothing' if the file does not exist, and
+-- 'Left' if some other error occurs.
+readFileSafely :: FilePath -> IO (Maybe (Either String T.Text))
+readFileSafely filepath =
+  interactWithFileSafely $ T.readFile filepath
 
 -- | Convert between different floating-point types, preserving
 -- infinities and NaNs.

--- a/src/Language/Futhark/Semantic.hs
+++ b/src/Language/Futhark/Semantic.hs
@@ -66,7 +66,7 @@ includeToFilePath (ImportName s _) = fromPOSIX $ Posix.normalise s Posix.<.> "fu
 -- | Produce a human-readable canonicalized string from an
 -- 'ImportName'.
 includeToString :: ImportName -> String
-includeToString (ImportName s _) = Posix.normalise $ Posix.makeRelative "/" s
+includeToString (ImportName s _) = Posix.normalise s
 
 -- | The result of type checking some file.  Can be passed to further
 -- invocations of the type checker.

--- a/src/Language/Futhark/TypeChecker.hs
+++ b/src/Language/Futhark/TypeChecker.hs
@@ -14,6 +14,7 @@ module Language.Futhark.TypeChecker
     TypeError,
     Warnings,
     initialEnv,
+    envWithImports,
   )
 where
 
@@ -133,6 +134,13 @@ initialEnv =
       Just (name, TypeAbbr l ps $ RetType [] t)
     addIntrinsicT _ =
       Nothing
+
+-- | Produce an environment, based on the one passed in, where all of
+-- the provided imports have been @open@ened in order.  This could in principle
+-- also be done with 'checkDec', but this is more precise.
+envWithImports :: Imports -> Env -> Env
+envWithImports imports env =
+  mconcat (map (fileEnv . snd) (reverse imports)) <> env
 
 checkProgM :: UncheckedProg -> TypeM FileModule
 checkProgM (Prog doc decs) = do


### PR DESCRIPTION
I also took the liberty of cleaning up some other parts of how the
REPL works.

This is not as efficient as it could be for the REPL, since only the
type checking is cached.  However, that is good enough for a language
server, which only has the type checking part anyway.