### PR TITLE
Loc info for parse Error

### DIFF
--- a/src/Futhark/Compiler/Program.hs
+++ b/src/Futhark/Compiler/Program.hs
@@ -44,7 +44,7 @@ import Futhark.FreshNames
 import Futhark.Util (interactWithFileSafely, nubOrd, startupTime)
 import Futhark.Util.Pretty (Doc, line, ppr, text, (</>))
 import qualified Language.Futhark as E
-import Language.Futhark.Parser
+import Language.Futhark.Parser (parseFuthark)
 import Language.Futhark.Prelude
 import Language.Futhark.Semantic
 import qualified Language.Futhark.TypeChecker as E
@@ -91,25 +91,25 @@ orderedImports = fmap reverse . flip execStateT [] . mapM_ (spelunk [])
   where
     spelunk steps (include, mvar)
       | include `elem` steps = do
-        let problem =
-              ProgramError (locOf include) . text $
-                "Import cycle: "
-                  <> intercalate
-                    " -> "
-                    (map includeToString $ reverse $ include : steps)
-        modify ((include, Left (singleError problem)) :)
+          let problem =
+                ProgramError (locOf include) . text $
+                  "Import cycle: "
+                    <> intercalate
+                      " -> "
+                      (map includeToString $ reverse $ include : steps)
+          modify ((include, Left (singleError problem)) :)
       | otherwise = do
-        prev <- gets $ lookup include
-        case prev of
-          Just _ -> pure ()
-          Nothing -> do
-            res <- unChecked <$> liftIO (readMVar mvar)
-            case res of
-              Left errors ->
-                modify ((include, Left errors) :)
-              Right (file, more_imports) -> do
-                mapM_ (spelunk (include : steps)) more_imports
-                modify ((include, Right file) :)
+          prev <- gets $ lookup include
+          case prev of
+            Just _ -> pure ()
+            Nothing -> do
+              res <- unChecked <$> liftIO (readMVar mvar)
+              case res of
+                Left errors ->
+                  modify ((include, Left errors) :)
+                Right (file, more_imports) -> do
+                  mapM_ (spelunk (include : steps)) more_imports
+                  modify ((include, Right file) :)
 
 errorsToTop ::
   [(ImportName, WithErrors (LoadedFile E.UncheckedProg))] ->
@@ -167,7 +167,7 @@ handleFile state_mvar (LoadedFile file_name import_name file_contents mod_time) 
   case parseFuthark file_name file_contents of
     Left err ->
       pure . UncheckedImport . Left . singleError $
-        ProgramError (locOf import_name) $ text $ show err
+        ProgramError (locOf err) $ text $ show err
     Right prog -> do
       let imports = map (uncurry (mkImportFrom import_name)) $ E.progImports prog
       mvars <-
@@ -278,15 +278,15 @@ setEntryPoints extra_eps fps = map onFile
     fps' = map normalise fps
     onFile lf
       | includeToFilePath (lfImportName lf) `elem` fps' =
-        lf {lfMod = prog {E.progDecs = map onDec (E.progDecs prog)}}
+          lf {lfMod = prog {E.progDecs = map onDec (E.progDecs prog)}}
       | otherwise =
-        lf
+          lf
       where
         prog = lfMod lf
 
     onDec (E.ValDec vb)
       | E.valBindName vb `elem` extra_eps =
-        E.ValDec vb {E.valBindEntryPoint = Just E.NoInfo}
+          E.ValDec vb {E.valBindEntryPoint = Just E.NoInfo}
     onDec dec = dec
 
 prependRoots :: [FilePath] -> E.UncheckedProg -> E.UncheckedProg
@@ -325,14 +325,14 @@ unchangedImports ::
 unchangedImports src [] = pure ([], src)
 unchangedImports src (f : fs)
   | "/prelude" `isPrefixOf` includeToFilePath (lfImportName f) =
-    first (f :) <$> unchangedImports src fs
+      first (f :) <$> unchangedImports src fs
   | otherwise = do
-    changed <-
-      maybe True (either (const True) (> lfModTime f))
-        <$> liftIO (interactWithFileSafely (getModificationTime $ lfPath f))
-    if changed
-      then pure ([], fst $ lfMod f)
-      else first (f :) <$> unchangedImports src fs
+      changed <-
+        maybe True (either (const True) (> lfModTime f))
+          <$> liftIO (interactWithFileSafely (getModificationTime $ lfPath f))
+      if changed
+        then pure ([], fst $ lfMod f)
+        else first (f :) <$> unchangedImports src fs
 
 -- | A "loaded program" containing no actual files.  Use this as a
 -- starting point for 'reloadProg'
@@ -350,10 +350,10 @@ noLoadedProg =
 usableLoadedProg :: MonadIO m => LoadedProg -> [FilePath] -> m LoadedProg
 usableLoadedProg (LoadedProg roots imports src) new_roots
   | sort roots == sort new_roots = do
-    (imports', src') <- unchangedImports src imports
-    pure $ LoadedProg [] imports' src'
+      (imports', src') <- unchangedImports src imports
+      pure $ LoadedProg [] imports' src'
   | otherwise =
-    pure noLoadedProg
+      pure noLoadedProg
 
 -- | Extend a loaded program with (possibly new) files.
 extendProg ::

--- a/src/Language/Futhark/Parser/Lexer/Wrapper.hs
+++ b/src/Language/Futhark/Parser/Lexer/Wrapper.hs
@@ -24,8 +24,8 @@ import Control.Applicative (liftA)
 import qualified Data.ByteString.Internal as BS (w2c)
 import qualified Data.ByteString.Lazy as BS
 import Data.Int (Int64)
-import Data.Word (Word8)
 import Data.Loc (Loc)
+import Data.Word (Word8)
 
 type Byte = Word8
 
@@ -69,7 +69,7 @@ tabSize :: Int
 tabSize = 8
 
 alexMove :: AlexPosn -> Char -> AlexPosn
-alexMove (AlexPn a l c) '\t' = AlexPn (a + 1) l (c + tabSize - ((c -1) `mod` tabSize))
+alexMove (AlexPn a l c) '\t' = AlexPn (a + 1) l (c + tabSize - ((c - 1) `mod` tabSize))
 alexMove (AlexPn a l _) '\n' = AlexPn (a + 1) (l + 1) 1
 alexMove (AlexPn a l c) _ = AlexPn (a + 1) l (c + 1)
 

--- a/src/Language/Futhark/Parser/Lexer/Wrapper.hs
+++ b/src/Language/Futhark/Parser/Lexer/Wrapper.hs
@@ -10,6 +10,7 @@ module Language.Futhark.Parser.Lexer.Wrapper
     AlexPosn (..),
     AlexState (..),
     Byte,
+    LexerError (..),
     alexSetInput,
     alexGetInput,
     alexGetByte,
@@ -24,6 +25,7 @@ import qualified Data.ByteString.Internal as BS (w2c)
 import qualified Data.ByteString.Lazy as BS
 import Data.Int (Int64)
 import Data.Word (Word8)
+import Data.Loc (Loc)
 
 type Byte = Word8
 
@@ -79,7 +81,7 @@ data AlexState = AlexState
     alex_scd :: !Int -- the current startcode
   }
 
-runAlex' :: AlexPosn -> BS.ByteString -> Alex a -> Either String a
+runAlex' :: AlexPosn -> BS.ByteString -> Alex a -> Either LexerError a
 runAlex' start_pos input__ (Alex f) =
   case f
     ( AlexState
@@ -93,7 +95,12 @@ runAlex' start_pos input__ (Alex f) =
     Left msg -> Left msg
     Right (_, a) -> Right a
 
-newtype Alex a = Alex {unAlex :: AlexState -> Either String (AlexState, a)}
+newtype Alex a = Alex {unAlex :: AlexState -> Either LexerError (AlexState, a)}
+
+data LexerError = LexerError Loc String
+
+instance Show LexerError where
+  show (LexerError _ s) = s
 
 instance Functor Alex where
   fmap = liftA
@@ -126,8 +133,8 @@ alexSetInput (pos, c, inp, bpos) =
     } of
     state@AlexState {} -> Right (state, ())
 
-alexError :: String -> Alex a
-alexError message = Alex $ const $ Left message
+alexError :: Loc -> String -> Alex a
+alexError loc message = Alex $ const $ Left $ LexerError loc message
 
 alexGetStartCode :: Alex Int
 alexGetStartCode = Alex $ \s@AlexState {alex_scd = sc} -> Right (s, sc)

--- a/src/Language/Futhark/Parser/Monad.hs
+++ b/src/Language/Futhark/Parser/Monad.hs
@@ -53,11 +53,11 @@ import qualified Data.Text as T
 import Futhark.Util.Loc hiding (L) -- Lexer has replacements.
 import Futhark.Util.Pretty hiding (line)
 import Language.Futhark.Parser.Lexer
+import Language.Futhark.Parser.Lexer.Wrapper (LexerError (..))
 import Language.Futhark.Pretty ()
 import Language.Futhark.Prop
 import Language.Futhark.Syntax
 import Prelude hiding (mod)
-import Language.Futhark.Parser.Lexer.Wrapper (LexerError (..))
 
 addDoc :: DocComment -> UncheckedDec -> UncheckedDec
 addDoc doc (ValDec val) = ValDec (val {valBindDoc = Just doc})
@@ -137,13 +137,14 @@ combArrayElements = foldM comb
     comb x y
       | valueType x == valueType y = Right x
       | otherwise =
-        Left $ ParseError NoLoc $
-          "Elements " <> pretty x <> " and "
-            <> pretty y
-            <> " cannot exist in same array."
+          Left $
+            ParseError NoLoc $
+              "Elements " <> pretty x <> " and "
+                <> pretty y
+                <> " cannot exist in same array."
 
 arrayFromList :: [a] -> Array Int a
-arrayFromList l = listArray (0, length l -1) l
+arrayFromList l = listArray (0, length l - 1) l
 
 applyExp :: [UncheckedExp] -> ParserMonad UncheckedExp
 applyExp all_es@((Constr n [] _ loc1) : es) =
@@ -197,15 +198,15 @@ primTypeFromName loc s = maybe boom pure $ M.lookup s namesToPrimTypes
     boom = parseErrorAt loc $ Just $ "No type named " ++ nameToString s
 
 intNegate :: IntValue -> IntValue
-intNegate (Int8Value v) = Int8Value (- v)
-intNegate (Int16Value v) = Int16Value (- v)
-intNegate (Int32Value v) = Int32Value (- v)
-intNegate (Int64Value v) = Int64Value (- v)
+intNegate (Int8Value v) = Int8Value (-v)
+intNegate (Int16Value v) = Int16Value (-v)
+intNegate (Int32Value v) = Int32Value (-v)
+intNegate (Int64Value v) = Int64Value (-v)
 
 floatNegate :: FloatValue -> FloatValue
-floatNegate (Float16Value v) = Float16Value (- v)
-floatNegate (Float32Value v) = Float32Value (- v)
-floatNegate (Float64Value v) = Float64Value (- v)
+floatNegate (Float16Value v) = Float16Value (-v)
+floatNegate (Float32Value v) = Float32Value (-v)
+floatNegate (Float64Value v) = Float64Value (-v)
 
 primNegate :: PrimValue -> PrimValue
 primNegate (FloatValue v) = FloatValue $ floatNegate v
@@ -283,10 +284,10 @@ lexerErrToParseErr (LexerError loc msg) = ParseError loc msg
 
 parseInMonad :: ParserMonad a -> FilePath -> T.Text -> ReadLineMonad (Either ParseError a)
 parseInMonad p file program =
-      either
-      (pure . Left . lexerErrToParseErr)
-      (evalStateT (evalStateT (runExceptT p) env))
-      (scanTokensText (Pos file 1 1 0) program)
+  either
+    (pure . Left . lexerErrToParseErr)
+    (evalStateT (evalStateT (runExceptT p) env))
+    (scanTokensText (Pos file 1 1 0) program)
   where
     env = ParserEnv {parserFile = file}
 

--- a/src/Language/Futhark/Parser/Monad.hs
+++ b/src/Language/Futhark/Parser/Monad.hs
@@ -279,6 +279,9 @@ data ParseError = ParseError Loc String
 instance Show ParseError where
   show (ParseError _ s) = s
 
+instance Located ParseError where
+  locOf (ParseError loc _) = loc
+
 lexerErrToParseErr :: LexerError -> ParseError
 lexerErrToParseErr (LexerError loc msg) = ParseError loc msg
 

--- a/src/Language/Futhark/Parser/Monad.hs
+++ b/src/Language/Futhark/Parser/Monad.hs
@@ -283,8 +283,7 @@ lexerErrToParseErr (LexerError loc msg) = ParseError loc msg
 
 parseInMonad :: ParserMonad a -> FilePath -> T.Text -> ReadLineMonad (Either ParseError a)
 parseInMonad p file program =
-  either Left Right
-    <$> either
+      either
       (pure . Left . lexerErrToParseErr)
       (evalStateT (evalStateT (runExceptT p) env))
       (scanTokensText (Pos file 1 1 0) program)

--- a/src/Language/Futhark/Parser/Parser.y
+++ b/src/Language/Futhark/Parser/Parser.y
@@ -39,7 +39,6 @@ import Language.Futhark.Parser.Lexer
 import Futhark.Util.Pretty
 import Futhark.Util.Loc hiding (L) -- Lexer has replacements.
 import Language.Futhark.Parser.Monad
-import Language.Futhark.Parser.Lexer.Wrapper (LexerError (..))
 
 }
 

--- a/src/Language/Futhark/Parser/Parser.y
+++ b/src/Language/Futhark/Parser/Parser.y
@@ -39,6 +39,7 @@ import Language.Futhark.Parser.Lexer
 import Futhark.Util.Pretty
 import Futhark.Util.Loc hiding (L) -- Lexer has replacements.
 import Language.Futhark.Parser.Monad
+import Language.Futhark.Parser.Lexer.Wrapper (LexerError (..))
 
 }
 


### PR DESCRIPTION
The code compiles but the location info are still missing somehow, for example the code below will still emit `NoLoc`:

```futhark
def average (xs: []f64) = reduce (* 0 xs / f64.i64 (length xs)
```

Just managed to trace it back to [parseError](https://github.com/diku-dk/futhark/blob/f18ec76225b4c7c652d3b2148a382b9fbd4c5c36/src/Language/Futhark/Parser/Monad.hs#L241), `NoLoc` starts from there, will keep investigating