### PR TITLE
lsp: add documentation link for build-in functions

### DIFF
--- a/src/Futhark/LSP/Tool.hs
+++ b/src/Futhark/LSP/Tool.hs
@@ -38,10 +38,11 @@ getHoverInfoFromState state (Just path) l c = do
       Just $
         (prettyText qn <> " : " <> prettyText t)
           <> if isBuiltinLoc defloc
-            then mempty
+            then "\n\n" <> futharkDocUrl defloc
             else "\n\n**Definition: " <> T.pack (locStr (srclocOf defloc)) <> "**"
     bound
-      | isBuiltinLoc (boundLoc bound) -> Just "Builtin definition."
+      | isBuiltinLoc (boundLoc bound) ->
+          Just $ "Buildin definition: " <> futharkDocUrl (boundLoc bound)
       | otherwise -> Just $ "Definition: " <> T.pack (locStr (boundLoc bound))
 getHoverInfoFromState _ _ _ _ = Nothing
 
@@ -84,3 +85,11 @@ rangeFromLoc NoLoc = Range (Position 0 0) (Position 0 5) -- only when file not f
 
 rangeFromSrcLoc :: SrcLoc -> Range
 rangeFromSrcLoc = rangeFromLoc . locOf
+
+-- | Generate link to futhark documentation site for prelude functions.
+futharkDocUrl :: Loc -> T.Text
+futharkDocUrl loc =
+  let (Loc (Pos file _ _ _) _) = loc
+   in "[Documentation](https://futhark-lang.org/docs/prelude/doc"
+        <> T.replace ".fut" ".html" (T.pack file)
+        <> ")"


### PR DESCRIPTION
Add documentation link for prelude functions

Still unsure about whether to include definitions for prelude functions, it's true that the definition is a bit useless, but the UI looks a little bit wired

<img width="455" alt="Screen Shot 2022-04-14 at 15 37 08" src="https://user-images.githubusercontent.com/27280733/163402580-e69fcce8-76ce-47d8-86a7-7084294c413f.png">