### PR TITLE
lsp: fix diagnostics are not flushed

### DIFF
--- a/src/Futhark/LSP/Compile.hs
+++ b/src/Futhark/LSP/Compile.hs
@@ -9,7 +9,7 @@ import Control.Monad.IO.Class (MonadIO (liftIO))
 import qualified Data.Map as M
 import qualified Data.Text as T
 import Futhark.Compiler.Program (LoadedProg, lpWarnings, noLoadedProg, reloadProg)
-import Futhark.LSP.Diagnostic (maxDiagnostic, publishErrorDiagnostics, publishWarningDiagnostics)
+import Futhark.LSP.Diagnostic (diagnosticSource, maxDiagnostic, publishErrorDiagnostics, publishWarningDiagnostics)
 import Futhark.LSP.State (State (..), emptyState)
 import Futhark.Util (debug)
 import Language.Futhark.Warnings (listWarnings)
@@ -52,7 +52,7 @@ tryCompile (Just path) state = do
   let old_loaded_prog = getLoadedProg state
   vfs <- getVirtualFiles
   res <- liftIO $ reloadProg old_loaded_prog [path] (transformVFS vfs)
-  flushDiagnosticsBySource maxDiagnostic Nothing
+  flushDiagnosticsBySource maxDiagnostic diagnosticSource
   case res of
     Right new_loaded_prog -> do
       publishWarningDiagnostics $ listWarnings $ lpWarnings new_loaded_prog

--- a/src/Futhark/LSP/Diagnostic.hs
+++ b/src/Futhark/LSP/Diagnostic.hs
@@ -5,6 +5,7 @@
 module Futhark.LSP.Diagnostic
   ( publishWarningDiagnostics,
     publishErrorDiagnostics,
+    diagnosticSource,
     maxDiagnostic,
   )
 where
@@ -32,7 +33,7 @@ import Language.LSP.Types
 import Language.LSP.Types.Lens (HasVersion (version))
 
 mkDiagnostic :: Range -> DiagnosticSeverity -> T.Text -> Diagnostic
-mkDiagnostic range severity msg = Diagnostic range (Just severity) Nothing Nothing msg Nothing Nothing
+mkDiagnostic range severity msg = Diagnostic range (Just severity) Nothing diagnosticSource msg Nothing Nothing
 
 -- | Publish diagnostics from a Uri to Diagnostics mapping.
 publish :: [(Uri, [Diagnostic])] -> LspT () IO ()
@@ -74,3 +75,8 @@ publishErrorDiagnostics errors = do
 -- | The maximum number of diagnostics to report.
 maxDiagnostic :: Int
 maxDiagnostic = 100
+
+-- | The source of the diagnostics.  (That is, the Futhark compiler,
+-- but apparently the client must be told such things...)
+diagnosticSource :: Maybe T.Text
+diagnosticSource = Just "futhark"


### PR DESCRIPTION
This reverts commit cd000141224b7f2fb9634bad85f7b19435c22ee4.

Not sure what's the implementation detail in `lsp` package, but diagnostics are not flushed without `diagnosticSource`.

Re-pro steps:
1. open the correct futhark file
2. trigger an error/warning to get diagnostic
3. fix the problem just triggered
4. the diagnostic won't disappear