### PR TITLE
lsp: positionmap when use stale type-checked result

### DIFF
--- a/futhark.cabal
+++ b/futhark.cabal
@@ -216,6 +216,7 @@ library
       Futhark.LSP.Handlers
       Futhark.LSP.Tool
       Futhark.LSP.State
+      Futhark.LSP.PositionMapping
       Futhark.MonadFreshNames
       Futhark.Optimise.BlkRegTiling
       Futhark.Optimise.CSE
@@ -336,6 +337,7 @@ library
     , bmp >=1.2.6.3
     , containers >=0.6.2.1
     , cryptohash-md5
+    , Diff >=0.4.1
     , directory >=1.3.0.0
     , directory-tree >=0.12.1
     , dlist >=0.6.0.1

--- a/src/Futhark/LSP/Compile.hs
+++ b/src/Futhark/LSP/Compile.hs
@@ -66,7 +66,7 @@ tryCompile (Just path) old_loaded_prog = do
       case maybe_virtual_file of
         Nothing -> pure $ State (Just new_loaded_prog) M.empty -- should never happen
         Just virtual_file ->
-          pure $ State (Just new_loaded_prog) (M.singleton path (virtualFileText virtual_file))
+          pure $ State (Just new_loaded_prog) (M.singleton path virtual_file)
     -- TODO: only preserve the contents of the focused file for now, focus on useStale
     -- should preserve all files that has been type-checked
     -- maybe need an update on re-compile logic, don't discard all state afterwards

--- a/src/Futhark/LSP/Compile.hs
+++ b/src/Futhark/LSP/Compile.hs
@@ -54,7 +54,6 @@ tryReCompile state_mvar file_path = do
   old_state <- liftIO $ readIORef state_mvar
   let loaded_prog = getLoadedProg old_state
   new_state <- tryCompile old_state file_path loaded_prog
-  debug $ show $ staleData old_state
   case stateProgram new_state of
     Nothing -> do
       debug "Failed to (re)-compile, using old state or Nothing"

--- a/src/Futhark/LSP/PositionMapping.hs
+++ b/src/Futhark/LSP/PositionMapping.hs
@@ -32,7 +32,7 @@ mappingFromDiff stale current = PositionMapping $ rawMapping (getDiff stale curr
 -- | Transform current Pos to the stale pos for query
 -- Note: line and col in Pos is larger by one
 toStalePos :: Maybe PositionMapping -> Pos -> Maybe Pos
-toStalePos (Just (PositionMapping (_, new2old))) pos = do
+toStalePos (Just (PositionMapping (_, new2old))) pos =
   if l > Prelude.length new2old
     then Nothing
     else Just $ Pos file ((new2old !! (l - 1)) + 1) c o
@@ -40,15 +40,17 @@ toStalePos (Just (PositionMapping (_, new2old))) pos = do
     Pos file l c o = pos
 toStalePos Nothing pos = Just pos
 
-toCurrentPos :: PositionMapping -> Pos -> Maybe Pos
-toCurrentPos (PositionMapping (old2new, _)) pos = do
+-- some refactoring might be needed, same logic as toStalePos
+toCurrentPos :: Maybe PositionMapping -> Pos -> Maybe Pos
+toCurrentPos (Just (PositionMapping (old2new, _))) pos =
   if l > Prelude.length old2new
     then Nothing
     else Just $ Pos file ((old2new !! (l - 1)) + 1) c o
   where
     Pos file l c o = pos
+toCurrentPos Nothing pos = Just pos
 
-toCurrentLoc :: PositionMapping -> Loc -> Maybe Loc
+toCurrentLoc :: Maybe PositionMapping -> Loc -> Maybe Loc
 toCurrentLoc mapping loc = do
   let Loc start end = loc
   current_start <- toCurrentPos mapping start

--- a/src/Futhark/LSP/PositionMapping.hs
+++ b/src/Futhark/LSP/PositionMapping.hs
@@ -50,6 +50,7 @@ toCurrentPos (Just (PositionMapping (old2new, _))) pos =
     Pos file l c o = pos
 toCurrentPos Nothing pos = Just pos
 
+-- | Transform stale Loc gotten from stale AST to current Loc.
 toCurrentLoc :: Maybe PositionMapping -> Loc -> Maybe Loc
 toCurrentLoc mapping loc = do
   let Loc start end = loc

--- a/src/Futhark/LSP/PositionMapping.hs
+++ b/src/Futhark/LSP/PositionMapping.hs
@@ -4,6 +4,7 @@ module Futhark.LSP.PositionMapping
     PositionMapping,
     toStalePos,
     toCurrentLoc,
+    StaleFile (..),
   )
 where
 
@@ -11,13 +12,25 @@ import Data.Algorithm.Diff (Diff, PolyDiff (Both, First, Second), getDiff)
 import Data.Bifunctor (Bifunctor (bimap, first, second))
 import qualified Data.Text as T
 import Futhark.Util.Loc (Loc (Loc), Pos (Pos))
+import Language.LSP.VFS (VirtualFile)
 
 -- | A mapping between current file content and the stale (last successful compiled) file content
 -- currently, only supports entire line mapping
 -- more detailed mapping might be achieved via referring to haskell-language-server@efb4b94
--- also might be a good idea to separate the related logic into a separate module
 newtype PositionMapping = PositionMapping ([Int], [Int])
   deriving (Show)
+
+-- | Stale text document stored in state.
+data StaleFile = StaleFile
+  { -- | The last successful compiled file content.
+    staleContent :: VirtualFile,
+    -- | PositionMapping between current and stale file content.
+    -- Nothing if last type-check is successful.
+    staleMapping :: Maybe PositionMapping
+  }
+
+instance Show StaleFile where
+  show (StaleFile _ mapping) = show mapping
 
 -- | Compute PositionMapping using the diff between two texts.
 mappingFromDiff :: [T.Text] -> [T.Text] -> PositionMapping

--- a/src/Futhark/LSP/PositionMapping.hs
+++ b/src/Futhark/LSP/PositionMapping.hs
@@ -1,0 +1,56 @@
+-- | Provide mapping between position in stale content and current.
+module Futhark.LSP.PositionMapping
+  ( mappingFromDiff,
+    PositionMapping,
+    toStalePos,
+    toCurrentLoc,
+  )
+where
+
+import Data.Algorithm.Diff (Diff, PolyDiff (Both, First, Second), getDiff)
+import Data.Bifunctor (Bifunctor (bimap, first, second))
+import qualified Data.Text as T
+import Futhark.Util.Loc (Loc (Loc), Pos (Pos))
+
+-- | A mapping between current file content and the stale (last successful compiled) file content
+-- currently, only supports entire line mapping
+-- more detailed mapping might be achieved via referring to haskell-language-server@efb4b94
+-- also might be a good idea to separate the related logic into a separate module
+newtype PositionMapping = PositionMapping ([Int], [Int])
+  deriving (Show)
+
+-- | Compute PositionMapping using the diff between two texts.
+mappingFromDiff :: [T.Text] -> [T.Text] -> PositionMapping
+mappingFromDiff stale current = PositionMapping $ rawMapping (getDiff stale current) 0 0
+  where
+    rawMapping :: [Diff T.Text] -> Int -> Int -> ([Int], [Int])
+    rawMapping [] _ _ = ([], [])
+    rawMapping (Both _ _ : xs) lold lnew = bimap (lnew :) (lold :) $ rawMapping xs (lold + 1) (lnew + 1)
+    rawMapping (First _ : xs) lold lnew = first (-1 :) $ rawMapping xs (lold + 1) lnew
+    rawMapping (Second _ : xs) lold lnew = second (-1 :) $ rawMapping xs lold (lnew + 1)
+
+-- | Transform current Pos to the stale pos for query
+-- Note: line and col in Pos is larger by one
+toStalePos :: Maybe PositionMapping -> Pos -> Maybe Pos
+toStalePos (Just (PositionMapping (_, new2old))) pos = do
+  if l > Prelude.length new2old
+    then Nothing
+    else Just $ Pos file ((new2old !! (l - 1)) + 1) c o
+  where
+    Pos file l c o = pos
+toStalePos Nothing pos = Just pos
+
+toCurrentPos :: PositionMapping -> Pos -> Maybe Pos
+toCurrentPos (PositionMapping (old2new, _)) pos = do
+  if l > Prelude.length old2new
+    then Nothing
+    else Just $ Pos file ((old2new !! (l - 1)) + 1) c o
+  where
+    Pos file l c o = pos
+
+toCurrentLoc :: PositionMapping -> Loc -> Maybe Loc
+toCurrentLoc mapping loc = do
+  let Loc start end = loc
+  current_start <- toCurrentPos mapping start
+  current_end <- toCurrentPos mapping end
+  Just $ Loc current_start current_end

--- a/src/Futhark/LSP/State.hs
+++ b/src/Futhark/LSP/State.hs
@@ -18,7 +18,8 @@ import Language.LSP.VFS (VirtualFile)
 data State = State
   { -- | The loaded program.
     stateProgram :: Maybe LoadedProg,
-    -- | The last succussful type-checked files.
+    -- | The stale data, stored to provide PositionMapping when requested.
+    -- All files that have been opened have an entry.
     staleData :: M.Map FilePath StaleFile
   }
 
@@ -26,10 +27,11 @@ data State = State
 emptyState :: State
 emptyState = State Nothing M.empty
 
--- | Get the contents of a stale (last succuessfully complied) file's contents.
+-- | Get the contents of a stale (last successfully complied) file's contents.
 getStaleContent :: State -> FilePath -> Maybe VirtualFile
 getStaleContent state file_path = (Just . staleContent) =<< M.lookup file_path (staleData state)
 
+-- | Get the PositionMapping for a file.
 getStaleMapping :: State -> FilePath -> Maybe PositionMapping
 getStaleMapping state file_path = staleMapping =<< M.lookup file_path (staleData state)
 
@@ -42,10 +44,11 @@ updateStaleContent file_path file_content loadedProg state =
   -- so the PositionsMapping should be Nothing here, it's calculated after failed type-check.
   State (Just loadedProg) (M.insert file_path (StaleFile file_content Nothing) (staleData state))
 
+-- | Update the state with another pair of file_path and PositionMapping.
 updateStaleMapping :: Maybe FilePath -> Maybe PositionMapping -> State -> State
 updateStaleMapping (Just file_path) mapping state = do
   case M.lookup file_path (staleData state) of
-    Nothing -> state
+    Nothing -> state -- Only happends when the file have never been successfully type-checked before.
     Just (StaleFile file_content _mapping) ->
       State (stateProgram state) (M.insert file_path (StaleFile file_content mapping) (staleData state))
 updateStaleMapping _ _ state = state

--- a/src/Futhark/LSP/State.hs
+++ b/src/Futhark/LSP/State.hs
@@ -1,23 +1,25 @@
 -- | The language server state definition.
 module Futhark.LSP.State
-  ( State (State, stateProgram),
+  ( State (..),
     emptyState,
     getStaleContent,
+    getStaleMapping,
     updateStaleContent,
+    updateStaleMapping,
   )
 where
 
 import qualified Data.Map as M
 import Futhark.Compiler.Program (LoadedProg)
+import Futhark.LSP.PositionMapping (PositionMapping, StaleFile (..))
 import Language.LSP.VFS (VirtualFile)
 
 -- | The state of the language server.
 data State = State
   { -- | The loaded program.
     stateProgram :: Maybe LoadedProg,
-    -- | The last succussful type-checked file contents.
-    -- Using VirtualFile type for convenience, we just need {version, content}
-    staleProgram :: M.Map FilePath VirtualFile
+    -- | The last succussful type-checked files.
+    staleData :: M.Map FilePath StaleFile
   }
 
 -- | Initial state.
@@ -25,12 +27,25 @@ emptyState :: State
 emptyState = State Nothing M.empty
 
 -- | Get the contents of a stale (last succuessfully complied) file's contents.
-getStaleContent :: State -> Maybe FilePath -> Maybe VirtualFile
-getStaleContent state (Just file_path) = M.lookup file_path (staleProgram state)
-getStaleContent _ _ = Nothing
+getStaleContent :: State -> FilePath -> Maybe VirtualFile
+getStaleContent state file_path = (Just . staleContent) =<< M.lookup file_path (staleData state)
+
+getStaleMapping :: State -> FilePath -> Maybe PositionMapping
+getStaleMapping state file_path = staleMapping =<< M.lookup file_path (staleData state)
 
 -- | Update the state with another pair of file_path and contents.
 -- Could do a clean up becausae there is no need to store files that are not in lpFilePaths prog.
-updateStaleContent :: FilePath -> VirtualFile -> State -> State
-updateStaleContent file_path virtual_file state =
-  State (stateProgram state) (M.insert file_path virtual_file (staleProgram state))
+updateStaleContent :: FilePath -> VirtualFile -> LoadedProg -> State -> State
+updateStaleContent file_path file_content loadedProg state =
+  -- NOTE: insert will replace the old value if the key already exists.
+  -- updateStaleContent is only called after a successful type-check,
+  -- so the PositionsMapping should be Nothing here, it's calculated after failed type-check.
+  State (Just loadedProg) (M.insert file_path (StaleFile file_content Nothing) (staleData state))
+
+updateStaleMapping :: Maybe FilePath -> Maybe PositionMapping -> State -> State
+updateStaleMapping (Just file_path) mapping state = do
+  case M.lookup file_path (staleData state) of
+    Nothing -> state
+    Just (StaleFile file_content _mapping) ->
+      State (stateProgram state) (M.insert file_path (StaleFile file_content mapping) (staleData state))
+updateStaleMapping _ _ state = state

--- a/src/Futhark/LSP/State.hs
+++ b/src/Futhark/LSP/State.hs
@@ -1,8 +1,9 @@
 -- | The language server state definition.
 module Futhark.LSP.State
-  ( State (..),
+  ( State (State, stateProgram),
     emptyState,
     getStaleContent,
+    updateStaleContent,
   )
 where
 
@@ -15,6 +16,7 @@ data State = State
   { -- | The loaded program.
     stateProgram :: Maybe LoadedProg,
     -- | The last succussful type-checked file contents.
+    -- Using VirtualFile type for convenience, we just need {version, content}
     staleProgram :: M.Map FilePath VirtualFile
   }
 
@@ -26,3 +28,9 @@ emptyState = State Nothing M.empty
 getStaleContent :: State -> Maybe FilePath -> Maybe VirtualFile
 getStaleContent state (Just file_path) = M.lookup file_path (staleProgram state)
 getStaleContent _ _ = Nothing
+
+-- | Update the state with another pair of file_path and contents.
+-- Could do a clean up becausae there is no need to store files that are not in lpFilePaths prog.
+updateStaleContent :: FilePath -> VirtualFile -> State -> State
+updateStaleContent file_path virtual_file state =
+  State (stateProgram state) (M.insert file_path virtual_file (staleProgram state))

--- a/src/Futhark/LSP/State.hs
+++ b/src/Futhark/LSP/State.hs
@@ -7,15 +7,15 @@ module Futhark.LSP.State
 where
 
 import qualified Data.Map as M
-import qualified Data.Text as T
 import Futhark.Compiler.Program (LoadedProg)
+import Language.LSP.VFS (VirtualFile)
 
 -- | The state of the language server.
 data State = State
   { -- | The loaded program.
     stateProgram :: Maybe LoadedProg,
     -- | The last succussful type-checked file contents.
-    staleProgram :: M.Map FilePath T.Text
+    staleProgram :: M.Map FilePath VirtualFile
   }
 
 -- | Initial state.
@@ -23,6 +23,6 @@ emptyState :: State
 emptyState = State Nothing M.empty
 
 -- | Get the contents of a stale (last succuessfully complied) file's contents.
-getStaleContent :: State -> Maybe FilePath -> Maybe T.Text
+getStaleContent :: State -> Maybe FilePath -> Maybe VirtualFile
 getStaleContent state (Just file_path) = M.lookup file_path (staleProgram state)
 getStaleContent _ _ = Nothing

--- a/src/Futhark/LSP/State.hs
+++ b/src/Futhark/LSP/State.hs
@@ -5,14 +5,18 @@ module Futhark.LSP.State
   )
 where
 
+import qualified Data.Map as M
+import qualified Data.Text as T
 import Futhark.Compiler.Program (LoadedProg)
 
 -- | The state of the language server.
-newtype State = State
+data State = State
   { -- | The loaded program.
-    stateProgram :: Maybe LoadedProg
+    stateProgram :: Maybe LoadedProg,
+    -- | The last succussful type-checked file contents.
+    staleProgram :: M.Map FilePath T.Text
   }
 
 -- | Initial state.
 emptyState :: State
-emptyState = State Nothing
+emptyState = State Nothing M.empty

--- a/src/Futhark/LSP/State.hs
+++ b/src/Futhark/LSP/State.hs
@@ -2,6 +2,7 @@
 module Futhark.LSP.State
   ( State (..),
     emptyState,
+    getStaleContent,
   )
 where
 
@@ -20,3 +21,8 @@ data State = State
 -- | Initial state.
 emptyState :: State
 emptyState = State Nothing M.empty
+
+-- | Get the contents of a stale (last succuessfully complied) file's contents.
+getStaleContent :: State -> Maybe FilePath -> Maybe T.Text
+getStaleContent state (Just file_path) = M.lookup file_path (staleProgram state)
+getStaleContent _ _ = Nothing

--- a/src/Futhark/LSP/Tool.hs
+++ b/src/Futhark/LSP/Tool.hs
@@ -8,11 +8,19 @@ module Futhark.LSP.Tool
     rangeFromSrcLoc,
     rangeFromLoc,
     posToUri,
+    getMapping,
   )
 where
 
+import qualified Data.Text as T
 import Futhark.Compiler.Program (lpImports)
-import Futhark.LSP.State (State (..))
+import Futhark.LSP.PositionMapping
+  ( PositionMapping,
+    mappingFromDiff,
+    toCurrentLoc,
+    toStalePos,
+  )
+import Futhark.LSP.State (State (..), getStaleContent)
 import Futhark.Util.Loc (Loc (Loc, NoLoc), Pos (Pos), SrcLoc, locOf)
 import Futhark.Util.Pretty (prettyText)
 import Language.Futhark.Prop (isBuiltinLoc)
@@ -22,13 +30,15 @@ import Language.Futhark.Query
     atPos,
     boundLoc,
   )
+import Language.LSP.Server (LspM, getVirtualFile)
 import Language.LSP.Types
+import Language.LSP.VFS (VirtualFile, virtualFileText)
 
 -- | Retrieve hover info for the definition referenced at the given
 -- file at the given line and column number (the two 'Int's).
-getHoverInfoFromState :: State -> Maybe FilePath -> Int -> Int -> Maybe Hover
-getHoverInfoFromState state (Just path) l c = do
-  AtName _ (Just def) loc <- queryAtPos state $ Pos path l c 0
+getHoverInfoFromState :: State -> Maybe FilePath -> Maybe PositionMapping -> Int -> Int -> Maybe Hover
+getHoverInfoFromState state (Just path) mapping l c = do
+  AtName _ (Just def) loc <- queryAtPos state mapping $ Pos path l c 0
   let msg =
         case def of
           BoundTerm t _ -> prettyText t
@@ -37,33 +47,39 @@ getHoverInfoFromState state (Just path) l c = do
           BoundType {} -> "type"
       ms = HoverContents $ MarkupContent MkPlainText msg
   Just $ Hover ms (Just (rangeFromLoc loc))
-getHoverInfoFromState _ _ _ _ = Nothing
+getHoverInfoFromState _ _ _ _ _ = Nothing
 
 -- | Find the location of the definition referenced at the given file
 -- at the given line and column number (the two 'Int's).
-findDefinitionRange :: State -> Maybe FilePath -> Int -> Int -> Maybe Location
-findDefinitionRange state (Just path) l c = do
+findDefinitionRange :: State -> Maybe FilePath -> Maybe PositionMapping -> Int -> Int -> Maybe Location
+findDefinitionRange state (Just path) mapping l c = do
   -- some unnessecary operations inside `queryAtPos` for this function
   -- but shouldn't affect performance much since "Go to definition" is called less frequently
-  AtName _qn (Just bound) _loc <- queryAtPos state $ Pos path l c 0
+  AtName _qn (Just bound) _loc <- queryAtPos state mapping $ Pos path l c 0
   let loc = boundLoc bound
       Loc (Pos file_path _ _ _) _ = loc
   if isBuiltinLoc loc
     then Nothing
     else Just $ Location (filePathToUri file_path) (rangeFromLoc loc)
-findDefinitionRange _ _ _ _ = Nothing
+findDefinitionRange _ _ _ _ _ = Nothing
 
-queryAtPos :: State -> Pos -> Maybe AtPos
-queryAtPos state pos = do
-  -- TODO: maybe stale state
-  -- could add a check for this so that compute diff may not be needed
-  stale_pos <- useStale pos
-  -- pos from the current file content, convert to the stale pos for query
+queryAtPos :: State -> Maybe PositionMapping -> Pos -> Maybe AtPos
+queryAtPos state mapping pos = do
   loaded_prog <- stateProgram state
+  stale_pos <- toStalePos mapping pos
   atPos (lpImports loaded_prog) stale_pos -- TODO: AtPos is stale, need to covert to correct position
 
-useStale :: Pos -> Maybe Pos
-useStale pos = Just pos
+-- | Entry point for create PositionMapping.
+-- Nothing if diff is not needed.
+getMapping :: State -> Uri -> LspM () (Maybe PositionMapping)
+getMapping state uri = do
+  virtual_file <- getVirtualFile $ toNormalizedUri uri
+  pure $ computeMapping (getStaleContent state $ uriToFilePath uri) virtual_file
+  where
+    computeMapping :: Maybe T.Text -> Maybe VirtualFile -> Maybe PositionMapping
+    computeMapping (Just stale_content) (Just virtual_file) =
+      Just $ mappingFromDiff (T.lines stale_content) (T.lines $ virtualFileText virtual_file)
+    computeMapping _ _ = Nothing
 
 -- | Convert a Futhark 'Pos' to an LSP 'Uri'.
 posToUri :: Pos -> Uri

--- a/src/Futhark/LSP/Tool.hs
+++ b/src/Futhark/LSP/Tool.hs
@@ -73,15 +73,19 @@ queryAtPos state mapping pos = do
     updateAtPos :: AtPos -> Maybe AtPos
     updateAtPos (AtName qn (Just def) loc) = do
       let def_loc = boundLoc def
-          Loc (Pos file_path _ _ _) _ = def_loc
+          Loc (Pos def_file _ _ _) _ = def_loc
           Pos current_file _ _ _ = pos
       current_loc <- toCurrentLoc mapping loc
-      current_def_loc <- toCurrentLoc mapping def_loc
-      -- TODO: getting even trickier then expected
-      -- what if the definition is in a different **stale** file?
-      if file_path == current_file
-        then Just $ AtName qn (Just (updateBoundLoc def current_def_loc)) current_loc
-        else Just $ AtName qn (Just def) current_loc
+      if def_file == current_file
+        then do
+          current_def_loc <- toCurrentLoc mapping def_loc
+          Just $ AtName qn (Just (updateBoundLoc def current_def_loc)) current_loc
+        else do
+          -- TODO: getting even trickier then expected
+          -- what if the definition is in a different **stale** file?
+          -- how to compute a mapping for def_file?
+          -- we don't have the file contents if the file is not open, it doesn't exits in VFS
+          Just $ AtName qn (Just def) current_loc
     updateAtPos _ = Nothing
 
     updateBoundLoc :: BoundTo -> Loc -> BoundTo

--- a/src/Futhark/LSP/Tool.hs
+++ b/src/Futhark/LSP/Tool.hs
@@ -67,7 +67,16 @@ queryAtPos :: State -> Maybe PositionMapping -> Pos -> Maybe AtPos
 queryAtPos state mapping pos = do
   loaded_prog <- stateProgram state
   stale_pos <- toStalePos mapping pos
-  atPos (lpImports loaded_prog) stale_pos -- TODO: AtPos is stale, need to covert to correct position
+  query_result <- atPos (lpImports loaded_prog) stale_pos
+  updateAtPos query_result
+  where
+    updateAtPos :: AtPos -> Maybe AtPos
+    updateAtPos (AtName qn (Just def) loc) = do
+      current_loc <- toCurrentLoc mapping loc
+      -- TODO: update boundloc to current_loc
+      -- note, boundloc could be in another file, don't change in that case
+      Just $ AtName qn (Just def) current_loc
+    updateAtPos _ = Nothing
 
 -- | Entry point for create PositionMapping.
 -- Nothing if diff is not needed.

--- a/src/Futhark/LSP/Tool.hs
+++ b/src/Futhark/LSP/Tool.hs
@@ -54,10 +54,9 @@ findDefinitionRange state (Just path) l c = do
 findDefinitionRange _ _ _ _ = Nothing
 
 queryAtPos :: State -> Pos -> Maybe AtPos
-queryAtPos state pos =
-  case stateProgram state of
-    Nothing -> Nothing
-    Just loaded_prog -> atPos (lpImports loaded_prog) pos
+queryAtPos state pos = do
+  loaded_prog <- stateProgram state
+  atPos (lpImports loaded_prog) pos
 
 -- | Convert a Futhark 'Pos' to an LSP 'Uri'.
 posToUri :: Pos -> Uri

--- a/src/Futhark/LSP/Tool.hs
+++ b/src/Futhark/LSP/Tool.hs
@@ -55,8 +55,15 @@ findDefinitionRange _ _ _ _ = Nothing
 
 queryAtPos :: State -> Pos -> Maybe AtPos
 queryAtPos state pos = do
+  -- TODO: maybe stale state
+  -- could add a check for this so that compute diff may not be needed
+  stale_pos <- useStale pos
+  -- pos from the current file content, convert to the stale pos for query
   loaded_prog <- stateProgram state
-  atPos (lpImports loaded_prog) pos
+  atPos (lpImports loaded_prog) stale_pos -- TODO: AtPos is stale, need to covert to correct position
+
+useStale :: Pos -> Maybe Pos
+useStale pos = Just pos
 
 -- | Convert a Futhark 'Pos' to an LSP 'Uri'.
 posToUri :: Pos -> Uri


### PR DESCRIPTION
close #1621  , referencing [deltaFromDiff](https://github.com/haskell/haskell-language-server/blob/7518a3a7eb9c11b2dbbff0aed1d982fd3e3505a9/ghcide/src/Development/IDE/Core/PositionMapping.hs#L185)

The logic for computing mapping and converting between current and stale positions is ready.

But there is still some problems when we navigate between files, should be fixed in another PR probably. Using [heston](https://github.com/diku-dk/futhark-benchmarks/tree/master/misc/heston) for example:

1. Open `heston.fut`
2. Go to def (or simply open) `least_squares.fut` (State will be re-compiled, AST won't have `heston.fut` anymore)
3. Tigger some errors in `least_squares.fut`
4. Go back to `heston.fut` and try to Go to def to `least_squares.fut`