### PR TITLE
Simplify handling of uniqueness.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+* Some rare holes in consumption/alias checking, mostly related to
+  subtle interactions with higher-order functions.
+
 ## [0.21.11]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-* Some rare holes in consumption/alias checking, mostly related to
-  subtle interactions with higher-order functions.
-
 ## [0.21.11]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+* Somewhat simplified the handling of "uniqueness types" (which is a
+  term we are moving away from).  You should never see `*` in
+  non-function types, and they are better thought of as effect
+  indicators.
+
 ### Removed
 
 ### Changed

--- a/docs/language-reference.rst
+++ b/docs/language-reference.rst
@@ -368,8 +368,7 @@ A named value/constant can be declared as follows::
 
 The definition can be an arbitrary expression, including function
 calls and other values, although they must be in scope before the
-value is defined.  A constant value may not have a unique type (see
-`In-place updates`_).  If the return type contains any anonymous sizes
+value is defined.  If the return type contains any anonymous sizes
 (see `Size types`_), new existential sizes will be constructed for
 them.
 
@@ -1054,8 +1053,8 @@ lifted* (``'^t``).  Only fully lifted type parameters may be
 instantiated with a functional type.  Within a function, a lifted type
 parameter is treated as a functional type.
 
-See also `In-place updates`_ for details on how uniqueness types
-interact with higher-order functions.
+See also `In-place updates`_ for details on how consumption
+interacts with higher-order functions.
 
 Type Inference
 --------------
@@ -1065,7 +1064,7 @@ explicit type annotations can be left off.  Record field projection
 cannot in isolation be fully inferred, and may need type annotations
 where their inputs are bound.  The same goes when constructing sum
 types, as Futhark cannot assume that a given constructor only belongs
-to a single type.  Further, unique types (see `In-place updates`_)
+to a single type.  Further, consumed parameters (see `In-place updates`_)
 must be explicitly annotated.
 
 Type inference processes top-level declared in top-down order, and the
@@ -1414,8 +1413,9 @@ update.  This involves also checking that no *alias* of ``a`` is used.
 Generally, most language constructs produce new arrays, but some
 (slicing) create arrays that alias their input arrays.
 
-When defining a function parameter or return type, we can mark it as
-*unique* by prefixing it with an asterisk.  For example::
+When defining a function parameter we can mark it as *consuming* by
+prefixing it with an asterisk.  For a return type, we can mark it as
+*alias-free* by prefixing it with an asterisk.  For example::
 
   def modify (a: *[]i32) (i: i32) (x: i32): *[]i32 =
     a with [i] = a[i] + x
@@ -1453,18 +1453,18 @@ fresh arrays, with no aliases.  The main exceptions are ``if``,
 
 * The aliases of a value returned from a function is the most
   interesting case, and depends on whether the return value is
-  declared *unique* (with an asterisk ``*``) or not.  If it is
-  declared unique, then it has no aliases.  Otherwise, it aliases all
-  arguments passed for *non-unique* parameters.
+  declared *alias-free* (with an asterisk ``*``) or not.  If it is
+  declared alias-free, then it has no aliases.  Otherwise, it aliases
+  all arguments passed for *non-consumed* parameters.
 
 In-place Updates and Higher-Order Functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Uniqueness typing generally interacts poorly with higher-order
+Consumption generally interacts inflexibly with higher-order
 functions.  The issue is that we cannot control how many times a
 function argument is applied, or to what, so it is not safe to pass a
 function that consumes its argument.  The following two conservative
-rules govern the interaction between uniqueness types and higher-order
+rules govern the interaction between consumption and higher-order
 functions:
 
 1. In the expression ``let p = e1 in ...``, if *any* in-place update

--- a/prelude/array.fut
+++ b/prelude/array.fut
@@ -70,7 +70,7 @@ def concat [n] [m] 't (xs: [n]t) (ys: [m]t): *[]t = xs ++ ys
 -- | Concatenation where the result has a predetermined size.  If the
 -- provided size is wrong, the function will fail with a run-time
 -- error.
-def concat_to [n] [m] 't (k: i64) (xs: [n]t) (ys: [m]t): *[k]t = xs ++ ys :> *[k]t
+def concat_to [n] [m] 't (k: i64) (xs: [n]t) (ys: [m]t): *[k]t = xs ++ ys :> [k]t
 
 -- | Rotate an array some number of elements to the left.  A negative
 -- rotation amount is also supported.

--- a/prelude/zip.fut
+++ b/prelude/zip.fut
@@ -10,7 +10,7 @@
 -- We need a map to define some of the zip variants, but this file is
 -- depended upon by soacs.fut.  So we just define a quick-and-dirty
 -- internal one here that uses the intrinsic version.
-local def internal_map 'a [n] 'x (f: a -> x) (as: [n]a): [n]x =
+local def internal_map 'a [n] 'x (f: a -> x) (as: [n]a): *[n]x =
   intrinsics.map (f, as)
 
 -- | Construct an array of pairs from two arrays.

--- a/prelude/zip.fut
+++ b/prelude/zip.fut
@@ -10,7 +10,7 @@
 -- We need a map to define some of the zip variants, but this file is
 -- depended upon by soacs.fut.  So we just define a quick-and-dirty
 -- internal one here that uses the intrinsic version.
-local def internal_map 'a [n] 'x (f: a -> x) (as: [n]a): *[n]x =
+local def internal_map 'a [n] 'x (f: a -> x) (as: [n]a): [n]x =
   intrinsics.map (f, as)
 
 -- | Construct an array of pairs from two arrays.

--- a/src/Language/Futhark/TypeChecker/Terms.hs
+++ b/src/Language/Futhark/TypeChecker/Terms.hs
@@ -1451,16 +1451,16 @@ checkGlobalAliases params body_t loc = do
   let als =
         filter isGlobal . S.toList $
           boundArrayAliases body_t `S.difference` foldMap patNames params
-  case als of
-    v : _
-      | not $ null params ->
-          typeError loc mempty . withIndexLink "alias-free-variable" $
-            "Function result aliases the free variable "
-              <> pquote (pprName v)
-              <> "."
-              </> "Use" <+> pquote "copy" <+> "to break the aliasing."
-    _ ->
-      pure ()
+  unless (null params) $ do
+    case als of
+      v : _ ->
+        typeError loc mempty . withIndexLink "alias-free-variable" $
+          "Function result aliases the free variable "
+            <> pquote (pprName v)
+            <> "."
+            </> "Use" <+> pquote "copy" <+> "to break the aliasing."
+      _ ->
+        pure ()
 
 inferReturnUniqueness :: [Pat] -> PatType -> PatType
 inferReturnUniqueness params t =

--- a/src/Language/Futhark/TypeChecker/Terms.hs
+++ b/src/Language/Futhark/TypeChecker/Terms.hs
@@ -128,10 +128,10 @@ sliceShape _ _ t = pure (t, [])
 lexicalClosure :: [Pat] -> Occurrences -> TermTypeM Aliasing
 lexicalClosure params closure = do
   vtable <- asks $ scopeVtable . termScope
-  let isLocal v = case v `M.lookup` vtable of
-        Just (BoundV Local _ _) -> True
+  let isGlobal v = case v `M.lookup` vtable of
+        Just (BoundV Global _ _) -> True
         _ -> False
-  pure . S.map AliasBound . S.filter isLocal $
+  pure . S.map AliasBound . S.filter (not . isGlobal) $
     allOccurring closure S.\\ mconcat (map patNames params)
 
 noAliasesIfOverloaded :: PatType -> TermTypeM PatType
@@ -156,14 +156,7 @@ checkAscript loc (TypeDecl te NoInfo) e = do
   onFailure (CheckingAscription decl_t e_t) $
     unify (mkUsage loc "type ascription") decl_t e_t
 
-  -- We also have to make sure that uniqueness matches.  This is done
-  -- explicitly, because uniqueness is ignored by unification.
-  e_t' <- normTypeFully e_t
   decl_t' <- normTypeFully decl_t
-  unless (noSizes e_t' `subtypeOf` noSizes decl_t') $
-    typeError loc mempty $
-      "Type" <+> pquote (ppr e_t') <+> "is not a subtype of"
-        <+> pquote (ppr decl_t') <> "."
 
   pure (TypeDecl te' $ Info decl_t', e')
 
@@ -183,14 +176,7 @@ checkCoerce loc (TypeDecl te NoInfo) e = do
   onFailure (CheckingAscription decl_t e_t) $
     unify (mkUsage loc "type ascription") decl_t e_t_nonrigid
 
-  -- We also have to make sure that uniqueness matches.  This is done
-  -- explicitly, because uniqueness is ignored by unification.
-  e_t' <- normTypeFully e_t
   decl_t' <- normTypeFully decl_t
-  unless (noSizes e_t' `subtypeOf` noSizes decl_t') $
-    typeError loc mempty $
-      "Type" <+> pquote (ppr e_t') <+> "is not a subtype of"
-        <+> pquote (ppr decl_t') <> "."
 
   pure (TypeDecl te' $ Info decl_t', e', ext)
 
@@ -545,8 +531,6 @@ checkExp (AppExp (LetWith dest src slice ve body loc) _) =
 
     (elemt, _) <- sliceShape (Just (loc, Nonrigid)) slice' =<< normTypeFully t
 
-    unless (unique src_t) $ notConsumable loc $ pquote $ pprName $ identName src
-
     sequentially (unifies "type of target array" (toStruct elemt) =<< checkExp ve) $ \ve' _ -> do
       ve_t <- expTypeFully ve'
       when (AliasBound (identName src') `S.member` aliases ve_t) $
@@ -566,8 +550,6 @@ checkExp (Update src slice ve loc) = do
   sequentially (checkExp ve >>= unifies "type of target array" elemt) $ \ve' _ ->
     sequentially (checkExp src >>= unifies "type of target array" t) $ \src' _ -> do
       src_t <- expTypeFully src'
-
-      unless (unique src_t) $ notConsumable loc $ pquote $ ppr src
 
       let src_als = aliases src_t
       ve_t <- expTypeFully ve'
@@ -624,37 +606,40 @@ checkExp (Assert e1 e2 NoInfo loc) = do
   e1' <- require "being asserted" [Bool] =<< checkExp e1
   e2' <- checkExp e2
   pure $ Assert e1' e2' (Info (pretty e1)) loc
-checkExp (Lambda params body rettype_te NoInfo loc) =
-  removeSeminullOccurrences . noUnique . incLevel . bindingParams [] params $ \_ params' -> do
-    rettype_checked <- traverse checkTypeExpNonrigid rettype_te
-    let declared_rettype =
-          case rettype_checked of
-            Just (_, st, _) -> Just st
-            Nothing -> Nothing
-    (body', closure) <-
-      tapOccurrences $ checkFunBody params' body declared_rettype loc
-    body_t <- expTypeFully body'
+checkExp (Lambda params body rettype_te NoInfo loc) = do
+  (params', body', body_t, rettype', info) <-
+    removeSeminullOccurrences . noUnique . incLevel . bindingParams [] params $ \_ params' -> do
+      rettype_checked <- traverse checkTypeExpNonrigid rettype_te
+      let declared_rettype =
+            case rettype_checked of
+              Just (_, st, _) -> Just st
+              Nothing -> Nothing
+      (body', closure) <-
+        tapOccurrences $ checkFunBody params' body declared_rettype loc
+      body_t <- expTypeFully body'
 
-    params'' <- mapM updateTypes params'
+      params'' <- mapM updateTypes params'
 
-    (rettype', rettype_st) <-
-      case rettype_checked of
-        Just (te, st, ext) -> do
-          let st_structural = toStructural st
-          checkReturnAlias loc st_structural params'' body_t
-          pure (Just te, RetType ext st)
-        Nothing -> do
-          ret <-
-            inferReturnSizes params'' . toStruct $
-              inferReturnUniqueness params'' body_t
-          pure (Nothing, ret)
+      (rettype', rettype_st) <-
+        case rettype_checked of
+          Just (te, st, ext) -> do
+            let st_structural = toStructural st
+            checkReturnAlias loc st_structural params'' body_t
+            pure (Just te, RetType ext st)
+          Nothing -> do
+            ret <-
+              inferReturnSizes params'' . toStruct $
+                inferReturnUniqueness params'' body_t
+            pure (Nothing, ret)
 
-    checkGlobalAliases params' body_t loc
-    verifyFunctionParams Nothing params'
+      closure' <- lexicalClosure params'' closure
 
-    closure' <- lexicalClosure params'' closure
+      pure (params'', body', body_t, rettype', Info (closure', rettype_st))
 
-    pure $ Lambda params'' body' rettype' (Info (closure', rettype_st)) loc
+  checkGlobalAliases params' body_t loc
+  verifyFunctionParams Nothing params'
+
+  pure $ Lambda params' body' rettype' info loc
   where
     -- Inferring the sizes of the return type of a lambda is a lot
     -- like let-generalisation.  We wish to remove any rigid sizes
@@ -951,8 +936,8 @@ checkApply
 
       -- Unification ignores uniqueness in higher-order arguments, so
       -- we check for that here.
-      unless (toStructural argtype' `subtypeOf` toStructural tp1') $
-        typeError loc mempty "Uniqueness does not match."
+      unless (toStructural argtype' `subtypeOf` setUniqueness (toStructural tp1') Nonunique) $
+        typeError loc mempty "Consumption/aliasing does not match."
 
       (argext, parsubst) <-
         case pname of
@@ -1006,9 +991,9 @@ returnType ::
   PatType ->
   PatType
 returnType (Array _ Unique et shape) _ _ =
-  Array mempty Unique et shape
+  Array mempty Nonunique et shape -- Intentional!
 returnType (Array als Nonunique et shape) d arg =
-  Array (als <> arg_als) Unique et shape -- Intentional!
+  Array (als <> arg_als) Nonunique et shape
   where
     arg_als = aliases $ maskAliases arg d
 returnType (Scalar (Record fs)) d arg =
@@ -1016,9 +1001,9 @@ returnType (Scalar (Record fs)) d arg =
 returnType (Scalar (Prim t)) _ _ =
   Scalar $ Prim t
 returnType (Scalar (TypeVar _ Unique t targs)) _ _ =
-  Scalar $ TypeVar mempty Unique t targs
+  Scalar $ TypeVar mempty Nonunique t targs -- Intentional!
 returnType (Scalar (TypeVar als Nonunique t targs)) d arg =
-  Scalar $ TypeVar (als <> arg_als) Unique t targs -- Intentional!
+  Scalar $ TypeVar (als <> arg_als) Unique t targs
   where
     arg_als = aliases $ maskAliases arg d
 returnType (Scalar (Arrow old_als v t1 (RetType dims t2))) d arg =
@@ -1050,12 +1035,6 @@ consumeArg loc (Scalar (Record ets)) (RecordDiet ds) =
   concat . M.elems <$> traverse (uncurry $ consumeArg loc) (M.intersectionWith (,) ets ds)
 consumeArg loc (Scalar (Sum ets)) (SumDiet ds) =
   concat <$> traverse (uncurry $ consumeArg loc) (concat $ M.elems $ M.intersectionWith zip ets ds)
-consumeArg loc (Array _ Nonunique _ _) Consume =
-  typeError loc mempty . withIndexLink "consuming-parameter" $
-    "Consuming parameter passed non-unique argument."
-consumeArg loc (Scalar (TypeVar _ Nonunique _ _)) Consume =
-  typeError loc mempty . withIndexLink "consuming-parameter" $
-    "Consuming parameter passed non-unique argument."
 consumeArg loc (Scalar (Arrow _ _ t1 _)) (FuncDiet d _)
   | not $ contravariantArg t1 d =
       typeError loc mempty . withIndexLink "consuming-argument" $
@@ -1350,17 +1329,15 @@ hiddenParamNames params = hidden
     hidden = param_all_names `S.difference` param_names
 
 inferredReturnType :: SrcLoc -> [Pat] -> PatType -> TermTypeM StructType
-inferredReturnType loc params t =
+inferredReturnType loc params t = do
   -- The inferred type may refer to names that are bound by the
   -- parameter patterns, but which will not be visible in the type.
   -- These we must turn into fresh type variables, which will be
   -- existential in the return type.
   fmap (toStruct . fst) $
-    unscopeType
-      loc
-      (M.filterWithKey (const . (`S.member` hidden)) $ foldMap patternMap params)
-      $ inferReturnUniqueness params t
+    unscopeType loc hidden_params $ inferReturnUniqueness params t
   where
+    hidden_params = M.filterWithKey (const . (`S.member` hidden)) $ foldMap patternMap params
     hidden = hiddenParamNames params
 
 checkReturnAlias :: SrcLoc -> TypeBase () () -> [Pat] -> PatType -> TermTypeM ()
@@ -1443,12 +1420,12 @@ checkBinding (fname, maybe_retdecl, tparams, params, body, loc) =
 
     verifyFunctionParams (Just fname) params''
 
-    (tparams'', params''', rettype'') <-
+    (tparams'', params''', rettype') <-
       letGeneralise fname loc tparams' params'' rettype
 
     checkGlobalAliases params'' body_t loc
 
-    pure (tparams'', params''', maybe_retdecl'', rettype'', body')
+    pure (tparams'', params''', maybe_retdecl'', rettype', body')
 
 -- | Extract all the shape names that occur in positive position
 -- (roughly, left side of an arrow) in a given type.
@@ -1468,11 +1445,11 @@ typeDimNamesPos _ = mempty
 checkGlobalAliases :: [Pat] -> PatType -> SrcLoc -> TermTypeM ()
 checkGlobalAliases params body_t loc = do
   vtable <- asks $ scopeVtable . termScope
-  let isLocal v = case v `M.lookup` vtable of
-        Just (BoundV Local _ _) -> True
+  let isGlobal v = case v `M.lookup` vtable of
+        Just (BoundV Global _ _) -> True
         _ -> False
   let als =
-        filter (not . isLocal) . S.toList $
+        filter isGlobal . S.toList $
           boundArrayAliases body_t `S.difference` foldMap patNames params
   case als of
     v : _
@@ -1494,7 +1471,7 @@ inferReturnUniqueness params t =
       delve t'
         | all (`S.member` uniques) (boundArrayAliases t'),
           not $ any ((`S.member` forbidden) . aliasVar) (aliases t') =
-            t'
+            t' `setUniqueness` Unique
         | otherwise =
             t' `setUniqueness` Nonunique
    in delve t
@@ -1735,16 +1712,6 @@ checkFunBody params body maybe_rettype loc = do
       let usage = mkUsage (srclocOf body) "return type annotation"
       onFailure (CheckingReturn rettype (toStruct body_t')) $
         expect usage rettype $ toStruct body_t'
-
-      -- We also have to make sure that uniqueness matches.  This is done
-      -- explicitly, because uniqueness is ignored by unification.
-      rettype' <- normTypeFully rettype
-      body_t'' <- normTypeFully body_t' -- Substs may have changed.
-      unless (toStructural body_t'' `subtypeOf` toStructural rettype') $
-        typeError (srclocOf body) mempty $
-          "Body type" </> indent 2 (ppr body_t'')
-            </> "is not a subtype of annotated type"
-            </> indent 2 (ppr rettype')
     Nothing -> pure ()
 
   pure body'

--- a/src/Language/Futhark/TypeChecker/Terms/DoLoop.hs
+++ b/src/Language/Futhark/TypeChecker/Terms/DoLoop.hs
@@ -101,10 +101,6 @@ convergePat loop_loc pat body_cons body_t body_loc = do
   let -- Make the pattern unique where needed.
       pat' = uniquePat (patNames pat `S.intersection` body_cons) pat
 
-  pat_t <- normTypeFully $ patternType pat'
-  unless (toStructural body_t `subtypeOf` toStructural pat_t) $
-    unexpectedType (srclocOf body_loc) (toStruct body_t) [toStruct pat_t]
-
   -- Check that the new values of consumed merge parameters do not
   -- alias something bound outside the loop, AND that anything
   -- returned for a unique merge parameter does not alias anything
@@ -124,7 +120,7 @@ convergePat loop_loc pat body_cons body_t body_loc = do
               "Return value for loop parameter"
                 <+> pquote (pprName pat_v)
                 <+> "aliases"
-                <+> pprName v <> "."
+                <+> pquote (pprName v) <> "."
         | otherwise = do
             (cons, obs) <- get
             unless (S.null $ aliases t `S.intersection` cons) $

--- a/src/Language/Futhark/TypeChecker/Terms/Monad.hs
+++ b/src/Language/Futhark/TypeChecker/Terms/Monad.hs
@@ -77,7 +77,6 @@ module Language.Futhark.TypeChecker.Terms.Monad
     useAfterConsume,
     unusedSize,
     notConsumable,
-    unexpectedType,
     uniqueReturnAliased,
     returnAliased,
     badLetWithValue,
@@ -210,9 +209,15 @@ altOccurrences occurs1 occurs2 =
     cons1 = allConsumed occurs1
     cons2 = allConsumed occurs2
 
--- | Whether something is a global or a local variable.
-data Locality = Local | Global
-  deriving (Show)
+-- | How something was bound.
+data Locality
+  = -- | In the current function
+    Local
+  | -- | In an enclosing function, but not the current one.
+    Nonlocal
+  | -- | At global scope.
+    Global
+  deriving (Show, Eq, Ord)
 
 data ValBinding
   = -- | Aliases in parameters indicate the lexical
@@ -258,17 +263,6 @@ uniqueReturnAliased :: SrcLoc -> TermTypeM a
 uniqueReturnAliased loc =
   typeError loc mempty . withIndexLink "unique-return-aliased" $
     "A unique-typed component of the return value is aliased to some other component."
-
-unexpectedType :: MonadTypeChecker m => SrcLoc -> StructType -> [StructType] -> m a
-unexpectedType loc _ [] =
-  typeError loc mempty $
-    "Type of expression at" <+> text (locStr loc)
-      <+> "cannot have any type - possibly a bug in the type checker."
-unexpectedType loc t ts =
-  typeError loc mempty $
-    "Type of expression at" <+> text (locStr loc) <+> "must be one of"
-      <+> commasep (map ppr ts) <> ", but is"
-      <+> ppr t <> "."
 
 notConsumable :: MonadTypeChecker m => SrcLoc -> Doc -> m b
 notConsumable loc v =
@@ -933,7 +927,7 @@ noUnique m = do
   where
     f scope = scope {scopeVtable = M.map set $ scopeVtable scope}
 
-    set (BoundV l tparams t) = BoundV l tparams $ t `setUniqueness` Nonunique
+    set (BoundV l tparams t) = BoundV (max l Nonlocal) tparams t
     set (OverloadedF ts pts rt) = OverloadedF ts pts rt
     set EqualityF = EqualityF
     set (WasConsumed loc) = WasConsumed loc
@@ -951,11 +945,9 @@ checkIfConsumable loc als = do
   vtable <- asks $ scopeVtable . termScope
   let consumable v = case M.lookup v vtable of
         Just (BoundV Local _ t)
-          | arrayRank t > 0 -> unique t
-          | Scalar TypeVar {} <- t -> unique t
           | Scalar Arrow {} <- t -> False
           | otherwise -> True
-        Just (BoundV Global _ _) -> False
+        Just (BoundV l _ _) -> l == Local
         _ -> True
   -- The sort ensures that AliasBound vars are shown before AliasFree.
   case map aliasVar $ sort $ filter (not . consumable . aliasVar) $ S.toList als of

--- a/src/Language/Futhark/TypeChecker/Terms/Monad.hs
+++ b/src/Language/Futhark/TypeChecker/Terms/Monad.hs
@@ -385,10 +385,13 @@ envToTermScope env =
     }
   where
     vtable = M.mapWithKey valBinding $ envVtable env
-    valBinding k (TypeM.BoundV tps v) =
-      BoundV Global tps $
-        v
-          `setAliases` (if arrayRank v > 0 then S.singleton (AliasBound k) else mempty)
+    valBinding k (TypeM.BoundV tps t) =
+      BoundV Global tps $ t `setAliases` als
+      where
+        als =
+          case t of
+            Scalar (Arrow {}) -> mempty
+            _ -> S.singleton (AliasBound k)
 
 withEnv :: TermEnv -> Env -> TermEnv
 withEnv tenv env = tenv {termScope = termScope tenv <> envToTermScope env}

--- a/src/Language/Futhark/TypeChecker/Terms/Pat.hs
+++ b/src/Language/Futhark/TypeChecker/Terms/Pat.hs
@@ -58,29 +58,44 @@ boundAliases = S.map aliasVar . S.filter bound
     bound AliasBound {} = True
     bound AliasFree {} = False
 
-checkIfUsed :: Occurrences -> Ident -> TermTypeM ()
-checkIfUsed occs v
+checkIfUsed :: Bool -> Occurrences -> Ident -> TermTypeM ()
+checkIfUsed allow_consume occs v
+  | not allow_consume,
+    not $ unique $ unInfo $ identType v,
+    Just occ <- find consumes occs =
+      typeError (srclocOf occ) mempty $
+        "Consuming"
+          <+> pquote (pprName $ identName v)
+          <+> textwrap ("which is a non-consumable parameter bound at " <> locStr (locOf v) <> ".")
   | not $ identName v `S.member` allOccurring occs,
     not $ "_" `isPrefixOf` prettyName (identName v) =
-      warn (srclocOf v) $ "Unused variable" <+> pquote (pprName $ identName v) <+> "."
+      warn (srclocOf v) $
+        "Unused variable" <+> pquote (pprName $ identName v) <+> "."
   | otherwise =
       pure ()
+  where
+    consumes = maybe False (identName v `S.member`) . consumed
 
 -- | Bind these identifiers locally while running the provided action.
 -- Checks that the identifiers are used properly within the scope
 -- (e.g. consumption).
-binding :: [Ident] -> TermTypeM a -> TermTypeM a
-binding stms = check . handleVars
+binding ::
+  -- | Allow consumption, even if the type is not unique.
+  Bool ->
+  [Ident] ->
+  TermTypeM a ->
+  TermTypeM a
+binding allow_consume idents = check . handleVars
   where
     handleVars m =
-      localScope (`bindVars` stms) $ do
+      localScope (`bindVars` idents) $ do
         -- Those identifiers that can potentially also be sizes are
         -- added as type constraints.  This is necessary so that we
         -- can properly detect scope violations during unification.
         -- We do this for *all* identifiers, not just those that are
         -- integers, because they may become integers later due to
         -- inference...
-        forM_ stms $ \ident ->
+        forM_ idents $ \ident ->
           constrain (identName ident) $ ParamSize $ srclocOf ident
         m
 
@@ -92,7 +107,7 @@ binding stms = check . handleVars
       let inedges = boundAliases $ aliases tp
           update (BoundV l tparams in_t)
             -- If 'name' is record or sum-typed, don't alias the
-            -- components to 'name', because these no identity
+            -- components to 'name', because these have no identity
             -- beyond their components.
             | Array {} <- tp = BoundV l tparams (in_t `addAliases` S.insert (AliasBound name))
             | otherwise = BoundV l tparams in_t
@@ -114,11 +129,11 @@ binding stms = check . handleVars
       (a, usages) <- collectBindingsOccurrences m
       checkOccurrences usages
 
-      mapM_ (checkIfUsed usages) stms
+      mapM_ (checkIfUsed allow_consume usages) idents
 
       pure a
 
-    -- Collect and remove all occurences in @stms@.  This relies
+    -- Collect and remove all occurences of @idents@.  This relies
     -- on the fact that no variables shadow any other.
     collectBindingsOccurrences m = do
       (x, usage) <- collectOccurrences m
@@ -126,19 +141,16 @@ binding stms = check . handleVars
       occur rest
       pure (x, relevant)
       where
-        split =
-          unzip
-            . map
-              ( \occ ->
-                  let (obs1, obs2) = divide $ observed occ
-                      occ_cons = divide <$> consumed occ
-                      con1 = fst <$> occ_cons
-                      con2 = snd <$> occ_cons
-                   in ( occ {observed = obs1, consumed = con1},
-                        occ {observed = obs2, consumed = con2}
-                      )
+        onOcc occ =
+          let (obs1, obs2) = divide $ observed occ
+              occ_cons = divide <$> consumed occ
+              con1 = fst <$> occ_cons
+              con2 = snd <$> occ_cons
+           in ( occ {observed = obs1, consumed = con1},
+                occ {observed = obs2, consumed = con2}
               )
-        names = S.fromList $ map identName stms
+        split = unzip . map onOcc
+        names = S.fromList $ map identName idents
         divide s = (s `S.intersection` names, s `S.difference` names)
 
 bindingTypes ::
@@ -158,7 +170,7 @@ bindingTypes types m = do
 
 bindingTypeParams :: [TypeParam] -> TermTypeM a -> TermTypeM a
 bindingTypeParams tparams =
-  binding (mapMaybe typeParamIdent tparams)
+  binding False (mapMaybe typeParamIdent tparams)
     . bindingTypes (concatMap typeParamType tparams)
   where
     typeParamType (TypeParamType l v loc) =
@@ -183,7 +195,7 @@ bindingIdent (Ident v NoInfo vloc) t m =
   bindSpaced [(Term, v)] $ do
     v' <- checkName Term v vloc
     let ident = Ident v' (Info t) vloc
-    binding [ident] $ m ident
+    binding True [ident] $ m ident
 
 -- | Bind @let@-bound sizes.  This is usually followed by 'bindingPat'
 -- immediately afterwards.
@@ -193,7 +205,7 @@ bindingSizes sizes m = do
   foldM_ lookForDuplicates mempty sizes
   bindSpaced (map sizeWithSpace sizes) $ do
     sizes' <- mapM check sizes
-    binding (map sizeWithType sizes') $ m sizes'
+    binding False (map sizeWithType sizes') $ m sizes'
   where
     lookForDuplicates prev size
       | Just prevloc <- M.lookup (sizeName size) prev =
@@ -235,7 +247,7 @@ bindingPat ::
   TermTypeM a
 bindingPat sizes p t m = do
   checkForDuplicateNames (map sizeBinderToParam sizes) [p]
-  checkPat sizes p t $ \p' -> binding (S.toList $ patIdents p') $ do
+  checkPat sizes p t $ \p' -> binding True (S.toList $ patIdents p') $ do
     -- Perform an observation of every declared dimension.  This
     -- prevents unused-name warnings for otherwise unused dimensions.
     mapM_ observe $ patternDims p'
@@ -326,31 +338,20 @@ checkPat' sizes (RecordPat fs loc) NoneInferred =
 checkPat' sizes (PatAscription p (TypeDecl t NoInfo) loc) maybe_outer_t = do
   (t', st, _) <- checkTypeExpNonrigid t
 
-  let st' = fromStruct st
   case maybe_outer_t of
     Ascribed outer_t -> do
       st_forunify <- nonrigidFor sizes st
       unify (mkUsage loc "explicit type ascription") st_forunify (toStruct outer_t)
 
-      -- We also have to make sure that uniqueness matches.  This is
-      -- done explicitly, because it is ignored by unification.
-      st'' <- normTypeFully st'
       outer_t' <- normTypeFully outer_t
-      case unifyTypesU unifyUniqueness st'' outer_t' of
-        Just outer_t'' ->
-          PatAscription <$> checkPat' sizes p (Ascribed outer_t'')
-            <*> pure (TypeDecl t' (Info st))
-            <*> pure loc
-        Nothing ->
-          typeError loc mempty $
-            "Cannot match type" <+> pquote (ppr outer_t') <+> "with expected type"
-              <+> pquote (ppr st'') <> "."
-    NoneInferred ->
-      PatAscription <$> checkPat' sizes p (Ascribed st')
+      PatAscription
+        <$> checkPat' sizes p (Ascribed (addAliasesFromType st outer_t'))
         <*> pure (TypeDecl t' (Info st))
         <*> pure loc
-  where
-    unifyUniqueness u1 u2 = if u2 `subuniqueOf` u1 then Just u1 else Nothing
+    NoneInferred ->
+      PatAscription <$> checkPat' sizes p (Ascribed (fromStruct st))
+        <*> pure (TypeDecl t' (Info st))
+        <*> pure loc
 checkPat' _ (PatLit l NoInfo loc) (Ascribed t) = do
   t' <- patLitMkType l loc
   unify (mkUsage loc "matching against literal") t' (toStruct t)
@@ -415,7 +416,7 @@ bindingParams tps orig_ps m = do
   checkTypeParams tps $ \tps' -> bindingTypeParams tps' $ do
     let descend ps' (p : ps) =
           checkPat [] p NoneInferred $ \p' ->
-            binding (S.toList $ patIdents p') $ descend (p' : ps') ps
+            binding False (S.toList $ patIdents p') $ descend (p' : ps') ps
         descend ps' [] = do
           -- Perform an observation of every type parameter.  This
           -- prevents unused-name warnings for otherwise unused

--- a/src/Language/Futhark/TypeChecker/Terms/Pat.hs
+++ b/src/Language/Futhark/TypeChecker/Terms/Pat.hs
@@ -106,9 +106,6 @@ binding allow_consume idents = check . handleVars
     bindVar scope (Ident name (Info tp) _) =
       let inedges = boundAliases $ aliases tp
           update (BoundV l tparams in_t)
-            -- If 'name' is record or sum-typed, don't alias the
-            -- components to 'name', because these have no identity
-            -- beyond their components.
             | Array {} <- tp = BoundV l tparams (in_t `addAliases` S.insert (AliasBound name))
             | otherwise = BoundV l tparams in_t
           update b = b

--- a/src/Language/Futhark/TypeChecker/Types.hs
+++ b/src/Language/Futhark/TypeChecker/Types.hs
@@ -8,9 +8,9 @@
 module Language.Futhark.TypeChecker.Types
   ( checkTypeExp,
     renameRetType,
-    unifyTypesU,
     subtypeOf,
     subuniqueOf,
+    addAliasesFromType,
     checkForDuplicateNames,
     checkTypeParams,
     typeParamToArg,
@@ -35,6 +35,32 @@ import Futhark.Util.Pretty hiding ((<|>))
 import Language.Futhark
 import Language.Futhark.Traversals
 import Language.Futhark.TypeChecker.Monad
+
+addAliasesFromType :: StructType -> PatType -> PatType
+addAliasesFromType (Array _ u1 et1 shape1) (Array als _ _ _) =
+  Array als u1 et1 shape1
+addAliasesFromType
+  (Scalar (TypeVar _ u1 tv1 targs1))
+  (Scalar (TypeVar als2 _ _ _)) =
+    Scalar $ TypeVar als2 u1 tv1 targs1
+addAliasesFromType (Scalar (Record ts1)) (Scalar (Record ts2))
+  | length ts1 == length ts2,
+    sort (M.keys ts1) == sort (M.keys ts2) =
+      Scalar $ Record $ M.intersectionWith addAliasesFromType ts1 ts2
+addAliasesFromType
+  (Scalar (Arrow _ mn1 pt1 (RetType dims1 rt1)))
+  (Scalar (Arrow as2 _ pt2 (RetType _ rt2))) =
+    Scalar (Arrow as2 mn1 pt1' (RetType dims1 rt1'))
+    where
+      pt1' = addAliasesFromType pt1 pt2
+      rt1' = addAliasesFromType rt1 rt2
+addAliasesFromType (Scalar (Sum cs1)) (Scalar (Sum cs2))
+  | length cs1 == length cs2,
+    sort (M.keys cs1) == sort (M.keys cs2) =
+      Scalar $ Sum $ M.intersectionWith (zipWith addAliasesFromType) cs1 cs2
+addAliasesFromType (Scalar (Prim t)) _ = Scalar $ Prim t
+addAliasesFromType t1 t2 =
+  error $ "addAliasesFromType invalid args: " ++ show (t1, t2)
 
 -- | @unifyTypes uf t1 t2@ attempts to unify @t1@ and @t2@.  If
 -- unification cannot happen, 'Nothing' is returned, otherwise a type

--- a/tests/issue1074.fut
+++ b/tests/issue1074.fut
@@ -1,4 +1,3 @@
-
 def dot [n] (x: [n]bool) (y: [n]bool):i64 =
   i64.sum (map2 (\x y -> i64.bool <| x && y) x y)
 

--- a/tests/issue596.fut
+++ b/tests/issue596.fut
@@ -1,5 +1,5 @@
 -- ==
--- error: passed non-unique
+-- error: Consuming "xs"
 
 def consume (xs: *[]i32) = xs
 

--- a/tests/issue728.fut
+++ b/tests/issue728.fut
@@ -9,7 +9,7 @@ type^ csr 't = {row_off: []i32, col_idx: []i32, vals: []t}
 def expand_reduce 'a 'b [n]
                   (sz: a -> i32) (get: a -> i32 -> b)
                   (f: b -> b -> b) (ne:b)
-                  (arr:[n]a) : []b =
+                  (arr:[n]a) : *[]b =
   let (vals, flags) = expand_with_flags ne sz get arr
   in []
 

--- a/tests/issue844.fut
+++ b/tests/issue844.fut
@@ -1,5 +1,5 @@
 -- ==
--- error: non-unique
+-- error: Consuming "xs"
 
 module type mt = {
   type~ t

--- a/tests/issue879.fut
+++ b/tests/issue879.fut
@@ -1,5 +1,5 @@
 -- ==
--- error: consume variable "s"
+-- error: Consuming "s"
 
 def f (xs: [10]i32) : [10]i32 = xs
 

--- a/tests/issue880.fut
+++ b/tests/issue880.fut
@@ -1,5 +1,5 @@
 -- ==
--- error: Would consume variable "xs"
+-- error: Consuming "xs"
 
 type t = {xs: [10]i32}
 

--- a/tests/types/inference32.fut
+++ b/tests/types/inference32.fut
@@ -1,7 +1,7 @@
 -- Inferring a unique type is never allowed - it must always be put
 -- there explicitly!
 -- ==
--- error: passed non-unique argument
+-- error: Consuming "xs"
 
 def consume (xs: *[]i32) = xs
 

--- a/tests/types/tricky.fut
+++ b/tests/types/tricky.fut
@@ -2,8 +2,8 @@
 -- input { 4 }
 -- output { [1i32, 1i32, 1i32] [4i32, 4i32, 4i32] }
 
-type^ t [n] = ([n]i32, i32 -> [n]i32)
+type^ t [n] = ([n]i32, i32 -> *[n]i32)
 
 def v : t [] = let three = 3 in (replicate three 1, \i -> replicate three i)
 
-def main x = (v.0, v.1 x)
+def main x = (copy v.0, v.1 x)

--- a/tests/types/tricky.fut
+++ b/tests/types/tricky.fut
@@ -2,7 +2,7 @@
 -- input { 4 }
 -- output { [1i32, 1i32, 1i32] [4i32, 4i32, 4i32] }
 
-type^ t [n] = ([n]i32, i32 -> *[n]i32)
+type^ t [n] = ([n]i32, i32 -> [n]i32)
 
 def v : t [] = let three = 3 in (replicate three 1, \i -> replicate three i)
 

--- a/tests/uniqueness/uniqueness-error14.fut
+++ b/tests/uniqueness/uniqueness-error14.fut
@@ -1,7 +1,7 @@
 -- This program tests whether the compiler catches some of the more
 -- nasty side cases of aliasing in loops.
 -- ==
--- error: Type of expression
+-- error: "arr" aliases "barr"
 
 def main(): i32 =
   let arr = copy(iota(10))

--- a/tests/uniqueness/uniqueness-error22.fut
+++ b/tests/uniqueness/uniqueness-error22.fut
@@ -1,9 +1,9 @@
 -- Test that we cannot consume anything inside an anonymous function.
 -- ==
--- error: non-unique
+-- error: Would consume variable "a"
 
 def f(a: *[]i64) = a[0]
 
-def main(n: i64): i32 =
+def main(n: i64) =
   let a = iota(n) in
-  reduce (\(sum: i32, i: i32): i32  -> sum + f(a)) 0 (iota(10))
+  foldl (\sum i  -> sum + f(a)) 0 (iota(10))

--- a/tests/uniqueness/uniqueness-error27.fut
+++ b/tests/uniqueness/uniqueness-error27.fut
@@ -1,7 +1,7 @@
 -- You may not consume a free variable inside of a lambda.
 --
 -- ==
--- error: non-unique
+-- error: Would consume variable "a"
 
 def consume(a: *[]i32): []i32 = a
 

--- a/tests/uniqueness/uniqueness-error33.fut
+++ b/tests/uniqueness/uniqueness-error33.fut
@@ -1,5 +1,5 @@
 -- Type ascriptions must respect uniqueness.
 -- ==
--- error: \*\[.*\]i32
+-- error: aliased to "x"
 
-def main (x: []i32) = x : *[]i32
+def main (x: []i32) : *[]i32 = x : *[]i32

--- a/tests/uniqueness/uniqueness-error34.fut
+++ b/tests/uniqueness/uniqueness-error34.fut
@@ -1,5 +1,5 @@
 -- Pattern bindings must respect uniqueness.
 -- ==
--- error: \*\[.*\]i32
+-- error: aliased to "x"
 
-def main (x: []i32) = let y : *[]i32 = x in y
+def main (x: []i32) : *[]i32 = let y : *[]i32 = x in y

--- a/tests/uniqueness/uniqueness-error35.fut
+++ b/tests/uniqueness/uniqueness-error35.fut
@@ -1,5 +1,5 @@
 -- Loop parameters must respect uniqueness.
 -- ==
--- error: \*\[.*\]i32
+-- error: Consuming "x"
 
 def main (x: []i32) = loop (x: *[]i32) for i < 10 do x

--- a/tests/uniqueness/uniqueness-error48.fut
+++ b/tests/uniqueness/uniqueness-error48.fut
@@ -1,6 +1,6 @@
 -- Record updates should respect uniqueness and aliases.
 -- ==
--- error: not a subtype
+-- error: "s", which is not consumable
 
 type^ state = { size: i64, world: []i32 }
 

--- a/tests/uniqueness/uniqueness-error49.fut
+++ b/tests/uniqueness/uniqueness-error49.fut
@@ -1,6 +1,6 @@
 -- Do not let ascription screw up uniqueness/aliasing.
 -- ==
--- error: Would consume variable "xs"
+-- error: Consuming "xs"
 
 def f 't (x: t) = id (x : t)
 def main (xs: []i32) = f xs with [0] = 0

--- a/tests/uniqueness/uniqueness-error51.fut
+++ b/tests/uniqueness/uniqueness-error51.fut
@@ -1,6 +1,6 @@
 -- Type inference should not eliminate uniqueness checking.
 -- ==
--- error: Would consume variable "xs"
+-- error: Consuming "xs"
 
 def f {xs: []i32} : {xs: []i32} = {xs}
 

--- a/tests/uniqueness/uniqueness-error59.fut
+++ b/tests/uniqueness/uniqueness-error59.fut
@@ -1,0 +1,8 @@
+-- ==
+-- error: aliases the free variable "global"
+
+def global = ([1,2,3], 0)
+
+def return_global () = global
+
+def main i = (return_global ()).0 with [i] = 0

--- a/tests/uniqueness/uniqueness55.fut
+++ b/tests/uniqueness/uniqueness55.fut
@@ -1,0 +1,7 @@
+-- Proper aliasing inference for function.
+
+let f xs = map (+1i32) xs
+
+def main (xss: *[][]i32) =
+  let xss[0] = f xss[0]
+  in xss


### PR DESCRIPTION
I want to eventually move away from the term "uniqueness types" and
recast this language feature as a kind of effect system.

You should never see `*` in non-function types, and they are better
thought of as effect indicators.