### PR TITLE
Makefile installs futhark in wrong location if destination directory does not exist.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ build:
 	cabal build
 
 install: build
-	install -D $$(cabal -v0 list-bin exe:futhark) $(PREFIX)/bin
+	install -D $$(cabal -v0 list-bin exe:futhark) $(PREFIX)/bin/futhark
 
 docs:
 	cabal haddock \


### PR DESCRIPTION
If the installation directory does not exist, the futhark binary will be installed as a binary with the name of the destination folder.
For example, by default running `make install` will install futhark at `~/.local/bin/futhark`. If the directory `~/.local/bin/` does not exist, it would be installed as `~/.local/bin`. 
This patch fixes this issue by  specifying  the desired installation name in the Makefile. 