### PR TITLE
Remove the SplitSpace IR construct and supporting machinery.

### DIFF
--- a/src/Futhark/CodeGen/ImpGen/GPU/Group.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/Group.hs
@@ -342,8 +342,6 @@ compileGroupExp dest e =
 compileGroupOp :: OpCompiler GPUMem KernelEnv Imp.KernelOp
 compileGroupOp pat (Alloc size space) =
   kernelAlloc pat size space
-compileGroupOp pat (Inner (SizeOp (SplitSpace o w i elems_per_thread))) =
-  splitSpace pat o w i elems_per_thread
 compileGroupOp pat (Inner (SegOp (SegMap lvl space _ body))) = do
   compileFlatId lvl space
 

--- a/src/Futhark/IR/GPU/Simplify.hs
+++ b/src/Futhark/IR/GPU/Simplify.hs
@@ -56,17 +56,6 @@ simplifyKernelOp f (OtherOp op) = do
 simplifyKernelOp _ (SegOp op) = do
   (op', hoisted) <- simplifySegOp op
   pure (SegOp op', hoisted)
-simplifyKernelOp _ (SizeOp (SplitSpace o w i elems_per_thread)) =
-  (,)
-    <$> ( SizeOp
-            <$> ( SplitSpace
-                    <$> Engine.simplify o
-                    <*> Engine.simplify w
-                    <*> Engine.simplify i
-                    <*> Engine.simplify elems_per_thread
-                )
-        )
-    <*> pure mempty
 simplifyKernelOp _ (SizeOp (GetSize key size_class)) =
   pure (SizeOp $ GetSize key size_class, mempty)
 simplifyKernelOp _ (SizeOp (GetSizeMax size_class)) =

--- a/src/Futhark/IR/Parse.hs
+++ b/src/Futhark/IR/Parse.hs
@@ -810,26 +810,6 @@ pSizeOp =
               <*> pName
               <* pComma
               <*> pSubExp
-          ),
-      keyword "split_space"
-        *> parens
-          ( GPU.SplitSpace GPU.SplitContiguous
-              <$> pSubExp
-              <* pComma
-              <*> pSubExp
-              <* pComma
-              <*> pSubExp
-          ),
-      keyword "split_space_strided"
-        *> parens
-          ( GPU.SplitSpace
-              <$> (GPU.SplitStrided <$> pSubExp)
-              <* pComma
-              <*> pSubExp
-              <* pComma
-              <*> pSubExp
-              <* pComma
-              <*> pSubExp
           )
     ]
 

--- a/src/Futhark/Pass/ExplicitAllocations/MC.hs
+++ b/src/Futhark/Pass/ExplicitAllocations/MC.hs
@@ -11,8 +11,7 @@ import Futhark.IR.MCMem
 import Futhark.Pass.ExplicitAllocations
 import Futhark.Pass.ExplicitAllocations.SegOp
 
-instance SizeSubst (MCOp rep op) where
-  opSizeSubst _ _ = mempty
+instance SizeSubst (MCOp rep op)
 
 handleSegOp :: SegOp () MC -> AllocM MC MCMem (SegOp () MCMem)
 handleSegOp op = do

--- a/src/Futhark/Pass/ExplicitAllocations/SegOp.hs
+++ b/src/Futhark/Pass/ExplicitAllocations/SegOp.hs
@@ -13,8 +13,7 @@ import Futhark.IR.GPUMem
 import qualified Futhark.IR.Mem.IxFun as IxFun
 import Futhark.Pass.ExplicitAllocations
 
-instance SizeSubst (SegOp lvl rep) where
-  opSizeSubst _ _ = mempty
+instance SizeSubst (SegOp lvl rep)
 
 allocInKernelBody ::
   Allocable fromrep torep inner =>


### PR DESCRIPTION
This is one of the major dividends from removing the parallel Stream
SOAC.