### PR TITLE
Avoid type suffixes on values printed in REPL.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * `futhark repl` is now delightfully more colourful.
 
+* `futhark repl` no longer prints scalar types with type suffixes (#1724).
+
 ### Removed
 
 ### Changed

--- a/futhark.cabal
+++ b/futhark.cabal
@@ -357,6 +357,7 @@ library
       Language.Futhark
       Language.Futhark.Core
       Language.Futhark.Interpreter
+      Language.Futhark.Interpreter.Values
       Language.Futhark.FreeVars
       Language.Futhark.Parser
       Language.Futhark.Parser.Monad

--- a/src/Futhark/CLI/REPL.hs
+++ b/src/Futhark/CLI/REPL.hs
@@ -302,7 +302,7 @@ onExp e = do
           r <- runInterpreter $ I.interpretExp ienv e'
           case r of
             Left err -> liftIO $ print err
-            Right v -> liftIO $ putStrLn $ prettyString v
+            Right v -> liftIO $ putDoc $ I.prettyValue v <> hardline
       | otherwise -> liftIO $ do
           T.putStrLn $ "Inferred type of expression: " <> prettyText (typeOf e')
           T.putStrLn $

--- a/src/Futhark/CLI/Run.hs
+++ b/src/Futhark/CLI/Run.hs
@@ -82,7 +82,7 @@ interpret config fp = do
 putValue :: I.Value -> TypeBase () () -> IO ()
 putValue v t
   | I.isEmptyArray v = T.putStrLn $ I.prettyEmptyArray t v
-  | otherwise = putStrLn $ prettyString v
+  | otherwise = T.putStrLn $ I.valueText v
 
 data InterpreterConfig = InterpreterConfig
   { interpreterEntryPoint :: Name,

--- a/src/Futhark/Util/Pretty.hs
+++ b/src/Futhark/Util/Pretty.hs
@@ -16,6 +16,8 @@ module Futhark.Util.Pretty
     -- * Rendering to terminal
     putDoc,
     hPutDoc,
+    putDocLn,
+    hPutDocLn,
 
     -- * Building blocks
     module Prettyprinter,
@@ -53,6 +55,12 @@ import System.IO (Handle, hIsTerminalDevice, stdout)
 putDoc :: Doc AnsiStyle -> IO ()
 putDoc = hPutDoc stdout
 
+-- | Like 'putDoc', but with a final newline.
+putDocLn :: Doc AnsiStyle -> IO ()
+putDocLn h = do
+  putDoc h
+  putStrLn ""
+
 -- | Print a doc with styling to the given file; stripping colors if
 -- the file does not seem to support such things.
 hPutDoc :: Handle -> Doc AnsiStyle -> IO ()
@@ -61,6 +69,12 @@ hPutDoc h d = do
   if colours
     then Prettyprinter.Render.Terminal.hPutDoc h d
     else Prettyprinter.Render.Text.hPutDoc h d
+
+-- | Like 'hPutDoc', but with a final newline.
+hPutDocLn :: Handle -> Doc AnsiStyle -> IO ()
+hPutDocLn h d = do
+  hPutDoc h d
+  putStrLn ""
 
 -- | Produce text suitable for printing on the given handle.  This
 -- mostly means stripping any control characters if the handle is not

--- a/src/Language/Futhark/Interpreter.hs
+++ b/src/Language/Futhark/Interpreter.hs
@@ -19,10 +19,14 @@ module Language.Futhark.Interpreter
     BreakReason (..),
     StackFrame (..),
     typeCheckerEnv,
-    Value (ValuePrim, ValueRecord),
+
+    -- * Values
+    Value,
     fromTuple,
     isEmptyArray,
     prettyEmptyArray,
+    prettyValue,
+    valueText,
   )
 where
 
@@ -52,6 +56,8 @@ import Futhark.Util.Loc
 import Futhark.Util.Pretty hiding (apply)
 import Language.Futhark hiding (Shape, Value, matchDims)
 import qualified Language.Futhark as F
+import Language.Futhark.Interpreter.Values hiding (Value)
+import qualified Language.Futhark.Interpreter.Values
 import Language.Futhark.Primitive (floatValue, intValue)
 import qualified Language.Futhark.Primitive as P
 import qualified Language.Futhark.Semantic as T
@@ -132,65 +138,8 @@ getSizes = get
 extSizeEnv :: EvalM Env
 extSizeEnv = i64Env <$> getSizes
 
-prettyRecord :: (a -> Doc ann) -> M.Map Name a -> Doc ann
-prettyRecord p m
-  | Just vs <- areTupleFields m =
-      parens $ commasep $ map p vs
-  | otherwise =
-      braces $ commasep $ map field $ M.toList m
-  where
-    field (k, v) = pretty k <+> equals <+> p v
-
 valueStructType :: ValueType -> StructType
 valueStructType = first (ConstSize . fromIntegral)
-
--- | A shape is a tree to accomodate the case of records.  It is
--- parameterised over the representation of dimensions.
-data Shape d
-  = ShapeDim d (Shape d)
-  | ShapeLeaf
-  | ShapeRecord (M.Map Name (Shape d))
-  | ShapeSum (M.Map Name [Shape d])
-  deriving (Eq, Show, Functor, Foldable, Traversable)
-
--- | The shape of an array.
-type ValueShape = Shape Int64
-
-instance Pretty d => Pretty (Shape d) where
-  pretty ShapeLeaf = mempty
-  pretty (ShapeDim d s) = brackets (pretty d) <> pretty s
-  pretty (ShapeRecord m) = prettyRecord pretty m
-  pretty (ShapeSum cs) =
-    mconcat (punctuate " | " cs')
-    where
-      ppConstr (name, fs) = sep $ ("#" <> pretty name) : map pretty fs
-      cs' = map ppConstr $ M.toList cs
-
-emptyShape :: ValueShape -> Bool
-emptyShape (ShapeDim d s) = d == 0 || emptyShape s
-emptyShape _ = False
-
-typeShape :: M.Map VName (Shape d) -> TypeBase d () -> Shape d
-typeShape shapes = go
-  where
-    go (Array _ _ shape et) =
-      foldr ShapeDim (go (Scalar et)) $ shapeDims shape
-    go (Scalar (Record fs)) =
-      ShapeRecord $ M.map go fs
-    go (Scalar (Sum cs)) =
-      ShapeSum $ M.map (map go) cs
-    go (Scalar (TypeVar _ _ (QualName [] v) []))
-      | Just shape <- M.lookup v shapes =
-          shape
-    go _ =
-      ShapeLeaf
-
-structTypeShape :: M.Map VName ValueShape -> StructType -> Shape (Maybe Int64)
-structTypeShape shapes = fmap dim . typeShape shapes'
-  where
-    dim (ConstSize d) = Just $ fromIntegral d
-    dim _ = Nothing
-    shapes' = M.map (fmap $ ConstSize . fromIntegral) shapes
 
 resolveTypeParams :: [VName] -> StructType -> StructType -> Env
 resolveTypeParams names = match
@@ -243,56 +192,6 @@ resolveExistentials names = match
       | d1 `elem` names = M.singleton d1 d2
     matchDims _ _ = mempty
 
--- | A fully evaluated Futhark value.
-data Value
-  = ValuePrim !PrimValue
-  | ValueArray ValueShape !(Array Int Value)
-  | -- Stores the full shape.
-    ValueRecord (M.Map Name Value)
-  | ValueFun (Value -> EvalM Value)
-  | -- Stores the full shape.
-    ValueSum ValueShape Name [Value]
-  | -- The update function and the array.
-    ValueAcc (Value -> Value -> EvalM Value) !(Array Int Value)
-
-instance Eq Value where
-  ValuePrim (SignedValue x) == ValuePrim (SignedValue y) =
-    P.doCmpEq (P.IntValue x) (P.IntValue y)
-  ValuePrim (UnsignedValue x) == ValuePrim (UnsignedValue y) =
-    P.doCmpEq (P.IntValue x) (P.IntValue y)
-  ValuePrim (FloatValue x) == ValuePrim (FloatValue y) =
-    P.doCmpEq (P.FloatValue x) (P.FloatValue y)
-  ValuePrim (BoolValue x) == ValuePrim (BoolValue y) =
-    P.doCmpEq (P.BoolValue x) (P.BoolValue y)
-  ValueArray _ x == ValueArray _ y = x == y
-  ValueRecord x == ValueRecord y = x == y
-  ValueSum _ n1 vs1 == ValueSum _ n2 vs2 = n1 == n2 && vs1 == vs2
-  ValueAcc _ x == ValueAcc _ y = x == y
-  _ == _ = False
-
-instance Pretty Value where
-  pretty = pprPrec (0 :: Int)
-    where
-      pprPrec _ (ValuePrim v) = pretty v
-      pprPrec _ (ValueArray _ a) =
-        let elements = elems a -- [Value]
-            (x : _) = elements
-            separator = case x of
-              ValueArray _ _ -> comma <> line
-              _ -> comma <> space
-         in brackets $ align $ cat $ punctuate separator (map pretty elements)
-      pprPrec _ (ValueRecord m) = prettyRecord pretty m
-      pprPrec _ ValueFun {} = "#<fun>"
-      pprPrec _ ValueAcc {} = "#<acc>"
-      pprPrec p (ValueSum _ n vs) =
-        parensIf (p > 0) $ "#" <> sep (pretty n : map (pprPrec 1) vs)
-
-valueShape :: Value -> ValueShape
-valueShape (ValueArray shape _) = shape
-valueShape (ValueRecord fs) = ShapeRecord $ M.map valueShape fs
-valueShape (ValueSum shape _ _) = shape
-valueShape _ = ShapeLeaf
-
 checkShape :: Shape (Maybe Int64) -> ValueShape -> Maybe ValueShape
 checkShape (ShapeDim Nothing shape1) (ShapeDim d2 shape2) =
   ShapeDim d2 <$> checkShape shape1 shape2
@@ -314,61 +213,27 @@ checkShape (ShapeSum shapes1) ShapeLeaf =
 checkShape _ shape2 =
   Just shape2
 
--- | Does the value correspond to an empty array?
-isEmptyArray :: Value -> Bool
-isEmptyArray = emptyShape . valueShape
-
--- | String representation of an empty array with the provided element
--- type.  This is prettyString ad-hoc - don't expect good results unless the
--- element type is a primitive.
-prettyEmptyArray :: TypeBase () () -> Value -> T.Text
-prettyEmptyArray t v =
-  "empty(" <> dims (valueShape v) <> prettyText t' <> ")"
-  where
-    t' = stripArray (arrayRank t) t
-    dims (ShapeDim n rowshape) =
-      "[" <> prettyText n <> "]" <> dims rowshape
-    dims _ = ""
-
--- | Create an array value; failing if that would result in an
--- irregular array.
-mkArray :: TypeBase Int64 () -> [Value] -> Maybe Value
-mkArray t [] =
-  pure $ toArray (typeShape mempty t) []
-mkArray _ (v : vs) = do
-  let v_shape = valueShape v
-  guard $ all ((== v_shape) . valueShape) vs
-  pure $ toArray' v_shape $ v : vs
-
-arrayLength :: Integral int => Array Int Value -> int
-arrayLength = fromIntegral . (+ 1) . snd . bounds
-
-toTuple :: [Value] -> Value
-toTuple = ValueRecord . M.fromList . zip tupleFieldNames
-
-fromTuple :: Value -> Maybe [Value]
-fromTuple (ValueRecord m) = areTupleFields m
-fromTuple _ = Nothing
+type Value = Language.Futhark.Interpreter.Values.Value EvalM
 
 asInteger :: Value -> Integer
 asInteger (ValuePrim (SignedValue v)) = P.valueIntegral v
 asInteger (ValuePrim (UnsignedValue v)) =
   toInteger (P.valueIntegral (P.doZExt v Int64) :: Word64)
-asInteger v = error $ "Unexpectedly not an integer: " <> prettyString v
+asInteger v = error $ "Unexpectedly not an integer: " <> show v
 
 asInt :: Value -> Int
 asInt = fromIntegral . asInteger
 
 asSigned :: Value -> IntValue
 asSigned (ValuePrim (SignedValue v)) = v
-asSigned v = error $ "Unexpected not a signed integer: " <> prettyString v
+asSigned v = error $ "Unexpected not a signed integer: " <> show v
 
 asInt64 :: Value -> Int64
 asInt64 = fromIntegral . asInteger
 
 asBool :: Value -> Bool
 asBool (ValuePrim (BoolValue x)) = x
-asBool v = error $ "Unexpectedly not a boolean: " <> prettyString v
+asBool v = error $ "Unexpectedly not a boolean: " <> show v
 
 lookupInEnv ::
   (Env -> M.Map VName x) ->
@@ -470,7 +335,7 @@ bad loc env s = stacking loc env $ do
 
 trace :: String -> Value -> EvalM ()
 trace w v = do
-  liftF $ ExtOpTrace w (T.unpack $ prettyTextOneLine v) ()
+  liftF $ ExtOpTrace w (T.unpack $ docText $ oneLine $ prettyValue v) ()
 
 typeCheckerEnv :: Env -> T.Env
 typeCheckerEnv env =
@@ -495,19 +360,11 @@ break loc = do
 
 fromArray :: Value -> (ValueShape, [Value])
 fromArray (ValueArray shape as) = (shape, elems as)
-fromArray v = error $ "Expected array value, but found: " <> prettyString v
-
-toArray :: ValueShape -> [Value] -> Value
-toArray shape vs = ValueArray shape (listArray (0, length vs - 1) vs)
-
-toArray' :: ValueShape -> [Value] -> Value
-toArray' rowshape vs = ValueArray shape (listArray (0, length vs - 1) vs)
-  where
-    shape = ShapeDim (genericLength vs) rowshape
+fromArray v = error $ "Expected array value, but found: " <> show v
 
 apply :: SrcLoc -> Env -> Value -> Value -> EvalM Value
 apply loc env (ValueFun f) v = stacking loc env (f v)
-apply _ _ f _ = error $ "Cannot apply non-function: " <> prettyString f
+apply _ _ f _ = error $ "Cannot apply non-function: " <> show f
 
 apply2 :: SrcLoc -> Env -> Value -> Value -> Value -> EvalM Value
 apply2 loc env f x y = stacking loc env $ do
@@ -518,7 +375,7 @@ matchPat :: Env -> Pat -> Value -> EvalM Env
 matchPat env p v = do
   m <- runMaybeT $ patternMatch env p v
   case m of
-    Nothing -> error $ "matchPat: missing case for " <> prettyString p ++ " and " <> prettyString v
+    Nothing -> error $ "matchPat: missing case for " <> prettyString p ++ " and " <> show v
     Just env' -> pure env'
 
 patternMatch :: Env -> Pat -> Value -> MaybeT EvalM Env
@@ -883,15 +740,15 @@ evalAppExp env t (Coerce e te loc) = do
   case checkShape (structTypeShape (envShapes env) t) (valueShape v) of
     Just _ -> pure v
     Nothing ->
-      bad loc env $
+      bad loc env . docText $
         "Value `"
-          <> prettyText v
+          <> prettyValue v
           <> "` of shape `"
-          <> prettyText (valueShape v)
+          <> pretty (valueShape v)
           <> "` cannot match shape of type `"
-          <> prettyText te
+          <> pretty te
           <> "` (`"
-          <> prettyText t
+          <> pretty t
           <> "`)"
 evalAppExp env _ (LetPat sizes p e body _) = do
   v <- eval env e
@@ -1003,7 +860,7 @@ evalAppExp env _ (Match e cs _) = do
   match v (NE.toList cs)
   where
     match _ [] =
-      error "Pat match failure."
+      error "Pattern match failure."
     match v (c : cs') = do
       c' <- evalCase v env c
       case c' of
@@ -1075,14 +932,14 @@ eval env (Negate e _) = do
     ValuePrim (FloatValue (Float16Value v)) -> pure $ FloatValue $ Float16Value (-v)
     ValuePrim (FloatValue (Float32Value v)) -> pure $ FloatValue $ Float32Value (-v)
     ValuePrim (FloatValue (Float64Value v)) -> pure $ FloatValue $ Float64Value (-v)
-    _ -> error $ "Cannot negate " <> prettyString ev
+    _ -> error $ "Cannot negate " <> show ev
 eval env (Not e _) = do
   ev <- eval env e
   ValuePrim <$> case ev of
     ValuePrim (BoolValue b) -> pure $ BoolValue $ not b
     ValuePrim (SignedValue iv) -> pure $ SignedValue $ P.doComplement iv
     ValuePrim (UnsignedValue iv) -> pure $ UnsignedValue $ P.doComplement iv
-    _ -> error $ "Cannot logically negate " <> prettyString ev
+    _ -> error $ "Cannot logically negate " <> show ev
 eval env (Update src is v loc) =
   maybe oob pure
     =<< writeArray <$> mapM (evalDimIndex env) is <*> eval env src <*> eval env v
@@ -1387,48 +1244,48 @@ initialCtx =
         ValueFun $ \v ->
           case fromTuple v of
             Just [x, y] -> f x y
-            _ -> error $ "Expected pair; got: " <> prettyString v
+            _ -> error $ "Expected pair; got: " <> show v
     fun3t f =
       TermValue Nothing $
         ValueFun $ \v ->
           case fromTuple v of
             Just [x, y, z] -> f x y z
-            _ -> error $ "Expected triple; got: " <> prettyString v
+            _ -> error $ "Expected triple; got: " <> show v
 
     fun5t f =
       TermValue Nothing $
         ValueFun $ \v ->
           case fromTuple v of
             Just [x, y, z, a, b] -> f x y z a b
-            _ -> error $ "Expected pentuple; got: " <> prettyString v
+            _ -> error $ "Expected pentuple; got: " <> show v
 
     fun6t f =
       TermValue Nothing $
         ValueFun $ \v ->
           case fromTuple v of
             Just [x, y, z, a, b, c] -> f x y z a b c
-            _ -> error $ "Expected sextuple; got: " <> prettyString v
+            _ -> error $ "Expected sextuple; got: " <> show v
 
     fun7t f =
       TermValue Nothing $
         ValueFun $ \v ->
           case fromTuple v of
             Just [x, y, z, a, b, c, d] -> f x y z a b c d
-            _ -> error $ "Expected septuple; got: " <> prettyString v
+            _ -> error $ "Expected septuple; got: " <> show v
 
     fun8t f =
       TermValue Nothing $
         ValueFun $ \v ->
           case fromTuple v of
             Just [x, y, z, a, b, c, d, e] -> f x y z a b c d e
-            _ -> error $ "Expected sextuple; got: " <> prettyString v
+            _ -> error $ "Expected sextuple; got: " <> show v
 
     fun10t fun =
       TermValue Nothing $
         ValueFun $ \v ->
           case fromTuple v of
             Just [x, y, z, a, b, c, d, e, f, g] -> fun x y z a b c d e f g
-            _ -> error $ "Expected octuple; got: " <> prettyString v
+            _ -> error $ "Expected octuple; got: " <> show v
 
     bopDef fs = fun2 $ \x y ->
       case (x, y) of
@@ -1437,12 +1294,12 @@ initialCtx =
               breakOnNaN [x', y'] z
               pure $ ValuePrim z
         _ ->
-          bad noLoc mempty $
-            "Cannot apply operator to arguments "
-              <> quote (prettyText x)
-              <> " and "
-              <> quote (prettyText y)
-              <> "."
+          bad noLoc mempty . docText $
+            "Cannot apply operator to arguments"
+              <+> dquotes (prettyValue x)
+              <+> "and"
+              <+> dquotes (prettyValue y)
+                <> "."
       where
         bopDef' (valf, retf, op) (x, y) = do
           x' <- valf x
@@ -1456,10 +1313,10 @@ initialCtx =
               breakOnNaN [x'] r
               pure $ ValuePrim r
         _ ->
-          bad noLoc mempty $
-            "Cannot apply function to argument "
-              <> quote (prettyText x)
-              <> "."
+          bad noLoc mempty . docText $
+            "Cannot apply function to argument"
+              <+> dquotes (prettyValue x)
+                <> "."
       where
         unopDef' (valf, retf, op) x = do
           x' <- valf x
@@ -1474,10 +1331,9 @@ initialCtx =
               breakOnNaN [x, y] z
               pure $ ValuePrim z
         _ ->
-          bad noLoc mempty $
-            "Cannot apply operator to argument "
-              <> quote (prettyText v)
-              <> "."
+          bad noLoc mempty . docText $
+            "Cannot apply operator to argument"
+              <+> dquotes (prettyValue v) <> "."
 
     def "!" =
       Just $
@@ -1590,21 +1446,21 @@ initialCtx =
                         breakOnNaN vs res
                         pure $ ValuePrim res
                   _ ->
-                    error $ "Cannot apply " <> prettyString s ++ " to " <> prettyString x
+                    error $ "Cannot apply " <> prettyString s ++ " to " <> show x
       | "sign_" `isPrefixOf` s =
           Just $
             fun1 $ \x ->
               case x of
                 (ValuePrim (UnsignedValue x')) ->
                   pure $ ValuePrim $ SignedValue x'
-                _ -> error $ "Cannot sign: " <> prettyString x
+                _ -> error $ "Cannot sign: " <> show x
       | "unsign_" `isPrefixOf` s =
           Just $
             fun1 $ \x ->
               case x of
                 (ValuePrim (SignedValue x')) ->
                   pure $ ValuePrim $ UnsignedValue x'
-                _ -> error $ "Cannot unsign: " <> prettyString x
+                _ -> error $ "Cannot unsign: " <> show x
     def s
       | "map_stream" `isPrefixOf` s =
           Just $ fun2t stream
@@ -1622,7 +1478,7 @@ initialCtx =
             _ ->
               error $
                 "Invalid arguments to map intrinsic:\n"
-                  ++ unlines [prettyString t, prettyString v]
+                  ++ unlines [prettyString t, show v]
       where
         typeRowShape = sequenceA . structTypeShape mempty . stripArray 1
     def s | "reduce" `isPrefixOf` s = Just $
@@ -1644,7 +1500,7 @@ initialCtx =
                 foldl' update arr' $
                   zip (map asInt $ snd $ fromArray is) (snd $ fromArray vs)
           _ ->
-            error $ "scatter expects array, but got: " <> prettyString arr
+            error $ "scatter expects array, but got: " <> show arr
       where
         update arr' (i, v) =
           if i >= 0 && i < arrayLength arr'
@@ -1658,7 +1514,7 @@ initialCtx =
               foldl' update arr $
                 zip (map fromTuple $ snd $ fromArray is) (snd $ fromArray vs)
           _ ->
-            error $ "scatter_2d expects array, but got: " <> prettyString arr
+            error $ "scatter_2d expects array, but got: " <> show arr
       where
         update :: Value -> (Maybe [Value], Value) -> Value
         update arr (Just idxs@[_, _], v) =
@@ -1673,7 +1529,7 @@ initialCtx =
               foldl' update arr $
                 zip (map fromTuple $ snd $ fromArray is) (snd $ fromArray vs)
           _ ->
-            error $ "scatter_3d expects array, but got: " <> prettyString arr
+            error $ "scatter_3d expects array, but got: " <> show arr
       where
         update :: Value -> (Maybe [Value], Value) -> Value
         update arr (Just idxs@[_, _, _], v) =
@@ -1745,9 +1601,9 @@ initialCtx =
                 ValueAcc _ dest_arr' ->
                   pure $ ValueArray dest_shape dest_arr'
                 _ ->
-                  error $ "scatter_stream produced: " <> prettyString acc'
+                  error $ "scatter_stream produced: " <> show acc'
           _ ->
-            error $ "scatter_stream expects array, but got: " <> prettyString (dest, vs)
+            error $ "scatter_stream expects array, but got: " <> prettyString (show vs, show vs)
     def "hist_stream" = Just $
       fun5t $ \dest op _ne f vs ->
         case (dest, vs) of
@@ -1760,9 +1616,9 @@ initialCtx =
                 ValueAcc _ dest_arr' ->
                   pure $ ValueArray dest_shape dest_arr'
                 _ ->
-                  error $ "hist_stream produced: " <> prettyString acc'
+                  error $ "hist_stream produced: " <> show acc'
           _ ->
-            error $ "hist_stream expects array, but got: " <> prettyString (dest, vs)
+            error $ "hist_stream expects array, but got: " <> prettyString (show dest, show vs)
     def "acc_write" = Just $
       fun3t $ \acc i v ->
         case (acc, i) of
@@ -1776,7 +1632,7 @@ initialCtx =
                   pure $ ValueAcc op $ acc_arr // [(fromIntegral i', res)]
                 else pure acc
           _ ->
-            error $ "acc_write invalid arguments: " <> prettyString (acc, i, v)
+            error $ "acc_write invalid arguments: " <> prettyString (show acc, show i, show v)
     --
     def "flat_index_2d" = Just . fun6t $ \arr offset n1 s1 n2 s2 -> do
       let offset' = asInt64 offset
@@ -1908,7 +1764,7 @@ initialCtx =
         pure $ toTuple $ listPair $ unzip $ map (fromPair . fromTuple) $ snd $ fromArray x
       where
         fromPair (Just [x, y]) = (x, y)
-        fromPair l = error $ "Not a pair: " <> prettyString l
+        fromPair _ = error "Not a pair"
     def "zip" = Just $
       fun2t $ \xs ys -> do
         let ShapeDim _ xs_rowshape = valueShape xs
@@ -1980,7 +1836,7 @@ initialCtx =
     stream f arg@(ValueArray _ xs) =
       let n = ValuePrim $ SignedValue $ Int64Value $ arrayLength xs
        in apply2 noLoc mempty f n arg
-    stream _ arg = error $ "Cannot stream: " <> prettyString arg
+    stream _ arg = error $ "Cannot stream: " <> show arg
 
 interpretExp :: Ctx -> Exp -> F ExtOp Value
 interpretExp ctx e = runEvalM (ctxImports ctx) $ eval (ctxEnv ctx) e

--- a/src/Language/Futhark/Interpreter/Values.hs
+++ b/src/Language/Futhark/Interpreter/Values.hs
@@ -1,0 +1,220 @@
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | The value representation used in the interpreter.
+--
+-- Kept simple and free of unnecessary operational details (in
+-- particular, no references to the interpreter monad).
+module Language.Futhark.Interpreter.Values
+  ( -- * Shapes
+    Shape (..),
+    ValueShape,
+    typeShape,
+    structTypeShape,
+
+    -- * Values
+    Value (..),
+    valueShape,
+    prettyValue,
+    valueText,
+    fromTuple,
+    mkArray,
+    arrayLength,
+    isEmptyArray,
+    prettyEmptyArray,
+    toArray,
+    toArray',
+    toTuple,
+  )
+where
+
+import Control.Monad (guard)
+import Data.Array
+import Data.List (genericLength)
+import qualified Data.Map as M
+import Data.Maybe
+import Data.Monoid hiding (Sum)
+import qualified Data.Text as T
+import Futhark.Util.Pretty hiding (apply)
+import Language.Futhark hiding (Shape, Value, matchDims)
+import qualified Language.Futhark.Primitive as P
+import Prelude hiding (break, mod)
+
+prettyRecord :: (a -> Doc ann) -> M.Map Name a -> Doc ann
+prettyRecord p m
+  | Just vs <- areTupleFields m =
+      parens $ commasep $ map p vs
+  | otherwise =
+      braces $ commasep $ map field $ M.toList m
+  where
+    field (k, v) = pretty k <+> equals <+> p v
+
+-- | A shape is a tree to accomodate the case of records.  It is
+-- parameterised over the representation of dimensions.
+data Shape d
+  = ShapeDim d (Shape d)
+  | ShapeLeaf
+  | ShapeRecord (M.Map Name (Shape d))
+  | ShapeSum (M.Map Name [Shape d])
+  deriving (Eq, Show, Functor, Foldable, Traversable)
+
+-- | The shape of an array.
+type ValueShape = Shape Int64
+
+instance Pretty d => Pretty (Shape d) where
+  pretty ShapeLeaf = mempty
+  pretty (ShapeDim d s) = brackets (pretty d) <> pretty s
+  pretty (ShapeRecord m) = prettyRecord pretty m
+  pretty (ShapeSum cs) =
+    mconcat (punctuate " | " cs')
+    where
+      ppConstr (name, fs) = sep $ ("#" <> pretty name) : map pretty fs
+      cs' = map ppConstr $ M.toList cs
+
+emptyShape :: ValueShape -> Bool
+emptyShape (ShapeDim d s) = d == 0 || emptyShape s
+emptyShape _ = False
+
+typeShape :: M.Map VName (Shape d) -> TypeBase d () -> Shape d
+typeShape shapes = go
+  where
+    go (Array _ _ shape et) =
+      foldr ShapeDim (go (Scalar et)) $ shapeDims shape
+    go (Scalar (Record fs)) =
+      ShapeRecord $ M.map go fs
+    go (Scalar (Sum cs)) =
+      ShapeSum $ M.map (map go) cs
+    go (Scalar (TypeVar _ _ (QualName [] v) []))
+      | Just shape <- M.lookup v shapes =
+          shape
+    go _ =
+      ShapeLeaf
+
+structTypeShape :: M.Map VName ValueShape -> StructType -> Shape (Maybe Int64)
+structTypeShape shapes = fmap dim . typeShape shapes'
+  where
+    dim (ConstSize d) = Just $ fromIntegral d
+    dim _ = Nothing
+    shapes' = M.map (fmap $ ConstSize . fromIntegral) shapes
+
+-- | A fully evaluated Futhark value.
+data Value m
+  = ValuePrim !PrimValue
+  | ValueArray ValueShape !(Array Int (Value m))
+  | -- Stores the full shape.
+    ValueRecord (M.Map Name (Value m))
+  | ValueFun (Value m -> m (Value m))
+  | -- Stores the full shape.
+    ValueSum ValueShape Name [Value m]
+  | -- The update function and the array.
+    ValueAcc (Value m -> Value m -> m (Value m)) !(Array Int (Value m))
+
+instance Show (Value m) where
+  show (ValuePrim v) = "ValuePrim " <> show v <> ""
+  show (ValueArray shape vs) = unwords ["ValueArray", show shape, show vs]
+  show (ValueRecord fs) = "ValueRecord " <> show fs
+  show (ValueSum shape c vs) = unwords ["ValueSum", show shape, show c, show vs]
+  show ValueFun {} = "ValueFun _"
+  show ValueAcc {} = "ValueAcc _"
+
+instance Eq (Value m) where
+  ValuePrim (SignedValue x) == ValuePrim (SignedValue y) =
+    P.doCmpEq (P.IntValue x) (P.IntValue y)
+  ValuePrim (UnsignedValue x) == ValuePrim (UnsignedValue y) =
+    P.doCmpEq (P.IntValue x) (P.IntValue y)
+  ValuePrim (FloatValue x) == ValuePrim (FloatValue y) =
+    P.doCmpEq (P.FloatValue x) (P.FloatValue y)
+  ValuePrim (BoolValue x) == ValuePrim (BoolValue y) =
+    P.doCmpEq (P.BoolValue x) (P.BoolValue y)
+  ValueArray _ x == ValueArray _ y = x == y
+  ValueRecord x == ValueRecord y = x == y
+  ValueSum _ n1 vs1 == ValueSum _ n2 vs2 = n1 == n2 && vs1 == vs2
+  ValueAcc _ x == ValueAcc _ y = x == y
+  _ == _ = False
+
+prettyValueWith :: (PrimValue -> Doc a) -> Value m -> Doc a
+prettyValueWith pprPrim = pprPrec (0 :: Int)
+  where
+    pprPrec _ (ValuePrim v) = pprPrim v
+    pprPrec _ (ValueArray _ a) =
+      let elements = elems a -- [Value]
+          (x : _) = elements
+          separator = case x of
+            ValueArray _ _ -> comma <> line
+            _ -> comma <> space
+       in brackets $ align $ cat $ punctuate separator (map (pprPrec 0) elements)
+    pprPrec _ (ValueRecord m) = prettyRecord (pprPrec 0) m
+    pprPrec _ ValueFun {} = "#<fun>"
+    pprPrec _ ValueAcc {} = "#<acc>"
+    pprPrec p (ValueSum _ n vs) =
+      parensIf (p > 0) $ "#" <> sep (pretty n : map (pprPrec 1) vs)
+
+-- | Prettyprint value.
+prettyValue :: Value m -> Doc a
+prettyValue = prettyValueWith pprPrim
+  where
+    pprPrim (UnsignedValue (Int8Value v)) = pretty v
+    pprPrim (UnsignedValue (Int16Value v)) = pretty v
+    pprPrim (UnsignedValue (Int32Value v)) = pretty v
+    pprPrim (UnsignedValue (Int64Value v)) = pretty v
+    pprPrim (SignedValue (Int8Value v)) = pretty v
+    pprPrim (SignedValue (Int16Value v)) = pretty v
+    pprPrim (SignedValue (Int32Value v)) = pretty v
+    pprPrim (SignedValue (Int64Value v)) = pretty v
+    pprPrim (BoolValue True) = "true"
+    pprPrim (BoolValue False) = "false"
+    pprPrim (FloatValue v) = pretty v
+
+-- | The value in the textual format.
+valueText :: Value m -> T.Text
+valueText = docText . prettyValueWith pretty
+
+valueShape :: Value m -> ValueShape
+valueShape (ValueArray shape _) = shape
+valueShape (ValueRecord fs) = ShapeRecord $ M.map valueShape fs
+valueShape (ValueSum shape _ _) = shape
+valueShape _ = ShapeLeaf
+
+-- | Does the value correspond to an empty array?
+isEmptyArray :: Value m -> Bool
+isEmptyArray = emptyShape . valueShape
+
+-- | String representation of an empty array with the provided element
+-- type.  This is pretty ad-hoc - don't expect good results unless the
+-- element type is a primitive.
+prettyEmptyArray :: TypeBase () () -> Value m -> T.Text
+prettyEmptyArray t v =
+  "empty(" <> dims (valueShape v) <> prettyText t' <> ")"
+  where
+    t' = stripArray (arrayRank t) t
+    dims (ShapeDim n rowshape) =
+      "[" <> prettyText n <> "]" <> dims rowshape
+    dims _ = ""
+
+toArray :: ValueShape -> [Value m] -> Value m
+toArray shape vs = ValueArray shape (listArray (0, length vs - 1) vs)
+
+toArray' :: ValueShape -> [Value m] -> Value m
+toArray' rowshape vs = ValueArray shape (listArray (0, length vs - 1) vs)
+  where
+    shape = ShapeDim (genericLength vs) rowshape
+
+-- | Create an array value; failing if that would result in an
+-- irregular array.
+mkArray :: TypeBase Int64 () -> [Value m] -> Maybe (Value m)
+mkArray t [] =
+  pure $ toArray (typeShape mempty t) []
+mkArray _ (v : vs) = do
+  let v_shape = valueShape v
+  guard $ all ((== v_shape) . valueShape) vs
+  pure $ toArray' v_shape $ v : vs
+
+arrayLength :: Integral int => Array Int (Value m) -> int
+arrayLength = fromIntegral . (+ 1) . snd . bounds
+
+toTuple :: [Value m] -> Value m
+toTuple = ValueRecord . M.fromList . zip tupleFieldNames
+
+fromTuple :: Value m -> Maybe [Value m]
+fromTuple (ValueRecord m) = areTupleFields m
+fromTuple _ = Nothing


### PR DESCRIPTION
This change looks bigger than it really is, because I also took the
opportunity to move the interpreter value representation to a separate
module.  The idea is to further separate out non-monadic operations on
values.

Closes #1724.