### PR TITLE
Refactor SegLevel for GPU representation.

### DIFF
--- a/src/Futhark/CodeGen/ImpGen/GPU.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU.hs
@@ -166,12 +166,12 @@ segOpCompiler ::
   CallKernelGen ()
 segOpCompiler pat (SegMap lvl space _ kbody) =
   compileSegMap pat lvl space kbody
-segOpCompiler pat (SegRed lvl@SegThread {} space reds _ kbody) =
+segOpCompiler pat (SegRed lvl@(SegThread _ _) space reds _ kbody) =
   compileSegRed pat lvl space reds kbody
-segOpCompiler pat (SegScan lvl@SegThread {} space scans _ kbody) =
+segOpCompiler pat (SegScan lvl@(SegThread _ _) space scans _ kbody) =
   compileSegScan pat lvl space scans kbody
-segOpCompiler pat (SegHist (SegThread num_groups group_size _) space ops _ kbody) =
-  compileSegHist pat num_groups group_size space ops kbody
+segOpCompiler pat (SegHist lvl@(SegThread _ _) space ops _ kbody) =
+  compileSegHist pat lvl space ops kbody
 segOpCompiler pat segop =
   compilerBugS $ "segOpCompiler: unexpected " ++ prettyString (segLevel segop) ++ " for rhs of pattern " ++ prettyString pat
 

--- a/src/Futhark/CodeGen/ImpGen/GPU/SegMap.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/SegMap.hs
@@ -23,10 +23,11 @@ compileSegMap ::
   KernelBody GPUMem ->
   CallKernelGen ()
 compileSegMap pat lvl space kbody = do
+  attrs <- lvlKernelAttrs lvl
+
   let (is, dims) = unzip $ unSegSpace space
       dims' = map pe64 dims
-      group_size' = pe64 <$> segGroupSize lvl
-      attrs = defKernelAttrs (segNumGroups lvl) (segGroupSize lvl)
+      group_size' = pe64 <$> kAttrGroupSize attrs
 
   emit $ Imp.DebugPrint "\n# SegMap" Nothing
   case lvl of
@@ -58,4 +59,6 @@ compileSegMap pat lvl space kbody = do
             compileStms mempty (kernelBodyStms kbody) $
               zipWithM_ (compileGroupResult space) (patElems pat) $
                 kernelBodyResult kbody
+    SegThreadInGroup {} ->
+      error "compileSegMap: SegThreadInGroup"
   emit $ Imp.DebugPrint "" Nothing

--- a/src/Futhark/Optimise/ReduceDeviceSyncs/MigrationTable.hs
+++ b/src/Futhark/Optimise/ReduceDeviceSyncs/MigrationTable.hs
@@ -1108,10 +1108,7 @@ graphedScalarOperands e =
     collectHostOp (OtherOp op) = collectFree op
     collectHostOp GPUBody {} = pure ()
 
-    collectSegLevel (SegThread (Count num) (Count size) _) =
-      collectSubExp num >> collectSubExp size
-    collectSegLevel (SegGroup (Count num) (Count size) _) =
-      collectSubExp num >> collectSubExp size
+    collectSegLevel = mapM_ captureName . namesToList . freeIn
 
     collectSegSpace space =
       mapM_ collectSubExp (segSpaceDims space)

--- a/src/Futhark/Optimise/TileLoops.hs
+++ b/src/Futhark/Optimise/TileLoops.hs
@@ -132,7 +132,6 @@ tileInBody branch_variant initial_variance initial_lvl initial_space res_ts (Bod
           Just . injectPrelude initial_space variance prestms' used
             <$> tileGeneric
               (tiling2d $ reverse $ zip top_gtids_rev top_kdims_rev)
-              initial_lvl
               res_ts
               (stmPat stm_to_tile)
               (gtid_x, gtid_y)
@@ -154,7 +153,6 @@ tileInBody branch_variant initial_variance initial_lvl initial_space res_ts (Bod
           Just . injectPrelude initial_space variance prestms' used
             <$> tileGeneric
               (tiling1d $ reverse top_space_rev)
-              initial_lvl
               res_ts
               (stmPat stm_to_tile)
               gtid
@@ -404,7 +402,7 @@ tileDoLoop initial_space variance prestms used_in_body (host_stms, tiling, tiled
         mergeinit' <-
           fmap (map Var) $
             certifying (stmAuxCerts aux) $
-              tilingSegMap tiling "tiled_loopinit" (scalarLevel tiling) ResultPrivate $
+              tilingSegMap tiling "tiled_loopinit" ResultPrivate $
                 \in_bounds slice ->
                   fmap varsRes $
                     protectOutOfBounds "loopinit" in_bounds merge_ts $ do
@@ -447,7 +445,7 @@ tileDoLoop initial_space variance prestms used_in_body (host_stms, tiling, tiled
 doPrelude :: Tiling -> PrivStms -> Stms GPU -> [VName] -> Builder GPU [VName]
 doPrelude tiling privstms prestms prestms_live =
   -- Create a SegMap that takes care of the prelude for every thread.
-  tilingSegMap tiling "prelude" (scalarLevel tiling) ResultPrivate $
+  tilingSegMap tiling "prelude" ResultPrivate $
     \in_bounds slice -> do
       ts <- mapM lookupType prestms_live
       fmap varsRes . protectOutOfBounds "pre" in_bounds ts $ do
@@ -578,7 +576,6 @@ data ResidualTileArgs = ResidualTileArgs
 data Tiling = Tiling
   { tilingSegMap ::
       String ->
-      SegLevel ->
       ResultManifest ->
       (PrimExp VName -> [DimIndex SubExp] -> Builder GPU Result) ->
       Builder GPU [VName],
@@ -604,13 +601,7 @@ data Tiling = Tiling
   }
 
 type DoTiling gtids kdims =
-  SegLevel -> gtids -> kdims -> SubExp -> Builder GPU Tiling
-
-scalarLevel :: Tiling -> SegLevel
-scalarLevel tiling =
-  SegThread (segNumGroups lvl) (segGroupSize lvl) SegNoVirt
-  where
-    lvl = tilingLevel tiling
+  gtids -> kdims -> SubExp -> Builder GPU Tiling
 
 protectOutOfBounds ::
   String ->
@@ -643,7 +634,7 @@ postludeGeneric ::
   [Type] ->
   Builder GPU [VName]
 postludeGeneric tiling privstms pat accs' poststms poststms_res res_ts =
-  tilingSegMap tiling "thread_res" (scalarLevel tiling) ResultPrivate $ \in_bounds slice -> do
+  tilingSegMap tiling "thread_res" ResultPrivate $ \in_bounds slice -> do
     -- Read our per-thread result from the tiled loop.
     forM_ (zip (patNames pat) accs') $ \(us, everyone) -> do
       everyone_t <- lookupType everyone
@@ -664,7 +655,6 @@ type TiledBody = Names -> PrivStms -> Builder GPU [VName]
 
 tileGeneric ::
   DoTiling gtids kdims ->
-  SegLevel ->
   [Type] ->
   Pat Type ->
   gtids ->
@@ -675,8 +665,8 @@ tileGeneric ::
   Stms GPU ->
   Result ->
   TileM (Stms GPU, Tiling, TiledBody)
-tileGeneric doTiling initial_lvl res_ts pat gtids kdims w form inputs poststms poststms_res = do
-  (tiling, tiling_stms) <- runBuilder $ doTiling initial_lvl gtids kdims w
+tileGeneric doTiling res_ts pat gtids kdims w form inputs poststms poststms_res = do
+  (tiling, tiling_stms) <- runBuilder $ doTiling gtids kdims w
 
   pure (tiling_stms, tiling, tiledBody tiling)
   where
@@ -690,7 +680,7 @@ tileGeneric doTiling initial_lvl res_ts pat gtids kdims w form inputs poststms p
 
       -- We don't use a Replicate here, because we want to enforce a
       -- scalar memory space.
-      mergeinits <- tilingSegMap tiling "mergeinit" (scalarLevel tiling) ResultPrivate $ \in_bounds slice ->
+      mergeinits <- tilingSegMap tiling "mergeinit" ResultPrivate $ \in_bounds slice ->
         -- Constant neutral elements (a common case) do not need protection from OOB.
         if freeIn red_nes == mempty
           then pure $ subExpsRes red_nes
@@ -776,16 +766,15 @@ readTile1D ::
   SubExp ->
   VName ->
   VName ->
-  Count NumGroups SubExp ->
-  Count GroupSize SubExp ->
+  KernelGrid ->
   TileKind ->
   PrivStms ->
   SubExp ->
   [InputArray] ->
   Builder GPU [InputTile]
-readTile1D tile_size gid gtid num_groups group_size kind privstms tile_id inputs =
+readTile1D tile_size gid gtid (KernelGrid _num_groups group_size) kind privstms tile_id inputs =
   fmap (inputsToTiles inputs)
-    . segMap1D "full_tile" lvl ResultNoSimplify
+    . segMap1D "full_tile" lvl ResultNoSimplify tile_size
     $ \ltid -> do
       j <-
         letSubExp "j"
@@ -813,18 +802,17 @@ readTile1D tile_size gid gtid num_groups group_size kind privstms tile_id inputs
           TileFull ->
             mapM readTileElem arrs
   where
-    lvl = SegThread num_groups group_size SegNoVirt
+    lvl = SegThreadInGroup SegNoVirt
 
 processTile1D ::
   VName ->
   VName ->
   SubExp ->
   SubExp ->
-  Count NumGroups SubExp ->
-  Count GroupSize SubExp ->
+  KernelGrid ->
   ProcessTileArgs ->
   Builder GPU [VName]
-processTile1D gid gtid kdim tile_size num_groups group_size tile_args = do
+processTile1D gid gtid kdim tile_size (KernelGrid _num_groups group_size) tile_args = do
   let red_comm = processComm tile_args
       privstms = processPrivStms tile_args
       map_lam = processMapLam tile_args
@@ -833,7 +821,7 @@ processTile1D gid gtid kdim tile_size num_groups group_size tile_args = do
       tile_id = processTileId tile_args
       accs = processAcc tile_args
 
-  segMap1D "acc" lvl ResultPrivate $ \ltid -> do
+  segMap1D "acc" lvl ResultPrivate (unCount group_size) $ \ltid -> do
     reconstructGtids1D group_size gtid gid ltid
     addPrivStms [DimFix $ Var ltid] privstms
 
@@ -857,18 +845,17 @@ processTile1D gid gtid kdim tile_size num_groups group_size tile_args = do
           (eBody [pure $ Op $ OtherOp $ Screma tile_size tiles' form'])
           (resultBodyM thread_accs)
   where
-    lvl = SegThread num_groups group_size SegNoVirt
+    lvl = SegThreadInGroup SegNoVirt
 
 processResidualTile1D ::
   VName ->
   VName ->
   SubExp ->
   SubExp ->
-  Count NumGroups SubExp ->
-  Count GroupSize SubExp ->
+  KernelGrid ->
   ResidualTileArgs ->
   Builder GPU [VName]
-processResidualTile1D gid gtid kdim tile_size num_groups group_size args = do
+processResidualTile1D gid gtid kdim tile_size grid args = do
   -- The number of residual elements that are not covered by
   -- the whole tiles.
   residual_input <-
@@ -899,8 +886,7 @@ processResidualTile1D gid gtid kdim tile_size num_groups group_size args = do
           tile_size
           gid
           gtid
-          num_groups
-          group_size
+          grid
           TilePartial
           privstms
           num_whole_tiles
@@ -921,61 +907,52 @@ processResidualTile1D gid gtid kdim tile_size num_groups group_size args = do
       let tile_args =
             ProcessTileArgs privstms red_comm red_lam map_lam tiles accs num_whole_tiles
       resultBody . map Var
-        <$> processTile1D gid gtid kdim residual_input num_groups group_size tile_args
+        <$> processTile1D gid gtid kdim residual_input grid tile_args
 
 tiling1d :: [(VName, SubExp)] -> DoTiling VName SubExp
-tiling1d dims_on_top initial_lvl gtid kdim w = do
+tiling1d dims_on_top gtid kdim w = do
   gid <- newVName "gid"
   gid_flat <- newVName "gid_flat"
 
-  (lvl, space) <-
-    if null dims_on_top
-      then
-        pure
-          ( SegGroup (segNumGroups initial_lvl) (segGroupSize initial_lvl) $ segVirt initial_lvl,
-            SegSpace gid_flat [(gid, unCount $ segNumGroups initial_lvl)]
-          )
-      else do
-        group_size <-
-          letSubExp "computed_group_size" $
-            BasicOp $
-              BinOp (SMin Int64) (unCount (segGroupSize initial_lvl)) kdim
+  tile_size_key <- nameFromString . prettyString <$> newVName "tile_size"
+  tile_size <- letSubExp "tile_size" $ Op $ SizeOp $ GetSize tile_size_key SizeGroup
+  let group_size = tile_size
 
-        -- How many groups we need to exhaust the innermost dimension.
-        ldim <-
-          letSubExp "ldim" $
-            BasicOp $
-              BinOp (SDivUp Int64 Unsafe) kdim group_size
+  (grid, space) <- do
+    -- How many groups we need to exhaust the innermost dimension.
+    ldim <-
+      letSubExp "ldim" . BasicOp $
+        BinOp (SDivUp Int64 Unsafe) kdim group_size
 
-        num_groups <-
-          letSubExp "computed_num_groups"
-            =<< foldBinOp (Mul Int64 OverflowUndef) ldim (map snd dims_on_top)
+    num_groups <-
+      letSubExp "computed_num_groups"
+        =<< foldBinOp (Mul Int64 OverflowUndef) ldim (map snd dims_on_top)
 
-        pure
-          ( SegGroup (Count num_groups) (Count group_size) SegNoVirt,
-            SegSpace gid_flat $ dims_on_top ++ [(gid, ldim)]
-          )
-  let tile_size = unCount $ segGroupSize lvl
+    pure
+      ( KernelGrid (Count num_groups) (Count group_size),
+        SegSpace gid_flat $ dims_on_top ++ [(gid, ldim)]
+      )
+  let tiling_lvl = SegThreadInGroup SegNoVirt
 
   pure
     Tiling
-      { tilingSegMap = \desc lvl' manifest f -> segMap1D desc lvl' manifest $ \ltid -> do
+      { tilingSegMap = \desc manifest f -> segMap1D desc tiling_lvl manifest tile_size $ \ltid -> do
           letBindNames [gtid]
             =<< toExp (le64 gid * pe64 tile_size + le64 ltid)
           f (untyped $ le64 gtid .<. pe64 kdim) [DimFix $ Var ltid],
         tilingReadTile =
-          readTile1D tile_size gid gtid (segNumGroups lvl) (segGroupSize lvl),
+          readTile1D tile_size gid gtid grid,
         tilingProcessTile =
-          processTile1D gid gtid kdim tile_size (segNumGroups lvl) (segGroupSize lvl),
+          processTile1D gid gtid kdim tile_size grid,
         tilingProcessResidualTile =
-          processResidualTile1D gid gtid kdim tile_size (segNumGroups lvl) (segGroupSize lvl),
+          processResidualTile1D gid gtid kdim tile_size grid,
         tilingTileReturns = tileReturns dims_on_top [(kdim, tile_size)],
         tilingTileShape = Shape [tile_size],
         tilingNumWholeTiles =
           letSubExp "num_whole_tiles" $
             BasicOp $
               BinOp (SQuot Int64 Unsafe) w tile_size,
-        tilingLevel = lvl,
+        tilingLevel = SegGroup SegNoVirt (Just grid),
         tilingSpace = space
       }
 
@@ -1015,18 +992,16 @@ readTile2D ::
   (VName, VName) ->
   (VName, VName) ->
   SubExp ->
-  Count NumGroups SubExp ->
-  Count GroupSize SubExp ->
   TileKind ->
   PrivStms ->
   SubExp ->
   [InputArray] ->
   Builder GPU [InputTile]
-readTile2D (kdim_x, kdim_y) (gtid_x, gtid_y) (gid_x, gid_y) tile_size num_groups group_size kind privstms tile_id inputs =
+readTile2D (kdim_x, kdim_y) (gtid_x, gtid_y) (gid_x, gid_y) tile_size kind privstms tile_id inputs =
   fmap (inputsToTiles inputs)
     . segMap2D
       "full_tile"
-      (SegThread num_groups group_size (SegNoVirtFull (SegSeqDims [])))
+      (SegThread (SegNoVirtFull (SegSeqDims [])) Nothing)
       ResultNoSimplify
       (tile_size, tile_size)
     $ \(ltid_x, ltid_y) -> do
@@ -1088,11 +1063,9 @@ processTile2D ::
   (VName, VName) ->
   (SubExp, SubExp) ->
   SubExp ->
-  Count NumGroups SubExp ->
-  Count GroupSize SubExp ->
   ProcessTileArgs ->
   Builder GPU [VName]
-processTile2D (gid_x, gid_y) (gtid_x, gtid_y) (kdim_x, kdim_y) tile_size num_groups group_size tile_args = do
+processTile2D (gid_x, gid_y) (gtid_x, gtid_y) (kdim_x, kdim_y) tile_size tile_args = do
   let privstms = processPrivStms tile_args
       red_comm = processComm tile_args
       red_lam = processRedLam tile_args
@@ -1106,7 +1079,7 @@ processTile2D (gid_x, gid_y) (gtid_x, gtid_y) (kdim_x, kdim_y) tile_size num_gro
 
   segMap2D
     "acc"
-    (SegThread num_groups group_size (SegNoVirtFull (SegSeqDims [])))
+    (SegThreadInGroup (SegNoVirtFull (SegSeqDims [])))
     ResultPrivate
     (tile_size, tile_size)
     $ \(ltid_x, ltid_y) -> do
@@ -1146,82 +1119,69 @@ processResidualTile2D ::
   (VName, VName) ->
   (SubExp, SubExp) ->
   SubExp ->
-  Count NumGroups SubExp ->
-  Count GroupSize SubExp ->
   ResidualTileArgs ->
   Builder GPU [VName]
-processResidualTile2D
-  gids
-  gtids
-  kdims
-  tile_size
-  num_groups
-  group_size
-  args = do
-    -- The number of residual elements that are not covered by
-    -- the whole tiles.
-    residual_input <-
-      letSubExp "residual_input" $
-        BasicOp $
-          BinOp (SRem Int64 Unsafe) w tile_size
+processResidualTile2D gids gtids kdims tile_size args = do
+  -- The number of residual elements that are not covered by
+  -- the whole tiles.
+  residual_input <-
+    letSubExp "residual_input" $
+      BasicOp $
+        BinOp (SRem Int64 Unsafe) w tile_size
 
-    letTupExp "acc_after_residual"
-      =<< eIf
-        (toExp $ pe64 residual_input .==. 0)
-        (resultBodyM $ map Var accs)
-        (nonemptyTile residual_input)
-    where
-      privstms = residualPrivStms args
-      red_comm = residualComm args
-      red_lam = residualRedLam args
-      map_lam = residualMapLam args
-      accs = residualAcc args
-      inputs = residualInput args
-      num_whole_tiles = residualNumWholeTiles args
-      w = residualInputSize args
+  letTupExp "acc_after_residual"
+    =<< eIf
+      (toExp $ pe64 residual_input .==. 0)
+      (resultBodyM $ map Var accs)
+      (nonemptyTile residual_input)
+  where
+    privstms = residualPrivStms args
+    red_comm = residualComm args
+    red_lam = residualRedLam args
+    map_lam = residualMapLam args
+    accs = residualAcc args
+    inputs = residualInput args
+    num_whole_tiles = residualNumWholeTiles args
+    w = residualInputSize args
 
-      nonemptyTile residual_input = renameBody <=< runBodyBuilder $ do
-        -- Collectively construct a tile.  Threads that are out-of-bounds
-        -- provide a blank dummy value.
-        full_tile <-
-          readTile2D
-            kdims
-            gtids
-            gids
-            tile_size
-            num_groups
-            group_size
-            TilePartial
-            privstms
-            num_whole_tiles
-            inputs
+    nonemptyTile residual_input = renameBody <=< runBodyBuilder $ do
+      -- Collectively construct a tile.  Threads that are out-of-bounds
+      -- provide a blank dummy value.
+      full_tile <-
+        readTile2D
+          kdims
+          gtids
+          gids
+          tile_size
+          TilePartial
+          privstms
+          num_whole_tiles
+          inputs
 
-        let slice =
-              DimSlice (intConst Int64 0) residual_input (intConst Int64 1)
-        tiles <- forM full_tile $ \case
-          InputTiled perm tile' ->
-            InputTiled perm
-              <$> letExp "partial_tile" (BasicOp $ Index tile' (Slice [slice, slice]))
-          InputUntiled arr ->
-            pure $ InputUntiled arr
+      let slice =
+            DimSlice (intConst Int64 0) residual_input (intConst Int64 1)
+      tiles <- forM full_tile $ \case
+        InputTiled perm tile' ->
+          InputTiled perm
+            <$> letExp "partial_tile" (BasicOp $ Index tile' (Slice [slice, slice]))
+        InputUntiled arr ->
+          pure $ InputUntiled arr
 
-        let tile_args =
-              ProcessTileArgs privstms red_comm red_lam map_lam tiles accs num_whole_tiles
+      let tile_args =
+            ProcessTileArgs privstms red_comm red_lam map_lam tiles accs num_whole_tiles
 
-        -- Now each thread performs a traversal of the tile and
-        -- updates its accumulator.
-        resultBody . map Var
-          <$> processTile2D
-            gids
-            gtids
-            kdims
-            tile_size
-            num_groups
-            group_size
-            tile_args
+      -- Now each thread performs a traversal of the tile and
+      -- updates its accumulator.
+      resultBody . map Var
+        <$> processTile2D
+          gids
+          gtids
+          kdims
+          tile_size
+          tile_args
 
 tiling2d :: [(VName, SubExp)] -> DoTiling (VName, VName) (SubExp, SubExp)
-tiling2d dims_on_top _initial_lvl (gtid_x, gtid_y) (kdim_x, kdim_y) w = do
+tiling2d dims_on_top (gtid_x, gtid_y) (kdim_x, kdim_y) w = do
   gid_x <- newVName "gid_x"
   gid_y <- newVName "gid_y"
 
@@ -1246,24 +1206,26 @@ tiling2d dims_on_top _initial_lvl (gtid_x, gtid_y) (kdim_x, kdim_y) w = do
         (num_groups_y : map snd dims_on_top)
 
   gid_flat <- newVName "gid_flat"
-  let lvl = SegGroup (Count num_groups) (Count group_size) (SegNoVirtFull (SegSeqDims []))
+  let grid = KernelGrid (Count num_groups) (Count group_size)
+      lvl = SegGroup (SegNoVirtFull (SegSeqDims [])) (Just grid)
       space =
         SegSpace gid_flat $
           dims_on_top ++ [(gid_x, num_groups_x), (gid_y, num_groups_y)]
+      tiling_lvl = SegThreadInGroup SegNoVirt
 
   pure
     Tiling
-      { tilingSegMap = \desc lvl' manifest f ->
-          segMap2D desc lvl' manifest (tile_size, tile_size) $ \(ltid_x, ltid_y) -> do
+      { tilingSegMap = \desc manifest f ->
+          segMap2D desc tiling_lvl manifest (tile_size, tile_size) $ \(ltid_x, ltid_y) -> do
             reconstructGtids2D tile_size (gtid_x, gtid_y) (gid_x, gid_y) (ltid_x, ltid_y)
             f
               ( untyped $
                   le64 gtid_x .<. pe64 kdim_x .&&. le64 gtid_y .<. pe64 kdim_y
               )
               [DimFix $ Var ltid_x, DimFix $ Var ltid_y],
-        tilingReadTile = readTile2D (kdim_x, kdim_y) (gtid_x, gtid_y) (gid_x, gid_y) tile_size (segNumGroups lvl) (segGroupSize lvl),
-        tilingProcessTile = processTile2D (gid_x, gid_y) (gtid_x, gtid_y) (kdim_x, kdim_y) tile_size (segNumGroups lvl) (segGroupSize lvl),
-        tilingProcessResidualTile = processResidualTile2D (gid_x, gid_y) (gtid_x, gtid_y) (kdim_x, kdim_y) tile_size (segNumGroups lvl) (segGroupSize lvl),
+        tilingReadTile = readTile2D (kdim_x, kdim_y) (gtid_x, gtid_y) (gid_x, gid_y) tile_size,
+        tilingProcessTile = processTile2D (gid_x, gid_y) (gtid_x, gtid_y) (kdim_x, kdim_y) tile_size,
+        tilingProcessResidualTile = processResidualTile2D (gid_x, gid_y) (gtid_x, gtid_y) (kdim_x, kdim_y) tile_size,
         tilingTileReturns = tileReturns dims_on_top [(kdim_x, tile_size), (kdim_y, tile_size)],
         tilingTileShape = Shape [tile_size, tile_size],
         tilingNumWholeTiles =

--- a/src/Futhark/Pass/ExplicitAllocations/GPU.hs
+++ b/src/Futhark/Pass/ExplicitAllocations/GPU.hs
@@ -20,32 +20,48 @@ instance SizeSubst (HostOp rep op) where
   opIsConst (SizeOp GetSizeMax {}) = True
   opIsConst _ = False
 
-allocAtLevel :: SegLevel -> AllocM fromrep trep a -> AllocM fromrep trep a
+allocAtLevel :: SegLevel -> AllocM GPU GPUMem a -> AllocM GPU GPUMem a
 allocAtLevel lvl = local $ \env ->
   env
     { allocSpace = space,
-      aggressiveReuse = True
+      aggressiveReuse = True,
+      allocInOp = handleHostOp (Just lvl)
     }
   where
     space = case lvl of
-      SegThread {} -> DefaultSpace
       SegGroup {} -> Space "local"
+      SegThread {} -> DefaultSpace
+      SegThreadInGroup {} -> DefaultSpace
 
 handleSegOp ::
+  Maybe SegLevel ->
   SegOp SegLevel GPU ->
   AllocM GPU GPUMem (SegOp SegLevel GPUMem)
-handleSegOp op = do
+handleSegOp outer_lvl op = do
   num_threads <-
-    letSubExp "num_threads" $
-      BasicOp $
-        BinOp
-          (Mul Int64 OverflowUndef)
-          (unCount (segNumGroups lvl))
-          (unCount (segGroupSize lvl))
-  allocAtLevel lvl $ mapSegOpM (mapper num_threads) op
+    letSubExp "num_threads"
+      =<< case maybe_grid of
+        Just grid ->
+          pure . BasicOp $
+            BinOp
+              (Mul Int64 OverflowUndef)
+              (unCount (gridNumGroups grid))
+              (unCount (gridGroupSize grid))
+        Nothing ->
+          foldBinOp
+            (Mul Int64 OverflowUndef)
+            (intConst Int64 1)
+            (segSpaceDims $ segSpace op)
+  allocAtLevel (segLevel op) $ mapSegOpM (mapper num_threads) op
   where
+    maybe_grid =
+      case (outer_lvl, segLevel op) of
+        (Just (SegThread _ (Just grid)), _) -> Just grid
+        (Just (SegGroup _ (Just grid)), _) -> Just grid
+        (_, SegThread _ (Just grid)) -> Just grid
+        (_, SegGroup _ (Just grid)) -> Just grid
+        _ -> Nothing
     scope = scopeOfSegSpace $ segSpace op
-    lvl = segLevel op
     mapper num_threads =
       identitySegOpMapper
         { mapOnSegOpBody =
@@ -56,20 +72,22 @@ handleSegOp op = do
         }
     f = case segLevel op of
       SegThread {} -> inThread
+      SegThreadInGroup {} -> inThread
       SegGroup {} -> inGroup
     inThread env = env {envExpHints = inThreadExpHints}
     inGroup env = env {envExpHints = inGroupExpHints}
 
 handleHostOp ::
+  Maybe SegLevel ->
   HostOp GPU (SOAC GPU) ->
   AllocM GPU GPUMem (MemOp (HostOp GPUMem ()))
-handleHostOp (SizeOp op) =
+handleHostOp _ (SizeOp op) =
   pure $ Inner $ SizeOp op
-handleHostOp (OtherOp op) =
+handleHostOp _ (OtherOp op) =
   error $ "Cannot allocate memory in SOAC: " ++ prettyString op
-handleHostOp (SegOp op) =
-  Inner . SegOp <$> handleSegOp op
-handleHostOp (GPUBody ts (Body _ stms res)) =
+handleHostOp outer_lvl (SegOp op) =
+  Inner . SegOp <$> handleSegOp outer_lvl op
+handleHostOp _ (GPUBody ts (Body _ stms res)) =
   fmap (Inner . GPUBody ts) . buildBody_ . allocInStms stms $ pure res
 
 kernelExpHints :: Exp GPUMem -> AllocM GPU GPUMem [ExpHint]
@@ -79,9 +97,9 @@ kernelExpHints (BasicOp (Manifest perm v)) = do
       dims' = rearrangeShape perm dims
       ixfun = IxFun.permute (IxFun.iota $ map pe64 dims') perm_inv
   pure [Hint ixfun DefaultSpace]
-kernelExpHints (Op (Inner (SegOp (SegMap lvl@SegThread {} space ts body)))) =
+kernelExpHints (Op (Inner (SegOp (SegMap lvl@(SegThread _ _) space ts body)))) =
   zipWithM (mapResultHint lvl space) ts $ kernelBodyResult body
-kernelExpHints (Op (Inner (SegOp (SegRed lvl@SegThread {} space reds ts body)))) =
+kernelExpHints (Op (Inner (SegOp (SegRed lvl@(SegThread _ _) space reds ts body)))) =
   (map (const NoHint) red_res <>) <$> zipWithM (mapResultHint lvl space) (drop num_reds ts) map_res
   where
     num_reds = segBinOpResults reds
@@ -166,11 +184,11 @@ inThreadExpHints e = do
 
 -- | The pass from 'GPU' to 'GPUMem'.
 explicitAllocations :: Pass GPU GPUMem
-explicitAllocations = explicitAllocationsGeneric handleHostOp kernelExpHints
+explicitAllocations = explicitAllocationsGeneric (handleHostOp Nothing) kernelExpHints
 
 -- | Convert some 'GPU' stms to 'GPUMem'.
 explicitAllocationsInStms ::
   (MonadFreshNames m, HasScope GPUMem m) =>
   Stms GPU ->
   m (Stms GPUMem)
-explicitAllocationsInStms = explicitAllocationsInStmsGeneric handleHostOp kernelExpHints
+explicitAllocationsInStms = explicitAllocationsInStmsGeneric (handleHostOp Nothing) kernelExpHints

--- a/src/Futhark/Pass/ExtractKernels/Intragroup.hs
+++ b/src/Futhark/Pass/ExtractKernels/Intragroup.hs
@@ -60,12 +60,9 @@ intraGroupParallelise knest lam = runMaybeT $ do
   let body = lambdaBody lam
 
   group_size <- newVName "computed_group_size"
-  let intra_lvl = SegThread (Count num_groups) (Count $ Var group_size) SegNoVirt
-
   (wss_min, wss_avail, log, kbody) <-
-    lift $
-      localScope (scopeOfLParams $ lambdaParams lam) $
-        intraGroupParalleliseBody intra_lvl body
+    lift . localScope (scopeOfLParams $ lambdaParams lam) $
+      intraGroupParalleliseBody body
 
   outside_scope <- lift askScope
   -- outside_scope may also contain the inputs, even though those are
@@ -116,12 +113,10 @@ intraGroupParallelise knest lam = runMaybeT $ do
 
   let nested_pat = loopNestingPat first_nest
       rts = map (length ispace `stripArray`) $ patTypes nested_pat
-      lvl = SegGroup (Count num_groups) (Count $ Var group_size) SegNoVirt
+      grid = KernelGrid (Count num_groups) (Count $ Var group_size)
+      lvl = SegGroup SegNoVirt (Just grid)
       kstm =
-        Let nested_pat aux $
-          Op $
-            SegOp $
-              SegMap lvl kspace rts kbody'
+        Let nested_pat aux $ Op $ SegOp $ SegMap lvl kspace rts kbody'
 
   let intra_min_par = intra_avail_par
   pure
@@ -184,21 +179,21 @@ parallelMin ws =
         accAvailPar = S.singleton ws
       }
 
-intraGroupBody :: SegLevel -> Body SOACS -> IntraGroupM (Body GPU)
-intraGroupBody lvl body = do
-  stms <- collectStms_ $ intraGroupStms lvl $ bodyStms body
+intraGroupBody :: Body SOACS -> IntraGroupM (Body GPU)
+intraGroupBody body = do
+  stms <- collectStms_ $ intraGroupStms $ bodyStms body
   pure $ mkBody stms $ bodyResult body
 
-intraGroupStm :: SegLevel -> Stm SOACS -> IntraGroupM ()
-intraGroupStm lvl stm@(Let pat aux e) = do
+intraGroupStm :: Stm SOACS -> IntraGroupM ()
+intraGroupStm stm@(Let pat aux e) = do
   scope <- askScope
-  let lvl' = SegThread (segNumGroups lvl) (segGroupSize lvl) SegNoVirt
+  let lvl = SegThread SegNoVirt Nothing
 
   case e of
     DoLoop merge form loopbody ->
       localScope (scopeOf form') $
         localScope (scopeOfFParams $ map fst merge) $ do
-          loopbody' <- intraGroupBody lvl loopbody
+          loopbody' <- intraGroupBody loopbody
           certifying (stmAuxCerts aux) $
             letBind pat $
               DoLoop merge form' loopbody'
@@ -207,13 +202,13 @@ intraGroupStm lvl stm@(Let pat aux e) = do
           ForLoop i it bound inps -> ForLoop i it bound inps
           WhileLoop cond -> WhileLoop cond
     Match cond cases defbody ifdec -> do
-      cases' <- mapM (traverse $ intraGroupBody lvl) cases
-      defbody' <- intraGroupBody lvl defbody
+      cases' <- mapM (traverse intraGroupBody) cases
+      defbody' <- intraGroupBody defbody
       certifying (stmAuxCerts aux) . letBind pat $
         Match cond cases' defbody' ifdec
     Op soac
       | "sequential_outer" `inAttrs` stmAuxAttrs aux ->
-          intraGroupStms lvl . fmap (certify (stmAuxCerts aux))
+          intraGroupStms . fmap (certify (stmAuxCerts aux))
             =<< runBuilder_ (FOT.transformSOAC pat soac)
     Op (Screma w arrs form)
       | Just lam <- isMapSOAC form -> do
@@ -229,7 +224,7 @@ intraGroupStm lvl stm@(Let pat aux e) = do
                     distOnInnerMap =
                       distributeMap,
                     distOnTopLevelStms =
-                      liftInner . collectStms_ . intraGroupStms lvl,
+                      liftInner . collectStms_ . intraGroupStms,
                     distSegLevel = \minw _ _ -> do
                       lift $ parallelMin minw
                       pure lvl,
@@ -252,7 +247,7 @@ intraGroupStm lvl stm@(Let pat aux e) = do
           let scanfun' = soacsLambdaToGPU scanfun
               mapfun' = soacsLambdaToGPU mapfun
           certifying (stmAuxCerts aux) $
-            addStms =<< segScan lvl' pat mempty w [SegBinOp Noncommutative scanfun' nes mempty] mapfun' arrs [] []
+            addStms =<< segScan lvl pat mempty w [SegBinOp Noncommutative scanfun' nes mempty] mapfun' arrs [] []
           parallelMin [w]
     Op (Screma w arrs form)
       | Just (reds, map_lam) <- isRedomapSOAC form,
@@ -260,7 +255,7 @@ intraGroupStm lvl stm@(Let pat aux e) = do
           let red_lam' = soacsLambdaToGPU red_lam
               map_lam' = soacsLambdaToGPU map_lam
           certifying (stmAuxCerts aux) $
-            addStms =<< segRed lvl' pat mempty w [SegBinOp comm red_lam' nes mempty] map_lam' arrs [] []
+            addStms =<< segRed lvl pat mempty w [SegBinOp comm red_lam' nes mempty] map_lam' arrs [] []
           parallelMin [w]
     Op (Hist w arrs ops bucket_fun) -> do
       ops' <- forM ops $ \(HistOp num_bins rf dests nes op) -> do
@@ -270,7 +265,7 @@ intraGroupStm lvl stm@(Let pat aux e) = do
 
       let bucket_fun' = soacsLambdaToGPU bucket_fun
       certifying (stmAuxCerts aux) $
-        addStms =<< segHist lvl' pat w [] [] ops' bucket_fun' arrs
+        addStms =<< segHist lvl pat w [] [] ops' bucket_fun' arrs
       parallelMin [w]
     Op (Stream w arrs accs lam)
       | chunk_size_param : _ <- lambdaParams lam -> do
@@ -281,7 +276,7 @@ intraGroupStm lvl stm@(Let pat aux e) = do
               replace se = se
               replaceSets (IntraAcc x y log) =
                 IntraAcc (S.map (map replace) x) (S.map (map replace) y) log
-          censor replaceSets $ intraGroupStms lvl stream_stms
+          censor replaceSets $ intraGroupStms stream_stms
     Op (Scatter w ivs lam dests) -> do
       write_i <- newVName "write_i"
       space <- mkSegSpace [(write_i, w)]
@@ -308,23 +303,22 @@ intraGroupStm lvl stm@(Let pat aux e) = do
       certifying (stmAuxCerts aux) $ do
         let ts = zipWith (stripArray . length) dests_ws $ patTypes pat
             body = KernelBody () kstms krets
-        letBind pat $ Op $ SegOp $ SegMap lvl' space ts body
+        letBind pat $ Op $ SegOp $ SegMap lvl space ts body
 
       parallelMin [w]
     _ ->
       addStm $ soacsStmToGPU stm
 
-intraGroupStms :: SegLevel -> Stms SOACS -> IntraGroupM ()
-intraGroupStms lvl = mapM_ (intraGroupStm lvl)
+intraGroupStms :: Stms SOACS -> IntraGroupM ()
+intraGroupStms = mapM_ intraGroupStm
 
 intraGroupParalleliseBody ::
   (MonadFreshNames m, HasScope GPU m) =>
-  SegLevel ->
   Body SOACS ->
   m ([[SubExp]], [[SubExp]], Log, KernelBody GPU)
-intraGroupParalleliseBody lvl body = do
+intraGroupParalleliseBody body = do
   (IntraAcc min_ws avail_ws log, kstms) <-
-    runIntraGroupM $ intraGroupStms lvl $ bodyStms body
+    runIntraGroupM $ intraGroupStms $ bodyStms body
   pure
     ( S.toList min_ws,
       S.toList avail_ws,

--- a/src/Futhark/Pass/ExtractKernels/StreamKernel.hs
+++ b/src/Futhark/Pass/ExtractKernels/StreamKernel.hs
@@ -74,7 +74,9 @@ segThreadCapped ws desc r = do
             (SDivUp Int64 Unsafe)
             (eSubExp w)
             (eSubExp =<< asIntS Int64 group_size)
-      pure $ SegThread (Count usable_groups) (Count group_size) SegNoVirt
+      let grid = KernelGrid (Count usable_groups) (Count group_size)
+      pure $ SegThread SegNoVirt (Just grid)
     NoRecommendation v -> do
       (num_groups, _) <- numberOfGroups desc w group_size
-      pure $ SegThread (Count num_groups) (Count group_size) v
+      let grid = KernelGrid (Count num_groups) (Count group_size)
+      pure $ SegThread v (Just grid)

--- a/src/Futhark/Pass/ExtractKernels/ToGPU.hs
+++ b/src/Futhark/Pass/ExtractKernels/ToGPU.hs
@@ -34,10 +34,12 @@ segThread ::
   String ->
   m SegLevel
 segThread desc =
-  SegThread
-    <$> (Count <$> getSize (desc ++ "_num_groups") SizeNumGroups)
-    <*> (Count <$> getSize (desc ++ "_group_size") SizeGroup)
-    <*> pure SegVirt
+  SegThread SegVirt <$> (Just <$> kernelGrid)
+  where
+    kernelGrid =
+      KernelGrid
+        <$> (Count <$> getSize (desc ++ "_num_groups") SizeNumGroups)
+        <*> (Count <$> getSize (desc ++ "_group_size") SizeGroup)
 
 injectSOACS ::
   ( Monad m,

--- a/tests/tiling/tiling_1d.fut
+++ b/tests/tiling/tiling_1d.fut
@@ -4,4 +4,4 @@
 -- structure gpu { SegMap/DoLoop/SegMap 2 }
 
 def main (xs: []i32) =
-  map (\x -> i32.sum (map (+x) xs)) xs
+  map (\x -> #[sequential] i32.sum (map (+x) xs)) xs

--- a/tests/tiling/tiling_2d.fut
+++ b/tests/tiling/tiling_2d.fut
@@ -6,4 +6,4 @@
 -- SegMap/DoLoop/DoLoop/SegMap/DoLoop 3 }
 
 def main (xs: [][]i32) (ys: [][]i32) =
-  map (\xs' -> map (\ys' -> i32.sum (map2 (*) xs' ys')) ys) xs
+  map (\xs' -> map (\ys' -> #[sequential] i32.sum (map2 (*) xs' ys')) ys) xs


### PR DESCRIPTION
Now we have three levels: SegThread, SegGroup, and SegThreadInGroup.

Also, the specification of the grid size has been decoupled and made optional.  This allows us to generate flat parallelism without being forced to worry about the low-level details of how many threads to launch (although flattening will still presently mostly do that).  We still have freedom to decide if we wish, for example in tiling, which has also been slightly rewritten.