### PR TITLE
Add .git to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 /*
 !/*/
 
+# The previous lines explicitly unignores .git
+/.git
+
 # Ignore Emacs autosave files.
 
 \#*\#


### PR DESCRIPTION
The two first lines of our .gitignore explicitly unignore the .git folder.

This creates problems for tools such as ripgrep which rely on parsing the .gitignore file. See for instance the discussion here: https://github.com/BurntSushi/ripgrep/issues/2329

On another note, perhaps we might want to get rid of those two lines? As an alternative, we could codify that the /scratch directory is ignored, and could be used for the same purpose as the root directory currently is.