### PR TITLE
Correct number of locks for local memory case.

### DIFF
--- a/src/Futhark/CodeGen/ImpGen/GPU/SegHist.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/SegHist.hs
@@ -542,10 +542,7 @@ prepareIntermediateArraysLocal num_subhistos_per_group groups_per_segment =
           AtomicCAS f -> pure $ const $ pure f
           AtomicLocking f -> pure $ \hist_H_chk -> do
             let lock_shape =
-                  Shape $
-                    tvSize num_subhistos_per_group
-                      : shapeDims (histOpShape op)
-                      ++ [hist_H_chk]
+                  Shape [tvSize num_subhistos_per_group, hist_H_chk]
 
             let dims = map pe64 $ shapeDims lock_shape
 


### PR DESCRIPTION
Previously we would create a lock for every single element, but this is wasteful (and unnecessary) in the case of vectorised operators, where we (at least currently) take the lock based only on the non-vector indexes.

It might be worth changing that (as it would cause less lock contention), and then this commit would have to be reverted.