### PR TITLE
Generate reqd_work_group_size for OpenCL kernels.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Generalised histograms now supported in AD.  Work by Lotte Bruun and
   Ulrik Larsen.
 
+* OpenCL kernels now embed group size information, which can
+  potentially be used for better register allocation by the OpenCL
+  implementation.
+
 ### Removed
 
 ### Changed

--- a/rts/c/opencl.h
+++ b/rts/c/opencl.h
@@ -517,6 +517,12 @@ static char* mk_compile_opts(struct opencl_context *ctx,
                    "-DLOCKSTEP_WIDTH=%d ",
                    (int)ctx->lockstep_width);
 
+  // XXX: Ugh
+  w += snprintf(compile_opts+w, compile_opts_size-w,
+                "-D%s=%d ",
+                "max_group_size",
+                (int)ctx->max_group_size);
+
   for (int i = 0; i < ctx->cfg.num_sizes; i++) {
     w += snprintf(compile_opts+w, compile_opts_size-w,
                   "-D%s=%d ",

--- a/rts/python/opencl.py
+++ b/rts/python/opencl.py
@@ -217,6 +217,8 @@ def initialise_opencl_object(self,
     if (len(program_src) >= 0):
         build_options += ["-DLOCKSTEP_WIDTH={}".format(lockstep_width)]
 
+        build_options += ["-D{}={}".format('max_group_size', max_group_size)]
+
         build_options += ["-D{}={}".format(s.
                                            replace('z', 'zz').
                                            replace('.', 'zi').

--- a/src/Futhark/CodeGen/Backends/COpenCL.hs
+++ b/src/Futhark/CodeGen/Backends/COpenCL.hs
@@ -326,16 +326,30 @@ staticOpenCLArray name "device" t vs = do
 staticOpenCLArray _ space _ _ =
   error $ "OpenCL backend cannot create static array in memory space '" ++ space ++ "'"
 
+kernelConstToExp :: KernelConst -> C.Exp
+kernelConstToExp (SizeConst key) =
+  [C.cexp|*ctx->tuning_params.$id:key|]
+kernelConstToExp (SizeMaxConst size_class) =
+  [C.cexp|ctx->opencl.$id:field|]
+  where
+    field = "max_" <> prettyString size_class
+
+compileGroupDim :: GroupDim -> GC.CompilerM op s C.Exp
+compileGroupDim (Left e) = GC.compileExp e
+compileGroupDim (Right kc) = pure $ kernelConstToExp kc
+
 callKernel :: GC.OpCompiler OpenCL ()
-callKernel (GetSize v key) =
-  GC.stm [C.cstm|$id:v = *ctx->tuning_params.$id:key;|]
+callKernel (GetSize v key) = do
+  let e = kernelConstToExp $ SizeConst key
+  GC.stm [C.cstm|$id:v = $exp:e;|]
 callKernel (CmpSizeLe v key x) = do
+  let e = kernelConstToExp $ SizeConst key
   x' <- GC.compileExp x
-  GC.stm [C.cstm|$id:v = *ctx->tuning_params.$id:key <= $exp:x';|]
+  GC.stm [C.cstm|$id:v = $exp:e <= $exp:x';|]
   sizeLoggingCode v key x'
-callKernel (GetSizeMax v size_class) =
-  let field = "max_" ++ prettyString size_class
-   in GC.stm [C.cstm|$id:v = ctx->opencl.$id:field;|]
+callKernel (GetSizeMax v size_class) = do
+  let e = kernelConstToExp $ SizeMaxConst size_class
+  GC.stm [C.cstm|$id:v = $exp:e;|]
 callKernel (LaunchKernel safety name args num_workgroups workgroup_size) = do
   -- The other failure args are set automatically when the kernel is
   -- first created.
@@ -349,7 +363,7 @@ callKernel (LaunchKernel safety name args num_workgroups workgroup_size) = do
 
   zipWithM_ setKernelArg [numFailureParams safety ..] args
   num_workgroups' <- mapM GC.compileExp num_workgroups
-  workgroup_size' <- mapM GC.compileExp workgroup_size
+  workgroup_size' <- mapM compileGroupDim workgroup_size
   local_bytes <- foldM localBytes [C.cexp|0|] args
 
   launchKernel name num_workgroups' workgroup_size' local_bytes

--- a/src/Futhark/CodeGen/Backends/GenericC/Pretty.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC/Pretty.hs
@@ -7,6 +7,7 @@ module Futhark.CodeGen.Backends.GenericC.Pretty
     definitionsText,
     typeText,
     idText,
+    funcText,
     funcsText,
   )
 where
@@ -29,5 +30,8 @@ typeText = T.pack . MPP.pretty 8000 . MPP.ppr
 idText :: C.Id -> T.Text
 idText = T.pack . MPP.pretty 8000 . MPP.ppr
 
+funcText :: C.Func -> T.Text
+funcText = T.pack . MPP.pretty 8000 . MPP.ppr
+
 funcsText :: [C.Func] -> T.Text
-funcsText = T.unlines . map (T.pack . MPP.pretty 8000 . MPP.ppr)
+funcsText = T.unlines . map funcText

--- a/src/Futhark/CodeGen/ImpCode/OpenCL.hs
+++ b/src/Futhark/CodeGen/ImpCode/OpenCL.hs
@@ -16,6 +16,8 @@ module Futhark.CodeGen.ImpCode.OpenCL
     numFailureParams,
     KernelTarget (..),
     FailureMsg (..),
+    GroupDim,
+    KernelConst (..),
     module Futhark.CodeGen.ImpCode,
     module Futhark.IR.GPU.Sizes,
   )
@@ -24,6 +26,7 @@ where
 import Data.Map qualified as M
 import Data.Text qualified as T
 import Futhark.CodeGen.ImpCode
+import Futhark.CodeGen.ImpCode.GPU (GroupDim, KernelConst (..))
 import Futhark.IR.GPU.Sizes
 import Futhark.Util.Pretty
 
@@ -92,7 +95,7 @@ numFailureParams SafetyFull = 3
 
 -- | Host-level OpenCL operation.
 data OpenCL
-  = LaunchKernel KernelSafety KernelName [KernelArg] [Exp] [Exp]
+  = LaunchKernel KernelSafety KernelName [KernelArg] [Exp] [GroupDim]
   | GetSize VName Name
   | CmpSizeLe VName Name Exp
   | GetSizeMax VName SizeClass

--- a/src/Futhark/CodeGen/ImpGen/GPU/Transpose.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/Transpose.hs
@@ -327,7 +327,7 @@ mapTransposeKernel desc block_dim_int args t kind =
           <> mapTranspose block_dim args t kind,
       kernelUses = uses,
       kernelNumGroups = map untyped num_groups,
-      kernelGroupSize = map untyped group_size,
+      kernelGroupSize = map (Left . untyped) group_size,
       kernelName = nameFromString name,
       kernelFailureTolerant = True,
       kernelCheckLocalMemory = False

--- a/src/Futhark/IR/Prop/Names.hs
+++ b/src/Futhark/IR/Prop/Names.hs
@@ -213,6 +213,9 @@ instance (FreeIn a, FreeIn b, FreeIn c) => FreeIn (a, b, c) where
 instance (FreeIn a, FreeIn b, FreeIn c, FreeIn d) => FreeIn (a, b, c, d) where
   freeIn' (a, b, c, d) = freeIn' a <> freeIn' b <> freeIn' c <> freeIn' d
 
+instance (FreeIn a, FreeIn b) => FreeIn (Either a b) where
+  freeIn' = either freeIn' freeIn'
+
 instance FreeIn a => FreeIn [a] where
   freeIn' = foldMap freeIn'
 


### PR DESCRIPTION
In principle this allows better register allocations for OpenCL kernels.  If nothing else, it fixes cases where the NVIDIA OpenCL implementation would use so many registers that we couldn't even launch the kernel with a large group size.