### PR TITLE
futhark-literate: Add :audio directive

### DIFF
--- a/docs/man/futhark-literate.rst
+++ b/docs/man/futhark-literate.rst
@@ -32,7 +32,7 @@ programming techniques.
 **Warning:** Do not run untrusted programs.  See SAFETY below.
 
 Image directives and builtin functions shell out to ``convert`` (from
-ImageMagick).  Video generation uses ``ffmpeg``.
+ImageMagick).  Video and audio generation uses ``ffmpeg``.
 
 For an input file ``foo.fut``, all generated files will be in a
 directory named ``foo-img``.  A ``file`` parameter passed to a
@@ -193,6 +193,12 @@ The following directives are supported:
 
   Use ``set term png size width,height`` to change the size to
   ``width`` by ``height`` pixels.
+
+* ``> :audio e``
+
+  Creates a sound-file from ``e``, which must be an expression of type ``[]i8``.
+  It is interpreted as a 8-bit PCM audio at 44100 Hz and turned into a
+  wave-soundfile.
 
 FUTHARKSCRIPT
 =============

--- a/tests_literate/audio.fut
+++ b/tests_literate/audio.fut
@@ -1,0 +1,9 @@
+def fs = 44100i64
+def standard_pitch = 440.0f32
+
+def main =
+  tabulate fs (\k -> f32.sin (2 * f32.pi * f32.i64 k * standard_pitch / f32.i64 fs))
+     |> map ((*) (f32.i8 i8.highest))
+     |> map i8.f32
+
+-- > :audio main

--- a/tests_literate/expected/audio.md
+++ b/tests_literate/expected/audio.md
@@ -1,0 +1,18 @@
+
+```futhark
+def fs = 44100i64
+def standard_pitch = 440.0f32
+
+def main =
+  tabulate fs (\k -> f32.sin (2 * f32.pi * f32.i64 k * standard_pitch / f32.i64 fs))
+     |> map ((*) (f32.i8 i8.highest))
+     |> map i8.f32
+```
+
+```
+> :audio main
+```
+
+
+![](audio-img/dc2770fc8484099098130e52533f3283-audio.wav)
+


### PR DESCRIPTION
So far it only handles 8-bit audio at 44100 Hz, but we should be able to extend it if needed.