### PR TITLE
Do not use static arrays in GPU codegen.

### DIFF
--- a/src/Futhark/CodeGen/Backends/GenericC.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC.hs
@@ -66,7 +66,6 @@ defaultOperations =
       opsAllocate = defAllocate,
       opsDeallocate = defDeallocate,
       opsCopy = defCopy,
-      opsStaticArray = defStaticArray,
       opsMemoryType = defMemoryType,
       opsCompiler = defCompiler,
       opsFatMemory = True,
@@ -87,8 +86,6 @@ defaultOperations =
       copyMemoryDefaultSpace destmem destoffset srcmem srcoffset size
     defCopy _ _ _ _ _ _ _ _ =
       error "Cannot copy to or from non-default memory space"
-    defStaticArray _ _ _ _ =
-      error "Cannot create static array in non-default memory space"
     defMemoryType _ =
       error "Has no type for non-default memory space"
     defCompiler _ =

--- a/src/Futhark/CodeGen/Backends/GenericC/Code.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC/Code.hs
@@ -324,9 +324,7 @@ compileCode (DeclareMem name space) =
 compileCode (DeclareScalar name vol t) = do
   let ct = primTypeToCType t
   decl [C.cdecl|$tyquals:(volQuals vol) $ty:ct $id:name;|]
-compileCode (DeclareArray name ScalarSpace {} _ _) =
-  error $ "Cannot declare array " ++ prettyString name ++ " in scalar space."
-compileCode (DeclareArray name DefaultSpace t vs) = do
+compileCode (DeclareArray name t vs) = do
   name_realtype <- newVName $ baseString name ++ "_realtype"
   let ct = primTypeToCType t
   case vs of
@@ -342,13 +340,6 @@ compileCode (DeclareArray name DefaultSpace t vs) = do
                                  (unsigned char*)$id:name_realtype,
                                  0,
                                  $string:(prettyString name)};|]
-compileCode (DeclareArray name (Space space) t vs) =
-  join $
-    asks (opsStaticArray . envOperations)
-      <*> pure name
-      <*> pure space
-      <*> pure t
-      <*> pure vs
 -- For assignments of the form 'x = x OP e', we generate C assignment
 -- operators to make the resulting code slightly nicer.  This has no
 -- effect on performance.

--- a/src/Futhark/CodeGen/Backends/GenericC/Monad.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC/Monad.hs
@@ -18,7 +18,6 @@ module Futhark.CodeGen.Backends.GenericC.Monad
     Deallocate,
     CopyBarrier (..),
     Copy,
-    StaticArray,
 
     -- * Monadic compiler interface
     CompilerM,
@@ -187,9 +186,6 @@ type Allocate op s =
 -- given size,, which is in the given memory space.
 type Deallocate op s = C.Exp -> C.Exp -> C.Exp -> SpaceId -> CompilerM op s ()
 
--- | Create a static array of values - initialised at load time.
-type StaticArray op s = VName -> SpaceId -> PrimType -> ArrayContents -> CompilerM op s ()
-
 -- | Whether a copying operation should implicitly function as a
 -- barrier regarding further operations on the source.  This is a
 -- rather subtle detail and is mostly useful for letting some
@@ -222,7 +218,6 @@ data Operations op s = Operations
     opsAllocate :: Allocate op s,
     opsDeallocate :: Deallocate op s,
     opsCopy :: Copy op s,
-    opsStaticArray :: StaticArray op s,
     opsMemoryType :: MemoryType op s,
     opsCompiler :: OpCompiler op s,
     opsError :: ErrorCompiler op s,

--- a/src/Futhark/CodeGen/Backends/GenericPython.hs
+++ b/src/Futhark/CodeGen/Backends/GenericPython.hs
@@ -162,7 +162,7 @@ defaultOperations =
 
 data CompilerEnv op s = CompilerEnv
   { envOperations :: Operations op s,
-    envVarExp :: M.Map VName PyExp
+    envVarExp :: M.Map String PyExp
   }
 
 envOpCompiler :: CompilerEnv op s -> OpCompiler op s
@@ -480,7 +480,7 @@ withConstantSubsts (Imp.Constants ps _) =
   where
     constExp p =
       M.singleton
-        (Imp.paramName p)
+        (compileName $ Imp.paramName p)
         (Index (Var "self.constants") $ IdxExp $ String $ prettyText $ Imp.paramName p)
 
 compileConstants :: Imp.Constants op -> CompilerM op s ()
@@ -1094,8 +1094,9 @@ compilePrimValue (BoolValue v) = Bool v
 compilePrimValue UnitValue = Var "None"
 
 compileVar :: VName -> CompilerM op s PyExp
-compileVar v =
-  asks $ fromMaybe (Var $ compileName v) . M.lookup v . envVarExp
+compileVar v = asks $ fromMaybe (Var v') . M.lookup v' . envVarExp
+  where
+    v' = compileName v
 
 -- | Tell me how to compile a @v@, and I'll Compile any @PrimExp v@ for you.
 compilePrimExp :: Monad m => (v -> m PyExp) -> Imp.PrimExp v -> m PyExp

--- a/src/Futhark/CodeGen/Backends/GenericPython.hs
+++ b/src/Futhark/CodeGen/Backends/GenericPython.hs
@@ -28,7 +28,6 @@ module Futhark.CodeGen.Backends.GenericPython
     ReadScalar,
     Allocate,
     Copy,
-    StaticArray,
     EntryOutput,
     EntryInput,
     CompilerEnv (..),
@@ -102,9 +101,6 @@ type Copy op s =
   PrimType ->
   CompilerM op s ()
 
--- | Create a static array of values - initialised at load time.
-type StaticArray op s = VName -> Imp.SpaceId -> PrimType -> Imp.ArrayContents -> CompilerM op s ()
-
 -- | Construct the Python array being returned from an entry point.
 type EntryOutput op s =
   VName ->
@@ -129,7 +125,6 @@ data Operations op s = Operations
     opsReadScalar :: ReadScalar op s,
     opsAllocate :: Allocate op s,
     opsCopy :: Copy op s,
-    opsStaticArray :: StaticArray op s,
     opsCompiler :: OpCompiler op s,
     opsEntryOutput :: EntryOutput op s,
     opsEntryInput :: EntryInput op s
@@ -145,7 +140,6 @@ defaultOperations =
       opsReadScalar = defReadScalar,
       opsAllocate = defAllocate,
       opsCopy = defCopy,
-      opsStaticArray = defStaticArray,
       opsCompiler = defCompiler,
       opsEntryOutput = defEntryOutput,
       opsEntryInput = defEntryInput
@@ -159,8 +153,6 @@ defaultOperations =
       error "Cannot allocate in non-default memory space"
     defCopy _ _ _ _ _ _ _ _ =
       error "Cannot copy to or from non-default memory space"
-    defStaticArray _ _ _ _ =
-      error "Cannot create static array in non-default memory space"
     defCompiler _ =
       error "The default compiler cannot compile extended operations"
     defEntryOutput _ _ _ _ =
@@ -187,9 +179,6 @@ envAllocate = opsAllocate . envOperations
 
 envCopy :: CompilerEnv op s -> Copy op s
 envCopy = opsCopy . envOperations
-
-envStaticArray :: CompilerEnv op s -> StaticArray op s
-envStaticArray = opsStaticArray . envOperations
 
 envEntryOutput :: CompilerEnv op s -> EntryOutput op s
 envEntryOutput = opsEntryOutput . envOperations
@@ -1197,14 +1186,7 @@ compileCode (Imp.DeclareScalar v _ Unit) = do
   v' <- compileVar v
   stm $ Assign v' $ Var "True"
 compileCode Imp.DeclareScalar {} = pure ()
-compileCode (Imp.DeclareArray name (Space space) t vs) =
-  join $
-    asks envStaticArray
-      <*> pure name
-      <*> pure space
-      <*> pure t
-      <*> pure vs
-compileCode (Imp.DeclareArray name _ t vs) = do
+compileCode (Imp.DeclareArray name t vs) = do
   let arr_name = compileName name <> "_arr"
   -- It is important to store the Numpy array in a temporary variable
   -- to prevent it from going "out-of-scope" before calling

--- a/src/Futhark/CodeGen/Backends/MulticoreISPC.hs
+++ b/src/Futhark/CodeGen/Backends/MulticoreISPC.hs
@@ -500,7 +500,7 @@ compileCode (DeclareScalar name _ t) = do
   let ct = GC.primTypeToCType t
   quals <- getVariabilityQuals name
   GC.decl [C.cdecl|$tyquals:quals $ty:ct $id:name;|]
-compileCode (DeclareArray name DefaultSpace t vs) = do
+compileCode (DeclareArray name t vs) = do
   name_realtype <- newVName $ baseString name ++ "_realtype"
   let ct = GC.primTypeToCType t
   case vs of

--- a/src/Futhark/CodeGen/Backends/PyOpenCL.hs
+++ b/src/Futhark/CodeGen/Backends/PyOpenCL.hs
@@ -345,10 +345,9 @@ copyOpenCLMemory destmem destidx Imp.DefaultSpace srcmem srcidx (Imp.Space "devi
             ArgKeyword "device_offset" $ asLong srcidx,
             ArgKeyword "is_blocking" $ Var "synchronous"
           ]
-copyOpenCLMemory destmem destidx (Imp.Space "device") srcmem srcidx Imp.DefaultSpace nbytes bt = do
-  let divide = BinOp "//" nbytes (Integer $ Imp.primByteSize bt)
-      end = BinOp "+" srcidx divide
-      src = Index srcmem (IdxRange srcidx end)
+copyOpenCLMemory destmem destidx (Imp.Space "device") srcmem srcidx Imp.DefaultSpace nbytes _ = do
+  let end = BinOp "+" srcidx nbytes
+      src = Index (Py.simpleCall "createArray" [srcmem, List [nbytes], Var "np.byte"]) (IdxRange srcidx end)
   Py.stm $
     ifNotZeroSize nbytes $
       Exp $

--- a/src/Futhark/CodeGen/ImpGen.hs
+++ b/src/Futhark/CodeGen/ImpGen.hs
@@ -994,15 +994,13 @@ defCompileBasicOp (Pat [pe]) (Concat i (x :| ys) _) = do
 defCompileBasicOp (Pat [pe]) (ArrayLit es _)
   | Just vs@(v : _) <- mapM isLiteral es = do
       dest_mem <- entryArrayLoc <$> lookupArray (patElemName pe)
-      dest_space <- entryMemSpace <$> lookupMemory (memLocName dest_mem)
       let t = primValueType v
       static_array <- newVNameForFun "static_array"
       emit $ Imp.DeclareArray static_array t $ Imp.ArrayValues vs
       let static_src =
             MemLoc static_array [intConst Int64 $ fromIntegral $ length es] $
               IxFun.iota [fromIntegral $ length es]
-          entry = MemVar Nothing $ MemEntry dest_space
-      addVar static_array entry
+      addVar static_array $ MemVar Nothing $ MemEntry DefaultSpace
       copy t dest_mem static_src
   | otherwise =
       forM_ (zip [0 ..] es) $ \(i, e) ->

--- a/src/Futhark/CodeGen/ImpGen/GPU.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU.hs
@@ -217,9 +217,7 @@ withAcc pat inputs lam = do
       | Just (op_lam, _) <- op,
         AtomicLocking _ <- atomicUpdateLocking atomics op_lam = do
           let num_locks = 100151
-          locks_arr <-
-            sStaticArray "withacc_locks" (Space "device") int32 $
-              Imp.ArrayZeros num_locks
+          locks_arr <- genZeroes "withacc_locks" num_locks
           let locks = Locks locks_arr num_locks
               extend env = env {hostLocks = M.insert c locks $ hostLocks env}
           localEnv extend $ locksForInputs atomics inputs'

--- a/src/Futhark/CodeGen/ImpGen/GPU/SegHist.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/SegHist.hs
@@ -185,9 +185,7 @@ prepareAtomicUpdateGlobal l dests slug =
                 ++ [tvSize (slugNumSubhistos slug)]
                 ++ shapeDims (histShape (slugOp slug))
 
-      locks <-
-        sStaticArray "hist_locks" (Space "device") int32 $
-          Imp.ArrayZeros num_locks
+      locks <- genZeroes "hist_locks" num_locks
       let l' = Locking locks 0 1 0 (pure . (`rem` fromIntegral num_locks) . flattenIndex dims)
       pure (Just l', f l' (Space "global") dests)
 

--- a/src/Futhark/CodeGen/ImpGen/GPU/SegRed.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/SegRed.hs
@@ -189,9 +189,7 @@ nonsegmentedReduction segred_pat num_groups group_size space reds body = do
       global_tid = Imp.le64 $ segFlat space
       w = last dims'
 
-  counter <-
-    sStaticArray "counter" (Space "device") int32 $
-      Imp.ArrayZeros (fromIntegral maxNumOps)
+  counter <- genZeroes "counters" $ fromIntegral maxNumOps
 
   reds_group_res_arrs <- groupResultArrays num_groups group_size reds
 
@@ -430,9 +428,7 @@ largeSegmentsReduction segred_pat num_groups group_size space reds body = do
   -- if the group count exceeds the maximum group size, which is at
   -- most 1024 anyway.
   let num_counters = fromIntegral maxNumOps * 1024
-  counter <-
-    sStaticArray "counter" (Space "device") int32 $
-      Imp.ArrayZeros num_counters
+  counter <- genZeroes "counters" num_counters
 
   sKernelThread "segred_large" (segFlat space) (defKernelAttrs num_groups group_size) $ do
     constants <- kernelConstants <$> askEnv

--- a/src/Futhark/CodeGen/ImpGen/GPU/SegScan/SinglePass.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/SegScan/SinglePass.hs
@@ -260,7 +260,7 @@ compileSegScan pat lvl space scanOp kbody = do
   emit $ Imp.DebugPrint "Register constraint" $ Just $ untyped (fromIntegral reg_constraint :: Imp.TExp Int32)
   emit $ Imp.DebugPrint "sumT'" $ Just $ untyped (fromIntegral sumT' :: Imp.TExp Int32)
 
-  globalId <- sStaticArray "id_counter" (Space "device") int32 $ Imp.ArrayZeros 1
+  globalId <- genZeroes "id_counter" 1
   statusFlags <- sAllocArray "status_flags" int8 (Shape [unCount num_groups]) (Space "device")
   (aggregateArrays, incprefixArrays) <-
     fmap unzip $

--- a/src/Futhark/CodeGen/ImpGen/GPU/ToOpenCL.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/ToOpenCL.hs
@@ -700,7 +700,6 @@ inKernelOperations env mode body =
       GC.opsAllocate = cannotAllocate,
       GC.opsDeallocate = cannotDeallocate,
       GC.opsCopy = copyInKernel,
-      GC.opsStaticArray = noStaticArrays,
       GC.opsFatMemory = False,
       GC.opsError = errorInKernel,
       GC.opsCall = callInKernel,
@@ -837,10 +836,6 @@ inKernelOperations env mode body =
     copyInKernel _ _ _ _ _ _ _ _ =
       error "Cannot bulk copy in kernel."
 
-    noStaticArrays :: GC.StaticArray KernelOp KernelState
-    noStaticArrays _ _ _ _ =
-      error "Cannot create static array in kernel."
-
     kernelMemoryType space =
       pure [C.cty|$tyquals:(pointerQuals space) $ty:defaultMemBlockType|]
 
@@ -910,7 +905,7 @@ typesInCode (For _ e c) = typesInExp e <> typesInCode c
 typesInCode (While (TPrimExp e) c) = typesInExp e <> typesInCode c
 typesInCode DeclareMem {} = mempty
 typesInCode (DeclareScalar _ _ t) = S.singleton t
-typesInCode (DeclareArray _ _ t _) = S.singleton t
+typesInCode (DeclareArray _ t _) = S.singleton t
 typesInCode (Allocate _ (Count (TPrimExp e)) _) = typesInExp e
 typesInCode Free {} = mempty
 typesInCode (Copy _ _ (Count (TPrimExp e1)) _ _ (Count (TPrimExp e2)) _ (Count (TPrimExp e3))) =

--- a/src/Futhark/CodeGen/ImpGen/Multicore.hs
+++ b/src/Futhark/CodeGen/ImpGen/Multicore.hs
@@ -105,8 +105,7 @@ withAcc pat inputs lam = do
         AtomicLocking _ <- atomicUpdateLocking atomics op_lam = do
           let num_locks = 100151
           locks_arr <-
-            sStaticArray "withacc_locks" DefaultSpace int32 $
-              Imp.ArrayZeros num_locks
+            sStaticArray "withacc_locks" int32 $ Imp.ArrayZeros num_locks
           let locks = Locks locks_arr num_locks
               extend env = env {hostLocks = M.insert c locks $ hostLocks env}
           localEnv extend $ locksForInputs atomics inputs'

--- a/src/Futhark/CodeGen/ImpGen/Multicore/SegHist.hs
+++ b/src/Futhark/CodeGen/ImpGen/Multicore/SegHist.hs
@@ -96,7 +96,7 @@ onOpAtomic op = do
       let num_locks = 100151 -- This number is taken from the GPU backend
           dims = map pe64 $ shapeDims (histOpShape op <> histShape op)
       locks <-
-        sStaticArray "hist_locks" DefaultSpace int32 $
+        sStaticArray "hist_locks" int32 $
           Imp.ArrayZeros num_locks
       let l' = Locking locks 0 1 0 (pure . (`rem` fromIntegral num_locks) . flattenIndex dims)
       pure $ f l'


### PR DESCRIPTION
Instead, just use replicate kernels.  That's faster, but more importantly it lets us simplify the static arrays mechanism, which was always quite hacky.