### PR TITLE
Refactor Op representation.

### DIFF
--- a/futhark.cabal
+++ b/futhark.cabal
@@ -174,7 +174,6 @@ library
       Futhark.Analysis.PrimExp.Convert
       Futhark.Analysis.PrimExp.Parse
       Futhark.Analysis.PrimExp.Simplify
-      Futhark.Analysis.Rephrase
       Futhark.Analysis.SymbolTable
       Futhark.Analysis.UsageTable
       Futhark.Bench
@@ -301,6 +300,7 @@ library
       Futhark.IR.Prop.TypeOf
       Futhark.IR.Prop.Types
       Futhark.IR.Rep
+      Futhark.IR.Rephrase
       Futhark.IR.RetType
       Futhark.IR.SOACS
       Futhark.IR.SOACS.SOAC

--- a/src/Futhark/Actions.hs
+++ b/src/Futhark/Actions.hs
@@ -54,7 +54,6 @@ import Futhark.Compiler.CLI
 import Futhark.IR
 import Futhark.IR.GPUMem (GPUMem)
 import Futhark.IR.MCMem (MCMem)
-import Futhark.IR.Prop.Aliases
 import Futhark.IR.SOACS (SOACS)
 import Futhark.IR.SeqMem (SeqMem)
 import Futhark.Optimise.Fusion.GraphRep qualified
@@ -75,7 +74,7 @@ printAction =
     }
 
 -- | Print the result to stdout, alias annotations.
-printAliasesAction :: (ASTRep rep, CanBeAliased (Op rep)) => Action rep
+printAliasesAction :: AliasableRep rep => Action rep
 printAliasesAction =
   Action
     { actionName = "Prettyprint",

--- a/src/Futhark/Analysis/Alias.hs
+++ b/src/Futhark/Analysis/Alias.hs
@@ -10,6 +10,7 @@
 -- the building blocks do).
 module Futhark.Analysis.Alias
   ( aliasAnalysis,
+    AliasableRep,
 
     -- * Ad-hoc utilities
     analyseFun,
@@ -26,7 +27,7 @@ import Futhark.IR.Aliases
 
 -- | Perform alias analysis on a Futhark program.
 aliasAnalysis ::
-  (ASTRep rep, CanBeAliased (Op rep)) =>
+  AliasableRep rep =>
   Prog rep ->
   Prog (Aliases rep)
 aliasAnalysis prog =
@@ -37,7 +38,7 @@ aliasAnalysis prog =
 
 -- | Perform alias analysis on function.
 analyseFun ::
-  (ASTRep rep, CanBeAliased (Op rep)) =>
+  AliasableRep rep =>
   FunDef rep ->
   FunDef (Aliases rep)
 analyseFun (FunDef entry attrs fname restype params body) =
@@ -47,9 +48,7 @@ analyseFun (FunDef entry attrs fname restype params body) =
 
 -- | Perform alias analysis on Body.
 analyseBody ::
-  ( ASTRep rep,
-    CanBeAliased (Op rep)
-  ) =>
+  AliasableRep rep =>
   AliasTable ->
   Body rep ->
   Body (Aliases rep)
@@ -59,7 +58,7 @@ analyseBody atable (Body rep stms result) =
 
 -- | Perform alias analysis on statements.
 analyseStms ::
-  (ASTRep rep, CanBeAliased (Op rep)) =>
+  AliasableRep rep =>
   AliasTable ->
   Stms rep ->
   (Stms (Aliases rep), AliasesAndConsumed)
@@ -72,7 +71,7 @@ analyseStms orig_aliases =
        in (stms <> oneStm stm', atable')
 
 analyseStm ::
-  (ASTRep rep, CanBeAliased (Op rep)) =>
+  AliasableRep rep =>
   AliasTable ->
   Stm rep ->
   Stm (Aliases rep)
@@ -84,7 +83,7 @@ analyseStm aliases (Let pat (StmAux cs attrs dec) e) =
 
 -- | Perform alias analysis on expression.
 analyseExp ::
-  (ASTRep rep, CanBeAliased (Op rep)) =>
+  AliasableRep rep =>
   AliasTable ->
   Exp rep ->
   Exp (Aliases rep)
@@ -124,7 +123,7 @@ analyseExp aliases e = mapExp analyse e
 
 -- | Perform alias analysis on lambda.
 analyseLambda ::
-  (ASTRep rep, CanBeAliased (Op rep)) =>
+  AliasableRep rep =>
   AliasTable ->
   Lambda rep ->
   Lambda (Aliases rep)

--- a/src/Futhark/Analysis/Metrics.hs
+++ b/src/Futhark/Analysis/Metrics.hs
@@ -32,8 +32,8 @@ instance OpMetrics a => OpMetrics (Maybe a) where
   opMetrics Nothing = pure ()
   opMetrics (Just x) = opMetrics x
 
-instance OpMetrics () where
-  opMetrics () = pure ()
+instance OpMetrics (NoOp rep) where
+  opMetrics NoOp = pure ()
 
 newtype CountMetrics = CountMetrics [([Text], Text)]
 

--- a/src/Futhark/Analysis/SymbolTable.hs
+++ b/src/Futhark/Analysis/SymbolTable.hs
@@ -323,7 +323,7 @@ class IndexOp op where
     Maybe Indexed
   indexOp _ _ _ _ = Nothing
 
-instance IndexOp ()
+instance IndexOp (NoOp rep)
 
 indexExp ::
   (IndexOp (Op rep), ASTRep rep) =>
@@ -390,7 +390,7 @@ defBndEntry vtable patElem als stm =
     }
 
 bindingEntries ::
-  (ASTRep rep, Aliases.Aliased rep, IndexOp (Op rep)) =>
+  (Aliases.Aliased rep, IndexOp (Op rep)) =>
   Stm rep ->
   SymbolTable rep ->
   [LetBoundEntry rep]
@@ -436,7 +436,7 @@ insertEntries entries vtable =
     add vtable' (name, entry) = insertEntry name entry vtable'
 
 insertStm ::
-  (ASTRep rep, IndexOp (Op rep), Aliases.Aliased rep) =>
+  (IndexOp (Op rep), Aliases.Aliased rep) =>
   Stm rep ->
   SymbolTable rep ->
   SymbolTable rep
@@ -475,7 +475,7 @@ insertStm stm vtable =
         update' e = e
 
 insertStms ::
-  (ASTRep rep, IndexOp (Op rep), Aliases.Aliased rep) =>
+  (IndexOp (Op rep), Aliases.Aliased rep) =>
   Stms rep ->
   SymbolTable rep ->
   SymbolTable rep

--- a/src/Futhark/Analysis/UsageTable.hs
+++ b/src/Futhark/Analysis/UsageTable.hs
@@ -153,7 +153,7 @@ usageInBody = foldMap consumedUsage . namesToList . consumedInBody
 
 -- | Produce a usage table reflecting the use of the free variables in
 -- a single statement.
-usageInStm :: (ASTRep rep, Aliased rep) => Stm rep -> UsageTable
+usageInStm :: Aliased rep => Stm rep -> UsageTable
 usageInStm (Let pat rep e) =
   mconcat
     [ usageInPat pat `without` patNames pat,

--- a/src/Futhark/CLI/Dev.hs
+++ b/src/Futhark/CLI/Dev.hs
@@ -13,13 +13,13 @@ import Futhark.Actions
 import Futhark.Analysis.Alias qualified as Alias
 import Futhark.Analysis.Metrics (OpMetrics)
 import Futhark.Compiler.CLI hiding (compilerMain)
-import Futhark.IR (ASTRep, Op, Prog, prettyString)
+import Futhark.IR (Op, Prog, prettyString)
+import Futhark.IR.Aliases (AliasableRep)
 import Futhark.IR.GPU qualified as GPU
 import Futhark.IR.GPUMem qualified as GPUMem
 import Futhark.IR.MC qualified as MC
 import Futhark.IR.MCMem qualified as MCMem
 import Futhark.IR.Parse
-import Futhark.IR.Prop.Aliases (CanBeAliased)
 import Futhark.IR.SOACS qualified as SOACS
 import Futhark.IR.Seq qualified as Seq
 import Futhark.IR.SeqMem qualified as SeqMem
@@ -154,8 +154,7 @@ data UntypedAction
   | SeqMemAction (BackendAction SeqMem.SeqMem)
   | PolyAction
       ( forall (rep :: Data.Kind.Type).
-        ( ASTRep rep,
-          (CanBeAliased (Op rep)),
+        ( AliasableRep rep,
           (OpMetrics (Op rep))
         ) =>
         Action rep

--- a/src/Futhark/CodeGen/ImpGen/Multicore.hs
+++ b/src/Futhark/CodeGen/ImpGen/Multicore.hs
@@ -122,9 +122,9 @@ compileMCExp dest e =
 
 compileMCOp ::
   Pat LetDecMem ->
-  MCOp MCMem () ->
+  MCOp NoOp MCMem ->
   ImpM MCMem HostEnv Imp.Multicore ()
-compileMCOp _ (OtherOp ()) = pure ()
+compileMCOp _ (OtherOp NoOp) = pure ()
 compileMCOp pat (ParOp par_op op) = do
   let space = getSpace op
   dPrimV_ (segFlat space) (0 :: Imp.TExp Int64)

--- a/src/Futhark/CodeGen/ImpGen/Sequential.hs
+++ b/src/Futhark/CodeGen/ImpGen/Sequential.hs
@@ -19,4 +19,4 @@ compileProg = ImpGen.compileProg () ops Imp.DefaultSpace
     ops = ImpGen.defaultOperations opCompiler
     opCompiler dest (Alloc e space) =
       ImpGen.compileAlloc dest e space
-    opCompiler _ (Inner ()) = pure ()
+    opCompiler _ (Inner NoOp) = pure ()

--- a/src/Futhark/IR/GPU.hs
+++ b/src/Futhark/IR/GPU.hs
@@ -17,6 +17,7 @@ where
 
 import Futhark.Builder
 import Futhark.Construct
+import Futhark.IR.Aliases (Aliases)
 import Futhark.IR.GPU.Op
 import Futhark.IR.GPU.Sizes
 import Futhark.IR.Pretty
@@ -30,18 +31,21 @@ import Futhark.IR.TypeCheck qualified as TC
 data GPU
 
 instance RepTypes GPU where
-  type Op GPU = HostOp GPU (SOAC GPU)
+  type OpC GPU = HostOp SOAC
 
 instance ASTRep GPU where
   expTypesFromPat = pure . expExtTypesFromPat
 
-instance TC.CheckableOp GPU where
+instance TC.Checkable GPU where
   checkOp = typeCheckGPUOp Nothing
     where
+      -- GHC 9.2 goes into an infinite loop without the type annotation.
+      typeCheckGPUOp ::
+        Maybe SegLevel ->
+        HostOp SOAC (Aliases GPU) ->
+        TC.TypeM GPU ()
       typeCheckGPUOp lvl =
         typeCheckHostOp (typeCheckGPUOp . Just) lvl typeCheckSOAC
-
-instance TC.Checkable GPU
 
 instance Buildable GPU where
   mkBody = Body ()

--- a/src/Futhark/IR/GPU/Simplify.hs
+++ b/src/Futhark/IR/GPU/Simplify.hs
@@ -43,9 +43,9 @@ simplifyKernelOp ::
   ( Engine.SimplifiableRep rep,
     BodyDec rep ~ ()
   ) =>
-  Simplify.SimplifyOp rep op ->
-  HostOp (Wise rep) op ->
-  Engine.SimpleM rep (HostOp (Wise rep) op, Stms (Wise rep))
+  Simplify.SimplifyOp rep (op (Wise rep)) ->
+  HostOp op (Wise rep) ->
+  Engine.SimpleM rep (HostOp op (Wise rep), Stms (Wise rep))
 simplifyKernelOp f (OtherOp op) = do
   (op', stms) <- f op
   pure (OtherOp op', stms)

--- a/src/Futhark/IR/MC.hs
+++ b/src/Futhark/IR/MC.hs
@@ -37,15 +37,13 @@ import Futhark.Pass
 data MC
 
 instance RepTypes MC where
-  type Op MC = MCOp MC (SOAC MC)
+  type OpC MC = MCOp SOAC
 
 instance ASTRep MC where
   expTypesFromPat = pure . expExtTypesFromPat
 
-instance TypeCheck.CheckableOp MC where
+instance TypeCheck.Checkable MC where
   checkOp = typeCheckMCOp typeCheckSOAC
-
-instance TypeCheck.Checkable MC
 
 instance Buildable MC where
   mkBody = Body ()

--- a/src/Futhark/IR/Mem.hs
+++ b/src/Futhark/IR/Mem.hs
@@ -105,6 +105,7 @@ import Control.Monad.Reader
 import Control.Monad.State
 import Data.Foldable (traverse_)
 import Data.Function ((&))
+import Data.Kind qualified
 import Data.List (elemIndex, find)
 import Data.Map.Strict qualified as M
 import Data.Maybe
@@ -115,6 +116,7 @@ import Futhark.Analysis.PrimExp.Simplify
 import Futhark.Analysis.SymbolTable qualified as ST
 import Futhark.IR.Aliases
   ( Aliases,
+    CanBeAliased (..),
     removeExpAliases,
     removePatAliases,
     removeScopeAliases,
@@ -163,8 +165,9 @@ type Mem rep inner =
     RetType rep ~ RetTypeMem,
     BranchType rep ~ BranchTypeMem,
     ASTRep rep,
-    OpReturns inner,
-    Op rep ~ MemOp inner
+    OpReturns (inner rep),
+    RephraseOp inner,
+    Op rep ~ MemOp inner rep
   )
 
 instance IsRetType FunReturns where
@@ -174,29 +177,33 @@ instance IsRetType FunReturns where
 instance IsBodyType BodyReturns where
   primBodyType = MemPrim
 
-data MemOp inner
+data MemOp (inner :: Data.Kind.Type -> Data.Kind.Type) (rep :: Data.Kind.Type)
   = -- | Allocate a memory block.
     Alloc SubExp Space
-  | Inner inner
+  | Inner (inner rep)
   deriving (Eq, Ord, Show)
 
 -- | A helper for defining 'TraverseOpStms'.
 traverseMemOpStms ::
   Monad m =>
-  OpStmsTraverser m inner rep ->
-  OpStmsTraverser m (MemOp inner) rep
+  OpStmsTraverser m (inner rep) rep ->
+  OpStmsTraverser m (MemOp inner rep) rep
 traverseMemOpStms _ _ op@Alloc {} = pure op
 traverseMemOpStms onInner f (Inner inner) = Inner <$> onInner f inner
 
-instance FreeIn inner => FreeIn (MemOp inner) where
+instance RephraseOp inner => RephraseOp (MemOp inner) where
+  rephraseInOp _ (Alloc e space) = pure (Alloc e space)
+  rephraseInOp r (Inner x) = Inner <$> rephraseInOp r x
+
+instance FreeIn (inner rep) => FreeIn (MemOp inner rep) where
   freeIn' (Alloc size _) = freeIn' size
   freeIn' (Inner k) = freeIn' k
 
-instance TypedOp inner => TypedOp (MemOp inner) where
+instance TypedOp (inner rep) => TypedOp (MemOp inner rep) where
   opType (Alloc _ space) = pure [Mem space]
   opType (Inner k) = opType k
 
-instance AliasedOp inner => AliasedOp (MemOp inner) where
+instance AliasedOp (inner rep) => AliasedOp (MemOp inner rep) where
   opAliases Alloc {} = [mempty]
   opAliases (Inner k) = opAliases k
 
@@ -204,31 +211,27 @@ instance AliasedOp inner => AliasedOp (MemOp inner) where
   consumedInOp (Inner k) = consumedInOp k
 
 instance CanBeAliased inner => CanBeAliased (MemOp inner) where
-  type OpWithAliases (MemOp inner) = MemOp (OpWithAliases inner)
-  removeOpAliases (Alloc se space) = Alloc se space
-  removeOpAliases (Inner k) = Inner $ removeOpAliases k
-
   addOpAliases _ (Alloc se space) = Alloc se space
   addOpAliases aliases (Inner k) = Inner $ addOpAliases aliases k
 
-instance Rename inner => Rename (MemOp inner) where
+instance Rename (inner rep) => Rename (MemOp inner rep) where
   rename (Alloc size space) = Alloc <$> rename size <*> pure space
   rename (Inner k) = Inner <$> rename k
 
-instance Substitute inner => Substitute (MemOp inner) where
+instance Substitute (inner rep) => Substitute (MemOp inner rep) where
   substituteNames subst (Alloc size space) = Alloc (substituteNames subst size) space
   substituteNames subst (Inner k) = Inner $ substituteNames subst k
 
-instance PP.Pretty inner => PP.Pretty (MemOp inner) where
+instance PP.Pretty (inner rep) => PP.Pretty (MemOp inner rep) where
   pretty (Alloc e DefaultSpace) = "alloc" <> PP.apply [PP.pretty e]
   pretty (Alloc e s) = "alloc" <> PP.apply [PP.pretty e, PP.pretty s]
   pretty (Inner k) = PP.pretty k
 
-instance OpMetrics inner => OpMetrics (MemOp inner) where
+instance OpMetrics (inner rep) => OpMetrics (MemOp inner rep) where
   opMetrics Alloc {} = seen "Alloc"
   opMetrics (Inner k) = opMetrics k
 
-instance IsOp inner => IsOp (MemOp inner) where
+instance IsOp (inner rep) => IsOp (MemOp inner rep) where
   safeOp (Alloc (Constant (IntValue (Int64Value k))) _) = k >= 0
   safeOp Alloc {} = False
   safeOp (Inner k) = safeOp k
@@ -236,13 +239,10 @@ instance IsOp inner => IsOp (MemOp inner) where
   cheapOp Alloc {} = True
 
 instance CanBeWise inner => CanBeWise (MemOp inner) where
-  type OpWithWisdom (MemOp inner) = MemOp (OpWithWisdom inner)
-  removeOpWisdom (Alloc size space) = Alloc size space
-  removeOpWisdom (Inner k) = Inner $ removeOpWisdom k
   addOpWisdom (Alloc size space) = Alloc size space
   addOpWisdom (Inner k) = Inner $ addOpWisdom k
 
-instance ST.IndexOp inner => ST.IndexOp (MemOp inner) where
+instance ST.IndexOp (inner rep) => ST.IndexOp (MemOp inner rep) where
   indexOp vtable k (Inner op) is = ST.indexOp vtable k op is
   indexOp _ _ _ _ = Nothing
 
@@ -1117,12 +1117,12 @@ class IsOp op => OpReturns op where
   opReturns :: (Mem rep inner, Monad m, HasScope rep m) => op -> m [ExpReturns]
   opReturns op = extReturns <$> opType op
 
-instance OpReturns inner => OpReturns (MemOp inner) where
+instance OpReturns (inner rep) => OpReturns (MemOp inner rep) where
   opReturns (Alloc _ space) = pure [MemMem space]
   opReturns (Inner op) = opReturns op
 
-instance OpReturns () where
-  opReturns () = pure []
+instance OpReturns (NoOp rep) where
+  opReturns NoOp = pure []
 
 applyFunReturns ::
   Typed dec =>

--- a/src/Futhark/IR/Parse.hs
+++ b/src/Futhark/IR/Parse.hs
@@ -941,7 +941,7 @@ pSegLevel =
         <$> (lexeme "groups=" $> GPU.Count <*> pSubExp <* pSemi)
         <*> (lexeme "groupsize=" $> GPU.Count <*> pSubExp)
 
-pHostOp :: PR rep -> Parser op -> Parser (GPU.HostOp rep op)
+pHostOp :: PR rep -> Parser (op rep) -> Parser (GPU.HostOp op rep)
 pHostOp pr pOther =
   choice
     [ GPU.SegOp <$> pSegOp pr pSegLevel,
@@ -950,7 +950,7 @@ pHostOp pr pOther =
       keyword "gpu" $> GPU.GPUBody <*> (pColon *> pTypes) <*> braces (pBody pr)
     ]
 
-pMCOp :: PR rep -> Parser op -> Parser (MC.MCOp rep op)
+pMCOp :: PR rep -> Parser (op rep) -> Parser (MC.MCOp op rep)
 pMCOp pr pOther =
   choice
     [ MC.ParOp . Just
@@ -1060,7 +1060,7 @@ pLParamMem = pMemInfo pSubExp (pure NoUniqueness) pMemBind
 pLetDecMem :: Parser LetDecMem
 pLetDecMem = pMemInfo pSubExp (pure NoUniqueness) pMemBind
 
-pMemOp :: Parser inner -> Parser (MemOp inner)
+pMemOp :: Parser (inner rep) -> Parser (MemOp inner rep)
 pMemOp pInner =
   choice
     [ keyword "alloc"

--- a/src/Futhark/IR/Pretty.hs
+++ b/src/Futhark/IR/Pretty.hs
@@ -33,6 +33,9 @@ class
   ppExpDec :: ExpDec rep -> Exp rep -> Maybe (Doc a)
   ppExpDec _ _ = Nothing
 
+instance Pretty (NoOp rep) where
+  pretty NoOp = "noop"
+
 instance Pretty VName where
   pretty (VName vn i) = pretty vn <> "_" <> pretty (show i)
 

--- a/src/Futhark/IR/Prop.hs
+++ b/src/Futhark/IR/Prop.hs
@@ -13,6 +13,7 @@ module Futhark.IR.Prop
     module Futhark.IR.Prop.Patterns,
     module Futhark.IR.Prop.Names,
     module Futhark.IR.RetType,
+    module Futhark.IR.Rephrase,
 
     -- * Built-in functions
     isBuiltInFunction,
@@ -49,6 +50,7 @@ import Futhark.IR.Prop.Rearrange
 import Futhark.IR.Prop.Reshape
 import Futhark.IR.Prop.TypeOf
 import Futhark.IR.Prop.Types
+import Futhark.IR.Rephrase
 import Futhark.IR.RetType
 import Futhark.IR.Syntax
 import Futhark.Transform.Rename (Rename, Renameable)
@@ -177,7 +179,7 @@ certify :: Certs -> Stm rep -> Stm rep
 certify cs1 (Let pat (StmAux cs2 attrs dec) e) =
   Let pat (StmAux (cs2 <> cs1) attrs dec) e
 
--- | A handy shorthand for properties that we usually want to things
+-- | A handy shorthand for properties that we usually want for things
 -- we stuff into ASTs.
 type ASTConstraints a =
   (Eq a, Ord a, Show a, Rename a, Substitute a, FreeIn a, Pretty a)
@@ -190,9 +192,9 @@ class (ASTConstraints op, TypedOp op) => IsOp op where
   -- | Should we try to hoist this out of branches?
   cheapOp :: op -> Bool
 
-instance IsOp () where
-  safeOp () = True
-  cheapOp () = True
+instance IsOp (NoOp rep) where
+  safeOp NoOp = True
+  cheapOp NoOp = True
 
 -- | Representation-specific attributes; also means the rep supports
 -- some basic facilities.
@@ -208,7 +210,8 @@ class
     FreeIn (LParamInfo rep),
     FreeIn (RetType rep),
     FreeIn (BranchType rep),
-    IsOp (Op rep)
+    IsOp (Op rep),
+    RephraseOp (OpC rep)
   ) =>
   ASTRep rep
   where

--- a/src/Futhark/IR/Prop/Names.hs
+++ b/src/Futhark/IR/Prop/Names.hs
@@ -222,6 +222,9 @@ instance FreeIn a => FreeIn [a] where
 instance FreeIn a => FreeIn (S.Set a) where
   freeIn' = foldMap freeIn'
 
+instance FreeIn (NoOp rep) where
+  freeIn' NoOp = mempty
+
 instance
   ( FreeDec (ExpDec rep),
     FreeDec (BodyDec rep),

--- a/src/Futhark/IR/Prop/TypeOf.hs
+++ b/src/Futhark/IR/Prop/TypeOf.hs
@@ -147,10 +147,11 @@ expExtType (Op op) = opType op
 
 -- | The number of values returned by an expression.
 expExtTypeSize ::
+  forall rep.
   (RepTypes rep, TypedOp (Op rep)) =>
   Exp rep ->
   Int
-expExtTypeSize = length . feelBad . expExtType
+expExtTypeSize = length . (feelBad :: FeelBad rep [ExtType] -> [ExtType]) . expExtType
 
 -- FIXME, this is a horrible quick hack.
 newtype FeelBad rep a = FeelBad {feelBad :: a}
@@ -178,5 +179,5 @@ loopExtType params =
 class TypedOp op where
   opType :: HasScope t m => op -> m [ExtType]
 
-instance TypedOp () where
-  opType () = pure []
+instance TypedOp (NoOp rep) where
+  opType NoOp = pure []

--- a/src/Futhark/IR/Rep.hs
+++ b/src/Futhark/IR/Rep.hs
@@ -4,6 +4,8 @@
 -- which is then used to invoke the type families defined here.
 module Futhark.IR.Rep
   ( RepTypes (..),
+    Op,
+    NoOp (..),
     module Futhark.IR.RetType,
   )
 where
@@ -12,6 +14,11 @@ import Data.Kind qualified
 import Futhark.IR.Prop.Types
 import Futhark.IR.RetType
 import Futhark.IR.Syntax.Core (DeclExtType, DeclType, ExtType, Type)
+
+-- | Returns nothing and does nothing.  Placeholder for when we don't
+-- really want an operation.
+data NoOp rep = NoOp
+  deriving (Eq, Ord, Show)
 
 -- | A collection of type families giving various common types for a
 -- representation, along with constraints specifying that the types
@@ -85,7 +92,14 @@ class
 
   type BranchType l = ExtType
 
-  -- | Extensible operation.
-  type Op l :: Data.Kind.Type
+  -- | Type constructor for the extensible operation.  The somewhat
+  -- funky definition is to ensure that we can change the "inner"
+  -- representation in a generic way (e.g. add aliasing information)
+  -- In most code, you will use the 'Op' alias instead.
+  type OpC l :: Data.Kind.Type -> Data.Kind.Type
 
-  type Op l = ()
+  type OpC l = NoOp
+
+-- | Apply the 'OpC' constructor of a representation to that
+-- representation.
+type Op l = OpC l l

--- a/src/Futhark/IR/Rephrase.hs
+++ b/src/Futhark/IR/Rephrase.hs
@@ -1,6 +1,7 @@
--- | Facilities for changing the rep of some fragment, with no
--- context.  We call this "rephrasing", for no deep reason.
-module Futhark.Analysis.Rephrase
+-- | Facilities for changing the representation of some fragment,
+-- within a monadic context.  We call this "rephrasing", for no deep
+-- reason.
+module Futhark.IR.Rephrase
   ( rephraseProg,
     rephraseFunDef,
     rephraseExp,
@@ -10,10 +11,12 @@ module Futhark.Analysis.Rephrase
     rephrasePat,
     rephrasePatElem,
     Rephraser (..),
+    RephraseOp (..),
   )
 where
 
-import Futhark.IR
+import Futhark.IR.Syntax
+import Futhark.IR.Traversals
 
 -- | A collection of functions that together allow us to rephrase some
 -- IR fragment, in some monad @m@.  If we let @m@ be the 'Maybe'
@@ -101,3 +104,11 @@ mapper rephraser =
       mapOnLParam = rephraseParam (rephraseLParamDec rephraser),
       mapOnOp = rephraseOp rephraser
     }
+
+-- | Rephrasing any fragments inside an Op from one representation to
+-- another.
+class RephraseOp op where
+  rephraseInOp :: Monad m => Rephraser m from to -> op from -> m (op to)
+
+instance RephraseOp NoOp where
+  rephraseInOp _ NoOp = pure NoOp

--- a/src/Futhark/IR/SOACS.hs
+++ b/src/Futhark/IR/SOACS.hs
@@ -27,15 +27,13 @@ import Futhark.IR.TypeCheck qualified as TC
 data SOACS
 
 instance RepTypes SOACS where
-  type Op SOACS = SOAC SOACS
+  type OpC SOACS = SOAC
 
 instance ASTRep SOACS where
   expTypesFromPat = pure . expExtTypesFromPat
 
-instance TC.CheckableOp SOACS where
+instance TC.Checkable SOACS where
   checkOp = typeCheckSOAC
-
-instance TC.Checkable SOACS
 
 instance Buildable SOACS where
   mkBody = Body ()

--- a/src/Futhark/IR/Seq.hs
+++ b/src/Futhark/IR/Seq.hs
@@ -30,16 +30,13 @@ import Futhark.Pass
 -- | The phantom type for the Seq representation.
 data Seq
 
-instance RepTypes Seq where
-  type Op Seq = ()
+instance RepTypes Seq
 
 instance ASTRep Seq where
   expTypesFromPat = pure . expExtTypesFromPat
 
-instance TC.CheckableOp Seq where
-  checkOp = pure
-
-instance TC.Checkable Seq
+instance TC.Checkable Seq where
+  checkOp NoOp = pure ()
 
 instance Buildable Seq where
   mkBody = Body ()
@@ -60,7 +57,7 @@ instance TraverseOpStms (Engine.Wise Seq) where
   traverseOpStms _ = pure
 
 simpleSeq :: Simplify.SimpleOps Seq
-simpleSeq = Simplify.bindableSimpleOps (const $ pure ((), mempty))
+simpleSeq = Simplify.bindableSimpleOps (const $ pure (NoOp, mempty))
 
 -- | Simplify a sequential program.
 simplifyProg :: Prog Seq -> PassM (Prog Seq)

--- a/src/Futhark/IR/SeqMem.hs
+++ b/src/Futhark/IR/SeqMem.hs
@@ -28,20 +28,16 @@ instance RepTypes SeqMem where
   type LParamInfo SeqMem = LParamMem
   type RetType SeqMem = RetTypeMem
   type BranchType SeqMem = BranchTypeMem
-  type Op SeqMem = MemOp ()
+  type OpC SeqMem = MemOp NoOp
 
 instance ASTRep SeqMem where
   expTypesFromPat = pure . map snd . bodyReturnsFromPat
 
 instance PrettyRep SeqMem
 
-instance TC.CheckableOp SeqMem where
-  checkOp (Alloc size _) =
-    TC.require [Prim int64] size
-  checkOp (Inner ()) =
-    pure ()
-
 instance TC.Checkable SeqMem where
+  checkOp (Alloc size _) = TC.require [Prim int64] size
+  checkOp (Inner NoOp) = pure ()
   checkFParamDec = checkMemInfo
   checkLParamDec = checkMemInfo
   checkLetBoundDec = checkMemInfo
@@ -73,4 +69,4 @@ simplifyProg = simplifyProgGeneric simpleSeqMem
 
 simpleSeqMem :: Engine.SimpleOps SeqMem
 simpleSeqMem =
-  simpleGeneric (const mempty) $ const $ pure ((), mempty)
+  simpleGeneric (const mempty) $ const $ pure (NoOp, mempty)

--- a/src/Futhark/Optimise/ArrayShortCircuiting.hs
+++ b/src/Futhark/Optimise/ArrayShortCircuiting.hs
@@ -71,11 +71,11 @@ removeAllocsInStms stms = do
     & pure
 
 pass ::
-  (Mem rep inner, LetDec rep ~ LetDecMem, CanBeAliased inner) =>
+  (Mem rep inner, LetDec rep ~ LetDecMem, AliasableRep rep) =>
   String ->
   String ->
   (Prog (Aliases rep) -> Pass.PassM (M.Map Name CoalsTab)) ->
-  (inner -> UpdateM inner inner) ->
+  (inner rep -> UpdateM (inner rep) (inner rep)) ->
   (CoalsTab -> [FParam (Aliases rep)] -> (Names, [FParam (Aliases rep)])) ->
   Pass rep rep
 pass flag desc mk on_inner on_fparams =
@@ -107,12 +107,18 @@ replaceResMem coaltab res =
     Just entry -> res {resSubExp = Var $ dstmem entry}
     Nothing -> res
 
-updateStms :: (Mem rep inner, LetDec rep ~ LetDecMem) => Stms rep -> UpdateM inner (Stms rep)
+updateStms ::
+  (Mem rep inner, LetDec rep ~ LetDecMem) =>
+  Stms rep ->
+  UpdateM (inner rep) (Stms rep)
 updateStms stms = do
   stms' <- mapM replaceInStm stms
   removeAllocsInStms stms'
 
-replaceInStm :: (Mem rep inner, LetDec rep ~ LetDecMem) => Stm rep -> UpdateM inner (Stm rep)
+replaceInStm ::
+  (Mem rep inner, LetDec rep ~ LetDecMem) =>
+  Stm rep ->
+  UpdateM (inner rep) (Stm rep)
 replaceInStm (Let (Pat elems) d e) = do
   elems' <- mapM replaceInPatElem elems
   e' <- replaceInExp elems' e
@@ -123,7 +129,11 @@ replaceInStm (Let (Pat elems) d e) = do
       fromMaybe p <$> lookupAndReplace vname PatElem u
     replaceInPatElem p = pure p
 
-replaceInExp :: (Mem rep inner, LetDec rep ~ LetDecMem) => [PatElem LetDecMem] -> Exp rep -> UpdateM inner (Exp rep)
+replaceInExp ::
+  (Mem rep inner, LetDec rep ~ LetDecMem) =>
+  [PatElem LetDecMem] ->
+  Exp rep ->
+  UpdateM (inner rep) (Exp rep)
 replaceInExp _ e@(BasicOp _) = pure e
 replaceInExp pat_elems (Match cond_ses cases defbody dec) = do
   defbody' <- replaceInIfBody defbody
@@ -149,7 +159,7 @@ replaceInExp _ e@Apply {} = pure e
 replaceInSegOp ::
   (Mem rep inner, LetDec rep ~ LetDecMem) =>
   SegOp lvl rep ->
-  UpdateM inner (SegOp lvl rep)
+  UpdateM (inner rep) (SegOp lvl rep)
 replaceInSegOp (SegMap lvl sp tps body) = do
   stms <- updateStms $ kernelBodyStms body
   pure $ SegMap lvl sp tps $ body {kernelBodyStms = stms}
@@ -163,11 +173,11 @@ replaceInSegOp (SegHist lvl sp hist_ops tps body) = do
   stms <- updateStms $ kernelBodyStms body
   pure $ SegHist lvl sp hist_ops tps $ body {kernelBodyStms = stms}
 
-replaceInHostOp :: HostOp GPUMem () -> UpdateM (HostOp GPUMem ()) (HostOp GPUMem ())
+replaceInHostOp :: HostOp NoOp GPUMem -> UpdateM (HostOp NoOp GPUMem) (HostOp NoOp GPUMem)
 replaceInHostOp (SegOp op) = SegOp <$> replaceInSegOp op
 replaceInHostOp op = pure op
 
-replaceInMCOp :: MCOp MCMem () -> UpdateM (MCOp MCMem ()) (MCOp MCMem ())
+replaceInMCOp :: MCOp NoOp MCMem -> UpdateM (MCOp NoOp MCMem) (MCOp NoOp MCMem)
 replaceInMCOp (ParOp par_op op) =
   ParOp <$> traverse replaceInSegOp par_op <*> replaceInSegOp op
 replaceInMCOp op = pure op
@@ -187,7 +197,7 @@ generalizeIxfun
       else pure m
 generalizeIxfun _ _ m = pure m
 
-replaceInIfBody :: (Mem rep inner, LetDec rep ~ LetDecMem) => Body rep -> UpdateM inner (Body rep)
+replaceInIfBody :: (Mem rep inner, LetDec rep ~ LetDecMem) => Body rep -> UpdateM (inner rep) (Body rep)
 replaceInIfBody b@(Body _ stms res) = do
   coaltab <- asks envCoalesceTab
   stms' <- updateStms stms

--- a/src/Futhark/Optimise/ArrayShortCircuiting/DataStructs.hs
+++ b/src/Futhark/Optimise/ArrayShortCircuiting/DataStructs.hs
@@ -379,7 +379,7 @@ appendCoalsInfo mb info_new coalstab =
 -- argument. Otherwise look up the type of the argument and return a 'LeafExp'
 -- if it is a 'PrimType'.
 vnameToPrimExp ::
-  (CanBeAliased (Op rep), RepTypes rep) =>
+  (AliasableRep rep) =>
   ScopeTab rep ->
   ScalarTab ->
   VName ->

--- a/src/Futhark/Optimise/ArrayShortCircuiting/MemRefAggreg.hs
+++ b/src/Futhark/Optimise/ArrayShortCircuiting/MemRefAggreg.hs
@@ -75,7 +75,7 @@ translateAccessSummary _ _ _ = Undeterminable
 
 -- | This function computes the written and read memory references for the current statement
 getUseSumFromStm ::
-  (Op rep ~ MemOp inner, HasMemBlock (Aliases rep)) =>
+  (Op rep ~ MemOp inner rep, HasMemBlock (Aliases rep)) =>
   TopdownEnv rep ->
   CoalsTab ->
   Stm (Aliases rep) ->
@@ -152,7 +152,7 @@ getUseSumFromStm _ _ _ =
 --     2. fails the entries in active coalesced table for which the write set
 --          overlaps the uses of the destination (to that point)
 recordMemRefUses ::
-  (CanBeAliased (Op rep), RepTypes rep, Op rep ~ MemOp inner, HasMemBlock (Aliases rep)) =>
+  (AliasableRep rep, Op rep ~ MemOp inner rep, HasMemBlock (Aliases rep)) =>
   TopdownEnv rep ->
   BotUpEnv ->
   Stm (Aliases rep) ->
@@ -254,7 +254,7 @@ recordMemRefUses td_env bu_env stm =
 --
 -- This check is conservative, so unless we can guarantee that there is no
 -- overlap, we return 'False'.
-noMemOverlap :: (CanBeAliased (Op rep), RepTypes rep) => TopdownEnv rep -> AccessSummary -> AccessSummary -> Bool
+noMemOverlap :: (AliasableRep rep) => TopdownEnv rep -> AccessSummary -> AccessSummary -> Bool
 noMemOverlap _ _ (Set mr)
   | mr == mempty = True
 noMemOverlap _ (Set mr) _

--- a/src/Futhark/Optimise/InPlaceLowering.hs
+++ b/src/Futhark/Optimise/InPlaceLowering.hs
@@ -118,7 +118,7 @@ inPlaceLowering onOp lower =
     descend [] m = m
     descend (stm : stms) m = bindingStm stm $ descend stms m
 
-type Constraints rep = (Buildable rep, CanBeAliased (Op rep))
+type Constraints rep = (Buildable rep, AliasableRep rep)
 
 optimiseBody ::
   Constraints rep =>
@@ -198,7 +198,7 @@ optimiseExp e = mapExpM optimise e
         }
 
 onSegOp ::
-  (Buildable rep, CanBeAliased (Op rep)) =>
+  Constraints rep =>
   SegOp lvl (Aliases rep) ->
   ForwardingM rep (SegOp lvl (Aliases rep))
 onSegOp op =

--- a/src/Futhark/Optimise/InPlaceLowering/LowerIntoStm.hs
+++ b/src/Futhark/Optimise/InPlaceLowering/LowerIntoStm.hs
@@ -47,7 +47,7 @@ lowerUpdate ::
   ( MonadFreshNames m,
     Buildable rep,
     LetDec rep ~ Type,
-    CanBeAliased (Op rep)
+    AliasableRep rep
   ) =>
   LowerUpdate rep m
 lowerUpdate scope (Let pat aux (DoLoop merge form body)) updates = do

--- a/src/Futhark/Optimise/ReduceDeviceSyncs.hs
+++ b/src/Futhark/Optimise/ReduceDeviceSyncs.hs
@@ -351,7 +351,7 @@ optimizeWithAccInput acc (shape, arrs, Just (op, nes)) = do
 
 -- | Optimize a host operation. 'Index' statements are added to kernel code
 -- that depends on migrated scalars.
-optimizeHostOp :: HostOp GPU op -> ReduceM (HostOp GPU op)
+optimizeHostOp :: HostOp op GPU -> ReduceM (HostOp op GPU)
 optimizeHostOp (SegOp (SegMap lvl space types kbody)) =
   SegOp . SegMap lvl space types <$> addReadsToKernelBody kbody
 optimizeHostOp (SegOp (SegRed lvl space ops types kbody)) = do

--- a/src/Futhark/Optimise/Simplify/Engine.hs
+++ b/src/Futhark/Optimise/Simplify/Engine.hs
@@ -557,7 +557,7 @@ provides :: Stm rep -> [VName]
 provides = patNames . stmPat
 
 expandUsage ::
-  (ASTRep rep, Aliased rep) =>
+  Aliased rep =>
   (Stm rep -> UT.UsageTable) ->
   ST.SymbolTable rep ->
   UT.UsageTable ->
@@ -666,7 +666,7 @@ loopInvariantStm vtable =
   all (`nameIn` ST.availableAtClosestLoop vtable) . namesToList . freeIn
 
 matchBlocker ::
-  (ASTRep rep, CanBeWise (Op rep)) =>
+  SimplifiableRep rep =>
   [SubExp] ->
   MatchDec rt ->
   SimpleM rep (BlockPred (Wise rep))
@@ -966,8 +966,10 @@ type SimplifiableRep rep =
     Simplifiable (RetType rep),
     Simplifiable (BranchType rep),
     TraverseOpStms (Wise rep),
-    CanBeWise (Op rep),
-    ST.IndexOp (OpWithWisdom (Op rep)),
+    CanBeWise (OpC rep),
+    ST.IndexOp (Op (Wise rep)),
+    AliasedOp (Op (Wise rep)),
+    RephraseOp (OpC rep),
     BuilderOps (Wise rep),
     IsOp (Op rep)
   )

--- a/src/Futhark/Optimise/Sink.hs
+++ b/src/Futhark/Optimise/Sink.hs
@@ -264,8 +264,8 @@ type SinkRep rep = Aliases rep
 
 sink ::
   ( Buildable rep,
-    CanBeAliased (Op rep),
-    ST.IndexOp (OpWithAliases (Op rep))
+    AliasableRep rep,
+    ST.IndexOp (Op (Aliases rep))
   ) =>
   Sinker (SinkRep rep) (Op (SinkRep rep)) ->
   Pass rep rep

--- a/src/Futhark/Pass/ExpandAllocations.hs
+++ b/src/Futhark/Pass/ExpandAllocations.hs
@@ -11,7 +11,6 @@ import Data.Either (rights)
 import Data.List (find, foldl')
 import Data.Map.Strict qualified as M
 import Data.Maybe
-import Futhark.Analysis.Rephrase
 import Futhark.Analysis.SymbolTable qualified as ST
 import Futhark.Error
 import Futhark.IR

--- a/src/Futhark/Pass/ExplicitAllocations/GPU.hs
+++ b/src/Futhark/Pass/ExplicitAllocations/GPU.hs
@@ -79,8 +79,8 @@ handleSegOp outer_lvl op = do
 
 handleHostOp ::
   Maybe SegLevel ->
-  HostOp GPU (SOAC GPU) ->
-  AllocM GPU GPUMem (MemOp (HostOp GPUMem ()))
+  HostOp SOAC GPU ->
+  AllocM GPU GPUMem (MemOp (HostOp NoOp) GPUMem)
 handleHostOp _ (SizeOp op) =
   pure $ Inner $ SizeOp op
 handleHostOp _ (OtherOp op) =

--- a/src/Futhark/Pass/ExplicitAllocations/Seq.hs
+++ b/src/Futhark/Pass/ExplicitAllocations/Seq.hs
@@ -10,4 +10,8 @@ import Futhark.Pass
 import Futhark.Pass.ExplicitAllocations
 
 explicitAllocations :: Pass Seq SeqMem
-explicitAllocations = explicitAllocationsGeneric DefaultSpace (pure . Inner) defaultExpHints
+explicitAllocations =
+  explicitAllocationsGeneric
+    DefaultSpace
+    (const $ pure $ Inner NoOp)
+    defaultExpHints

--- a/src/Futhark/Pass/ExtractKernels/BlockedKernel.hs
+++ b/src/Futhark/Pass/ExtractKernels/BlockedKernel.hs
@@ -21,8 +21,8 @@ import Control.Monad
 import Control.Monad.Writer
 import Futhark.Analysis.PrimExp
 import Futhark.IR
+import Futhark.IR.Aliases (AliasableRep)
 import Futhark.IR.GPU.Op (SegVirt (..))
-import Futhark.IR.Prop.Aliases
 import Futhark.IR.SegOp
 import Futhark.MonadFreshNames
 import Futhark.Tools
@@ -37,7 +37,7 @@ type DistRep rep =
     LetDec rep ~ Type,
     ExpDec rep ~ (),
     BodyDec rep ~ (),
-    CanBeAliased (Op rep)
+    AliasableRep rep
   )
 
 data ThreadRecommendation = ManyThreads | NoRecommendation SegVirt

--- a/src/Futhark/Pass/ExtractKernels/StreamKernel.hs
+++ b/src/Futhark/Pass/ExtractKernels/StreamKernel.hs
@@ -38,7 +38,7 @@ data KernelSize = KernelSize
   deriving (Eq, Ord, Show)
 
 numberOfGroups ::
-  (MonadBuilder m, Op (Rep m) ~ HostOp (Rep m) inner) =>
+  (MonadBuilder m, Op (Rep m) ~ HostOp inner (Rep m)) =>
   String ->
   SubExp ->
   SubExp ->

--- a/src/Futhark/Pass/ExtractKernels/ToGPU.hs
+++ b/src/Futhark/Pass/ExtractKernels/ToGPU.hs
@@ -13,7 +13,6 @@ where
 
 import Control.Monad.Identity
 import Data.List ()
-import Futhark.Analysis.Rephrase
 import Futhark.IR
 import Futhark.IR.GPU
 import Futhark.IR.SOACS (SOACS)
@@ -21,7 +20,7 @@ import Futhark.IR.SOACS.SOAC qualified as SOAC
 import Futhark.Tools
 
 getSize ::
-  (MonadBuilder m, Op (Rep m) ~ HostOp (Rep m) inner) =>
+  (MonadBuilder m, Op (Rep m) ~ HostOp inner (Rep m)) =>
   String ->
   SizeClass ->
   m SubExp
@@ -30,7 +29,7 @@ getSize desc size_class = do
   letSubExp desc $ Op $ SizeOp $ GetSize size_key size_class
 
 segThread ::
-  (MonadBuilder m, Op (Rep m) ~ HostOp (Rep m) inner) =>
+  (MonadBuilder m, Op (Rep m) ~ HostOp inner (Rep m)) =>
   String ->
   m SegLevel
 segThread desc =

--- a/src/Futhark/Pass/ExtractMulticore.hs
+++ b/src/Futhark/Pass/ExtractMulticore.hs
@@ -9,7 +9,6 @@ import Control.Monad.Identity
 import Control.Monad.Reader
 import Control.Monad.State
 import Data.Bitraversable
-import Futhark.Analysis.Rephrase
 import Futhark.IR
 import Futhark.IR.MC
 import Futhark.IR.MC qualified as MC

--- a/src/Futhark/Transform/FirstOrderTransform.hs
+++ b/src/Futhark/Transform/FirstOrderTransform.hs
@@ -35,7 +35,7 @@ type FirstOrderRep rep =
     BuilderOps rep,
     LetDec SOACS ~ LetDec rep,
     LParamInfo SOACS ~ LParamInfo rep,
-    CanBeAliased (Op rep)
+    Alias.AliasableRep rep
   )
 
 -- | First-order-transform a single function, with the given scope
@@ -69,7 +69,7 @@ type Transformer m =
     Buildable (Rep m),
     BuilderOps (Rep m),
     LParamInfo SOACS ~ LParamInfo (Rep m),
-    CanBeAliased (Op (Rep m))
+    Alias.AliasableRep (Rep m)
   )
 
 transformBody ::
@@ -375,7 +375,7 @@ transformLambda ::
     LocalScope somerep m,
     SameScope somerep rep,
     LetDec rep ~ LetDec SOACS,
-    CanBeAliased (Op rep)
+    Alias.AliasableRep rep
   ) =>
   Lambda SOACS ->
   m (AST.Lambda rep)

--- a/src/Futhark/Transform/Rename.hs
+++ b/src/Futhark/Transform/Rename.hs
@@ -325,6 +325,9 @@ instance Rename ExtSize where
 instance Rename () where
   rename = pure
 
+instance Rename (NoOp rep) where
+  rename NoOp = pure NoOp
+
 instance Rename d => Rename (DimIndex d) where
   rename (DimFix i) = DimFix <$> rename i
   rename (DimSlice i n s) = DimSlice <$> rename i <*> rename n <*> rename s

--- a/src/Futhark/Transform/Substitute.hs
+++ b/src/Futhark/Transform/Substitute.hs
@@ -138,6 +138,9 @@ instance Substitute Rank where
 instance Substitute () where
   substituteNames _ = id
 
+instance Substitute (NoOp rep) where
+  substituteNames _ = id
+
 instance Substitute d => Substitute (ShapeBase d) where
   substituteNames substs (Shape es) =
     Shape $ map (substituteNames substs) es


### PR DESCRIPTION
Op is now OpC, which is a higher-rank type parameterised on the inner representation.  This makes it easier to define the few representation transformers we have left.