### PR TITLE
Remove copyCopyToCopy rule.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+* A somewhat obscure simplification rule could mess up use of memory.
+
 ## [0.23.1]
 
 ### Added

--- a/src/Futhark/IR/Mem/Simplify.hs
+++ b/src/Futhark/IR/Mem/Simplify.hs
@@ -110,8 +110,7 @@ callKernelRules :: SimplifyMemory rep inner => RuleBook (Wise rep)
 callKernelRules =
   standardRules
     <> ruleBook
-      [ RuleBasicOp copyCopyToCopy,
-        RuleMatch unExistentialiseMemory,
+      [ RuleMatch unExistentialiseMemory,
         RuleOp decertifySafeAlloc
       ]
       []
@@ -182,34 +181,6 @@ unExistentialiseMemory vtable pat _ (cond, cases, defbody, ifdec)
       | otherwise =
           fixable
 unExistentialiseMemory _ _ _ _ = Skip
-
--- | If we are copying something that is itself a copy, just copy the
--- original one instead.
-copyCopyToCopy ::
-  ( BuilderOps rep,
-    LetDec rep ~ (VarWisdom, MemBound u)
-  ) =>
-  TopDownRuleBasicOp rep
-copyCopyToCopy vtable pat@(Pat [pat_elem]) _ (Copy v1)
-  | Just (BasicOp (Copy v2), v1_cs) <- ST.lookupExp v1 vtable,
-    Just (_, MemArray _ _ _ (ArrayIn srcmem src_ixfun)) <-
-      ST.entryLetBoundDec =<< ST.lookup v1 vtable,
-    Just (Mem src_space) <- ST.lookupType srcmem vtable,
-    (_, MemArray _ _ _ (ArrayIn destmem dest_ixfun)) <- patElemDec pat_elem,
-    Just (Mem dest_space) <- ST.lookupType destmem vtable,
-    src_space == dest_space,
-    dest_ixfun == src_ixfun =
-      Simplify $ certifying v1_cs $ letBind pat $ BasicOp $ Copy v2
-copyCopyToCopy vtable pat _ (Copy v0)
-  | Just (BasicOp (Rearrange perm v1), v0_cs) <- ST.lookupExp v0 vtable,
-    Just (BasicOp (Copy v2), v1_cs) <- ST.lookupExp v1 vtable = Simplify $ do
-      v0' <-
-        certifying (v0_cs <> v1_cs) $
-          letExp "rearrange_v0" $
-            BasicOp $
-              Rearrange perm v2
-      letBind pat $ BasicOp $ Copy v0'
-copyCopyToCopy _ _ _ _ = Skip
 
 -- If an allocation is statically known to be safe, then we can remove
 -- the certificates on it.  This can help hoist things that would


### PR DESCRIPTION
This is a very old (5+ years) rule that is much too naive in its handling of memory.  We have better optimisations now, that aren't buggy.