### PR TITLE
Use ImportName consistently.

### DIFF
--- a/src/Futhark/CLI/Doc.hs
+++ b/src/Futhark/CLI/Doc.hs
@@ -14,6 +14,7 @@ import Futhark.Doc.Generator
 import Futhark.Pipeline (FutharkM, Verbosity (..), runFutharkM)
 import Futhark.Util (directoryContents, trim)
 import Futhark.Util.Options
+import Language.Futhark.Semantic (mkInitialImport)
 import Language.Futhark.Syntax (DocComment (..), progDoc)
 import System.Directory (createDirectoryIfMissing)
 import System.Exit
@@ -59,7 +60,7 @@ futFiles dir = filter isFut <$> directoryContents dir
 
 printDecs :: DocConfig -> FilePath -> [FilePath] -> Imports -> IO ()
 printDecs cfg dir files imports = do
-  let direct_imports = map (normalise . dropExtension) files
+  let direct_imports = map (mkInitialImport . normalise . dropExtension) files
       (file_htmls, _warnings) =
         renderFiles direct_imports $
           filter (not . ignored) imports

--- a/src/Futhark/CLI/Misc.hs
+++ b/src/Futhark/CLI/Misc.hs
@@ -23,6 +23,7 @@ import Futhark.Util.Options
 import Futhark.Util.Pretty (prettyTextOneLine)
 import Language.Futhark.Parser.Lexer (scanTokens)
 import Language.Futhark.Prop (isBuiltin)
+import Language.Futhark.Semantic (includeToString)
 import System.Environment (getExecutablePath)
 import System.Exit
 import System.FilePath
@@ -36,7 +37,7 @@ mainImports = mainWithOptions () [] "program" $ \args () ->
     [file] -> Just $ do
       (_, prog_imports, _) <- readProgramOrDie file
       liftIO . putStr . unlines . map (++ ".fut") . filter (not . isBuiltin) $
-        map fst prog_imports
+        map (includeToString . fst) prog_imports
     _ -> Nothing
 
 -- | @futhark hash@

--- a/src/Futhark/Compiler/Program.hs
+++ b/src/Futhark/Compiler/Program.hs
@@ -274,7 +274,7 @@ data CheckedFile = CheckedFile
 asImports :: [LoadedFile CheckedFile] -> Imports
 asImports = map f
   where
-    f lf = (includeToString (lfImportName lf), cfMod $ lfMod lf)
+    f lf = (lfImportName lf, cfMod $ lfMod lf)
 
 typeCheckProg ::
   [LoadedFile CheckedFile] ->
@@ -353,7 +353,7 @@ data LoadedProg = LoadedProg
 lpImports :: LoadedProg -> Imports
 lpImports = map f . lpFiles
   where
-    f lf = (includeToString (lfImportName lf), cfMod $ lfMod lf)
+    f lf = (lfImportName lf, cfMod $ lfMod lf)
 
 -- | All warnings of a 'LoadedProg'.
 lpWarnings :: LoadedProg -> Warnings

--- a/src/Futhark/Doc/Generator.hs
+++ b/src/Futhark/Doc/Generator.hs
@@ -117,7 +117,7 @@ vnameToFileMap = mconcat . map forFile
       mconcat (map (vname Type) (M.keys abs))
         <> forEnv file_env
       where
-        file' = makeRelative "/" file
+        file' = makeRelative "/" $ includeToFilePath file
         vname ns v = M.singleton (qualLeaf v) (file', ns)
         vname' ((ns, _), v) = vname ns v
 
@@ -133,13 +133,13 @@ vnameToFileMap = mconcat . map forFile
 -- @important_imports@ considered most important.  The HTML files must
 -- be written to the specific locations indicated in the return value,
 -- or the relative links will be wrong.
-renderFiles :: [FilePath] -> Imports -> ([(FilePath, Html)], Warnings)
+renderFiles :: [ImportName] -> Imports -> ([(FilePath, Html)], Warnings)
 renderFiles important_imports imports = runWriter $ do
   (import_pages, documented) <- runWriterT $
     forM imports $ \(current, fm) ->
       let ctx =
             Context
-              { ctxCurrent = makeRelative "/" current,
+              { ctxCurrent = makeRelative "/" $ includeToFilePath current,
                 ctxFileMod = fm,
                 ctxImports = imports,
                 ctxNoLink = mempty,
@@ -155,15 +155,19 @@ renderFiles important_imports imports = runWriter $ do
 
             pure
               ( current,
-                ( H.docTypeHtml ! A.lang "en" $
-                    addBoilerplateWithNav important_imports imports ("doc" </> current) current $
-                      H.main $
-                        maybe_abstract
-                          <> selfLink "synopsis" (H.h2 "Synopsis")
-                          <> (H.div ! A.id "overview") synopsis
-                          <> selfLink "description" (H.h2 "Description")
-                          <> description
-                          <> maybe_sections,
+                ( H.docTypeHtml ! A.lang "en"
+                    $ addBoilerplateWithNav
+                      important_imports
+                      imports
+                      ("doc" </> includeToFilePath current)
+                      (includeToString current)
+                    $ H.main
+                    $ maybe_abstract
+                      <> selfLink "synopsis" (H.h2 "Synopsis")
+                      <> (H.div ! A.id "overview") synopsis
+                      <> selfLink "description" (H.h2 "Description")
+                      <> description
+                      <> maybe_sections,
                   first_paragraph
                 )
               )
@@ -175,7 +179,8 @@ renderFiles important_imports imports = runWriter $ do
       ++ map (importHtml *** fst) import_pages
   where
     file_map = vnameToFileMap imports
-    importHtml import_name = "doc" </> makeRelative "/" import_name <.> "html"
+    importHtml import_name =
+      "doc" </> makeRelative "/" (fromString (includeToString import_name)) <.> "html"
 
 -- | The header documentation (which need not be present) can contain
 -- an abstract and further sections.
@@ -201,7 +206,7 @@ headerDoc prog =
     firstParagraph = unlines . takeWhile (not . paragraphSeparator) . lines
     paragraphSeparator = all isSpace
 
-contentsPage :: [FilePath] -> [(String, Html)] -> Html
+contentsPage :: [ImportName] -> [(ImportName, Html)] -> Html
 contentsPage important_imports pages =
   H.docTypeHtml $
     addBoilerplate "index.html" "Futhark Library Documentation" $
@@ -229,12 +234,15 @@ contentsPage important_imports pages =
         (H.dt ! A.class_ "desc_header") (importLink "index.html" name)
           <> (H.dd ! A.class_ "desc_doc") maybe_abstract
 
-importLink :: FilePath -> String -> Html
+importLink :: FilePath -> ImportName -> Html
 importLink current name =
-  let file = relativise ("doc" </> makeRelative "/" name -<.> "html") current
-   in (H.a ! A.href (fromString file) $ fromString name)
+  let file =
+        relativise
+          ("doc" </> makeRelative "/" (includeToFilePath name) -<.> "html")
+          current
+   in (H.a ! A.href (fromString file) $ fromString (includeToString name))
 
-indexPage :: [FilePath] -> Imports -> Documented -> FileMap -> Html
+indexPage :: [ImportName] -> Imports -> Documented -> FileMap -> Html
 indexPage important_imports imports documented fm =
   H.docTypeHtml $
     addBoilerplateWithNav important_imports imports "doc-index.html" "Index" $
@@ -344,7 +352,7 @@ addBoilerplate current titleText content =
     futhark_doc_url =
       "https://futhark.readthedocs.io/en/latest/man/futhark-doc.html"
 
-addBoilerplateWithNav :: [FilePath] -> Imports -> String -> String -> Html -> Html
+addBoilerplateWithNav :: [ImportName] -> Imports -> String -> String -> Html -> Html
 addBoilerplateWithNav important_imports imports current titleText content =
   addBoilerplate current titleText $
     (H.nav ! A.id "filenav" $ files) <> content
@@ -390,7 +398,7 @@ synopsisOpened (ModParens me _) = do
   Just $ parens <$> me'
 synopsisOpened (ModImport _ (Info file) _) = Just $ do
   current <- asks ctxCurrent
-  let dest = fromString $ relativise file current <> ".html"
+  let dest = fromString $ relativise (includeToFilePath file) current <> ".html"
   pure $ keyword "import " <> (H.a ! A.href dest) (fromString $ show file)
 synopsisOpened (ModAscript _ se _ _) = Just $ do
   se' <- synopsisSigExp se
@@ -762,13 +770,13 @@ identifierLinks loc (c : s') = (c :) <$> identifierLinks loc s'
 lookupName :: (Namespace, String, Maybe FilePath) -> DocM (Maybe VName)
 lookupName (namespace, name, file) = do
   current <- asks ctxCurrent
-  let file' = includeToString . mkImportFrom (mkInitialImport current) <$> file
+  let file' = mkImportFrom (mkInitialImport current) <$> file
   env <- lookupEnvForFile file'
   case M.lookup (namespace, nameFromString name) . envNameMap =<< env of
     Nothing -> pure Nothing
     Just qn -> pure $ Just $ qualLeaf qn
 
-lookupEnvForFile :: Maybe FilePath -> DocM (Maybe Env)
+lookupEnvForFile :: Maybe ImportName -> DocM (Maybe Env)
 lookupEnvForFile Nothing = asks $ Just . fileEnv . ctxFileMod
 lookupEnvForFile (Just file) = asks $ fmap fileEnv . lookup file . ctxImports
 

--- a/src/Futhark/Internalise/Defunctorise.hs
+++ b/src/Futhark/Internalise/Defunctorise.hs
@@ -10,7 +10,7 @@ import Data.Maybe
 import Data.Set qualified as S
 import Futhark.MonadFreshNames
 import Language.Futhark
-import Language.Futhark.Semantic (FileModule (..), Imports)
+import Language.Futhark.Semantic (FileModule (..), Imports, includeToString)
 import Language.Futhark.Traversals
 import Prelude hiding (abs, mod)
 
@@ -61,7 +61,7 @@ type TySet = S.Set VName
 data Env = Env
   { envScope :: Scope,
     envGenerating :: Bool,
-    envImports :: M.Map String Scope,
+    envImports :: M.Map ImportName Scope,
     envAbs :: TySet
   }
 
@@ -110,7 +110,7 @@ bindingNames names m = do
 generating :: TransformM a -> TransformM a
 generating = local $ \env -> env {envGenerating = True}
 
-bindingImport :: String -> Scope -> TransformM a -> TransformM a
+bindingImport :: ImportName -> Scope -> TransformM a -> TransformM a
 bindingImport name scope = local $ \env ->
   env {envImports = M.insert name scope $ envImports env}
 
@@ -118,10 +118,10 @@ bindingAbs :: TySet -> TransformM a -> TransformM a
 bindingAbs abs = local $ \env ->
   env {envAbs = abs <> envAbs env}
 
-lookupImport :: String -> TransformM Scope
+lookupImport :: ImportName -> TransformM Scope
 lookupImport name = maybe bad pure =<< asks (M.lookup name . envImports)
   where
-    bad = error $ "Defunctorise: unknown import: " ++ name
+    bad = error $ "Defunctorise: unknown import: " ++ includeToString name
 
 lookupMod' :: QualName VName -> Scope -> Either String Mod
 lookupMod' mname scope =

--- a/src/Language/Futhark/Query.hs
+++ b/src/Language/Futhark/Query.hs
@@ -370,7 +370,7 @@ containingModule :: Imports -> Pos -> Maybe FileModule
 containingModule imports (Pos file _ _ _) =
   snd <$> find ((== file') . fst) imports
   where
-    file' = includeToString $ mkInitialImport $ fst $ Posix.splitExtension file
+    file' = mkInitialImport $ fst $ Posix.splitExtension file
 
 -- | Information about what is at the given source location.
 data AtPos = AtName (QualName VName) (Maybe BoundTo) Loc

--- a/src/Language/Futhark/Semantic.hs
+++ b/src/Language/Futhark/Semantic.hs
@@ -30,12 +30,6 @@ import System.FilePath qualified as Native
 import System.FilePath.Posix qualified as Posix
 import Prelude hiding (mod)
 
--- | Canonical reference to a Futhark code file.  Does not include the
--- @.fut@ extension.  This is most often a path relative to the
--- current working directory of the compiler.
-newtype ImportName = ImportName Posix.FilePath
-  deriving (Eq, Ord, Show)
-
 -- | Create an import name immediately from a file path specified by
 -- the user.
 mkInitialImport :: Native.FilePath -> ImportName
@@ -85,7 +79,7 @@ data FileModule = FileModule
   }
 
 -- | A mapping from import names to imports.  The ordering is significant.
-type Imports = [(String, FileModule)]
+type Imports = [(ImportName, FileModule)]
 
 -- | The space inhabited by a name.
 data Namespace

--- a/src/Language/Futhark/Syntax.hs
+++ b/src/Language/Futhark/Syntax.hs
@@ -63,6 +63,7 @@ module Language.Futhark.Syntax
     PatBase (..),
 
     -- * Module language
+    ImportName (..),
     SpecBase (..),
     SigExpBase (..),
     TypeRefBase (..),
@@ -115,6 +116,7 @@ import Language.Futhark.Primitive
     IntType (..),
     IntValue (..),
   )
+import System.FilePath.Posix qualified as Posix
 import Prelude
 
 -- | No information functor.  Usually used for placeholder type- or
@@ -1125,12 +1127,20 @@ deriving instance Show (SigBindBase NoInfo Name)
 instance Located (SigBindBase f vn) where
   locOf = locOf . sigLoc
 
+-- | Canonical reference to a Futhark code file.  Does not include the
+-- @.fut@ extension.  This is most often a path relative to the
+-- working directory of the compiler.  In a multi-file program, a file
+-- is known by exactly one import name, even if it is referenced
+-- relatively by different names by files in different subdirectories.
+newtype ImportName = ImportName Posix.FilePath
+  deriving (Eq, Ord, Show)
+
 -- | Module expression.
 data ModExpBase f vn
   = ModVar (QualName vn) SrcLoc
   | ModParens (ModExpBase f vn) SrcLoc
   | -- | The contents of another file as a module.
-    ModImport FilePath (f FilePath) SrcLoc
+    ModImport FilePath (f ImportName) SrcLoc
   | ModDecs [DecBase f vn] SrcLoc
   | -- | Functor application.  The first mapping is from parameter
     -- names to argument names, while the second maps names in the
@@ -1201,7 +1211,7 @@ data DecBase f vn
   | ModDec (ModBindBase f vn)
   | OpenDec (ModExpBase f vn) SrcLoc
   | LocalDec (DecBase f vn) SrcLoc
-  | ImportDec FilePath (f FilePath) SrcLoc
+  | ImportDec FilePath (f ImportName) SrcLoc
 
 deriving instance Show (DecBase Info VName)
 

--- a/src/Language/Futhark/TypeChecker/Monad.hs
+++ b/src/Language/Futhark/TypeChecker/Monad.hs
@@ -151,9 +151,9 @@ underscoreUse loc name =
       <+> dquotes (pretty name)
         <> ": variables prefixed with underscore may not be accessed."
 
--- | A mapping from import strings to 'Env's.  This is used to resolve
--- @import@ declarations.
-type ImportTable = M.Map String Env
+-- | A mapping from import import names to 'Env's.  This is used to
+-- resolve @import@ declarations.
+type ImportTable = M.Map ImportName Env
 
 data Context = Context
   { contextEnv :: Env,
@@ -239,18 +239,18 @@ lookupMTy loc qn = do
     explode = unknownVariable Signature qn loc
 
 -- | Look up an import.
-lookupImport :: SrcLoc -> FilePath -> TypeM (FilePath, Env)
+lookupImport :: SrcLoc -> FilePath -> TypeM (ImportName, Env)
 lookupImport loc file = do
   imports <- asks contextImportTable
   my_path <- asks contextImportName
-  let canonical_import = includeToString $ mkImportFrom my_path file
+  let canonical_import = mkImportFrom my_path file
   case M.lookup canonical_import imports of
     Nothing ->
       typeError loc mempty $
         "Unknown import"
-          <+> dquotes (pretty canonical_import)
+          <+> dquotes (pretty (includeToText canonical_import))
           </> "Known:"
-          <+> commasep (map pretty (M.keys imports))
+          <+> commasep (map (pretty . includeToText) (M.keys imports))
     Just scope -> pure (canonical_import, scope)
 
 -- | Evaluate a 'TypeM' computation within an extended (/not/


### PR DESCRIPTION
Previously some parts of the compiler would use FilePaths directly, and it is ambiguous whether those refer to canonical import names. Now it should be clearer.