### PR TITLE
Support rev AD of scanomaps and scatters with non-identity lambdas.

### DIFF
--- a/src/Futhark/AD/Rev/SOAC.hs
+++ b/src/Futhark/AD/Rev/SOAC.hs
@@ -130,6 +130,14 @@ vjpSOAC ops pat _aux (Screma w as form) m
         redomapToMapAndReduce pat (w, reds, map_lam, as)
       vjpStm ops mapstm $ vjpStm ops redstm m
 
+-- Differentiating Scanomaps
+vjpSOAC ops pat _aux (Screma w as form) m
+  | Just (scans, map_lam) <-
+      isScanomapSOAC form = do
+      (mapstm, scanstm) <-
+        scanomapToMapAndScan pat (w, scans, map_lam, as)
+      vjpStm ops mapstm $ vjpStm ops scanstm m
+
 -- Differentiating Scatter
 vjpSOAC ops pat aux (Scatter w lam ass written_info) m =
   vjpScatter ops pat aux (w, lam, ass, written_info) m

--- a/tests/ad/issue1879.fut
+++ b/tests/ad/issue1879.fut
@@ -1,0 +1,14 @@
+-- ==
+-- entry: main_ad
+-- compiled input { [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]] }
+-- output { [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]] }
+-- compiled input { [[1.0, 2.0, 3.0], [7.0, 8.0, 9.0]] }
+-- output {  [[1.0, 1.0, 1.0], [0.0, 0.0, 0.0]] }
+
+def f [n] (xs: [n][3]f64) =
+  let p x = if x[0] < 5 then true else false
+  let (res, sizes) = partition p xs
+  in res |> flatten |> f64.sum
+
+entry main_ad xs =
+  vjp f xs 1.0


### PR DESCRIPTION
Fixes #1879.