### PR TITLE
Record which tuning params are relevant to which entry points.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+* The manifest file now lists which tuning parameters are relevant for
+  each entry point. (#1884)
+
+* A command `tuning_params` has been added to the server protocol.
+
 ### Removed
 
 ### Changed

--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,5 @@
 packages: futhark.cabal
-index-state: 2022-12-07T11:58:45Z
+index-state: 2023-03-10T13:52:14Z
 
 package futhark
   ghc-options: -j -fwrite-ide-info -hiedir=.hie

--- a/docs/manifest.schema.json
+++ b/docs/manifest.schema.json
@@ -13,6 +13,12 @@
                 "type": "object",
                 "properties": {
                     "cfun": {"type": "string"},
+                    "tuning_params": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
                     "outputs": {
                         "type": "array",
                         "items": {

--- a/docs/server-protocol.rst
+++ b/docs/server-protocol.rst
@@ -146,10 +146,24 @@ Corresponds to :c:func:`futhark_context_unpause_profiling`.
 
 Corresponds to :c:func:`futhark_context_report`.
 
-``set_tuning_param``
-....................
+``set_tuning_param`` *param* *value*
+....................................
 
 Corresponds to :c:func:`futhark_context_config_set_tuning_param`.
+
+``tuning_params`` *entry*
+.........................
+
+For each tuning parameters relevant to the given entry point, print
+its name, then a space, then its class.
+
+This is similar to on :c:func:`futhark_tuning_params_for_sum`, but
+note that this command prints *names* and not *integers*.
+
+``tuning_param_class`` *param*
+..............................
+
+Corresponds to :c:func:`futhark_get_tuning_param_class`.
 
 Record Commands
 ~~~~~~~~~~~~~~~

--- a/futhark.cabal
+++ b/futhark.cabal
@@ -483,8 +483,8 @@ library
     , filepath >=1.4.1.1
     , free >=4.12.4
     , futhark-data >= 1.1.0.0
-    , futhark-server >= 1.2.1.0
-    , futhark-manifest >= 1.1.0.0
+    , futhark-server >= 1.2.2.0
+    , futhark-manifest >= 1.2.0.1
     , githash >=0.1.6.1
     , half >= 0.3
     , haskeline
@@ -498,7 +498,6 @@ library
     , neat-interpolation >=0.3
     , parallel >=3.2.1.0
     , random >= 1.2.0
-    , process >=1.4.3.0
     , process-extras >=0.7.2
     , regex-tdfa >=1.2
     , srcloc >=0.4

--- a/nix/futhark-manifest.nix
+++ b/nix/futhark-manifest.nix
@@ -4,8 +4,8 @@
 }:
 mkDerivation {
   pname = "futhark-manifest";
-  version = "1.1.0.0";
-  sha256 = "f676f515ab0d9ab5805f04a6e05d20d5641ba93fd6c4fd233aa79a9fcd1a2ef8";
+  version = "1.2.0.1";
+  sha256 = "Bj5E84pvspyONfQZ7rYJWu1y1GnXuWaHdAgtj1IZS58=";
   libraryHaskellDepends = [ aeson base bytestring containers text ];
   testHaskellDepends = [
     base QuickCheck quickcheck-instances tasty tasty-hunit

--- a/nix/futhark-server.nix
+++ b/nix/futhark-server.nix
@@ -3,8 +3,8 @@
 }:
 mkDerivation {
   pname = "futhark-server";
-  version = "1.2.1.0";
-  sha256 = "7bd141337811fb631336b1df6ba7f323d0316230581288d1481ab1d6e861b244";
+  version = "1.2.2.0";
+  sha256 = "rWofkL4KdmlP4ixB9Dzvf9+PMzCq3J9y1Em6ZNarAa0=";
   libraryHaskellDepends = [
     base binary bytestring directory futhark-data mtl process temporary
     text

--- a/src/Futhark/CodeGen/Backends/GenericC/CLI.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC/CLI.hs
@@ -296,7 +296,7 @@ printResult manifest = concatMap f
 
 cliEntryPoint ::
   Manifest -> T.Text -> EntryPoint -> (C.Definition, C.Initializer)
-cliEntryPoint manifest entry_point_name (EntryPoint cfun outputs inputs) =
+cliEntryPoint manifest entry_point_name (EntryPoint cfun _tuning_params outputs inputs) =
   let (input_items, pack_input, free_input, free_parsed, input_args) =
         unzip5 $ readInputs manifest $ map inputType inputs
 

--- a/src/Futhark/CodeGen/Backends/PyOpenCL/Boilerplate.hs
+++ b/src/Futhark/CodeGen/Backends/PyOpenCL/Boilerplate.hs
@@ -15,8 +15,8 @@ import Futhark.CodeGen.ImpCode.OpenCL
   ( ErrorMsg (..),
     ErrorMsgPart (..),
     FailureMsg (..),
+    ParamMap,
     PrimType (..),
-    SizeClass (..),
     errorMsgArgTypes,
     sizeDefault,
     untyped,
@@ -31,7 +31,7 @@ errorMsgNumArgs = length . errorMsgArgTypes
 -- | Python code (as a string) that calls the
 -- @initiatialize_opencl_object@ procedure.  Should be put in the
 -- class constructor.
-openClInit :: [PrimType] -> String -> M.Map Name SizeClass -> [FailureMsg] -> T.Text
+openClInit :: [PrimType] -> String -> ParamMap -> [FailureMsg] -> T.Text
 openClInit types assign sizes failures =
   [text|
 size_heuristics=$size_heuristics
@@ -76,10 +76,10 @@ formatFailure (FailureMsg (ErrorMsg parts) backtrace) =
     onPart (ErrorString s) = formatEscape $ T.unpack s
     onPart ErrorVal {} = "{}"
 
-sizeClassesToPython :: M.Map Name SizeClass -> PyExp
+sizeClassesToPython :: ParamMap -> PyExp
 sizeClassesToPython = Dict . map f . M.toList
   where
-    f (size_name, size_class) =
+    f (size_name, (size_class, _)) =
       ( String $ prettyText size_name,
         Dict
           [ (String "class", String $ prettyText size_class),

--- a/src/Futhark/CodeGen/ImpCode.hs
+++ b/src/Futhark/CodeGen/ImpCode.hs
@@ -75,6 +75,7 @@ module Futhark.CodeGen.ImpCode
     lexicalMemoryUsage,
     calledFuncs,
     callGraph,
+    ParamMap,
 
     -- * Typed enumerations
     Bytes,
@@ -105,7 +106,7 @@ import Data.Text qualified as T
 import Data.Traversable
 import Futhark.Analysis.PrimExp
 import Futhark.Analysis.PrimExp.Convert
-import Futhark.IR.GPU.Sizes (Count (..))
+import Futhark.IR.GPU.Sizes (Count (..), SizeClass (..))
 import Futhark.IR.Pretty ()
 import Futhark.IR.Prop.Names
 import Futhark.IR.Syntax.Core
@@ -405,6 +406,10 @@ callGraph f (Functions funs) =
       let grow v = maybe (S.singleton v) (S.insert v) (M.lookup v cur)
           next = M.map (foldMap grow) cur
        in if next == cur then cur else loop next
+
+-- | A mapping from names of tuning parameters to their class, as well
+-- as which functions make use of them (including transitively).
+type ParamMap = M.Map Name (SizeClass, S.Set Name)
 
 -- | A side-effect free expression whose execution will produce a
 -- single primitive value.

--- a/src/Futhark/CodeGen/ImpCode/OpenCL.hs
+++ b/src/Futhark/CodeGen/ImpCode/OpenCL.hs
@@ -39,7 +39,7 @@ data Program = Program
     -- | So we can detect whether the device is capable.
     openClUsedTypes :: [PrimType],
     -- | Runtime-configurable constants.
-    openClSizes :: M.Map Name SizeClass,
+    openClParams :: ParamMap,
     -- | Assertion failure error messages.
     openClFailures :: [FailureMsg],
     hostDefinitions :: Definitions OpenCL


### PR DESCRIPTION
This involves extending the manifest and server protocol, and modifying 'futhark autotune' to use this new information.

The main advantage (apart from general cleanup) is that we can now tune threshold parameters used in non-inlined functions.

Closes #1884.