### PR TITLE
Simplify normalisation pass.

### DIFF
--- a/src/Language/Futhark/Prop.hs
+++ b/src/Language/Futhark/Prop.hs
@@ -28,6 +28,7 @@ module Language.Futhark.Prop
     valBindTypeScheme,
     valBindBound,
     funType,
+    strip,
     similarExps,
 
     -- * Queries on patterns and params


### PR DESCRIPTION
In particular, it was excessively monadic.  There was no need for the outer monad.  Also, the ArrowArgM did not need to have an inner monad.

You may consider whether ArrowArgM needs to exist at all.  I suspect those functions would be simpler if they were written in a conventional functional style.

Similarly, Writer looks really seductive at first, but it's slow and when things get complicated, code using it is difficult to read (e.g. 'pass').  I used to use it a lot, but now I always use State instead.

It's pretty common for people who are experienced functional programmers, but new to Haskell, to over-monadify their code.