### PR TITLE
Use 64-bit transpose kernels for large arrays.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Some index optimisations removed certificates (#1952).
 
+* GPU backends can now transpose arrays whose size does not fit in a
+  32-bit integer (#1953).
+
 ## [0.24.3]
 
 ### Fixed


### PR DESCRIPTION
Unfortunately, using 64 bit index arithmetic in all cases results in unacceptable performance for small arrays, so we need this bit of multi-versioning.  Fortunately the transpose kernels are not large.

Fixes #1953.