### PR TITLE
Better unscoping

### DIFF
--- a/prelude/soacs.fut
+++ b/prelude/soacs.fut
@@ -181,8 +181,7 @@ def filter [n] 'a (p: a -> bool) (as: [n]a): *[]a =
 def partition [n] 'a (p: a -> bool) (as: [n]a): ?[k].([k]a, [n-k]a) =
   let p' x = if p x then 0 else 1
   let (as', is) = intrinsics.partition 2 p' as
-  let k = is[0]
-  in (as'[0:k], as'[k:n])
+  in (as'[0:is[0]], as'[is[0]:n])
 
 -- | Split an array by two predicates, producing three arrays.
 --
@@ -192,11 +191,9 @@ def partition [n] 'a (p: a -> bool) (as: [n]a): ?[k].([k]a, [n-k]a) =
 def partition2 [n] 'a (p1: a -> bool) (p2: a -> bool) (as: [n]a): ?[k][l].([k]a, [l]a, [n-k-l]a) =
   let p' x = if p1 x then 0 else if p2 x then 1 else 2
   let (as', is) = intrinsics.partition 3 p' as
-  let k = is[0]
-  let l = is[1]
-  in (as'[0:k],
-      as'[k:k+l] :> [l]a,
-      as'[k+l:n] :> [n-k-l]a)
+  in (as'[0:is[0]],
+      as'[is[0]:is[0]+is[1]] :> [is[1]]a,
+      as'[is[0]+is[1]:n] :> [n-is[0]-is[1]]a)
 
 -- | Return `true` if the given function returns `true` for all
 -- elements in the array.

--- a/src/Futhark/Util.hs
+++ b/src/Futhark/Util.hs
@@ -468,7 +468,7 @@ concatMapM f xs = mconcat <$> mapM f xs
 -- | Topological sorting of an array with an adjancency function,
 -- if there is a cycle, it cause an error
 -- @a `dep` b@ means 'a -> b', and the returned array guarantee that for i < j,
--- @not ( (ret !! i) `dep` (ret !! j) )@. (e.g. a depends of b)
+-- @not ( (ret !! j) `dep` (ret !! i) )@.
 topologicalSort :: (a -> a -> Bool) -> [a] -> [a]
 topologicalSort dep nodes =
   fst $ execState (mapM_ (sorting . snd) nodes_idx) (mempty, mempty)

--- a/src/Futhark/Util.hs
+++ b/src/Futhark/Util.hs
@@ -48,6 +48,7 @@ module Futhark.Util
     traverseFold,
     fixPoint,
     concatMapM,
+    topologicalSort,
   )
 where
 
@@ -57,12 +58,14 @@ import Control.Exception
 import Control.Monad
 import Control.Monad.State
 import Crypto.Hash.MD5 as MD5
+import Data.Bifunctor qualified as BiFunc
 import Data.ByteString qualified as BS
 import Data.ByteString.Base16 qualified as Base16
 import Data.Char
 import Data.Either
 import Data.Foldable (fold, toList)
 import Data.Function ((&))
+import Data.IntMap qualified as IM
 import Data.List (findIndex, foldl', genericDrop, genericSplitAt, sortBy)
 import Data.List.NonEmpty qualified as NE
 import Data.Map qualified as M
@@ -461,3 +464,31 @@ fixPoint f x =
 
 concatMapM :: (Monad m, Monoid b) => (a -> m b) -> [a] -> m b
 concatMapM f xs = mconcat <$> mapM f xs
+
+-- | Topological sorting of an array with an adjancency function,
+-- if there is a cycle, it cause an error
+-- @a `dep` b@ means 'a -> b', and the returned array guarantee that for i < j,
+-- @not ( (ret !! i) `dep` (ret !! j) )@. (e.g. a depends of b)
+topologicalSort :: (a -> a -> Bool) -> [a] -> [a]
+topologicalSort dep nodes =
+  fst $ execState (mapM_ (sorting . snd) nodes_idx) (mempty, mempty)
+  where
+    nodes_idx = zip nodes [0 ..]
+    depends_of a (b, i) =
+      if a `dep` b
+        then Just i
+        else Nothing
+
+    -- Using an IntMap Bool
+    -- when reading a lookup:
+    -- \* Nothing : never explored
+    -- \* Just True : being explored
+    -- \* Just False : explored
+    sorting i = do
+      status <- gets $ IM.lookup i . snd
+      when (status == Just True) $ error "topological sorting has encountered a cycle"
+      unless (status == Just False) $ do
+        let node = nodes !! i
+        modify $ BiFunc.second $ IM.insert i True
+        mapM_ sorting $ mapMaybe (depends_of node) nodes_idx
+        modify $ BiFunc.bimap (node :) (IM.insert i False)

--- a/src/Language/Futhark/Prop.hs
+++ b/src/Language/Futhark/Prop.hs
@@ -1498,7 +1498,7 @@ similarSlices slice1 slice2
 -- similar, but you can check for that!).  This is the machinery
 -- underlying expresssion unification.
 similarExps :: Exp -> Exp -> Maybe [(Exp, Exp)]
-similarExps e1 e2 | e1 == e2 = Just []
+similarExps e1 e2 | bareExp e1 == bareExp e2 = Just []
 similarExps e1 e2 | Just e1' <- stripExp e1 = similarExps e1' e2
 similarExps e1 e2 | Just e2' <- stripExp e2 = similarExps e1 e2'
 similarExps


### PR DESCRIPTION
Implementation of one of the after #1925 remarks, 
> ```futhark
> def partition [n] 'a (p: a -> bool) (as: [n]a): ?[k].([k]a, [n-k]a) =
>   let p' x = if p x then 0 else 1
>   let (as', is) = intrinsics.partition 2 p' as
>   in (take is[0] as', drop is[0] as')
> ```
> 
> it would be cool if the typing detect that the return type is `([d]t, [n-d]t)` without helping it with a let-bind
