### PR TITLE
Type-check aliasing in separate pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   multidimensional variants), as well as `split`, now have more
   precise types.
 
+* Local and anonymous (lambda) functions that *must* return unique
+  results (because they are passed to a higher order function that
+  requires this) must now have an explicit return type ascription that
+  declares this, using `*`.  This is very rare (in practice
+  unobserved) in real programs.
+
 ### Fixed
 
 * `futhark doc` produced some invalid links.

--- a/futhark.cabal
+++ b/futhark.cabal
@@ -442,6 +442,7 @@ library
       Language.Futhark.Traversals
       Language.Futhark.Tuple
       Language.Futhark.TypeChecker
+      Language.Futhark.TypeChecker.Consumption
       Language.Futhark.TypeChecker.Match
       Language.Futhark.TypeChecker.Modules
       Language.Futhark.TypeChecker.Monad

--- a/src/Futhark/IR/Pretty.hs
+++ b/src/Futhark/IR/Pretty.hs
@@ -43,9 +43,6 @@ instance Pretty Commutativity where
   pretty Commutative = "commutative"
   pretty Noncommutative = "noncommutative"
 
-instance Pretty NoUniqueness where
-  pretty _ = mempty
-
 instance Pretty Shape where
   pretty = mconcat . map (brackets . pretty) . shapeDims
 

--- a/src/Futhark/IR/Syntax/Core.hs
+++ b/src/Futhark/IR/Syntax/Core.hs
@@ -12,7 +12,6 @@ module Futhark.IR.Syntax.Core
     -- * Types
     Commutativity (..),
     Uniqueness (..),
-    NoUniqueness (..),
     ShapeBase (..),
     Shape,
     stripDims,
@@ -220,16 +219,6 @@ data Space
 
 -- | A string representing a specific non-default memory space.
 type SpaceId = String
-
--- | A fancier name for @()@ - encodes no uniqueness information.
-data NoUniqueness = NoUniqueness
-  deriving (Eq, Ord, Show)
-
-instance Semigroup NoUniqueness where
-  NoUniqueness <> NoUniqueness = NoUniqueness
-
-instance Monoid NoUniqueness where
-  mempty = NoUniqueness
 
 -- | The type of a value.  When comparing types for equality with
 -- '==', shapes must match.

--- a/src/Futhark/Internalise/Defunctorise.hs
+++ b/src/Futhark/Internalise/Defunctorise.hs
@@ -250,9 +250,8 @@ transformNames x = do
           mapOnName = \v ->
             pure $ qualLeaf $ fst $ lookupSubstInScope (qualName v) scope,
           mapOnStructType = astMap (substituter scope),
-          mapOnPatType = astMap (substituter scope),
-          mapOnStructRetType = astMap (substituter scope),
-          mapOnPatRetType = astMap (substituter scope)
+          mapOnParamType = astMap (substituter scope),
+          mapOnResRetType = astMap (substituter scope)
         }
     onExp scope e =
       -- One expression is tricky, because it interacts with scoping rules.
@@ -269,6 +268,9 @@ transformTypeExp = transformNames
 
 transformStructType :: StructType -> TransformM StructType
 transformStructType = transformNames
+
+transformResType :: ResType -> TransformM ResType
+transformResType = transformNames
 
 transformExp :: Exp -> TransformM Exp
 transformExp = transformNames
@@ -287,7 +289,7 @@ transformValBind (ValBind entry name tdecl (Info (RetType dims t)) tparams param
   entry' <- traverse (traverse transformEntry) entry
   name' <- transformName name
   tdecl' <- traverse transformTypeExp tdecl
-  t' <- transformStructType t
+  t' <- transformResType t
   e' <- transformExp e
   tparams' <- traverse transformNames tparams
   params' <- traverse transformNames params

--- a/src/Futhark/Internalise/Entry.hs
+++ b/src/Futhark/Internalise/Entry.hs
@@ -109,13 +109,13 @@ entryPointType types t ts
   | E.Scalar (E.Prim E.Unsigned {}) <- E.entryType t,
     [I.Prim ts0] <- ts =
       pure (u, I.TypeTransparent $ I.ValueType I.Unsigned (I.Rank 0) ts0)
-  | E.Array _ _ _ (E.Prim E.Unsigned {}) <- E.entryType t,
+  | E.Array _ _ (E.Prim E.Unsigned {}) <- E.entryType t,
     [I.Array ts0 r _] <- ts =
       pure (u, I.TypeTransparent $ I.ValueType I.Unsigned r ts0)
   | E.Scalar E.Prim {} <- E.entryType t,
     [I.Prim ts0] <- ts =
       pure (u, I.TypeTransparent $ I.ValueType I.Signed (I.Rank 0) ts0)
-  | E.Array _ _ _ E.Prim {} <- E.entryType t,
+  | E.Array _ _ E.Prim {} <- E.entryType t,
     [I.Array ts0 r _] <- ts =
       pure (u, I.TypeTransparent $ I.ValueType I.Signed r ts0)
   | otherwise = do

--- a/src/Futhark/Internalise/Exps.hs
+++ b/src/Futhark/Internalise/Exps.hs
@@ -951,7 +951,7 @@ internalisePat desc sizes p e m = do
   ses <- internaliseExp desc' e
   internalisePat' sizes p ses m
   where
-    desc' = case S.toList $ E.patIdents p of
+    desc' = case E.patIdents p of
       [v] -> baseString $ E.identName v
       _ -> desc
 

--- a/src/Futhark/Internalise/Exps.hs
+++ b/src/Futhark/Internalise/Exps.hs
@@ -465,7 +465,7 @@ internaliseAppExp desc _ (E.DoLoop sparams mergepat mergeexp form loopbody loc) 
 
       ts <- mapM subExpType mergeinit
       bindingLoopParams sparams' mergepat ts $ \shapepat mergepat' ->
-        bindingLambdaParams [x] (map rowType arr_ts) $ \x_params -> do
+        bindingLambdaParams [toParam E.Observe <$> x] (map rowType arr_ts) $ \x_params -> do
           let loopvars = zip x_params arr'
           forLoop mergepat' shapepat mergeinit $
             I.ForLoop i Int64 w loopvars
@@ -551,7 +551,7 @@ internaliseAppExp desc _ (E.DoLoop sparams mergepat mergeexp form loopbody loc) 
             )
 internaliseAppExp desc _ (E.LetWith name src idxs ve body loc) = do
   let pat = E.Id (E.identName name) (E.identType name) loc
-      src_t = E.fromStruct <$> E.identType src
+      src_t = E.identType src
       e = E.Update (E.Var (E.qualName $ E.identName src) src_t loc) idxs ve loc
   internaliseExp desc $
     E.AppExp
@@ -745,7 +745,7 @@ internaliseExp desc (E.Update src slice ve loc) = do
 internaliseExp desc (E.RecordUpdate src fields ve _ _) = do
   src' <- internaliseExp desc src
   ve' <- internaliseExp desc ve
-  replace (E.typeOf src `setAliases` ()) fields ve' src'
+  replace (E.typeOf src) fields ve' src'
   where
     replace (E.Scalar (E.Record m)) (f : fs) ve' src'
       | Just t <- M.lookup f m = do
@@ -834,12 +834,11 @@ internaliseExp _ (E.FloatLit v (Info t) _) =
 -- overloaded.
 internaliseExp desc (E.Project k e (Info rt) _) = do
   let i' = sum . map internalisedTypeSize $
-        case E.typeOf e `setAliases` () of
+        case E.typeOf e of
           E.Scalar (Record fs) ->
             map snd $ takeWhile ((/= k) . fst) $ sortFields fs
           t -> [t]
-  take (internalisedTypeSize $ rt `setAliases` ()) . drop i'
-    <$> internaliseExp desc e
+  take (internalisedTypeSize rt) . drop i' <$> internaliseExp desc e
 internaliseExp _ e@E.Lambda {} =
   error $ "internaliseExp: Unexpected lambda at " ++ locStr (srclocOf e)
 internaliseExp _ e@E.OpSection {} =
@@ -866,7 +865,7 @@ internaliseArg desc (arg, argdim) = do
         _ -> pure ()
       pure arg'
 
-internalisePatLit :: E.PatLit -> E.PatType -> I.PrimValue
+internalisePatLit :: E.PatLit -> E.StructType -> I.PrimValue
 internalisePatLit (E.PatLitPrim v) _ =
   internalisePrimValue v
 internalisePatLit (E.PatLitInt x) (E.Scalar (E.Prim (E.Signed it))) =
@@ -879,7 +878,7 @@ internalisePatLit l t =
   error $ "Nonsensical pattern and type: " ++ show (l, t)
 
 generateCond ::
-  E.Pat ->
+  E.Pat StructType ->
   [I.SubExp] ->
   InternaliseM ([Maybe I.PrimValue], [I.SubExp])
 generateCond orig_p orig_ses = do
@@ -944,7 +943,7 @@ generateCond orig_p orig_ses = do
 internalisePat ::
   String ->
   [E.SizeBinder VName] ->
-  E.Pat ->
+  E.Pat StructType ->
   E.Exp ->
   InternaliseM a ->
   InternaliseM a
@@ -958,13 +957,13 @@ internalisePat desc sizes p e m = do
 
 internalisePat' ::
   [E.SizeBinder VName] ->
-  E.Pat ->
+  E.Pat StructType ->
   [I.SubExp] ->
   InternaliseM a ->
   InternaliseM a
 internalisePat' sizes p ses m = do
   ses_ts <- mapM subExpType ses
-  stmPat p ses_ts $ \pat_names -> do
+  stmPat (toParam E.Observe <$> p) ses_ts $ \pat_names -> do
     bindExtSizes (AppRes (E.patternType p) (map E.sizeName sizes)) ses
     forM_ (zip pat_names ses) $ \(v, se) ->
       letBindNames [v] $ I.BasicOp $ I.SubExp se
@@ -1488,7 +1487,7 @@ bodyExtType (Body _ stms res) =
 internaliseLambda :: InternaliseLambda
 internaliseLambda (E.Parens e _) rowtypes =
   internaliseLambda e rowtypes
-internaliseLambda (E.Lambda params body _ (Info (_, RetType _ rettype)) _) rowtypes =
+internaliseLambda (E.Lambda params body _ (Info (RetType _ rettype)) _) rowtypes =
   bindingLambdaParams params rowtypes $ \params' -> do
     body' <- internaliseBody "lam" body
     rettype' <- internaliseLambdaReturnType rettype =<< bodyExtType body'
@@ -2162,9 +2161,9 @@ sizeExpForError e = do
   e' <- internaliseExp1 "size" e
   pure ["[", ErrorVal int64 e', "]"]
 
-typeExpForError :: E.TypeBase Size als -> InternaliseM [ErrorMsgPart SubExp]
+typeExpForError :: E.TypeBase Size u -> InternaliseM [ErrorMsgPart SubExp]
 typeExpForError (E.Scalar (E.Prim t)) = pure [ErrorString $ prettyText t]
-typeExpForError (E.Scalar (E.TypeVar _ _ v args)) = do
+typeExpForError (E.Scalar (E.TypeVar _ v args)) = do
   args' <- concat <$> mapM onArg args
   pure $ intersperse " " $ ErrorString (prettyText v) : args'
   where
@@ -2180,7 +2179,7 @@ typeExpForError (E.Scalar (E.Record fs))
   where
     onField (k, te) =
       (ErrorString (prettyText k <> ": ") :) <$> typeExpForError te
-typeExpForError (E.Array _ _ shape et) = do
+typeExpForError (E.Array _ shape et) = do
   shape' <- mconcat <$> mapM sizeExpForError (E.shapeDims shape)
   et' <- typeExpForError $ Scalar et
   pure $ shape' ++ et'

--- a/src/Futhark/Internalise/Monomorphise.hs
+++ b/src/Futhark/Internalise/Monomorphise.hs
@@ -487,10 +487,9 @@ transformRetTypeSizes argset (RetType dims ty) = do
 
 sizesForPat :: MonadFreshNames m => Pat ParamType -> m ([VName], Pat ParamType)
 sizesForPat pat = do
-  (params', sizes) <- runStateT (astMap tv pat) []
+  (params', sizes) <- runStateT (traverse (bitraverse onDim pure) pat) []
   pure (sizes, params')
   where
-    tv = identityMapper {mapOnStructType = bitraverse onDim pure}
     onDim d
       | d == anySize = do
           v <- lift $ newVName "size"

--- a/src/Futhark/Internalise/Monomorphise.hs
+++ b/src/Futhark/Internalise/Monomorphise.hs
@@ -65,8 +65,8 @@ data PolyBinding
       RecordReplacements
       ( VName,
         [TypeParam],
-        [Pat],
-        StructRetType,
+        [Pat ParamType],
+        ResRetType,
         Exp,
         [AttrInfo VName],
         SrcLoc
@@ -77,7 +77,7 @@ data PolyBinding
 -- record patterns.
 type RecordReplacements = M.Map VName RecordReplacement
 
-type RecordReplacement = M.Map Name (VName, PatType)
+type RecordReplacement = M.Map Name (VName, StructType)
 
 -- | To deduplicate size expressions, we want a looser notation of
 -- equality than the strict syntactical equality provided by the Eq
@@ -132,7 +132,7 @@ entryAssert (x : xs) body =
   where
     errmsg = Info "entry point arguments have invalid sizes."
     bool = Scalar $ Prim Bool
-    opt = foldFunType [(Observe, bool), (Observe, bool)] $ RetType [] bool
+    opt = foldFunType [bool, bool] $ RetType [] bool
     andop = Var (qualName (intrinsicVar "&&")) (Info opt) mempty
     eqop = Var (qualName (intrinsicVar "==")) (Info opt) mempty
     logAnd x' y =
@@ -333,13 +333,14 @@ instance Pretty (Shape MonoSize) where
 -- The kind of type relative to which we monomorphise.  What is most
 -- important to us is not the specific dimensions, but merely whether
 -- they are known or anonymous/local.
-type MonoType = TypeBase MonoSize ()
+type MonoType = TypeBase MonoSize NoUniqueness
 
 monoType :: TypeBase Size als -> MonoType
 monoType = noExts . (`evalState` (0, mempty)) . traverseDims onDim . toStruct
   where
     -- Remove exts from return types because we don't use them anymore.
-    noExts (Array as u shape t) = Array as u shape $ noExtsScalar t
+    noExts :: TypeBase MonoSize u -> TypeBase MonoSize u
+    noExts (Array u shape t) = Array u shape $ noExtsScalar t
     noExts (Scalar t) = Scalar $ noExtsScalar t
     noExtsScalar (Record fs) = Record $ M.map noExts fs
     noExtsScalar (Sum fs) = Sum $ M.map (map noExts) fs
@@ -404,7 +405,7 @@ replaceExp e =
 transformFName :: SrcLoc -> QualName VName -> StructType -> MonoM Exp
 transformFName loc fname t = do
   t' <- removeTypeVariablesInType t
-  t'' <- transformTypeSizes t'
+  t'' <- transformType t'
   let mono_t = monoType t'
   if baseTag (qualLeaf fname) <= maxIntrinsicTag
     then pure $ var fname t''
@@ -414,7 +415,7 @@ transformFName loc fname t = do
       case (maybe_fname, maybe_funbind) of
         -- The function has already been monomorphised.
         (Just (fname', infer), _) ->
-          applySizeArgs fname' t'' <$> infer t''
+          applySizeArgs fname' (toRes Nonunique t'') <$> infer t''
         -- An intrinsic function.
         (Nothing, Nothing) -> pure $ var fname t''
         -- A polymorphic function.
@@ -422,16 +423,16 @@ transformFName loc fname t = do
           (fname', infer, funbind') <- monomorphiseBinding False funbind mono_t
           tell $ Seq.singleton (qualLeaf fname, funbind')
           addLifted (qualLeaf fname) mono_t (fname', infer)
-          applySizeArgs fname' t'' <$> infer t''
+          applySizeArgs fname' (toRes Nonunique t'') <$> infer t''
   where
-    var fname' t'' = Var fname' (Info (fromStruct t'')) loc
+    var fname' t'' = Var fname' (Info t'') loc
 
     applySizeArg t' (i, f) size_arg =
       ( i - 1,
         mkApply
           f
           [(Observe, Nothing, size_arg)]
-          (AppRes (foldFunType (replicate i (Observe, i64)) (RetType [] (fromStruct t'))) [])
+          (AppRes (foldFunType (replicate i i64) (RetType [] t')) [])
       )
 
     applySizeArgs fname' t' size_args =
@@ -441,40 +442,36 @@ transformFName loc fname t = do
           ( length size_args - 1,
             Var
               (qualName fname')
-              ( Info
-                  ( foldFunType
-                      (map (const (Observe, i64)) size_args)
-                      (RetType [] $ fromStruct t')
-                  )
-              )
+              (Info (foldFunType (map (const i64) size_args) (RetType [] t')))
               loc
           )
           size_args
 
-transformTypeSizes :: TypeBase Size as -> MonoM (TypeBase Size as)
-transformTypeSizes typ =
+transformType :: TypeBase Size u -> MonoM (TypeBase Size u)
+transformType typ =
   case typ of
     Scalar scalar -> Scalar <$> transformScalarSizes scalar
-    Array as u shape scalar -> Array as u <$> mapM onDim shape <*> transformScalarSizes scalar
+    Array u shape scalar -> Array u <$> mapM onDim shape <*> transformScalarSizes scalar
   where
+    transformScalarSizes :: ScalarTypeBase Size u -> MonoM (ScalarTypeBase Size u)
     transformScalarSizes (Record fs) =
-      Record <$> traverse transformTypeSizes fs
+      Record <$> traverse transformType fs
     transformScalarSizes (Sum cs) =
-      Sum <$> (traverse . traverse) transformTypeSizes cs
+      Sum <$> (traverse . traverse) transformType cs
     transformScalarSizes (Arrow as argName d argT retT) = do
       retT' <- transformRetTypeSizes argset retT
-      Arrow as argName d <$> transformTypeSizes argT <*> pure retT'
+      Arrow as argName d <$> transformType argT <*> pure retT'
       where
         argset =
           fvVars (freeInType argT)
             <> case argName of
               Unnamed -> mempty
               Named vn -> S.singleton vn
-    transformScalarSizes (TypeVar as uniq qn args) =
-      TypeVar as uniq qn <$> mapM onArg args
+    transformScalarSizes (TypeVar u qn args) =
+      TypeVar u qn <$> mapM onArg args
       where
         onArg (TypeArgDim dim) = TypeArgDim <$> onDim dim
-        onArg (TypeArgType ty) = TypeArgType <$> transformTypeSizes ty
+        onArg (TypeArgType ty) = TypeArgType <$> transformType ty
     transformScalarSizes ty@Prim {} = pure ty
 
     onDim e
@@ -483,24 +480,17 @@ transformTypeSizes typ =
 
 transformRetTypeSizes :: S.Set VName -> RetTypeBase Size as -> MonoM (RetTypeBase Size as)
 transformRetTypeSizes argset (RetType dims ty) = do
-  ty' <- withArgs argset $ transformTypeSizes ty
+  ty' <- withArgs argset $ transformType ty
   rl <- parametrizing argset
   let dims' = dims <> map snd rl
   pure $ RetType dims' ty'
 
--- This blanks all alias information from the type, which we should
--- not need downstream anyway.
---
--- It also transforms any size expressions.
-transformType :: PatType -> MonoM PatType
-transformType = fmap (`setAliases` mempty) . transformTypeSizes
-
-sizesForPat :: MonadFreshNames m => Pat -> m ([VName], Pat)
+sizesForPat :: MonadFreshNames m => Pat ParamType -> m ([VName], Pat ParamType)
 sizesForPat pat = do
   (params', sizes) <- runStateT (astMap tv pat) []
   pure (sizes, params')
   where
-    tv = identityMapper {mapOnPatType = bitraverse onDim pure}
+    tv = identityMapper {mapOnStructType = bitraverse onDim pure}
     onDim d
       | d == anySize = do
           v <- lift $ newVName "size"
@@ -637,7 +627,7 @@ transformAppExp (BinOp (fname, _) (Info t) (e1, d1) (e2, d2) loc) res = do
       x <- newNameFromString "binop_p"
       pure
         ( Var (qualName x) (Info argtype) mempty,
-          Id x (Info $ fromStruct argtype) mempty
+          Id x (Info argtype) mempty
         )
 transformAppExp (LetWith id1 id2 idxs e1 body loc) res = do
   id1' <- transformIdent id1
@@ -736,7 +726,7 @@ transformExp (Lambda params e0 decl tp loc) = do
     Lambda params'
       <$> withParams paramed (scoping argset $ transformExp e0)
       <*> pure decl
-      <*> traverse (traverse transformRetType) tp
+      <*> traverse transformRetType tp
       <*> pure loc
 transformExp (OpSection qn t loc) =
   transformExp $ Var qn t loc
@@ -819,65 +809,64 @@ desugarBinOpSection ::
   QualName VName ->
   Maybe Exp ->
   Maybe Exp ->
-  PatType ->
-  (PName, StructType, Maybe VName) ->
-  (PName, StructType, Maybe VName) ->
-  (PatRetType, [VName]) ->
+  StructType ->
+  (PName, ParamType, Maybe VName) ->
+  (PName, ParamType, Maybe VName) ->
+  (ResRetType, [VName]) ->
   SrcLoc ->
   MonoM Exp
 desugarBinOpSection fname e_left e_right t (xp, xtype, xext) (yp, ytype, yext) (RetType dims rettype, retext) loc = do
-  t' <- transformTypeSizes t
+  t' <- transformType t
   op <- transformFName loc fname $ toStruct t
-  (v1, wrap_left, e1, p1) <- makeVarParam e_left . fromStruct =<< transformTypeSizes xtype
-  (v2, wrap_right, e2, p2) <- makeVarParam e_right . fromStruct =<< transformTypeSizes ytype
+  (v1, wrap_left, e1, p1) <- makeVarParam e_left =<< transformType xtype
+  (v2, wrap_right, e2, p2) <- makeVarParam e_right =<< transformType ytype
   let apply_left =
         mkApply
           op
           [(Observe, xext, e1)]
-          (AppRes (Scalar $ Arrow mempty yp Observe ytype (RetType [] t')) [])
+          (AppRes (Scalar $ Arrow mempty yp (diet ytype) (toStruct ytype) (RetType [] $ toRes Nonunique t')) [])
       onDim (Var d typ _)
         | Named p <- xp, qualLeaf d == p = Var (qualName v1) typ loc
         | Named p <- yp, qualLeaf d == p = Var (qualName v2) typ loc
       onDim d = d
       rettype' = first onDim rettype
-      rettype'' = toStruct rettype'
-  body <- scoping (S.fromList [v1, v2]) $ mkApply apply_left [(Observe, yext, e2)] <$> transformAppRes (AppRes rettype' retext)
-  rettype''' <- transformRetTypeSizes (S.fromList [v1, v2]) $ RetType dims rettype''
-  pure $
-    wrap_left $
-      wrap_right $
-        Lambda (p1 ++ p2) body Nothing (Info (mempty, rettype''')) loc
+  body <-
+    scoping (S.fromList [v1, v2]) $
+      mkApply apply_left [(Observe, yext, e2)]
+        <$> transformAppRes (AppRes (toStruct rettype') retext)
+  rettype'' <- transformRetTypeSizes (S.fromList [v1, v2]) $ RetType dims rettype'
+  pure . wrap_left . wrap_right $
+    Lambda (p1 ++ p2) body Nothing (Info rettype'') loc
   where
     patAndVar argtype = do
       x <- newNameFromString "x"
       pure
         ( x,
           Id x (Info argtype) mempty,
-          Var (qualName x) (Info argtype) mempty
+          Var (qualName x) (Info (toStruct argtype)) mempty
         )
 
     makeVarParam (Just e) argtype = do
       (v, pat, var_e) <- patAndVar argtype
       let wrap body =
-            AppExp (LetPat [] pat e body mempty) (Info $ AppRes (typeOf body) mempty)
+            AppExp (LetPat [] (fmap toStruct pat) e body mempty) (Info $ AppRes (typeOf body) mempty)
       pure (v, wrap, var_e, [])
     makeVarParam Nothing argtype = do
       (v, pat, var_e) <- patAndVar argtype
       pure (v, id, var_e, [pat])
 
-desugarProjectSection :: [Name] -> PatType -> SrcLoc -> MonoM Exp
+desugarProjectSection :: [Name] -> StructType -> SrcLoc -> MonoM Exp
 desugarProjectSection fields (Scalar (Arrow _ _ _ t1 (RetType dims t2))) loc = do
   p <- newVName "project_p"
-  let body = foldl project (Var (qualName p) (Info t1') mempty) fields
+  let body = foldl project (Var (qualName p) (Info t1) mempty) fields
   pure $
     Lambda
-      [Id p (Info t1') mempty]
+      [Id p (Info $ toParam Observe t1) mempty]
       body
       Nothing
-      (Info (mempty, RetType dims $ toStruct t2))
+      (Info (RetType dims t2))
       loc
   where
-    t1' = fromStruct t1
     project e field =
       case typeOf e of
         Scalar (Record fs)
@@ -891,18 +880,18 @@ desugarProjectSection fields (Scalar (Arrow _ _ _ t1 (RetType dims t2))) loc = d
               ++ prettyString field
 desugarProjectSection _ t _ = error $ "desugarOpSection: not a function type: " ++ prettyString t
 
-desugarIndexSection :: [DimIndex] -> PatType -> SrcLoc -> MonoM Exp
+desugarIndexSection :: [DimIndex] -> StructType -> SrcLoc -> MonoM Exp
 desugarIndexSection idxs (Scalar (Arrow _ _ _ t1 (RetType dims t2))) loc = do
   p <- newVName "index_i"
-  t1' <- fromStruct <$> transformTypeSizes t1
+  t1' <- transformType t1
   t2' <- transformType t2
-  let body = AppExp (Index (Var (qualName p) (Info t1') loc) idxs loc) (Info (AppRes t2' []))
+  let body = AppExp (Index (Var (qualName p) (Info t1') loc) idxs loc) (Info (AppRes (toStruct t2') []))
   pure $
     Lambda
-      [Id p (Info (fromStruct t1')) mempty]
+      [Id p (Info $ toParam Observe t1') mempty]
       body
       Nothing
-      (Info (mempty, RetType dims $ toStruct t2'))
+      (Info (RetType dims t2'))
       loc
 desugarIndexSection _ t _ = error $ "desugarIndexSection: not a function type: " ++ prettyString t
 
@@ -916,7 +905,7 @@ unfoldLetFuns (ValBind _ fname _ (Info rettype) dim_params params body _ _ loc :
     e' = unfoldLetFuns rest e
     e_t = typeOf e'
 
-transformPat :: Pat -> MonoM (Pat, RecordReplacements)
+transformPat :: Pat (TypeBase Size u) -> MonoM (Pat (TypeBase Size u), RecordReplacements)
 transformPat (Id v (Info (Scalar (Record fs))) loc) = do
   let fs' = M.toList fs
   (fs_ks, fs_ts) <- fmap unzip $
@@ -926,7 +915,7 @@ transformPat (Id v (Info (Scalar (Record fs))) loc) = do
     ( RecordPat
         (zip (map fst fs') (zipWith3 Id fs_ks (map Info fs_ts) $ repeat loc))
         loc,
-      M.singleton v $ M.fromList $ zip (map fst fs') $ zip fs_ks fs_ts
+      M.singleton v $ M.fromList $ zip (map fst fs') $ zip fs_ks $ map toStruct fs_ts
     )
 transformPat (Id v t loc) = do
   t' <- traverse transformType t
@@ -954,7 +943,7 @@ transformPat (PatConstr name t all_ps loc) = do
   (all_ps', rrs) <- mapAndUnzipM transformPat all_ps
   pure (PatConstr name t all_ps' loc, mconcat rrs)
 
-wildcard :: PatType -> SrcLoc -> Pat
+wildcard :: TypeBase Size u -> SrcLoc -> Pat (TypeBase Size u)
 wildcard (Scalar (Record fs)) loc =
   RecordPat (zip (M.keys fs) $ map ((`Wildcard` loc) . Info) $ M.elems fs) loc
 wildcard t loc =
@@ -1017,18 +1006,18 @@ inferSizeArgs tparams bind_t bind_r t = do
 noNamedParams :: MonoType -> MonoType
 noNamedParams = f
   where
-    f (Array () u shape t) = Array () u shape (f' t)
+    f :: TypeBase MonoSize u -> TypeBase MonoSize u
+    f (Array u shape t) = Array u shape (f' t)
     f (Scalar t) = Scalar $ f' t
-    f' (Arrow () _ d1 t1 (RetType dims t2)) =
-      Arrow () Unnamed d1 (f t1) (RetType dims (f t2))
-    f' (Record fs) =
-      Record $ fmap f fs
-    f' (Sum cs) =
-      Sum $ fmap (map f) cs
+    f' :: ScalarTypeBase MonoSize u -> ScalarTypeBase MonoSize u
+    f' (Record fs) = Record $ fmap f fs
+    f' (Sum cs) = Sum $ fmap (map f) cs
+    f' (Arrow u _ d1 t1 (RetType dims t2)) =
+      Arrow u Unnamed d1 (f t1) (RetType dims (f t2))
     f' t = t
 
-transformRetType :: StructRetType -> MonoM StructRetType
-transformRetType (RetType ext t) = RetType ext <$> transformTypeSizes t
+transformRetType :: RetTypeBase Size u -> MonoM (RetTypeBase Size u)
+transformRetType (RetType ext t) = RetType ext <$> transformType t
 
 -- | arrowArg takes a return type and returns it
 -- with the existentials bound moved at the right of arrows.
@@ -1076,8 +1065,8 @@ arrowArg scope argset args_params rety =
             <> case argName of
               Unnamed -> mempty
               Named vn -> S.singleton vn
-    arrowArgScalar env (TypeVar as uniq qn args) =
-      TypeVar as uniq qn <$> mapM arrowArgArg args
+    arrowArgScalar env (TypeVar u qn args) =
+      TypeVar u qn <$> mapM arrowArgArg args
       where
         arrowArgArg (TypeArgDim dim) = TypeArgDim <$> arrowArgSize dim
         arrowArgArg (TypeArgType ty) = TypeArgType <$> arrowArgType env ty
@@ -1087,8 +1076,8 @@ arrowArg scope argset args_params rety =
       (S.Set VName, [VName]) ->
       TypeBase Size as' ->
       Writer (S.Set VName, S.Set VName) (TypeBase Size as')
-    arrowArgType env (Array as u shape scalar) =
-      Array as u <$> traverse arrowArgSize shape <*> arrowArgScalar env scalar
+    arrowArgType env (Array u shape scalar) =
+      Array u <$> traverse arrowArgSize shape <*> arrowArgScalar env scalar
     arrowArgType env (Scalar ty) =
       Scalar <$> arrowArgScalar env ty
 
@@ -1107,16 +1096,16 @@ arrowArg scope argset args_params rety =
       Sum $ (M.map . map) (arrowCleanType paramed) cs
     arrowCleanScalar paramed (Arrow as argName d argT retT) =
       Arrow as argName d argT (arrowCleanRetType paramed retT)
-    arrowCleanScalar paramed (TypeVar as uniq qn args) =
-      TypeVar as uniq qn $ map arrowCleanArg args
+    arrowCleanScalar paramed (TypeVar u qn args) =
+      TypeVar u qn $ map arrowCleanArg args
       where
         arrowCleanArg (TypeArgDim dim) = TypeArgDim dim
         arrowCleanArg (TypeArgType ty) = TypeArgType $ arrowCleanType paramed ty
     arrowCleanScalar _ ty = ty
 
     arrowCleanType :: S.Set VName -> TypeBase Size as -> TypeBase Size as
-    arrowCleanType paramed (Array as u shape scalar) =
-      Array as u shape $ arrowCleanScalar paramed scalar
+    arrowCleanType paramed (Array u shape scalar) =
+      Array u shape $ arrowCleanScalar paramed scalar
     arrowCleanType paramed (Scalar ty) =
       Scalar $ arrowCleanScalar paramed ty
 
@@ -1143,9 +1132,9 @@ monomorphiseBinding entry (PolyBinding rr (name, tparams, params, rettype, body,
       typeSubstsM loc (noSizes bind_t) $ noNamedParams inst_t
     let shape_names = S.fromList $ map typeParamName $ shape_params ++ t_shape_params
         substs' = M.map (Subst []) substs
-        substPatType =
+        substStructType =
           substTypesAny (fmap (fmap (second (const mempty))) . (`M.lookup` substs'))
-        params' = map (substPat entry substPatType) params
+        params' = map (substPat entry substStructType) params
     (params'', rrs) <- withArgs shape_names $ mapAndUnzipM transformPat params'
     exp_naming <- paramGetClean shape_names
 
@@ -1208,7 +1197,7 @@ monomorphiseBinding entry (PolyBinding rr (name, tparams, params, rettype, body,
     updateExpTypes substs = astMap (mapper substs)
 
     hardTransformRetType (RetType dims ty) = do
-      ty' <- transformTypeSizes ty
+      ty' <- transformType ty
       unbounded <- askIntros $ fvVars $ freeInType ty'
       let dims' = S.toList unbounded
       pure $ RetType (dims' <> dims) ty'
@@ -1218,9 +1207,8 @@ monomorphiseBinding entry (PolyBinding rr (name, tparams, params, rettype, body,
         { mapOnExp = updateExpTypes substs,
           mapOnName = pure,
           mapOnStructType = pure . applySubst substs,
-          mapOnPatType = pure . applySubst substs,
-          mapOnStructRetType = pure . applySubst substs,
-          mapOnPatRetType = pure . applySubst substs
+          mapOnParamType = pure . applySubst substs,
+          mapOnResRetType = pure . applySubst substs
         }
 
     shapeParam tp = Id (typeParamName tp) (Info i64) $ srclocOf tp
@@ -1242,13 +1230,13 @@ monomorphiseBinding entry (PolyBinding rr (name, tparams, params, rettype, body,
 typeSubstsM ::
   MonadFreshNames m =>
   SrcLoc ->
-  TypeBase () () ->
+  TypeBase () NoUniqueness ->
   MonoType ->
   m (M.Map VName StructRetType, [TypeParam])
 typeSubstsM loc orig_t1 orig_t2 =
   runWriterT $ fst <$> execStateT (sub orig_t1 orig_t2) (mempty, mempty)
   where
-    subRet (Scalar (TypeVar _ _ v _)) rt =
+    subRet (Scalar (TypeVar _ v _)) rt =
       unless (baseTag (qualLeaf v) <= maxIntrinsicTag) $
         addSubst v rt
     subRet t1 (RetType _ t2) =
@@ -1258,7 +1246,7 @@ typeSubstsM loc orig_t1 orig_t2 =
       | Just t1' <- peelArray (arrayRank t1) t1,
         Just t2' <- peelArray (arrayRank t1) t2 =
           sub t1' t2'
-    sub (Scalar (TypeVar _ _ v _)) t =
+    sub (Scalar (TypeVar _ v _)) t =
       unless (baseTag (qualLeaf v) <= maxIntrinsicTag) $
         addSubst v $
           RetType [] t
@@ -1270,7 +1258,7 @@ typeSubstsM loc orig_t1 orig_t2 =
     sub (Scalar Prim {}) (Scalar Prim {}) = pure ()
     sub (Scalar (Arrow _ _ _ t1a (RetType _ t1b))) (Scalar (Arrow _ _ _ t2a t2b)) = do
       sub t1a t2a
-      subRet t1b t2b
+      subRet (toStruct t1b) (second (const NoUniqueness) t2b)
     sub (Scalar (Sum cs1)) (Scalar (Sum cs2)) =
       zipWithM_ typeSubstClause (sortConstrs cs1) (sortConstrs cs2)
       where
@@ -1298,7 +1286,7 @@ typeSubstsM loc orig_t1 orig_t2 =
     onDim MonoAnon = pure anySize
 
 -- Perform a given substitution on the types in a pattern.
-substPat :: Bool -> (PatType -> PatType) -> Pat -> Pat
+substPat :: Bool -> (t -> t) -> Pat t -> Pat t
 substPat entry f pat = case pat of
   TuplePat pats loc -> TuplePat (map (substPat entry f) pats) loc
   RecordPat fs loc -> RecordPat (map substField fs) loc
@@ -1328,9 +1316,8 @@ removeTypeVariables entry valbind = do
           { mapOnExp = onExp,
             mapOnName = pure,
             mapOnStructType = pure . applySubst (`M.lookup` subs),
-            mapOnPatType = pure . applySubst (`M.lookup` subs),
-            mapOnStructRetType = pure . applySubst (`M.lookup` subs),
-            mapOnPatRetType = pure . applySubst (`M.lookup` subs)
+            mapOnParamType = pure . applySubst (`M.lookup` subs),
+            mapOnResRetType = pure . applySubst (`M.lookup` subs)
           }
 
       onExp = astMap mapper

--- a/src/Language/Futhark/Core.hs
+++ b/src/Language/Futhark/Core.hs
@@ -3,6 +3,7 @@
 -- representation.
 module Language.Futhark.Core
   ( Uniqueness (..),
+    NoUniqueness (..),
 
     -- * Location utilities
     SrcLoc,
@@ -70,6 +71,20 @@ instance Monoid Uniqueness where
 instance Pretty Uniqueness where
   pretty Unique = "*"
   pretty Nonunique = mempty
+
+-- | A fancier name for @()@ - encodes no uniqueness information.
+-- Also has a different prettyprinting instance.
+data NoUniqueness = NoUniqueness
+  deriving (Eq, Ord, Show)
+
+instance Semigroup NoUniqueness where
+  NoUniqueness <> NoUniqueness = NoUniqueness
+
+instance Monoid NoUniqueness where
+  mempty = NoUniqueness
+
+instance Pretty NoUniqueness where
+  pretty _ = mempty
 
 -- | The abstract (not really) type representing names in the Futhark
 -- compiler.  'String's, being lists of characters, are very slow,

--- a/src/Language/Futhark/Interpreter/Values.hs
+++ b/src/Language/Futhark/Interpreter/Values.hs
@@ -76,8 +76,8 @@ emptyShape :: ValueShape -> Bool
 emptyShape (ShapeDim d s) = d == 0 || emptyShape s
 emptyShape _ = False
 
-typeShape :: TypeBase d () -> Shape d
-typeShape (Array _ _ shape et) =
+typeShape :: TypeBase d u -> Shape d
+typeShape (Array _ shape et) =
   foldr ShapeDim (typeShape (Scalar et)) $ shapeDims shape
 typeShape (Scalar (Record fs)) =
   ShapeRecord $ M.map typeShape fs

--- a/src/Language/Futhark/Parser/Monad.hs
+++ b/src/Language/Futhark/Parser/Monad.hs
@@ -87,7 +87,7 @@ mustBe (L loc _) expected =
     "Only the keyword '" <> expected <> "' may appear here."
 
 mustBeEmpty :: Located loc => loc -> ValueType -> ParserMonad ()
-mustBeEmpty _ (Array _ _ (Shape dims) _)
+mustBeEmpty _ (Array _ (Shape dims) _)
   | 0 `elem` dims = pure ()
 mustBeEmpty loc t =
   parseErrorAt loc $ Just $ prettyText t <> " is not an empty array."
@@ -156,7 +156,7 @@ applyExp es =
         index = AppExp (Index e (is ++ map DimFix xs) xloc) NoInfo
     op f x = pure $ mkApplyUT f x
 
-patternExp :: UncheckedPat -> ParserMonad UncheckedExp
+patternExp :: UncheckedPat t -> ParserMonad UncheckedExp
 patternExp (Id v _ loc) = pure $ Var (qualName v) NoInfo loc
 patternExp (TuplePat pats loc) = TupLit <$> mapM patternExp pats <*> pure loc
 patternExp (Wildcard _ loc) = parseErrorAt loc $ Just "cannot have wildcard here."

--- a/src/Language/Futhark/Parser/Parser.y
+++ b/src/Language/Futhark/Parser/Parser.y
@@ -525,14 +525,14 @@ SizeExp :: { SizeExp NoInfo Name }
          | '...[' Exp ']' { SizeExp $2 (srcspan $1 $>) }
          | '...['     ']' { SizeExpAny (srcspan $1 $>) }
 
-FunParam :: { PatBase NoInfo Name }
-FunParam : InnerPat { $1 }
+FunParam :: { PatBase NoInfo Name ParamType }
+FunParam : InnerPat { fmap (toParam Observe) $1 }
 
-FunParams1 :: { (PatBase NoInfo Name, [PatBase NoInfo Name]) }
+FunParams1 :: { (PatBase NoInfo Name ParamType, [PatBase NoInfo Name ParamType]) }
 FunParams1 : FunParam            { ($1, []) }
            | FunParam FunParams1 { ($1, fst $2 : snd $2) }
 
-FunParams :: { [PatBase NoInfo Name] }
+FunParams :: { [PatBase NoInfo Name ParamType ] }
 FunParams :                     { [] }
            | FunParam FunParams { $1 : $2 }
 
@@ -768,9 +768,9 @@ IfExp :: { UncheckedExp }
 
 LoopExp :: { UncheckedExp }
          : loop Pat LoopForm do Exp %prec ifprec
-           {% fmap (\t -> AppExp (DoLoop [] $2 t $3 $5 (srcspan $1 $>)) NoInfo) (patternExp $2) }
+           {% fmap (\t -> AppExp (DoLoop [] (fmap (toParam Observe) $2) t $3 $5 (srcspan $1 $>)) NoInfo) (patternExp $2) }
          | loop Pat '=' Exp LoopForm do Exp %prec ifprec
-           { AppExp (DoLoop [] $2 $4 $5 $7 (srcspan $1 $>)) NoInfo }
+           { AppExp (DoLoop [] (fmap (toParam Observe) $2) $4 $5 $7 (srcspan $1 $>)) NoInfo }
 
 MatchExp :: { UncheckedExp }
           : match Exp Cases
@@ -785,7 +785,7 @@ Case :: { CaseBase NoInfo Name }
       : case CPat '->' Exp
         { let loc = srcspan $1 $> in CasePat $2 $> loc }
 
-CPat :: { PatBase NoInfo Name }
+CPat :: { PatBase NoInfo Name StructType }
           : '#[' AttrInfo ']' CPat    { PatAttr $2 $4 (srcspan $1 $>) }
           | CInnerPat ':' TypeExp     { PatAscription $1 $3 (srcspan $1 $>) }
           | CInnerPat                 { $1 }
@@ -793,11 +793,11 @@ CPat :: { PatBase NoInfo Name }
                                             loc' = srcspan loc $>
                                         in PatConstr n NoInfo $2 loc'}
 
-CPats1 :: { [PatBase NoInfo Name] }
+CPats1 :: { [PatBase NoInfo Name StructType] }
            : CPat               { [$1] }
            | CPat ',' CPats1 { $1 : $3 }
 
-CInnerPat :: { PatBase NoInfo Name }
+CInnerPat :: { PatBase NoInfo Name StructType }
                : id                                 { let L loc (ID name) = $1 in Id name NoInfo (srclocOf loc) }
                | '(' BindingBinOp ')'               { Id $2 NoInfo (srcspan $1 $>) }
                | '_'                                { Wildcard NoInfo (srclocOf $1) }
@@ -809,11 +809,11 @@ CInnerPat :: { PatBase NoInfo Name }
                | Constr                             { let (n, loc) = $1
                                                       in PatConstr n NoInfo [] (srclocOf loc) }
 
-ConstrFields :: { [PatBase NoInfo Name] }
+ConstrFields :: { [PatBase NoInfo Name StructType] }
               : CInnerPat                { [$1] }
               | ConstrFields CInnerPat   { $1 ++ [$2] }
 
-CFieldPat :: { (Name, PatBase NoInfo Name) }
+CFieldPat :: { (Name, PatBase NoInfo Name StructType) }
                : FieldId '=' CPat
                { (fst $1, $3) }
                | FieldId ':' TypeExp
@@ -821,11 +821,11 @@ CFieldPat :: { (Name, PatBase NoInfo Name) }
                | FieldId
                { (fst $1, Id (fst $1) NoInfo (srclocOf (snd $1))) }
 
-CFieldPats :: { [(Name, PatBase NoInfo Name)] }
+CFieldPats :: { [(Name, PatBase NoInfo Name StructType)] }
                 : CFieldPats1 { $1 }
                 |             { [] }
 
-CFieldPats1 :: { [(Name, PatBase NoInfo Name)] }
+CFieldPats1 :: { [(Name, PatBase NoInfo Name StructType)] }
                  : CFieldPat ',' CFieldPats1 { $1 : $3 }
                  | CFieldPat                    { [$1] }
 
@@ -868,23 +868,23 @@ DimIndices1 :: { (UncheckedDimIndex, [UncheckedDimIndex]) }
              : DimIndex                 { ($1, []) }
              | DimIndex ',' DimIndices1 { ($1, fst $3 : snd $3) }
 
-VarId :: { IdentBase NoInfo Name }
+VarId :: { IdentBase NoInfo Name StructType }
 VarId : id { let L loc (ID name) = $1 in Ident name NoInfo (srclocOf loc) }
 
 FieldId :: { (Name, Loc) }
          : id     { let L loc (ID name) = $1 in (name, loc) }
          | natlit { let L loc (NATLIT x _) = $1 in (x, loc) }
 
-Pat :: { PatBase NoInfo Name }
+Pat :: { PatBase NoInfo Name StructType }
      : '#[' AttrInfo ']' Pat  { PatAttr $2 $4 (srcspan $1 $>) }
      | InnerPat ':' TypeExp   { PatAscription $1 $3 (srcspan $1 $>) }
      | InnerPat               { $1 }
 
-Pats1 :: { [PatBase NoInfo Name] }
+Pats1 :: { [PatBase NoInfo Name StructType] }
        : Pat                    { [$1] }
        | Pat ',' Pats1          { $1 : $3 }
 
-InnerPat :: { PatBase NoInfo Name }
+InnerPat :: { PatBase NoInfo Name StructType }
 InnerPat : id                               { let L loc (ID name) = $1 in Id name NoInfo (srclocOf loc) }
              | '(' BindingBinOp ')'         { Id $2 NoInfo (srcspan $1 $>) }
              | '_'                          { Wildcard NoInfo (srclocOf $1) }
@@ -893,7 +893,7 @@ InnerPat : id                               { let L loc (ID name) = $1 in Id nam
              | '(' Pat ',' Pats1 ')'        { TuplePat ($2:$4) (srcspan $1 $>) }
              | '{' FieldPats '}'            { RecordPat $2 (srcspan $1 $>) }
 
-FieldPat :: { (Name, PatBase NoInfo Name) }
+FieldPat :: { (Name, PatBase NoInfo Name StructType) }
               : FieldId '=' Pat
                 { (fst $1, $3) }
               | FieldId ':' TypeExp
@@ -901,11 +901,11 @@ FieldPat :: { (Name, PatBase NoInfo Name) }
               | FieldId
                 { (fst $1, Id (fst $1) NoInfo (srclocOf (snd $1))) }
 
-FieldPats :: { [(Name, PatBase NoInfo Name)] }
+FieldPats :: { [(Name, PatBase NoInfo Name StructType)] }
                : FieldPats1 { $1 }
                |            { [] }
 
-FieldPats1 :: { [(Name, PatBase NoInfo Name)] }
+FieldPats1 :: { [(Name, PatBase NoInfo Name StructType)] }
                : FieldPat ',' FieldPats1 { $1 : $3 }
                | FieldPat                    { [$1] }
 

--- a/src/Language/Futhark/Prop.hs
+++ b/src/Language/Futhark/Prop.hs
@@ -45,14 +45,12 @@ module Language.Futhark.Prop
     -- * Queries on types
     uniqueness,
     unique,
-    aliases,
     diet,
     arrayRank,
     arrayShape,
     orderZero,
     unfoldFunType,
     foldFunType,
-    foldFunTypeFromParams,
     typeVars,
     isAccType,
 
@@ -63,9 +61,12 @@ module Language.Futhark.Prop
     arrayOfWithAliases,
     toStructural,
     toStruct,
-    fromStruct,
-    setAliases,
-    addAliases,
+    toRes,
+    toParam,
+    resToParam,
+    paramToRes,
+    toStructRet,
+    toResRet,
     setUniqueness,
     noSizes,
     traverseDims,
@@ -127,7 +128,6 @@ where
 
 import Control.Monad
 import Control.Monad.State
-import Data.Bifoldable
 import Data.Bifunctor
 import Data.Bitraversable (bitraverse)
 import Data.Char
@@ -159,7 +159,7 @@ arrayRank = shapeRank . arrayShape
 
 -- | Return the shape of a type - for non-arrays, this is 'mempty'.
 arrayShape :: TypeBase dim as -> Shape dim
-arrayShape (Array _ _ ds _) = ds
+arrayShape (Array _ ds _) = ds
 arrayShape _ = mempty
 
 -- | Change the shape of a type to be just the rank.
@@ -199,8 +199,8 @@ traverseDims f = go mempty PosImmediate
       bitraverse (f bound b) pure t
     go bound b (Scalar (Record fields)) =
       Scalar . Record <$> traverse (go bound b) fields
-    go bound b (Scalar (TypeVar as u tn targs)) =
-      Scalar <$> (TypeVar as u tn <$> traverse (onTypeArg bound b) targs)
+    go bound b (Scalar (TypeVar as tn targs)) =
+      Scalar <$> (TypeVar as tn <$> traverse (onTypeArg bound b) targs)
     go bound b (Scalar (Sum cs)) =
       Scalar . Sum <$> traverse (traverse (go bound b)) cs
     go _ _ (Scalar (Prim t)) =
@@ -220,9 +220,9 @@ traverseDims f = go mempty PosImmediate
       TypeArgType <$> go bound b t
 
 -- | Return the uniqueness of a type.
-uniqueness :: TypeBase shape as -> Uniqueness
-uniqueness (Array _ u _ _) = u
-uniqueness (Scalar (TypeVar _ u _ _)) = u
+uniqueness :: TypeBase shape Uniqueness -> Uniqueness
+uniqueness (Array u _ _) = u
+uniqueness (Scalar (TypeVar u _ _)) = u
 uniqueness (Scalar (Sum ts))
   | any (any unique) ts = Unique
 uniqueness (Scalar (Record fs))
@@ -230,24 +230,17 @@ uniqueness (Scalar (Record fs))
 uniqueness _ = Nonunique
 
 -- | @unique t@ is 'True' if the type of the argument is unique.
-unique :: TypeBase shape as -> Bool
+unique :: TypeBase shape Uniqueness -> Bool
 unique = (== Unique) . uniqueness
-
--- | Return the set of all variables mentioned in the aliasing of a
--- type.
-aliases :: Monoid as => TypeBase shape as -> as
-aliases = bifoldMap (const mempty) id
 
 -- | @diet t@ returns a description of how a function parameter of
 -- type @t@ consumes its argument.
-diet :: TypeBase shape as -> Diet
+diet :: TypeBase shape Diet -> Diet
 diet (Scalar (Record ets)) = foldl max Observe $ fmap diet ets
 diet (Scalar (Prim _)) = Observe
 diet (Scalar (Arrow {})) = Observe
-diet (Array _ Unique _ _) = Consume
-diet (Array _ Nonunique _ _) = Observe
-diet (Scalar (TypeVar _ Unique _ _)) = Consume
-diet (Scalar (TypeVar _ Nonunique _ _)) = Observe
+diet (Array d _ _) = d
+diet (Scalar (TypeVar d _ _)) = d
 diet (Scalar (Sum cs)) = foldl max Observe $ foldMap (map diet) cs
 
 -- | Convert any type to one that has rank information, no alias
@@ -255,67 +248,84 @@ diet (Scalar (Sum cs)) = foldl max Observe $ foldMap (map diet) cs
 toStructural ::
   TypeBase dim as ->
   TypeBase () ()
-toStructural = flip setAliases () . first (const ())
+toStructural = bimap (const ()) (const ())
 
--- | Remove aliasing information from a type.
-toStruct ::
-  TypeBase dim as ->
-  TypeBase dim ()
-toStruct t = t `setAliases` ()
+-- | Remove uniquenss information from a type.
+toStruct :: TypeBase dim u -> TypeBase dim NoUniqueness
+toStruct = second (const NoUniqueness)
 
--- | Replace no aliasing with an empty alias set.
-fromStruct ::
-  TypeBase dim as ->
-  TypeBase dim Aliasing
-fromStruct t = t `setAliases` S.empty
+-- | Uses 'Observe'.
+toParam :: Diet -> TypeBase Size u -> ParamType
+toParam d = fmap (const d)
+
+-- | Convert to 'ResType'
+toRes :: Uniqueness -> TypeBase Size u -> ResType
+toRes u = fmap (const u)
+
+-- | Convert to 'ResRetType'
+toResRet :: Uniqueness -> RetTypeBase Size u -> ResRetType
+toResRet u = second (const u)
+
+-- | Convert to 'StructRetType'
+toStructRet :: RetTypeBase Size u -> StructRetType
+toStructRet = second (const NoUniqueness)
+
+-- | Preserves relation between 'Diet' and 'Uniqueness'.
+resToParam :: ResType -> ParamType
+resToParam = second f
+  where
+    f Unique = Consume
+    f Nonunique = Observe
+
+-- | Preserves relation between 'Diet' and 'Uniqueness'.
+paramToRes :: ParamType -> ResType
+paramToRes = second f
+  where
+    f Consume = Unique
+    f Observe = Nonunique
 
 -- | @peelArray n t@ returns the type resulting from peeling the first
 -- @n@ array dimensions from @t@.  Returns @Nothing@ if @t@ has less
 -- than @n@ dimensions.
-peelArray :: Int -> TypeBase dim as -> Maybe (TypeBase dim as)
-peelArray n (Array als u shape t)
+peelArray :: Int -> TypeBase dim u -> Maybe (TypeBase dim u)
+peelArray n (Array u shape t)
   | shapeRank shape == n =
-      Just $ Scalar t `addAliases` const als
+      Just $ second (const u) (Scalar t)
   | otherwise =
-      Array als u <$> stripDims n shape <*> pure t
+      Array u <$> stripDims n shape <*> pure t
 peelArray _ _ = Nothing
 
 -- | @arrayOf u s t@ constructs an array type.  The convenience
 -- compared to using the 'Array' constructor directly is that @t@ can
 -- itself be an array.  If @t@ is an @n@-dimensional array, and @s@ is
 -- a list of length @n@, the resulting type is of an @n+m@ dimensions.
--- The uniqueness of the new array will be @u@, no matter the
--- uniqueness of @t@.
 arrayOf ::
-  Monoid as =>
-  Uniqueness ->
   Shape dim ->
-  TypeBase dim as ->
-  TypeBase dim as
+  TypeBase dim NoUniqueness ->
+  TypeBase dim NoUniqueness
 arrayOf = arrayOfWithAliases mempty
 
--- | Like 'arrayOf', but you can pass in aliases of the resulting array.
+-- | Like 'arrayOf', but you can pass in uniqueness info of the
+-- resulting array.
 arrayOfWithAliases ::
-  Monoid as =>
-  as ->
-  Uniqueness ->
+  u ->
   Shape dim ->
-  TypeBase dim as ->
-  TypeBase dim as
-arrayOfWithAliases as2 u shape2 (Array as1 _ shape1 et) =
-  Array (as1 <> as2) u (shape2 <> shape1) et
-arrayOfWithAliases as u shape (Scalar t) =
-  Array as u shape (second (const ()) t)
+  TypeBase dim u ->
+  TypeBase dim u
+arrayOfWithAliases u shape2 (Array _ shape1 et) =
+  Array u (shape2 <> shape1) et
+arrayOfWithAliases u shape (Scalar t) =
+  Array u shape (second (const mempty) t)
 
 -- | @stripArray n t@ removes the @n@ outermost layers of the array.
 -- Essentially, it is the type of indexing an array of type @t@ with
 -- @n@ indexes.
 stripArray :: Int -> TypeBase dim as -> TypeBase dim as
-stripArray n (Array als u shape et)
+stripArray n (Array u shape et)
   | Just shape' <- stripDims n shape =
-      Array als u shape' et
+      Array u shape' et
   | otherwise =
-      Scalar et `setUniqueness` u `setAliases` als
+      second (const u) (Scalar et)
 stripArray _ t = t
 
 -- | Create a record type corresponding to a tuple with the given
@@ -375,15 +385,13 @@ matchDims ::
 matchDims onDims = matchDims' mempty
   where
     matchDims' ::
-      forall as'. Monoid as' => [VName] -> TypeBase d1 as' -> TypeBase d2 as' -> m (TypeBase d1 as')
+      forall u'. Monoid u' => [VName] -> TypeBase d1 u' -> TypeBase d2 u' -> m (TypeBase d1 u')
     matchDims' bound t1 t2 =
       case (t1, t2) of
-        (Array als1 u1 shape1 et1, Array als2 u2 shape2 et2) ->
-          flip setAliases (als1 <> als2)
-            <$> ( arrayOf (min u1 u2)
-                    <$> onShapes bound shape1 shape2
-                    <*> matchDims' bound (Scalar et1) (Scalar et2)
-                )
+        (Array u1 shape1 et1, Array u2 shape2 et2) ->
+          arrayOfWithAliases u1
+            <$> onShapes bound shape1 shape2
+            <*> matchDims' bound (second (const u2) (Scalar et1)) (second (const u2) (Scalar et2))
         (Scalar (Record f1), Scalar (Record f2)) ->
           Scalar . Record
             <$> traverse (uncurry (matchDims' bound)) (M.intersectionWith (,) f1 f2)
@@ -401,10 +409,10 @@ matchDims onDims = matchDims' mempty
                           <$> matchDims' bound' a1 a2
                           <*> (RetType dims1 <$> matchDims' bound' b1 b2)
                       )
-        ( Scalar (TypeVar als1 u v targs1),
-          Scalar (TypeVar als2 _ _ targs2)
+        ( Scalar (TypeVar als1 v targs1),
+          Scalar (TypeVar als2 _ targs2)
           ) ->
-            Scalar . TypeVar (als1 <> als2) u v
+            Scalar . TypeVar (als1 <> als2) v
               <$> zipWithM (matchTypeArg bound) targs1 targs2
         _ -> pure t1
 
@@ -418,29 +426,8 @@ matchDims onDims = matchDims' mempty
 
 -- | Set the uniqueness attribute of a type.  If the type is a record
 -- or sum type, the uniqueness of its components will be modified.
-setUniqueness :: TypeBase dim as -> Uniqueness -> TypeBase dim as
-setUniqueness (Array als _ shape et) u =
-  Array als u shape et
-setUniqueness (Scalar (TypeVar als _ t targs)) u =
-  Scalar $ TypeVar als u t targs
-setUniqueness (Scalar (Record ets)) u =
-  Scalar $ Record $ fmap (`setUniqueness` u) ets
-setUniqueness (Scalar (Sum ets)) u =
-  Scalar $ Sum $ fmap (map (`setUniqueness` u)) ets
-setUniqueness t _ = t
-
--- | @t \`setAliases\` als@ returns @t@, but with @als@ substituted for
--- any already present aliasing.
-setAliases :: TypeBase dim asf -> ast -> TypeBase dim ast
-setAliases t = addAliases t . const
-
--- | @t \`addAliases\` f@ returns @t@, but with any already present
--- aliasing replaced by @f@ applied to that aliasing.
-addAliases ::
-  TypeBase dim asf ->
-  (asf -> ast) ->
-  TypeBase dim ast
-addAliases = flip second
+setUniqueness :: TypeBase dim u1 -> u2 -> TypeBase dim u2
+setUniqueness t u = second (const u) t
 
 intValueType :: IntValue -> IntType
 intValueType Int8Value {} = Int8
@@ -462,7 +449,7 @@ primValueType BoolValue {} = Bool
 
 -- | The type of an Futhark term.  The aliasing will refer to itself, if
 -- the term is a non-tuple-typed variable.
-typeOf :: ExpBase Info VName -> PatType
+typeOf :: ExpBase Info VName -> StructType
 typeOf (Literal val _) = Scalar $ Prim $ primValueType val
 typeOf (IntLit _ (Info t) _) = t
 typeOf (FloatLit _ (Info t) _) = t
@@ -470,19 +457,14 @@ typeOf (Parens e _) = typeOf e
 typeOf (QualParens _ e _) = typeOf e
 typeOf (TupLit es _) = Scalar $ tupleRecord $ map typeOf es
 typeOf (RecordLit fs _) =
-  -- Reverse, because M.unions is biased to the left.
-  Scalar $ Record $ M.unions $ reverse $ map record fs
+  Scalar $ Record $ M.fromList $ map record fs
   where
-    record (RecordFieldExplicit name e _) = M.singleton name $ typeOf e
-    record (RecordFieldImplicit name (Info t) _) =
-      M.singleton (baseName name) $
-        t
-          `addAliases` S.insert (AliasBound name)
+    record (RecordFieldExplicit name e _) = (name, typeOf e)
+    record (RecordFieldImplicit name (Info t) _) = (baseName name, t)
 typeOf (ArrayLit _ (Info t) _) = t
 typeOf (StringLit vs loc) =
   Array
     mempty
-    Nonunique
     (Shape [sizeFromInteger (genericLength vs) loc])
     (Prim (Unsigned Int8))
 typeOf (Project _ _ (Info t) _) = t
@@ -492,17 +474,15 @@ typeOf (Ascript e _ _) = typeOf e
 typeOf (Coerce _ _ (Info t) _) = t
 typeOf (Negate e _) = typeOf e
 typeOf (Not e _) = typeOf e
-typeOf (Update e _ _ _) = typeOf e `setAliases` mempty
+typeOf (Update e _ _ _) = typeOf e
 typeOf (RecordUpdate _ _ _ (Info t) _) = t
 typeOf (Assert _ e _ _) = typeOf e
-typeOf (Lambda params _ _ (Info (als, t)) _) =
-  funType params t `setAliases` als
-typeOf (OpSection _ (Info t) _) =
-  t
+typeOf (Lambda params _ _ (Info t) _) = funType params t
+typeOf (OpSection _ (Info t) _) = t
 typeOf (OpSectionLeft _ _ _ (_, Info (pn, pt2)) (Info ret, _) _) =
-  Scalar $ Arrow mempty pn Observe pt2 ret
+  Scalar $ Arrow mempty pn (diet pt2) (toStruct pt2) ret
 typeOf (OpSectionRight _ _ _ (Info (pn, pt1), _) (Info ret) _) =
-  Scalar $ Arrow mempty pn Observe pt1 ret
+  Scalar $ Arrow mempty pn (diet pt1) (toStruct pt1) ret
 typeOf (ProjectSection _ (Info t) _) = t
 typeOf (IndexSection _ (Info t) _) = t
 typeOf (Constr _ _ (Info t) _) = t
@@ -510,48 +490,30 @@ typeOf (Attr _ e _) = typeOf e
 typeOf (AppExp _ (Info res)) = appResType res
 
 -- | The type of a function with the given parameters and return type.
-funType :: [PatBase Info VName] -> StructRetType -> StructType
+funType :: [Pat ParamType] -> ResRetType -> StructType
 funType params ret =
   let RetType _ t = foldr (arrow . patternParam) ret params
-   in t
+   in toStruct t
   where
     arrow (xp, d, xt) yt =
-      RetType [] $ Scalar $ Arrow () xp d xt' yt
-      where
-        xt' = xt `setUniqueness` Nonunique
+      RetType [] $ Scalar $ Arrow Nonunique xp d xt yt
 
 -- | @foldFunType ts ret@ creates a function type ('Arrow') that takes
 -- @ts@ as parameters and returns @ret@.
-foldFunType ::
-  Monoid as =>
-  [(Diet, TypeBase dim pas)] ->
-  RetTypeBase dim as ->
-  TypeBase dim as
+foldFunType :: [ParamType] -> ResRetType -> StructType
 foldFunType ps ret =
   let RetType _ t = foldr arrow ret ps
-   in t
+   in toStruct t
   where
-    arrow (d, t1) t2 =
-      RetType [] $ Scalar $ Arrow mempty Unnamed d t1' t2
-      where
-        t1' = toStruct t1 `setUniqueness` Nonunique
-
-foldFunTypeFromParams ::
-  Monoid as =>
-  [PatBase Info VName] ->
-  RetTypeBase Size as ->
-  TypeBase Size as
-foldFunTypeFromParams params =
-  foldFunType (zip (map diet params_ts) params_ts)
-  where
-    params_ts = map patternStructType params
+    arrow t1 t2 =
+      RetType [] $ Scalar $ Arrow Nonunique Unnamed (diet t1) (toStruct t1) t2
 
 -- | Extract the parameter types and return type from a type.
 -- If the type is not an arrow type, the list of parameter types is empty.
-unfoldFunType :: TypeBase dim as -> ([(Diet, TypeBase dim ())], TypeBase dim ())
+unfoldFunType :: TypeBase dim as -> ([TypeBase dim Diet], TypeBase dim NoUniqueness)
 unfoldFunType (Scalar (Arrow _ _ d t1 (RetType _ t2))) =
   let (ps, r) = unfoldFunType t2
-   in ((d, t1) : ps, r)
+   in (second (const d) t1 : ps, r)
 unfoldFunType t = ([], toStruct t)
 
 -- | The type scheme of a value binding, comprising the type
@@ -573,16 +535,16 @@ valBindBound vb =
       _ -> []
 
 -- | The type names mentioned in a type.
-typeVars :: Monoid as => TypeBase dim as -> S.Set VName
+typeVars :: TypeBase dim as -> S.Set VName
 typeVars t =
   case t of
     Scalar Prim {} -> mempty
-    Scalar (TypeVar _ _ tn targs) ->
+    Scalar (TypeVar _ tn targs) ->
       mconcat $ S.singleton (qualLeaf tn) : map typeArgFree targs
     Scalar (Arrow _ _ _ t1 (RetType _ t2)) -> typeVars t1 <> typeVars t2
     Scalar (Record fields) -> foldMap typeVars fields
     Scalar (Sum cs) -> mconcat $ (foldMap . fmap) typeVars cs
-    Array _ _ _ rt -> typeVars $ Scalar rt
+    Array _ _ rt -> typeVars $ Scalar rt
   where
     typeArgFree (TypeArgType ta) = typeVars ta
     typeArgFree TypeArgDim {} = mempty
@@ -600,7 +562,7 @@ orderZero (Scalar (Sum cs)) = all (all orderZero) cs
 
 -- | @patternOrderZero pat@ is 'True' if all of the types in the given pattern
 -- have order 0.
-patternOrderZero :: PatBase Info vn -> Bool
+patternOrderZero :: Pat (TypeBase d u) -> Bool
 patternOrderZero pat = case pat of
   TuplePat ps _ -> all patternOrderZero ps
   RecordPat fs _ -> all (patternOrderZero . snd) fs
@@ -613,8 +575,8 @@ patternOrderZero pat = case pat of
   PatAttr _ p _ -> patternOrderZero p
 
 -- | The set of identifiers bound in a pattern.
-patIdents :: (Functor f, Ord vn) => PatBase f vn -> S.Set (IdentBase f vn)
-patIdents (Id v t loc) = S.singleton $ Ident v t loc
+patIdents :: Pat (TypeBase Size u) -> S.Set (Ident StructType)
+patIdents (Id v t loc) = S.singleton $ Ident v (toStruct <$> t) loc
 patIdents (PatParens p _) = patIdents p
 patIdents (TuplePat pats _) = mconcat $ map patIdents pats
 patIdents (RecordPat fs _) = mconcat $ map (patIdents . snd) fs
@@ -625,7 +587,7 @@ patIdents (PatConstr _ _ ps _) = mconcat $ map patIdents ps
 patIdents (PatAttr _ p _) = patIdents p
 
 -- | The set of names bound in a pattern.
-patNames :: (Functor f, Ord vn) => PatBase f vn -> S.Set vn
+patNames :: Pat t -> S.Set VName
 patNames (Id v _ _) = S.singleton v
 patNames (PatParens p _) = patNames p
 patNames (TuplePat pats _) = mconcat $ map patNames pats
@@ -637,7 +599,7 @@ patNames (PatConstr _ _ ps _) = mconcat $ map patNames ps
 patNames (PatAttr _ p _) = patNames p
 
 -- | Each name bound in a pattern alongside its type.
-patternMap :: PatBase Info VName -> [(VName, PatType)]
+patternMap :: Pat t -> [(VName, t)]
 patternMap (Id v (Info t) _) = [(v, t)]
 patternMap (PatParens p _) = patternMap p
 patternMap (TuplePat pats _) = mconcat $ map patternMap pats
@@ -649,7 +611,7 @@ patternMap (PatConstr _ _ ps _) = mconcat $ map patternMap ps
 patternMap (PatAttr _ p _) = patternMap p
 
 -- | The type of values bound by the pattern.
-patternType :: PatBase Info VName -> PatType
+patternType :: Pat (TypeBase d u) -> TypeBase d u
 patternType (Wildcard (Info t) _) = t
 patternType (PatParens p _) = patternType p
 patternType (Id _ (Info t) _) = t
@@ -661,12 +623,12 @@ patternType (PatConstr _ (Info t) _ _) = t
 patternType (PatAttr _ p _) = patternType p
 
 -- | The type matched by the pattern, including shape declarations if present.
-patternStructType :: PatBase Info VName -> StructType
+patternStructType :: Pat (TypeBase Size u) -> StructType
 patternStructType = toStruct . patternType
 
 -- | When viewed as a function parameter, does this pattern correspond
 -- to a named parameter of some type?
-patternParam :: PatBase Info VName -> (PName, Diet, StructType)
+patternParam :: Pat ParamType -> (PName, Diet, StructType)
 patternParam (PatParens p _) =
   patternParam p
 patternParam (PatAttr _ p _) =
@@ -676,9 +638,9 @@ patternParam (PatAscription (Id v (Info t) _) _ _) =
 patternParam (Id v (Info t) _) =
   (Named v, diet t, toStruct t)
 patternParam p =
-  (Unnamed, diet p_t, p_t)
+  (Unnamed, diet p_t, toStruct p_t)
   where
-    p_t = patternStructType p
+    p_t = patternType p
 
 -- | Names of primitive types to types.  This is only valid if no
 -- shadowing is going on, but useful for tools.
@@ -701,7 +663,7 @@ namesToPrimTypes =
 data Intrinsic
   = IntrinsicMonoFun [PrimType] PrimType
   | IntrinsicOverloadedFun [PrimType] [Maybe PrimType] (Maybe PrimType)
-  | IntrinsicPolyFun [TypeParamBase VName] [(Diet, StructType)] (RetTypeBase Size ())
+  | IntrinsicPolyFun [TypeParamBase VName] [ParamType] (RetTypeBase Size Uniqueness)
   | IntrinsicType Liftedness [TypeParamBase VName] StructType
   | IntrinsicEquality -- Special cased.
 
@@ -710,17 +672,17 @@ intrinsicAcc =
   ( acc_v,
     IntrinsicType SizeLifted [TypeParamType Unlifted t_v mempty] $
       Scalar $
-        TypeVar () Nonunique (qualName acc_v) [arg]
+        TypeVar mempty (qualName acc_v) [arg]
   )
   where
     acc_v = VName "acc" 10
     t_v = VName "t" 11
-    arg = TypeArgType $ Scalar (TypeVar () Nonunique (qualName t_v) [])
+    arg = TypeArgType $ Scalar (TypeVar mempty (qualName t_v) [])
 
 -- | If this type corresponds to the builtin "acc" type, return the
 -- type of the underlying array.
-isAccType :: TypeBase d as -> Maybe (TypeBase d ())
-isAccType (Scalar (TypeVar _ _ (QualName [] v) [TypeArgType t]))
+isAccType :: TypeBase d u -> Maybe (TypeBase d NoUniqueness)
+isAccType (Scalar (TypeVar _ (QualName [] v) [TypeArgType t]))
   | v == fst intrinsicAcc =
       Just t
 isAccType _ = Nothing
@@ -733,7 +695,7 @@ intrinsicVar v =
   where
     bad = error $ "findBuiltin: " <> nameToString v
 
-mkBinOp :: Name -> PatType -> Exp -> Exp -> Exp
+mkBinOp :: Name -> StructType -> Exp -> Exp -> Exp
 mkBinOp op t x y =
   AppExp
     ( BinOp
@@ -761,252 +723,245 @@ intrinsics =
           ( [ ( "flatten",
                 IntrinsicPolyFun
                   [tp_a, sp_n, sp_m]
-                  [(Observe, Array () Nonunique (shape [n, m]) t_a)]
+                  [Array Observe (shape [n, m]) $ t_a mempty]
                   $ RetType []
                   $ Array
-                    ()
                     Nonunique
                     (Shape [size n `mkMul` size m])
-                    t_a
+                    (t_a mempty)
               ),
               ( "unflatten",
                 IntrinsicPolyFun
                   [tp_a, sp_n, sp_m]
-                  [ (Observe, Scalar $ Prim $ Signed Int64),
-                    (Observe, Scalar $ Prim $ Signed Int64),
-                    (Observe, Array () Nonunique (Shape [size n `mkMul` size m]) t_a)
+                  [ Scalar $ Prim $ Signed Int64,
+                    Scalar $ Prim $ Signed Int64,
+                    Array Observe (Shape [size n `mkMul` size m]) $ t_a mempty
                   ]
                   $ RetType []
-                  $ Array () Nonunique (shape [n, m]) t_a
+                  $ Array Nonunique (shape [n, m]) (t_a mempty)
               ),
               ( "concat",
                 IntrinsicPolyFun
                   [tp_a, sp_n, sp_m]
-                  [ (Observe, array_a $ shape [n]),
-                    (Observe, array_a $ shape [m])
+                  [ array_a Observe $ shape [n],
+                    array_a Observe $ shape [m]
                   ]
                   $ RetType []
-                  $ uarray_a
+                  $ array_a Unique
                   $ Shape [size n `mkAdd` size m]
               ),
               ( "transpose",
                 IntrinsicPolyFun
                   [tp_a, sp_n, sp_m]
-                  [(Observe, array_a $ shape [n, m])]
+                  [array_a Observe $ shape [n, m]]
                   $ RetType []
-                  $ array_a
+                  $ array_a Nonunique
                   $ shape [m, n]
               ),
               ( "scatter",
                 IntrinsicPolyFun
                   [tp_a, sp_n, sp_l]
-                  [ (Consume, Array () Unique (shape [n]) t_a),
-                    (Observe, Array () Nonunique (shape [l]) (Prim $ Signed Int64)),
-                    (Observe, Array () Nonunique (shape [l]) t_a)
+                  [ Array Consume (shape [n]) $ t_a mempty,
+                    Array Observe (shape [l]) (Prim $ Signed Int64),
+                    Array Observe (shape [l]) $ t_a mempty
                   ]
                   $ RetType []
-                  $ Array () Unique (shape [n]) t_a
+                  $ Array Unique (shape [n]) (t_a mempty)
               ),
               ( "scatter_2d",
                 IntrinsicPolyFun
                   [tp_a, sp_n, sp_m, sp_l]
-                  [ (Consume, uarray_a $ shape [n, m]),
-                    (Observe, Array () Nonunique (shape [l]) (tupInt64 2)),
-                    (Observe, Array () Nonunique (shape [l]) t_a)
+                  [ array_a Consume $ shape [n, m],
+                    Array Observe (shape [l]) (tupInt64 2),
+                    Array Observe (shape [l]) $ t_a mempty
                   ]
                   $ RetType []
-                  $ uarray_a
+                  $ array_a Unique
                   $ shape [n, m]
               ),
               ( "scatter_3d",
                 IntrinsicPolyFun
                   [tp_a, sp_n, sp_m, sp_k, sp_l]
-                  [ (Consume, uarray_a $ shape [n, m, k]),
-                    (Observe, Array () Nonunique (shape [l]) (tupInt64 3)),
-                    (Observe, Array () Nonunique (shape [l]) t_a)
+                  [ array_a Consume $ shape [n, m, k],
+                    Array Observe (shape [l]) (tupInt64 3),
+                    Array Observe (shape [l]) $ t_a mempty
                   ]
                   $ RetType []
-                  $ uarray_a
+                  $ array_a Unique
                   $ shape [n, m, k]
               ),
               ( "zip",
                 IntrinsicPolyFun
                   [tp_a, tp_b, sp_n]
-                  [ (Observe, array_a (shape [n])),
-                    (Observe, array_b (shape [n]))
+                  [ array_a Observe (shape [n]),
+                    array_b Observe (shape [n])
                   ]
                   $ RetType []
-                  $ tuple_uarray (Scalar t_a) (Scalar t_b)
+                  $ tuple_array Unique (Scalar $ t_a mempty) (Scalar $ t_b mempty)
                   $ shape [n]
               ),
               ( "unzip",
                 IntrinsicPolyFun
                   [tp_a, tp_b, sp_n]
-                  [(Observe, tuple_arr (Scalar t_a) (Scalar t_b) $ shape [n])]
+                  [tuple_array Observe (Scalar $ t_a mempty) (Scalar $ t_b mempty) $ shape [n]]
                   $ RetType [] . Scalar . Record . M.fromList
-                  $ zip tupleFieldNames [array_a $ shape [n], array_b $ shape [n]]
+                  $ zip tupleFieldNames [array_a Unique $ shape [n], array_b Unique $ shape [n]]
               ),
               ( "hist_1d",
                 IntrinsicPolyFun
                   [tp_a, sp_n, sp_m]
-                  [ (Consume, Scalar $ Prim $ Signed Int64),
-                    (Observe, uarray_a $ shape [m]),
-                    (Observe, Scalar t_a `arr` (Scalar t_a `arr` Scalar t_a)),
-                    (Observe, Scalar t_a),
-                    (Observe, Array () Nonunique (shape [n]) (tupInt64 1)),
-                    (Observe, array_a (shape [n]))
+                  [ Scalar $ Prim $ Signed Int64,
+                    array_a Consume $ shape [m],
+                    Scalar (t_a mempty) `arr` (Scalar (t_a mempty) `arr` Scalar (t_a Nonunique)),
+                    Scalar $ t_a Observe,
+                    Array Observe (shape [n]) (tupInt64 1),
+                    array_a Observe (shape [n])
                   ]
                   $ RetType []
-                  $ uarray_a
+                  $ array_a Unique
                   $ shape [m]
               ),
               ( "hist_2d",
                 IntrinsicPolyFun
                   [tp_a, sp_n, sp_m, sp_k]
-                  [ (Observe, Scalar $ Prim $ Signed Int64),
-                    (Consume, uarray_a $ shape [m, k]),
-                    (Observe, Scalar t_a `arr` (Scalar t_a `arr` Scalar t_a)),
-                    (Observe, Scalar t_a),
-                    (Observe, Array () Nonunique (shape [n]) (tupInt64 2)),
-                    (Observe, array_a (shape [n]))
+                  [ Scalar $ Prim $ Signed Int64,
+                    array_a Consume $ shape [m, k],
+                    Scalar (t_a mempty) `arr` (Scalar (t_a mempty) `arr` Scalar (t_a Nonunique)),
+                    Scalar $ t_a Observe,
+                    Array Observe (shape [n]) (tupInt64 2),
+                    array_a Observe (shape [n])
                   ]
                   $ RetType []
-                  $ uarray_a
+                  $ array_a Unique
                   $ shape [m, k]
               ),
               ( "hist_3d",
                 IntrinsicPolyFun
                   [tp_a, sp_n, sp_m, sp_k, sp_l]
-                  [ (Observe, Scalar $ Prim $ Signed Int64),
-                    (Consume, uarray_a $ shape [m, k, l]),
-                    (Observe, Scalar t_a `arr` (Scalar t_a `arr` Scalar t_a)),
-                    (Observe, Scalar t_a),
-                    (Observe, Array () Nonunique (shape [n]) (tupInt64 3)),
-                    (Observe, array_a (shape [n]))
+                  [ Scalar $ Prim $ Signed Int64,
+                    array_a Consume $ shape [m, k, l],
+                    Scalar (t_a mempty) `arr` (Scalar (t_a mempty) `arr` Scalar (t_a Nonunique)),
+                    Scalar $ t_a Observe,
+                    Array Observe (shape [n]) (tupInt64 3),
+                    array_a Observe (shape [n])
                   ]
                   $ RetType []
-                  $ uarray_a
+                  $ array_a Unique
                   $ shape [m, k, l]
               ),
               ( "map",
                 IntrinsicPolyFun
                   [tp_a, tp_b, sp_n]
-                  [ (Observe, Scalar t_a `arr` Scalar t_b),
-                    (Observe, array_a $ shape [n])
+                  [ Scalar (t_a mempty) `arr` Scalar (t_b Nonunique),
+                    array_a Observe $ shape [n]
                   ]
                   $ RetType []
-                  $ uarray_b
+                  $ array_b Unique
                   $ shape [n]
               ),
               ( "reduce",
                 IntrinsicPolyFun
                   [tp_a, sp_n]
-                  [ (Observe, Scalar t_a `arr` (Scalar t_a `arr` Scalar t_a)),
-                    (Observe, Scalar t_a),
-                    (Observe, array_a $ shape [n])
+                  [ Scalar (t_a mempty) `arr` (Scalar (t_a mempty) `arr` Scalar (t_a Nonunique)),
+                    Scalar $ t_a Observe,
+                    array_a Observe $ shape [n]
                   ]
                   $ RetType []
-                  $ Scalar t_a
+                  $ Scalar (t_a Unique)
               ),
               ( "reduce_comm",
                 IntrinsicPolyFun
                   [tp_a, sp_n]
-                  [ (Observe, Scalar t_a `arr` (Scalar t_a `arr` Scalar t_a)),
-                    (Observe, Scalar t_a),
-                    (Observe, array_a $ shape [n])
+                  [ Scalar (t_a mempty) `arr` (Scalar (t_a mempty) `arr` Scalar (t_a Nonunique)),
+                    Scalar $ t_a Observe,
+                    array_a Observe $ shape [n]
                   ]
-                  $ RetType []
-                  $ Scalar t_a
+                  $ RetType [] (Scalar (t_a Unique))
               ),
               ( "scan",
                 IntrinsicPolyFun
                   [tp_a, sp_n]
-                  [ (Observe, Scalar t_a `arr` (Scalar t_a `arr` Scalar t_a)),
-                    (Observe, Scalar t_a),
-                    (Observe, array_a $ shape [n])
+                  [ Scalar (t_a mempty) `arr` (Scalar (t_a mempty) `arr` Scalar (t_a Nonunique)),
+                    Scalar $ t_a Observe,
+                    array_a Observe $ shape [n]
                   ]
-                  $ RetType []
-                  $ uarray_a
-                  $ shape [n]
+                  $ RetType [] (array_a Unique $ shape [n])
               ),
               ( "partition",
                 IntrinsicPolyFun
                   [tp_a, sp_n]
-                  [ (Observe, Scalar (Prim $ Signed Int32)),
-                    (Observe, Scalar t_a `arr` Scalar (Prim $ Signed Int64)),
-                    (Observe, array_a $ shape [n])
+                  [ Scalar (Prim $ Signed Int32),
+                    Scalar (t_a mempty) `arr` Scalar (Prim $ Signed Int64),
+                    array_a Observe $ shape [n]
                   ]
                   ( RetType [k] . Scalar $
                       tupleRecord
-                        [ uarray_a $ shape [n],
-                          Array () Unique (shape [k]) (Prim $ Signed Int64)
+                        [ array_a Unique $ shape [n],
+                          Array Unique (shape [k]) (Prim $ Signed Int64)
                         ]
                   )
               ),
               ( "acc_write",
                 IntrinsicPolyFun
                   [sp_k, tp_a]
-                  [ (Consume, Scalar $ accType array_ka),
-                    (Observe, Scalar (Prim $ Signed Int64)),
-                    (Observe, Scalar t_a)
+                  [ Scalar $ accType Consume $ array_ka mempty,
+                    Scalar (Prim $ Signed Int64),
+                    Scalar $ t_a Observe
                   ]
                   $ RetType []
                   $ Scalar
-                  $ accType array_ka
+                  $ accType Unique (array_ka mempty)
               ),
               ( "scatter_stream",
                 IntrinsicPolyFun
                   [tp_a, tp_b, sp_k, sp_n]
-                  [ (Consume, uarray_ka),
-                    ( Observe,
-                      Scalar (accType array_ka)
-                        `carr` ( Scalar t_b
-                                   `arr` Scalar (accType $ array_a $ shape [k])
-                               )
-                    ),
-                    (Observe, array_b $ shape [n])
+                  [ array_ka Consume,
+                    Scalar (accType mempty (array_ka mempty))
+                      `carr` ( Scalar (t_b mempty)
+                                 `arr` Scalar (accType Unique $ array_a mempty $ shape [k])
+                             ),
+                    array_b Observe $ shape [n]
                   ]
-                  $ RetType [] uarray_ka
+                  $ RetType []
+                  $ array_ka Unique
               ),
               ( "hist_stream",
                 IntrinsicPolyFun
                   [tp_a, tp_b, sp_k, sp_n]
-                  [ (Consume, uarray_a $ shape [k]),
-                    (Observe, Scalar t_a `arr` (Scalar t_a `arr` Scalar t_a)),
-                    (Observe, Scalar t_a),
-                    ( Observe,
-                      Scalar (accType array_ka)
-                        `carr` ( Scalar t_b
-                                   `arr` Scalar (accType $ array_a $ shape [k])
-                               )
-                    ),
-                    (Observe, array_b $ shape [n])
+                  [ array_a Consume $ shape [k],
+                    Scalar (t_a mempty) `arr` (Scalar (t_a mempty) `arr` Scalar (t_a Nonunique)),
+                    Scalar $ t_a Observe,
+                    Scalar (accType mempty $ array_ka mempty)
+                      `carr` ( Scalar (t_b mempty)
+                                 `arr` Scalar (accType Unique $ array_a mempty $ shape [k])
+                             ),
+                    array_b Observe $ shape [n]
                   ]
                   $ RetType []
-                  $ uarray_a
+                  $ array_a Unique
                   $ shape [k]
               ),
               ( "jvp2",
                 IntrinsicPolyFun
                   [tp_a, tp_b]
-                  [ (Observe, Scalar t_a `arr` Scalar t_b),
-                    (Observe, Scalar t_a),
-                    (Observe, Scalar t_a)
+                  [ Scalar (t_a mempty) `arr` Scalar (t_b Nonunique),
+                    Scalar (t_a Observe),
+                    Scalar (t_a Observe)
                   ]
                   $ RetType []
                   $ Scalar
-                  $ tupleRecord [Scalar t_b, Scalar t_b]
+                  $ tupleRecord [Scalar $ t_b Nonunique, Scalar $ t_b Nonunique]
               ),
               ( "vjp2",
                 IntrinsicPolyFun
                   [tp_a, tp_b]
-                  [ (Observe, Scalar t_a `arr` Scalar t_b),
-                    (Observe, Scalar t_a),
-                    (Observe, Scalar t_b)
+                  [ Scalar (t_a mempty) `arr` Scalar (t_b Nonunique),
+                    Scalar (t_a Observe),
+                    Scalar (t_b Observe)
                   ]
                   $ RetType []
                   $ Scalar
-                  $ tupleRecord [Scalar t_b, Scalar t_a]
+                  $ tupleRecord [Scalar $ t_b Nonunique, Scalar $ t_a Nonunique]
               )
             ]
               ++
@@ -1014,91 +969,91 @@ intrinsics =
               [ ( "flat_index_2d",
                   IntrinsicPolyFun
                     [tp_a, sp_n]
-                    [ (Observe, array_a $ shape [n]),
-                      (Observe, Scalar (Prim $ Signed Int64)),
-                      (Observe, Scalar (Prim $ Signed Int64)),
-                      (Observe, Scalar (Prim $ Signed Int64)),
-                      (Observe, Scalar (Prim $ Signed Int64)),
-                      (Observe, Scalar (Prim $ Signed Int64))
+                    [ array_a Observe $ shape [n],
+                      Scalar (Prim $ Signed Int64),
+                      Scalar (Prim $ Signed Int64),
+                      Scalar (Prim $ Signed Int64),
+                      Scalar (Prim $ Signed Int64),
+                      Scalar (Prim $ Signed Int64)
                     ]
                     $ RetType [m, k]
-                    $ array_a
+                    $ array_a Nonunique
                     $ shape [m, k]
                 ),
                 ( "flat_update_2d",
                   IntrinsicPolyFun
                     [tp_a, sp_n, sp_k, sp_l]
-                    [ (Consume, uarray_a $ shape [n]),
-                      (Observe, Scalar (Prim $ Signed Int64)),
-                      (Observe, Scalar (Prim $ Signed Int64)),
-                      (Observe, Scalar (Prim $ Signed Int64)),
-                      (Observe, array_a $ shape [k, l])
+                    [ array_a Consume $ shape [n],
+                      Scalar (Prim $ Signed Int64),
+                      Scalar (Prim $ Signed Int64),
+                      Scalar (Prim $ Signed Int64),
+                      array_a Observe $ shape [k, l]
                     ]
                     $ RetType []
-                    $ uarray_a
+                    $ array_a Unique
                     $ shape [n]
                 ),
                 ( "flat_index_3d",
                   IntrinsicPolyFun
                     [tp_a, sp_n]
-                    [ (Observe, array_a $ shape [n]),
-                      (Observe, Scalar (Prim $ Signed Int64)),
-                      (Observe, Scalar (Prim $ Signed Int64)),
-                      (Observe, Scalar (Prim $ Signed Int64)),
-                      (Observe, Scalar (Prim $ Signed Int64)),
-                      (Observe, Scalar (Prim $ Signed Int64)),
-                      (Observe, Scalar (Prim $ Signed Int64)),
-                      (Observe, Scalar (Prim $ Signed Int64))
+                    [ array_a Observe $ shape [n],
+                      Scalar (Prim $ Signed Int64),
+                      Scalar (Prim $ Signed Int64),
+                      Scalar (Prim $ Signed Int64),
+                      Scalar (Prim $ Signed Int64),
+                      Scalar (Prim $ Signed Int64),
+                      Scalar (Prim $ Signed Int64),
+                      Scalar (Prim $ Signed Int64)
                     ]
                     $ RetType [m, k, l]
-                    $ array_a
+                    $ array_a Nonunique
                     $ shape [m, k, l]
                 ),
                 ( "flat_update_3d",
                   IntrinsicPolyFun
                     [tp_a, sp_n, sp_k, sp_l, sp_p]
-                    [ (Consume, uarray_a $ shape [n]),
-                      (Observe, Scalar (Prim $ Signed Int64)),
-                      (Observe, Scalar (Prim $ Signed Int64)),
-                      (Observe, Scalar (Prim $ Signed Int64)),
-                      (Observe, Scalar (Prim $ Signed Int64)),
-                      (Observe, array_a $ shape [k, l, p])
+                    [ array_a Consume $ shape [n],
+                      Scalar (Prim $ Signed Int64),
+                      Scalar (Prim $ Signed Int64),
+                      Scalar (Prim $ Signed Int64),
+                      Scalar (Prim $ Signed Int64),
+                      array_a Observe $ shape [k, l, p]
                     ]
                     $ RetType []
-                    $ uarray_a
+                    $ array_a Unique
                     $ shape [n]
                 ),
                 ( "flat_index_4d",
                   IntrinsicPolyFun
                     [tp_a, sp_n]
-                    [ (Observe, array_a $ shape [n]),
-                      (Observe, Scalar (Prim $ Signed Int64)),
-                      (Observe, Scalar (Prim $ Signed Int64)),
-                      (Observe, Scalar (Prim $ Signed Int64)),
-                      (Observe, Scalar (Prim $ Signed Int64)),
-                      (Observe, Scalar (Prim $ Signed Int64)),
-                      (Observe, Scalar (Prim $ Signed Int64)),
-                      (Observe, Scalar (Prim $ Signed Int64)),
-                      (Observe, Scalar (Prim $ Signed Int64)),
-                      (Observe, Scalar (Prim $ Signed Int64))
+                    [ array_a Observe $ shape [n],
+                      Scalar (Prim $ Signed Int64),
+                      Scalar (Prim $ Signed Int64),
+                      Scalar (Prim $ Signed Int64),
+                      Scalar (Prim $ Signed Int64),
+                      Scalar (Prim $ Signed Int64),
+                      Scalar (Prim $ Signed Int64),
+                      Scalar (Prim $ Signed Int64),
+                      Scalar (Prim $ Signed Int64),
+                      Scalar (Prim $ Signed Int64)
                     ]
                     $ RetType [m, k, l, p]
-                    $ array_a
+                    $ array_a Nonunique
                     $ shape [m, k, l, p]
                 ),
                 ( "flat_update_4d",
                   IntrinsicPolyFun
                     [tp_a, sp_n, sp_k, sp_l, sp_p, sp_q]
-                    [ (Consume, uarray_a $ shape [n]),
-                      (Observe, Scalar (Prim $ Signed Int64)),
-                      (Observe, Scalar (Prim $ Signed Int64)),
-                      (Observe, Scalar (Prim $ Signed Int64)),
-                      (Observe, Scalar (Prim $ Signed Int64)),
-                      (Observe, Scalar (Prim $ Signed Int64)),
-                      (Observe, array_a $ shape [k, l, p, q])
+                    [ array_a Consume $ shape [n],
+                      Scalar (Prim $ Signed Int64),
+                      Scalar (Prim $ Signed Int64),
+                      Scalar (Prim $ Signed Int64),
+                      Scalar (Prim $ Signed Int64),
+                      Scalar (Prim $ Signed Int64),
+                      array_a Observe $ shape [k, l, p, q]
                     ]
                     $ RetType []
-                    $ uarray_a
+                    $ array_a Unique
                     $ shape [n]
                 )
               ]
@@ -1122,6 +1077,8 @@ intrinsics =
             )
           ++
           -- This overrides the ! from Primitive.
+
+          -- This overrides the ! from Primitive.
           [ ( "!",
               IntrinsicOverloadedFun
                 ( map Signed [minBound .. maxBound]
@@ -1141,14 +1098,12 @@ intrinsics =
 
     [a, b, n, m, k, l, p, q] = zipWith VName (map nameFromString ["a", "b", "n", "m", "k", "l", "p", "q"]) [0 ..]
 
-    t_a = TypeVar () Nonunique (qualName a) []
-    array_a s = Array () Nonunique s t_a
-    uarray_a s = Array () Unique s t_a
+    t_a u = TypeVar u (qualName a) []
+    array_a u s = Array u s $ t_a mempty
     tp_a = TypeParamType Unlifted a mempty
 
-    t_b = TypeVar () Nonunique (qualName b) []
-    array_b s = Array () Nonunique s t_b
-    uarray_b s = Array () Unique s t_b
+    t_b u = TypeVar u (qualName b) []
+    array_b u s = Array u s $ t_b mempty
     tp_b = TypeParamType Unlifted b mempty
 
     [sp_n, sp_m, sp_k, sp_l, sp_p, sp_q] = map (`TypeParamDim` mempty) [n, m, k, l, p, q]
@@ -1156,18 +1111,16 @@ intrinsics =
     size = flip sizeFromName mempty . qualName
     shape = Shape . map size
 
-    tuple_arr x y s =
-      Array () Nonunique s (Record (M.fromList $ zip tupleFieldNames [x, y]))
-    tuple_uarray x y s = tuple_arr x y s `setUniqueness` Unique
+    tuple_array u x y s =
+      Array u s (Record (M.fromList $ zip tupleFieldNames [x, y]))
 
     arr x y = Scalar $ Arrow mempty Unnamed Observe x (RetType [] y)
     carr x y = Scalar $ Arrow mempty Unnamed Consume x (RetType [] y)
 
-    array_ka = Array () Nonunique (Shape [sizeFromName (qualName k) mempty]) t_a
-    uarray_ka = Array () Unique (Shape [sizeFromName (qualName k) mempty]) t_a
+    array_ka u = Array u (Shape [sizeFromName (qualName k) mempty]) $ t_a mempty
 
-    accType t =
-      TypeVar () Unique (qualName (fst intrinsicAcc)) [TypeArgType t]
+    accType u t =
+      TypeVar u (qualName (fst intrinsicAcc)) [TypeArgType t]
 
     namify i (x, y) = (VName (nameFromString x) i, y)
 

--- a/src/Language/Futhark/Prop.hs
+++ b/src/Language/Futhark/Prop.hs
@@ -1512,7 +1512,7 @@ type Case = CaseBase Info VName
 -- | A type with no aliasing information but shape annotations.
 type UncheckedType = TypeBase (Shape Name) ()
 
--- | An expression with no type annotations.
+-- | An unchecked type expression.
 type UncheckedTypeExp = TypeExp NoInfo Name
 
 -- | An identifier with no type annotations.

--- a/src/Language/Futhark/Prop.hs
+++ b/src/Language/Futhark/Prop.hs
@@ -65,7 +65,6 @@ module Language.Futhark.Prop
     toParam,
     resToParam,
     paramToRes,
-    toStructRet,
     toResRet,
     setUniqueness,
     noSizes,
@@ -265,10 +264,6 @@ toRes u = fmap (const u)
 -- | Convert to 'ResRetType'
 toResRet :: Uniqueness -> RetTypeBase Size u -> ResRetType
 toResRet u = second (const u)
-
--- | Convert to 'StructRetType'
-toStructRet :: RetTypeBase Size u -> StructRetType
-toStructRet = second (const NoUniqueness)
 
 -- | Preserves relation between 'Diet' and 'Uniqueness'.
 resToParam :: ResType -> ParamType

--- a/src/Language/Futhark/Prop.hs
+++ b/src/Language/Futhark/Prop.hs
@@ -918,7 +918,7 @@ intrinsics =
                   [ array_ka Consume,
                     Scalar (accType mempty (array_ka mempty))
                       `carr` ( Scalar (t_b mempty)
-                                 `arr` Scalar (accType Unique $ array_a mempty $ shape [k])
+                                 `arr` Scalar (accType Nonunique $ array_a mempty $ shape [k])
                              ),
                     array_b Observe $ shape [n]
                   ]
@@ -933,7 +933,7 @@ intrinsics =
                     Scalar $ t_a Observe,
                     Scalar (accType mempty $ array_ka mempty)
                       `carr` ( Scalar (t_b mempty)
-                                 `arr` Scalar (accType Unique $ array_a mempty $ shape [k])
+                                 `arr` Scalar (accType Nonunique $ array_a mempty $ shape [k])
                              ),
                     array_b Observe $ shape [n]
                   ]

--- a/src/Language/Futhark/Syntax.hs
+++ b/src/Language/Futhark/Syntax.hs
@@ -107,7 +107,6 @@ import Data.List.NonEmpty qualified as NE
 import Data.Map.Strict qualified as M
 import Data.Monoid hiding (Sum)
 import Data.Ord
-import Data.Set qualified as S
 import Data.Text qualified as T
 import Data.Traversable
 import Futhark.Util.Loc

--- a/src/Language/Futhark/Traversals.hs
+++ b/src/Language/Futhark/Traversals.hs
@@ -38,9 +38,8 @@ data ASTMapper m = ASTMapper
   { mapOnExp :: ExpBase Info VName -> m (ExpBase Info VName),
     mapOnName :: VName -> m VName,
     mapOnStructType :: StructType -> m StructType,
-    mapOnPatType :: PatType -> m PatType,
-    mapOnStructRetType :: StructRetType -> m StructRetType,
-    mapOnPatRetType :: PatRetType -> m PatRetType
+    mapOnParamType :: ParamType -> m ParamType,
+    mapOnResRetType :: ResRetType -> m ResRetType
   }
 
 -- | An 'ASTMapper' that just leaves its input unchanged.
@@ -50,9 +49,8 @@ identityMapper =
     { mapOnExp = pure,
       mapOnName = pure,
       mapOnStructType = pure,
-      mapOnPatType = pure,
-      mapOnStructRetType = pure,
-      mapOnPatRetType = pure
+      mapOnParamType = pure,
+      mapOnResRetType = pure
     }
 
 -- | The class of things that we can map an 'ASTMapper' across.
@@ -96,7 +94,7 @@ instance ASTMappable (AppExpBase Info VName) where
               <$> mapM (astMap tv) fparams
               <*> mapM (astMap tv) params
               <*> traverse (astMap tv) ret
-              <*> traverse (mapOnStructRetType tv) t
+              <*> traverse (mapOnResRetType tv) t
               <*> mapOnExp tv e
           )
       <*> mapOnExp tv body
@@ -112,7 +110,7 @@ instance ASTMappable (AppExpBase Info VName) where
   astMap tv (BinOp (fname, fname_loc) t (x, xext) (y, yext) loc) =
     BinOp
       <$> ((,) <$> astMap tv fname <*> pure fname_loc)
-      <*> traverse (mapOnPatType tv) t
+      <*> traverse (mapOnStructType tv) t
       <*> ((,) <$> mapOnExp tv x <*> pure xext)
       <*> ((,) <$> mapOnExp tv y <*> pure yext)
       <*> pure loc
@@ -131,18 +129,18 @@ instance ASTMappable (ExpBase Info VName) where
   astMap tv (Var name t loc) =
     Var
       <$> astMap tv name
-      <*> traverse (mapOnPatType tv) t
+      <*> traverse (mapOnStructType tv) t
       <*> pure loc
   astMap tv (Hole t loc) =
-    Hole <$> traverse (mapOnPatType tv) t <*> pure loc
+    Hole <$> traverse (mapOnStructType tv) t <*> pure loc
   astMap _ (Literal val loc) =
     pure $ Literal val loc
   astMap _ (StringLit vs loc) =
     pure $ StringLit vs loc
   astMap tv (IntLit val t loc) =
-    IntLit val <$> traverse (mapOnPatType tv) t <*> pure loc
+    IntLit val <$> traverse (mapOnStructType tv) t <*> pure loc
   astMap tv (FloatLit val t loc) =
-    FloatLit val <$> traverse (mapOnPatType tv) t <*> pure loc
+    FloatLit val <$> traverse (mapOnStructType tv) t <*> pure loc
   astMap tv (Parens e loc) =
     Parens <$> mapOnExp tv e <*> pure loc
   astMap tv (QualParens (name, nameloc) e loc) =
@@ -155,11 +153,11 @@ instance ASTMappable (ExpBase Info VName) where
   astMap tv (RecordLit fields loc) =
     RecordLit <$> astMap tv fields <*> pure loc
   astMap tv (ArrayLit els t loc) =
-    ArrayLit <$> mapM (mapOnExp tv) els <*> traverse (mapOnPatType tv) t <*> pure loc
+    ArrayLit <$> mapM (mapOnExp tv) els <*> traverse (mapOnStructType tv) t <*> pure loc
   astMap tv (Ascript e tdecl loc) =
     Ascript <$> mapOnExp tv e <*> astMap tv tdecl <*> pure loc
   astMap tv (Coerce e tdecl t loc) =
-    Coerce <$> mapOnExp tv e <*> astMap tv tdecl <*> traverse (mapOnPatType tv) t <*> pure loc
+    Coerce <$> mapOnExp tv e <*> astMap tv tdecl <*> traverse (mapOnStructType tv) t <*> pure loc
   astMap tv (Negate x loc) =
     Negate <$> mapOnExp tv x <*> pure loc
   astMap tv (Not x loc) =
@@ -175,10 +173,10 @@ instance ASTMappable (ExpBase Info VName) where
       <$> mapOnExp tv src
       <*> pure fs
       <*> mapOnExp tv v
-      <*> (Info <$> mapOnPatType tv t)
+      <*> (Info <$> mapOnStructType tv t)
       <*> pure loc
   astMap tv (Project field e t loc) =
-    Project field <$> mapOnExp tv e <*> traverse (mapOnPatType tv) t <*> pure loc
+    Project field <$> mapOnExp tv e <*> traverse (mapOnStructType tv) t <*> pure loc
   astMap tv (Assert e1 e2 desc loc) =
     Assert <$> mapOnExp tv e1 <*> mapOnExp tv e2 <*> pure desc <*> pure loc
   astMap tv (Lambda params body ret t loc) =
@@ -186,44 +184,44 @@ instance ASTMappable (ExpBase Info VName) where
       <$> mapM (astMap tv) params
       <*> mapOnExp tv body
       <*> traverse (astMap tv) ret
-      <*> traverse (traverse $ mapOnStructRetType tv) t
+      <*> traverse (mapOnResRetType tv) t
       <*> pure loc
   astMap tv (OpSection name t loc) =
     OpSection
       <$> astMap tv name
-      <*> traverse (mapOnPatType tv) t
+      <*> traverse (mapOnStructType tv) t
       <*> pure loc
   astMap tv (OpSectionLeft name t arg (Info (pa, t1a, argext), Info (pb, t1b)) (ret, retext) loc) =
     OpSectionLeft
       <$> astMap tv name
-      <*> traverse (mapOnPatType tv) t
+      <*> traverse (mapOnStructType tv) t
       <*> mapOnExp tv arg
       <*> ( (,)
-              <$> (Info <$> ((pa,,) <$> mapOnStructType tv t1a <*> pure argext))
-              <*> (Info <$> ((pb,) <$> mapOnStructType tv t1b))
+              <$> (Info <$> ((pa,,) <$> mapOnParamType tv t1a <*> pure argext))
+              <*> (Info <$> ((pb,) <$> mapOnParamType tv t1b))
           )
-      <*> ((,) <$> traverse (mapOnPatRetType tv) ret <*> traverse (mapM (mapOnName tv)) retext)
+      <*> ((,) <$> traverse (mapOnResRetType tv) ret <*> traverse (mapM (mapOnName tv)) retext)
       <*> pure loc
   astMap tv (OpSectionRight name t arg (Info (pa, t1a), Info (pb, t1b, argext)) t2 loc) =
     OpSectionRight
       <$> astMap tv name
-      <*> traverse (mapOnPatType tv) t
+      <*> traverse (mapOnStructType tv) t
       <*> mapOnExp tv arg
       <*> ( (,)
-              <$> (Info <$> ((pa,) <$> mapOnStructType tv t1a))
-              <*> (Info <$> ((pb,,) <$> mapOnStructType tv t1b <*> pure argext))
+              <$> (Info <$> ((pa,) <$> mapOnParamType tv t1a))
+              <*> (Info <$> ((pb,,) <$> mapOnParamType tv t1b <*> pure argext))
           )
-      <*> traverse (mapOnPatRetType tv) t2
+      <*> traverse (mapOnResRetType tv) t2
       <*> pure loc
   astMap tv (ProjectSection fields t loc) =
-    ProjectSection fields <$> traverse (mapOnPatType tv) t <*> pure loc
+    ProjectSection fields <$> traverse (mapOnStructType tv) t <*> pure loc
   astMap tv (IndexSection idxs t loc) =
     IndexSection
       <$> mapM (astMap tv) idxs
-      <*> traverse (mapOnPatType tv) t
+      <*> traverse (mapOnStructType tv) t
       <*> pure loc
   astMap tv (Constr name es t loc) =
-    Constr name <$> traverse (mapOnExp tv) es <*> traverse (mapOnPatType tv) t <*> pure loc
+    Constr name <$> traverse (mapOnExp tv) es <*> traverse (mapOnStructType tv) t <*> pure loc
   astMap tv (Attr attr e loc) =
     Attr attr <$> mapOnExp tv e <*> pure loc
   astMap tv (AppExp e res) =
@@ -275,16 +273,9 @@ instance ASTMappable (DimIndexBase Info VName) where
       <*> maybe (pure Nothing) (fmap Just . mapOnExp tv) j
       <*> maybe (pure Nothing) (fmap Just . mapOnExp tv) stride
 
-instance ASTMappable Alias where
-  astMap tv (AliasBound v) = AliasBound <$> mapOnName tv v
-  astMap tv (AliasFree v) = AliasFree <$> mapOnName tv v
-
-instance ASTMappable Aliasing where
-  astMap tv = fmap S.fromList . traverse (astMap tv) . S.toList
-
 instance ASTMappable AppRes where
   astMap tv (AppRes t ext) =
-    AppRes <$> mapOnPatType tv t <*> pure ext
+    AppRes <$> mapOnStructType tv t <*> pure ext
 
 type TypeTraverser f t dim1 als1 dim2 als2 =
   (QualName VName -> f (QualName VName)) ->
@@ -298,21 +289,21 @@ traverseScalarType ::
   TypeTraverser f ScalarTypeBase dim1 als1 dims als2
 traverseScalarType _ _ _ (Prim t) = pure $ Prim t
 traverseScalarType f g h (Record fs) = Record <$> traverse (traverseType f g h) fs
-traverseScalarType f g h (TypeVar als u t args) =
-  TypeVar <$> h als <*> pure u <*> f t <*> traverse (traverseTypeArg f g) args
+traverseScalarType f g h (TypeVar als t args) =
+  TypeVar <$> h als <*> f t <*> traverse (traverseTypeArg f g) args
 traverseScalarType f g h (Arrow als v u t1 (RetType dims t2)) =
   Arrow
     <$> h als
     <*> pure v
     <*> pure u
     <*> traverseType f g pure t1
-    <*> (RetType dims <$> traverseType f g h t2)
+    <*> (RetType dims <$> traverseType f g pure t2)
 traverseScalarType f g h (Sum cs) =
   Sum <$> (traverse . traverse) (traverseType f g h) cs
 
 traverseType :: Applicative f => TypeTraverser f TypeBase dim1 als1 dims als2
-traverseType f g h (Array als u shape et) =
-  Array <$> h als <*> pure u <*> traverse g shape <*> traverseScalarType f g pure et
+traverseType f g h (Array als shape et) =
+  Array <$> h als <*> traverse g shape <*> traverseScalarType f g pure et
 traverseType f g h (Scalar t) =
   Scalar <$> traverseScalarType f g h t
 
@@ -330,42 +321,48 @@ traverseTypeArg f g (TypeArgType t) =
 instance ASTMappable StructType where
   astMap tv = traverseType (astMap tv) (mapOnExp tv) pure
 
-instance ASTMappable PatType where
-  astMap tv = traverseType (astMap tv) (mapOnExp tv) (astMap tv)
+instance ASTMappable ParamType where
+  astMap tv = traverseType (astMap tv) (mapOnExp tv) pure
 
-instance ASTMappable StructRetType where
+instance ASTMappable (TypeBase Size Uniqueness) where
+  astMap tv = traverseType (astMap tv) (mapOnExp tv) pure
+
+instance ASTMappable ResRetType where
   astMap tv (RetType ext t) = RetType ext <$> astMap tv t
 
-instance ASTMappable PatRetType where
-  astMap tv (RetType ext t) = RetType ext <$> astMap tv t
-
-instance ASTMappable (IdentBase Info VName) where
+instance ASTMappable (IdentBase Info VName StructType) where
   astMap tv (Ident name (Info t) loc) =
-    Ident <$> mapOnName tv name <*> (Info <$> mapOnPatType tv t) <*> pure loc
+    Ident <$> mapOnName tv name <*> (Info <$> mapOnStructType tv t) <*> pure loc
 
 instance ASTMappable (SizeBinder VName) where
   astMap tv (SizeBinder name loc) =
     SizeBinder <$> mapOnName tv name <*> pure loc
 
-instance ASTMappable (PatBase Info VName) where
-  astMap tv (Id name (Info t) loc) =
-    Id <$> mapOnName tv name <*> (Info <$> mapOnPatType tv t) <*> pure loc
-  astMap tv (TuplePat pats loc) =
-    TuplePat <$> mapM (astMap tv) pats <*> pure loc
-  astMap tv (RecordPat fields loc) =
-    RecordPat <$> mapM (traverse $ astMap tv) fields <*> pure loc
-  astMap tv (PatParens pat loc) =
-    PatParens <$> astMap tv pat <*> pure loc
-  astMap tv (PatAscription pat t loc) =
-    PatAscription <$> astMap tv pat <*> astMap tv t <*> pure loc
-  astMap tv (Wildcard (Info t) loc) =
-    Wildcard <$> (Info <$> mapOnPatType tv t) <*> pure loc
-  astMap tv (PatLit v (Info t) loc) =
-    PatLit v <$> (Info <$> mapOnPatType tv t) <*> pure loc
-  astMap tv (PatConstr n (Info t) ps loc) =
-    PatConstr n <$> (Info <$> mapOnPatType tv t) <*> mapM (astMap tv) ps <*> pure loc
-  astMap tv (PatAttr attr p loc) =
-    PatAttr attr <$> astMap tv p <*> pure loc
+traversePat :: Monad m => (t1 -> m t2) -> PatBase Info VName t1 -> m (PatBase Info VName t2)
+traversePat f (Id name (Info t) loc) =
+  Id name <$> (Info <$> f t) <*> pure loc
+traversePat f (TuplePat pats loc) =
+  TuplePat <$> mapM (traversePat f) pats <*> pure loc
+traversePat f (RecordPat fields loc) =
+  RecordPat <$> mapM (traverse $ traversePat f) fields <*> pure loc
+traversePat f (PatParens pat loc) =
+  PatParens <$> traversePat f pat <*> pure loc
+traversePat f (PatAscription pat t loc) =
+  PatAscription <$> traversePat f pat <*> pure t <*> pure loc
+traversePat f (Wildcard (Info t) loc) =
+  Wildcard <$> (Info <$> f t) <*> pure loc
+traversePat f (PatLit v (Info t) loc) =
+  PatLit v <$> (Info <$> f t) <*> pure loc
+traversePat f (PatConstr n (Info t) ps loc) =
+  PatConstr n <$> (Info <$> f t) <*> mapM (traversePat f) ps <*> pure loc
+traversePat f (PatAttr attr p loc) =
+  PatAttr attr <$> traversePat f p <*> pure loc
+
+instance ASTMappable (PatBase Info VName StructType) where
+  astMap tv = traversePat $ mapOnStructType tv
+
+instance ASTMappable (PatBase Info VName ParamType) where
+  astMap tv = traversePat $ mapOnParamType tv
 
 instance ASTMappable (FieldBase Info VName) where
   astMap tv (RecordFieldExplicit name e loc) =
@@ -373,7 +370,7 @@ instance ASTMappable (FieldBase Info VName) where
   astMap tv (RecordFieldImplicit name t loc) =
     RecordFieldImplicit
       <$> mapOnName tv name
-      <*> traverse (mapOnPatType tv) t
+      <*> traverse (mapOnStructType tv) t
       <*> pure loc
 
 instance ASTMappable (CaseBase Info VName) where
@@ -408,7 +405,7 @@ bareField (RecordFieldExplicit name e loc) =
 bareField (RecordFieldImplicit name _ loc) =
   RecordFieldImplicit name NoInfo loc
 
-barePat :: PatBase Info VName -> PatBase NoInfo VName
+barePat :: PatBase Info VName t -> PatBase NoInfo VName t
 barePat (TuplePat ps loc) = TuplePat (map barePat ps) loc
 barePat (RecordPat fs loc) = RecordPat (map (fmap barePat) fs) loc
 barePat (PatParens p loc) = PatParens (barePat p) loc

--- a/src/Language/Futhark/Traversals.hs
+++ b/src/Language/Futhark/Traversals.hs
@@ -28,7 +28,6 @@ where
 
 import Data.Bifunctor
 import Data.List.NonEmpty qualified as NE
-import Data.Set qualified as S
 import Language.Futhark.Syntax
 
 -- | Express a monad mapping operation on a syntax node.  Each element

--- a/src/Language/Futhark/TypeChecker.hs
+++ b/src/Language/Futhark/TypeChecker.hs
@@ -199,7 +199,7 @@ bindingTypeParams tparams = localEnv env
         { envTypeTable =
             M.singleton v $
               TypeAbbr l [] . RetType [] . Scalar $
-                TypeVar () Nonunique (qualName v) []
+                TypeVar mempty (qualName v) []
         }
 
 checkTypeDecl ::
@@ -207,7 +207,7 @@ checkTypeDecl ::
   TypeM ([VName], TypeExp Info VName, StructType, Liftedness)
 checkTypeDecl te = do
   (te', svars, RetType dims st, l) <- checkTypeExp te
-  pure (svars ++ dims, te', st, l)
+  pure (svars ++ dims, te', toStruct st, l)
 
 -- In this function, after the recursion, we add the Env of the
 -- current Spec *after* the one that is returned from the recursive
@@ -264,7 +264,7 @@ checkSpecs (TypeSpec l name ps doc loc : specs) =
                 envTypeTable =
                   M.singleton name' $
                     TypeAbbr l ps' . RetType [] . Scalar $
-                      TypeVar () Nonunique (qualName name') $
+                      TypeVar mempty (qualName name') $
                         map typeParamToArg ps'
               }
       (abstypes, env, specs') <- localEnv tenv $ checkSpecs specs
@@ -554,7 +554,7 @@ checkTypeBind (TypeBind name l tps te NoInfo doc loc) =
   checkTypeParams tps $ \tps' -> do
     (te', svars, RetType dims t, l') <- bindingTypeParams tps' $ checkTypeExp te
 
-    let (witnessed, _) = determineSizeWitnesses t
+    let (witnessed, _) = determineSizeWitnesses $ toStruct t
     case L.find (`S.notMember` witnessed) svars of
       Just _ ->
         typeError (locOf te) mempty . withIndexLink "anonymous-nonconstructive" $
@@ -562,7 +562,7 @@ checkTypeBind (TypeBind name l tps te NoInfo doc loc) =
       Nothing ->
         pure ()
 
-    let elab_t = RetType (svars ++ dims) t
+    let elab_t = RetType (svars ++ dims) $ toStruct t
 
     let used_dims = fvVars $ freeInType t
     case filter ((`S.notMember` used_dims) . typeParamName) $
@@ -603,11 +603,11 @@ checkTypeBind (TypeBind name l tps te NoInfo doc loc) =
           TypeBind name' l tps' te' (Info elab_t) doc loc
         )
 
-entryPoint :: [Pat] -> Maybe (TypeExp Info VName) -> StructRetType -> EntryPoint
+entryPoint :: [Pat ParamType] -> Maybe (TypeExp Info VName) -> ResRetType -> EntryPoint
 entryPoint params orig_ret_te (RetType _ret orig_ret) =
   EntryPoint (map patternEntry params ++ more_params) rettype'
   where
-    (more_params, rettype') = onRetType orig_ret_te orig_ret
+    (more_params, rettype') = onRetType orig_ret_te $ toStruct orig_ret
 
     patternEntry (PatParens p _) =
       patternEntry p
@@ -623,10 +623,10 @@ entryPoint params orig_ret_te (RetType _ret orig_ret) =
     pname (Named v) = baseName v
     pname Unnamed = "_"
     onRetType (Just (TEArrow p t1_te t2_te _)) (Scalar (Arrow _ _ _ t1 (RetType _ t2))) =
-      let (xs, y) = onRetType (Just t2_te) t2
+      let (xs, y) = onRetType (Just t2_te) $ toStruct t2
        in (EntryParam (maybe "_" baseName p) (EntryType t1 (Just t1_te)) : xs, y)
     onRetType _ (Scalar (Arrow _ p _ t1 (RetType _ t2))) =
-      let (xs, y) = onRetType Nothing t2
+      let (xs, y) = onRetType Nothing $ toStruct t2
        in (EntryParam (pname p) (EntryType t1 Nothing) : xs, y)
     onRetType te t =
       ([], EntryType t te)
@@ -634,9 +634,9 @@ entryPoint params orig_ret_te (RetType _ret orig_ret) =
 checkEntryPoint ::
   SrcLoc ->
   [TypeParam] ->
-  [Pat] ->
+  [Pat ParamType] ->
   Maybe (TypeExp Info VName) ->
-  StructRetType ->
+  ResRetType ->
   TypeM ()
 checkEntryPoint loc tparams params maybe_tdecl rettype
   | any isTypeParam tparams =
@@ -659,7 +659,7 @@ checkEntryPoint loc tparams params maybe_tdecl rettype
         withIndexLink
           "size-polymorphic-entry"
           "Entry point functions must not be size-polymorphic in their return type."
-  | (constructive, _) <- foldMap determineSizeWitnesses param_ts,
+  | (constructive, _) <- foldMap (determineSizeWitnesses . toStruct) param_ts,
     Just p <- L.find (flip S.notMember constructive . typeParamName) tparams =
       typeError p mempty . withIndexLink "nonconstructive-entry" $
         "Entry point size parameter "
@@ -680,7 +680,7 @@ checkEntryPoint loc tparams params maybe_tdecl rettype
   where
     (RetType _ rettype_t) = rettype
     (rettype_params, rettype') = unfoldFunType rettype_t
-    param_ts = map patternStructType params ++ map snd rettype_params
+    param_ts = map patternType params ++ rettype_params
 
 checkValBind :: ValBindBase NoInfo Name -> TypeM (Env, ValBind)
 checkValBind (ValBind entry fname maybe_tdecl NoInfo tparams params body doc attrs loc) = do
@@ -733,7 +733,7 @@ nastyReturnType te t
     nastyType' (Just te') _ | niceTypeExp te' = False
     nastyType' _ t' = nastyType t'
 
-nastyParameter :: Pat -> Bool
+nastyParameter :: Pat ParamType -> Bool
 nastyParameter p = nastyType (patternType p) && not (ascripted p)
   where
     ascripted (PatAscription _ te _) = niceTypeExp te

--- a/src/Language/Futhark/TypeChecker/Consumption.hs
+++ b/src/Language/Futhark/TypeChecker/Consumption.hs
@@ -17,7 +17,6 @@ import Data.List.NonEmpty qualified as NE
 import Data.Map.Strict qualified as M
 import Data.Maybe
 import Data.Set qualified as S
-import Debug.Trace
 import Futhark.Util.Pretty hiding (space)
 import Language.Futhark
 import Language.Futhark.Traversals
@@ -629,13 +628,6 @@ convergeLoopParam loop_loc param body_cons body_als = do
     runStateT (checkMergeReturn param' body_als) (mempty, mempty)
 
   let body_cons' = body_cons <> S.map aliasVar param_cons
-  when False . traceM $
-    unlines
-      [ "convergeLoopParam",
-        prettyString param,
-        show body_cons,
-        prettyString body_als
-      ]
   if body_cons' == body_cons && patternType param'' == patternType param
     then pure param'
     else convergeLoopParam loop_loc param'' body_cons' body_als
@@ -656,7 +648,6 @@ checkLoop loop_loc (param, arg, form, body) = do
   param' <- convergeLoopParam loop_loc param (M.keysSet body_cons) body_als
 
   let param_t = patternType param'
-  when False . traceM $ unlines ["checkArg", prettyString param_t, prettyString arg]
   ((arg', arg_als), arg_cons) <- contain $ checkArg param_t arg
   consumed arg_cons
   free_bound <- boundFreeInExp body
@@ -782,13 +773,6 @@ checkExp (AppExp (BinOp (op, oploc) opt (x, xp) (y, yp) loc) appres) = do
   let at1 : at2 : _ = fst $ unfoldFunType op_als
   (x', x_als) <- checkArg at1 x
   (y', y_als) <- checkArg at2 y
-  when False . traceM $
-    unlines
-      [ prettyString op,
-        show op_als,
-        show x_als,
-        show y_als
-      ]
   pure
     ( AppExp (BinOp (op, oploc) opt (x', xp) (y', yp) loc) appres,
       op_als `applyArg` x_als `applyArg` y_als

--- a/src/Language/Futhark/TypeChecker/Consumption.hs
+++ b/src/Language/Futhark/TypeChecker/Consumption.hs
@@ -790,7 +790,7 @@ checkExp e@(Lambda params body te (Info (RetType ext ret)) loc) =
     let ret' = inferReturnUniqueness params ret body_als
         als = foldMap aliases (M.elems free_bound)
         ftype = funType params (RetType ext ret') `setAliases` als
-    traceM $
+    when False . traceM $
       unlines
         [ prettyString e,
           prettyString params,

--- a/src/Language/Futhark/TypeChecker/Consumption.hs
+++ b/src/Language/Futhark/TypeChecker/Consumption.hs
@@ -1,0 +1,909 @@
+-- | Check that a value definition does not violate any consumption
+-- constraints.
+module Language.Futhark.TypeChecker.Consumption
+  ( checkValDef,
+  )
+where
+
+import Control.Monad
+import Control.Monad.Reader
+import Control.Monad.State
+import Data.Bifoldable
+import Data.Bifunctor
+import Data.DList qualified as DL
+import Data.Foldable
+import Data.List qualified as L
+import Data.List.NonEmpty qualified as NE
+import Data.Map.Strict qualified as M
+import Data.Maybe
+import Data.Set qualified as S
+import Debug.Trace
+import Futhark.Util.Pretty hiding (space)
+import Language.Futhark
+import Language.Futhark.Traversals
+import Language.Futhark.TypeChecker.Monad (Notes, TypeError (..), withIndexLink)
+import Prelude hiding (mod)
+
+type Names = S.Set VName
+
+-- | A variable that is aliased.  Can be still in-scope, or have gone
+-- out of scope and be free.  In the latter case, it behaves more like
+-- an equivalence class.  See uniqueness-error18.fut for an example of
+-- why this is necessary.
+data Alias
+  = AliasBound {aliasVar :: VName}
+  | AliasFree {aliasVar :: VName}
+  deriving (Eq, Ord, Show)
+
+instance Pretty Alias where
+  pretty (AliasBound v) = prettyName v
+  pretty (AliasFree v) = "~" <> prettyName v
+
+instance Pretty (S.Set Alias) where
+  pretty = braces . commasep . map pretty . S.toList
+
+-- | The set of in-scope variables that are being aliased.
+boundAliases :: Aliases -> S.Set VName
+boundAliases = S.map aliasVar . S.filter bound
+  where
+    bound AliasBound {} = True
+    bound AliasFree {} = False
+
+-- | Aliases for a type, which is a set of the variables that are
+-- aliased.
+type Aliases = S.Set Alias
+
+type TypeAliases = TypeBase Size Aliases
+
+-- | @t \`setAliases\` als@ returns @t@, but with @als@ substituted for
+-- any already present aliases.
+setAliases :: TypeBase dim asf -> ast -> TypeBase dim ast
+setAliases t = addAliases t . const
+
+-- | @t \`addAliases\` f@ returns @t@, but with any already present
+-- aliases replaced by @f@ applied to that aliases.
+addAliases ::
+  TypeBase dim asf ->
+  (asf -> ast) ->
+  TypeBase dim ast
+addAliases = flip second
+
+aliases :: TypeAliases -> Aliases
+aliases = bifoldMap (const mempty) id
+
+setFieldAliases :: TypeAliases -> [Name] -> TypeAliases -> TypeAliases
+setFieldAliases ve_als (x : xs) (Scalar (Record fs)) =
+  Scalar $ Record $ M.adjust (setFieldAliases ve_als xs) x fs
+setFieldAliases ve_als _ _ = ve_als
+
+data Entry a
+  = Consumable {entryAliases :: a}
+  | Nonconsumable {entryAliases :: a}
+  deriving (Eq, Ord, Show)
+
+instance Functor Entry where
+  fmap f (Consumable als) = Consumable $ f als
+  fmap f (Nonconsumable als) = Nonconsumable $ f als
+
+newtype CheckEnv = CheckEnv
+  { envVtable :: M.Map VName (Entry TypeAliases)
+  }
+
+-- | A description of where an artificial compiler-generated
+-- intermediate name came from.
+data NameReason
+  = -- | Name is the result of a function application.
+    NameAppRes (Maybe (QualName VName)) SrcLoc
+  | NameLoopRes SrcLoc
+
+nameReason :: SrcLoc -> NameReason -> Doc a
+nameReason loc (NameAppRes Nothing apploc) =
+  "result of application at" <+> pretty (locStrRel loc apploc)
+nameReason loc (NameAppRes fname apploc) =
+  "result of applying"
+    <+> dquotes (pretty fname)
+    <+> parens ("at" <+> pretty (locStrRel loc apploc))
+nameReason loc (NameLoopRes apploc) =
+  "result of loop at" <+> pretty (locStrRel loc apploc)
+
+type Consumed = M.Map VName Loc
+
+data CheckState = CheckState
+  { stateConsumed :: Consumed,
+    stateErrors :: DL.DList TypeError,
+    stateNames :: M.Map VName NameReason,
+    stateCounter :: Int
+  }
+
+newtype CheckM a = CheckM (ReaderT CheckEnv (State CheckState) a)
+  deriving
+    ( Functor,
+      Applicative,
+      Monad,
+      MonadReader CheckEnv,
+      MonadState CheckState
+    )
+
+runCheckM :: CheckM a -> (a, [TypeError])
+runCheckM (CheckM m) =
+  let (a, s) = runState (runReaderT m env) initial_state
+   in (a, DL.toList (stateErrors s))
+  where
+    env =
+      CheckEnv
+        { envVtable = mempty
+        }
+    initial_state =
+      CheckState
+        { stateConsumed = mempty,
+          stateErrors = mempty,
+          stateNames = mempty,
+          stateCounter = 0
+        }
+
+describeVar :: Loc -> VName -> CheckM (Doc a)
+describeVar loc v =
+  gets $
+    maybe ("variable" <+> dquotes (prettyName v)) (nameReason (srclocOf loc))
+      . M.lookup v
+      . stateNames
+
+noConsumable :: CheckM a -> CheckM a
+noConsumable = local $ \env -> env {envVtable = M.map f $ envVtable env}
+  where
+    f = Nonconsumable . entryAliases
+
+addError :: Located loc => loc -> Notes -> Doc () -> CheckM ()
+addError loc notes e = modify $ \s ->
+  s {stateErrors = DL.snoc (stateErrors s) (TypeError (locOf loc) notes e)}
+
+incCounter :: CheckM Int
+incCounter =
+  state $ \s -> (stateCounter s, s {stateCounter = stateCounter s + 1})
+
+returnAliased :: Name -> SrcLoc -> CheckM ()
+returnAliased name loc =
+  addError loc mempty . withIndexLink "return-aliased" $
+    "Unique-typed return value is aliased to"
+      <+> dquotes (prettyName name) <> ", which is not consumable."
+
+uniqueReturnAliased :: SrcLoc -> CheckM ()
+uniqueReturnAliased loc =
+  addError loc mempty . withIndexLink "unique-return-aliased" $
+    "A unique-typed component of the return value is aliased to some other component."
+
+checkReturnAlias :: SrcLoc -> [Pat ParamType] -> ResType -> TypeAliases -> CheckM ()
+checkReturnAlias loc params rettp =
+  foldM_ (checkReturnAlias' params) S.empty . returnAliases rettp
+  where
+    checkReturnAlias' params' seen (Unique, names) = do
+      when (any (`S.member` S.map snd seen) $ S.toList names) $
+        uniqueReturnAliased loc
+      notAliasesParam params' names
+      pure $ seen `S.union` tag Unique names
+    checkReturnAlias' _ seen (Nonunique, names) = do
+      when (any (`S.member` seen) $ S.toList $ tag Unique names) $
+        uniqueReturnAliased loc
+      pure $ seen `S.union` tag Nonunique names
+
+    notAliasesParam params' names =
+      forM_ params' $ \p ->
+        let consumedNonunique (v, t) =
+              not (consumableParamType t) && (v `S.member` names)
+         in case find consumedNonunique $ patternMap p of
+              Just (v, _) ->
+                returnAliased (baseName v) loc
+              Nothing ->
+                pure ()
+
+    tag u = S.map (u,)
+
+    returnAliases (Scalar (Record ets1)) (Scalar (Record ets2)) =
+      concat $ M.elems $ M.intersectionWith returnAliases ets1 ets2
+    returnAliases expected got =
+      [(uniqueness expected, S.map aliasVar $ aliases got)]
+
+    consumableParamType (Array u _ _) = u == Consume
+    consumableParamType (Scalar Prim {}) = True
+    consumableParamType (Scalar (TypeVar u _ _)) = u == Consume
+    consumableParamType (Scalar (Record fs)) = all consumableParamType fs
+    consumableParamType (Scalar (Sum fs)) = all (all consumableParamType) fs
+    consumableParamType (Scalar Arrow {}) = False
+
+unscope :: Names -> Aliases -> Aliases
+unscope bound = S.map f
+  where
+    f (AliasFree v) = AliasFree v
+    f (AliasBound v) = if v `S.member` bound then AliasFree v else AliasBound v
+
+-- | Figure out the aliases of each bound name in a pattern.
+matchPat :: Pat t -> TypeAliases -> DL.DList (VName, (t, TypeAliases))
+matchPat (PatParens p _) t = matchPat p t
+matchPat (TuplePat ps _) t
+  | Just ts <- isTupleRecord t = mconcat $ zipWith matchPat ps ts
+matchPat (RecordPat fs1 _) (Scalar (Record fs2)) =
+  mconcat $
+    zipWith
+      matchPat
+      (map snd (sortFields (M.fromList fs1)))
+      (map snd (sortFields fs2))
+matchPat (Id v (Info t) _) als = DL.singleton (v, (t, als))
+matchPat (PatAscription p _ _) t = matchPat p t
+matchPat (PatConstr v _ ps _) (Scalar (Sum cs))
+  | Just ts <- M.lookup v cs = mconcat $ zipWith matchPat ps ts
+matchPat TuplePat {} _ = mempty
+matchPat RecordPat {} _ = mempty
+matchPat PatConstr {} _ = mempty
+matchPat Wildcard {} _ = mempty
+matchPat PatLit {} _ = mempty
+matchPat (PatAttr _ p _) t = matchPat p t
+
+bindingPat ::
+  Pat StructType ->
+  TypeAliases ->
+  CheckM (a, TypeAliases) ->
+  CheckM (a, TypeAliases)
+bindingPat p t = fmap (second (second (unscope (patNames p)))) . local bind
+  where
+    bind env =
+      env
+        { envVtable =
+            foldr (uncurry M.insert) (envVtable env) (fmap f (matchPat p t))
+        }
+      where
+        f (v, (_, als)) = (v, Consumable $ second (S.insert (AliasBound v)) als)
+
+bindingParam :: Pat ParamType -> CheckM (a, TypeAliases) -> CheckM (a, TypeAliases)
+bindingParam p m = do
+  mapM_ (noConsumable . bitraverse_ checkExp pure) p
+  second (second (unscope (patNames p))) <$> local bind m
+  where
+    bind env =
+      env
+        { envVtable =
+            foldr (uncurry M.insert) (envVtable env) (fmap f (patternMap p))
+        }
+    f (v, t)
+      | diet t == Consume = (v, Consumable $ t `setAliases` S.singleton (AliasBound v))
+      | otherwise = (v, Nonconsumable $ t `setAliases` S.singleton (AliasBound v))
+
+bindingIdent :: Diet -> Ident StructType -> CheckM (a, TypeAliases) -> CheckM (a, TypeAliases)
+bindingIdent d (Ident v (Info t) _) =
+  fmap (second (second (unscope (S.singleton v)))) . local bind
+  where
+    bind env = env {envVtable = M.insert v t' (envVtable env)}
+    d' = case d of
+      Consume -> Consumable
+      Observe -> Nonconsumable
+    t' = d' $ t `setAliases` S.singleton (AliasBound v)
+
+bindingParams :: [Pat ParamType] -> CheckM (a, TypeAliases) -> CheckM (a, TypeAliases)
+bindingParams params m =
+  noConsumable $
+    second (second (unscope (foldMap patNames params)))
+      <$> foldr bindingParam m params
+
+bindingLoopForm :: LoopFormBase Info VName -> CheckM (a, TypeAliases) -> CheckM (a, TypeAliases)
+bindingLoopForm (For ident _) m = bindingIdent Observe ident m
+bindingLoopForm (ForIn pat _) m = bindingParam pat' m
+  where
+    pat' = fmap (second (const Observe)) pat
+bindingLoopForm While {} m = m
+
+binding :: VName -> TypeAliases -> CheckM a -> CheckM a
+binding v t = local $ \env -> env {envVtable = M.insert v (Consumable t) (envVtable env)}
+
+addSelfAliases :: VName -> TypeAliases -> TypeAliases
+addSelfAliases v (Array als shape t) = Array (S.insert (AliasBound v) als) shape t
+addSelfAliases v (Scalar st) = Scalar $ addSelfAliases' st
+  where
+    addSelfAliases' (TypeVar als tn args) = TypeVar (S.insert (AliasBound v) als) tn args
+    addSelfAliases' (Record fs) = Record $ fmap (addSelfAliases v) fs
+    addSelfAliases' (Sum fs) = Sum $ fmap (map (addSelfAliases v)) fs
+    addSelfAliases' t@Arrow {} = t
+    addSelfAliases' t@Prim {} = t
+
+lookupAliases :: VName -> StructType -> CheckM Aliases
+lookupAliases v t =
+  asks $
+    aliases
+      . addSelfAliases v
+      . maybe (second (const mempty) t) entryAliases
+      . M.lookup v
+      . envVtable
+
+checkIfConsumed :: Loc -> Aliases -> CheckM ()
+checkIfConsumed rloc als = do
+  cons <- gets stateConsumed
+  let bad v = fmap (v,) $ v `M.lookup` cons
+  forM_ (mapMaybe (bad . aliasVar) $ S.toList als) $ \(v, wloc) -> do
+    v' <- describeVar rloc v
+    addError rloc mempty . withIndexLink "use-after-consume" $
+      "Using"
+        <+> v' <> ", but this was consumed at"
+        <+> pretty (locStrRel rloc wloc) <> ".  (Possibly through aliases.)"
+
+observeAliases :: Loc -> Aliases -> CheckM ()
+observeAliases = checkIfConsumed
+
+consumed :: Consumed -> CheckM ()
+consumed vs = modify $ \s -> s {stateConsumed = stateConsumed s <> vs}
+
+consumeAliases :: Loc -> Aliases -> CheckM ()
+consumeAliases loc als = do
+  vtable <- asks envVtable
+  let isBad v =
+        case v `M.lookup` vtable of
+          Just (Nonconsumable {}) -> True
+          Just _ -> False
+          Nothing -> True
+      checkIfConsumable (AliasBound v)
+        | isBad v = do
+            v' <- describeVar loc v
+            addError loc mempty . withIndexLink "not-consumable" $
+              "Would consume" <+> v' <> ", which is not consumable."
+      checkIfConsumable _ = pure ()
+  mapM_ checkIfConsumable $ S.toList als
+  checkIfConsumed loc als
+  consumed als'
+  where
+    als' = M.fromList $ map ((,loc) . aliasVar) $ S.toList als
+
+consume :: Loc -> VName -> StructType -> CheckM ()
+consume loc v t =
+  consumeAliases loc =<< lookupAliases v t
+
+-- | Observe the given name here and return its aliases.
+observeVar :: Loc -> VName -> StructType -> CheckM TypeAliases
+observeVar loc v t = do
+  als <-
+    asks $
+      maybe (addSelfAliases v $ second (const mempty) t) entryAliases
+        . M.lookup v
+        . envVtable
+  observeAliases loc (aliases als)
+  pure als
+
+-- Capture any newly consumed variables that occur during the provided action.
+contain :: CheckM a -> CheckM (a, Consumed)
+contain m = do
+  prev_cons <- gets stateConsumed
+  x <- m
+  new_cons <- gets $ (`M.difference` prev_cons) . stateConsumed
+  modify $ \s -> s {stateConsumed = prev_cons}
+  pure (x, new_cons)
+
+maskAliases :: Aliases -> Diet -> Aliases
+maskAliases _ Consume = mempty
+maskAliases als Observe = als
+
+-- | The two types are assumed to be approximately structurally equal,
+-- but not necessarily regarding sizes.  Combines aliases and prefers
+-- other information from first argument.
+combineAliases :: TypeAliases -> TypeAliases -> TypeAliases
+combineAliases (Array als1 et1 shape1) t2 =
+  Array (als1 <> aliases t2) et1 shape1
+combineAliases (Scalar (TypeVar als1 tv1 targs1)) t2 =
+  Scalar $ TypeVar (als1 <> aliases t2) tv1 targs1
+combineAliases (Scalar (Record ts1)) (Scalar (Record ts2))
+  | length ts1 == length ts2,
+    L.sort (M.keys ts1) == L.sort (M.keys ts2) =
+      Scalar $ Record $ M.intersectionWith combineAliases ts1 ts2
+combineAliases
+  (Scalar (Arrow als1 mn1 d1 pt1 (RetType dims1 rt1)))
+  (Scalar (Arrow als2 _ _ _ (RetType _ _))) =
+    Scalar (Arrow (als1 <> als2) mn1 d1 pt1 (RetType dims1 rt1))
+combineAliases (Scalar (Sum cs1)) (Scalar (Sum cs2))
+  | length cs1 == length cs2,
+    L.sort (M.keys cs1) == L.sort (M.keys cs2) =
+      Scalar $ Sum $ M.intersectionWith (zipWith combineAliases) cs1 cs2
+combineAliases (Scalar (Prim t)) _ = Scalar $ Prim t
+combineAliases t1 t2 =
+  error $ "combineAliases invalid args: " ++ show (t1, t2)
+
+-- An alias inhibits uniqueness if it is used in disjoint values.
+aliasesMultipleTimes :: TypeAliases -> Names
+aliasesMultipleTimes = S.fromList . map fst . filter ((> 1) . snd) . M.toList . delve
+  where
+    delve (Scalar (Record fs)) =
+      foldl' (M.unionWith (+)) mempty $ map delve $ M.elems fs
+    delve t =
+      M.fromList $ zip (map aliasVar $ S.toList (aliases t)) $ repeat (1 :: Int)
+
+consumingParams :: [Pat ParamType] -> Names
+consumingParams =
+  S.fromList . map fst . filter ((== Consume) . diet . snd) . foldMap patternMap
+
+arrayAliases :: TypeAliases -> Aliases
+arrayAliases (Array als _ _) = als
+arrayAliases (Scalar Prim {}) = mempty
+arrayAliases (Scalar (Record fs)) = foldMap arrayAliases fs
+arrayAliases (Scalar (TypeVar als _ _)) = als
+arrayAliases (Scalar Arrow {}) = mempty
+arrayAliases (Scalar (Sum fs)) =
+  mconcat $ concatMap (map arrayAliases) $ M.elems fs
+
+overlapCheck :: (Pretty src, Pretty ve) => Loc -> (src, TypeAliases) -> (ve, TypeAliases) -> CheckM ()
+overlapCheck loc (src, src_als) (ve, ve_als) =
+  when (any (`S.member` aliases src_als) (aliases ve_als)) $
+    addError loc mempty $
+      "Source array for in-place update"
+        </> indent 2 (pretty src)
+        </> "might alias update value"
+        </> indent 2 (pretty ve)
+        </> "Hint: use"
+        <+> dquotes "copy"
+        <+> "to remove aliases from the value."
+
+inferReturnUniqueness :: [Pat ParamType] -> ResType -> TypeAliases -> ResType
+inferReturnUniqueness params ret ret_als = delve ret ret_als
+  where
+    bound = foldMap patNames params
+    forbidden = aliasesMultipleTimes ret_als
+    consumings = consumingParams params
+    delve (Scalar (Record fs1)) (Scalar (Record fs2)) =
+      Scalar $ Record $ M.intersectionWith delve fs1 fs2
+    delve (Scalar (Sum cs1)) (Scalar (Sum cs2)) =
+      Scalar $ Sum $ M.intersectionWith (zipWith delve) cs1 cs2
+    delve t t_als
+      | all (`S.member` consumings) $
+          S.map aliasVar (arrayAliases t_als) `S.intersection` bound,
+        not $ any ((`S.member` forbidden) . aliasVar) (aliases t_als) =
+          t `setUniqueness` Unique
+      | otherwise =
+          t `setUniqueness` Nonunique
+
+-- | @returnType appres ret_type arg_diet arg_type@ gives result of applying
+-- an argument the given types to a function with the given return
+-- type, consuming the argument with the given diet.
+returnType :: Aliases -> ResType -> Diet -> TypeAliases -> TypeAliases
+returnType _ (Array Unique et shape) _ _ =
+  Array mempty et shape
+returnType appres (Array Nonunique et shape) d arg =
+  Array (appres <> arg_als) et shape
+  where
+    arg_als = maskAliases (aliases arg) d
+returnType appres (Scalar (Record fs)) d arg =
+  Scalar $ Record $ fmap (\et -> returnType appres et d arg) fs
+returnType _ (Scalar (Prim t)) _ _ =
+  Scalar $ Prim t
+returnType _ (Scalar (TypeVar Unique t targs)) _ _ =
+  Scalar $ TypeVar mempty t targs
+returnType appres (Scalar (TypeVar Nonunique t targs)) d arg =
+  Scalar $ TypeVar (appres <> arg_als) t targs
+  where
+    arg_als = maskAliases (aliases arg) d
+returnType _ (Scalar (Arrow _ v pd t1 (RetType dims t2))) d arg =
+  Scalar $ Arrow als v pd (t1 `setAliases` mempty) $ RetType dims t2
+  where
+    als = maskAliases (aliases arg) d
+returnType appres (Scalar (Sum cs)) d arg =
+  Scalar $ Sum $ (fmap . fmap) (\et -> returnType appres et d arg) cs
+
+checkSubExps :: ASTMappable e => e -> CheckM e
+checkSubExps = astMap identityMapper {mapOnExp = fmap fst . checkExp}
+
+noAliases :: Exp -> CheckM (Exp, TypeAliases)
+noAliases e = do
+  e' <- checkSubExps e
+  pure (e', second (const mempty) (typeOf e))
+
+aliasParts :: TypeAliases -> [Aliases]
+aliasParts (Scalar (Record ts)) = foldMap aliasParts $ M.elems ts
+aliasParts t = [aliases t]
+
+noSelfAliases :: Loc -> TypeAliases -> CheckM ()
+noSelfAliases loc = foldM_ check mempty . aliasParts
+  where
+    check seen als = do
+      when (any (`S.member` seen) als) $
+        addError loc mempty . withIndexLink "self-aliases-arg" $
+          "Argument passed for consuming parameter is self-aliased."
+      pure $ als <> seen
+
+consumeAsNeeded :: Loc -> ParamType -> TypeAliases -> CheckM ()
+consumeAsNeeded loc pt t =
+  when (diet pt == Consume) $ consumeAliases loc $ aliases t
+
+checkArg :: ParamType -> Exp -> CheckM (Exp, TypeAliases)
+checkArg p_t e = do
+  ((e', e_als), e_cons) <- contain $ checkExp e
+  consumed e_cons
+  let e_t = typeOf e'
+  when (e_cons /= mempty && not (orderZero e_t)) $
+    addError (locOf e) mempty $
+      "Argument of functional type"
+        </> indent 2 (pretty e_t)
+        </> "contains consumption, which is not allowed."
+  when (diet p_t == Consume) $ do
+    noSelfAliases (locOf e) e_als
+    consumeAsNeeded (locOf e) p_t e_als
+  pure (e', e_als)
+
+applyArg :: TypeAliases -> TypeAliases -> TypeAliases
+applyArg (Scalar (Arrow closure_als _ d _ (RetType _ rettype))) arg_als =
+  returnType closure_als rettype d arg_als
+applyArg t _ = error $ "applyArg: " <> show t
+
+-- Loops are tricky because we want to infer the uniqueness of their
+-- parameters.  This is pretty unusual: we do not do this for ordinary
+-- functions.
+type Loop = (Pat ParamType, Exp, LoopFormBase Info VName, Exp)
+
+-- | Mark bindings of consumed names as Consume.
+updateParamDiet :: Names -> Pat ParamType -> Pat ParamType
+updateParamDiet cons = recurse
+  where
+    recurse (Wildcard (Info t) wloc) =
+      Wildcard (Info $ t `setUniqueness` Observe) wloc
+    recurse (PatParens p ploc) =
+      PatParens (recurse p) ploc
+    recurse (PatAttr attr p ploc) =
+      PatAttr attr (recurse p) ploc
+    recurse (Id name (Info t) iloc)
+      | name `S.member` cons =
+          let t' = t `setUniqueness` Consume
+           in Id name (Info t') iloc
+      | otherwise =
+          let t' = t `setUniqueness` Observe
+           in Id name (Info t') iloc
+    recurse (TuplePat pats ploc) =
+      TuplePat (map recurse pats) ploc
+    recurse (RecordPat fs ploc) =
+      RecordPat (map (fmap recurse) fs) ploc
+    recurse (PatAscription p t ploc) =
+      PatAscription p t ploc
+    recurse p@PatLit {} = p
+    recurse (PatConstr n t ps ploc) =
+      PatConstr n t (map recurse ps) ploc
+
+convergeLoopParam :: Loc -> Pat ParamType -> Names -> TypeAliases -> CheckM (Pat ParamType)
+convergeLoopParam loop_loc param body_cons body_als = do
+  let -- Make the pattern Consume where needed.
+      param' = updateParamDiet (patNames param `S.intersection` body_cons) param
+
+  -- Check that the new values of consumed merge parameters do not
+  -- alias something bound outside the loop, AND that anything
+  -- returned for a unique merge parameter does not alias anything
+  -- else returned.
+  let checkMergeReturn (Id pat_v (Info pat_v_t) patloc) t = do
+        let free_als = boundAliases (aliases t) `S.difference` patNames param
+        when (diet pat_v_t == Consume) $ forM_ free_als $ \v ->
+          lift . addError loop_loc mempty $
+            "Return value for consuming loop parameter"
+              <+> dquotes (prettyName pat_v)
+              <+> "aliases"
+              <+> dquotes (prettyName v) <> "."
+        (cons, obs) <- get
+        unless (S.null $ aliases t `S.intersection` cons) $
+          lift . addError loop_loc mempty $
+            "Return value for loop parameter"
+              <+> dquotes (prettyName pat_v)
+              <+> "aliases other consumed loop parameter."
+        when
+          ( diet pat_v_t == Consume
+              && not (S.null (aliases t `S.intersection` (cons <> obs)))
+          )
+          $ lift . addError loop_loc mempty
+          $ "Return value for consuming loop parameter"
+            <+> dquotes (prettyName pat_v)
+            <+> "aliases previously returned value."
+        if diet pat_v_t == Consume
+          then put (cons <> aliases t, obs)
+          else put (cons, obs <> aliases t)
+
+        pure $ Id pat_v (Info pat_v_t) patloc
+      checkMergeReturn (Wildcard (Info pat_v_t) patloc) _ =
+        pure $ Wildcard (Info pat_v_t) patloc
+      checkMergeReturn (PatParens p _) t =
+        checkMergeReturn p t
+      checkMergeReturn (PatAscription p _ _) t =
+        checkMergeReturn p t
+      checkMergeReturn (RecordPat pfs patloc) (Scalar (Record tfs)) =
+        RecordPat . M.toList <$> sequence pfs' <*> pure patloc
+        where
+          pfs' = M.intersectionWith checkMergeReturn (M.fromList pfs) tfs
+      checkMergeReturn (TuplePat pats patloc) t
+        | Just ts <- isTupleRecord t =
+            TuplePat <$> zipWithM checkMergeReturn pats ts <*> pure patloc
+      checkMergeReturn p _ =
+        pure p
+
+  (param'', (param_cons, _)) <-
+    runStateT (checkMergeReturn param' body_als) (mempty, mempty)
+
+  let body_cons' = body_cons <> S.map aliasVar param_cons
+  traceM $
+    unlines
+      [ "convergeLoopParam",
+        prettyString param,
+        show body_cons,
+        prettyString body_als
+      ]
+  if body_cons' == body_cons && patternType param'' == patternType param
+    then pure param'
+    else convergeLoopParam loop_loc param'' body_cons' body_als
+
+checkLoop :: Loc -> Loop -> CheckM (Loop, TypeAliases)
+checkLoop loop_loc (param, arg, form, body) = do
+  form' <- checkSubExps form
+  -- We pretend that every part of the loop parameter has a consuming
+  -- diet, as we need to allow consumption in the body, which we then
+  -- use to infer the proper diet of the parameter.
+  ((body', body_cons), body_als) <-
+    noConsumable
+      . bindingParam (fmap (second (const Consume)) param)
+      . bindingLoopForm form'
+      $ do
+        ((body', body_als), body_cons) <- contain $ checkExp body
+        pure ((body', body_cons), body_als)
+  param' <- convergeLoopParam loop_loc param (M.keysSet body_cons) body_als
+
+  let param_t = patternType param'
+  traceM $ unlines ["checkArg", prettyString param_t, prettyString arg]
+  (arg', arg_als) <- checkArg param_t arg
+  v <- VName "internal_loop_result" <$> incCounter
+  modify $ \s -> s {stateNames = M.insert v (NameLoopRes (srclocOf loop_loc)) $ stateNames s}
+  let loopt =
+        funType [param'] (RetType [] $ paramToRes param_t)
+          `setAliases` S.singleton (AliasFree v)
+  pure
+    ( (param', arg', form', body'),
+      applyArg loopt arg_als `combineAliases` body_als
+    )
+
+checkExp :: Exp -> CheckM (Exp, TypeAliases)
+-- First we have the complicated cases.
+
+--
+checkExp (AppExp (Apply f args loc) appres) = do
+  -- Note Futhark uses right-to-left evaluation of applications.
+  (args', args_als) <- NE.unzip . NE.reverse <$> traverse checkArg' (NE.reverse args)
+  (f', f_als) <- checkExp f
+  v <- VName "internal_app_result" <$> incCounter
+  modify $ \s -> s {stateNames = M.insert v (NameAppRes (fname f) loc) $ stateNames s}
+  let res_als = foldl applyArg (second (S.insert (AliasFree v)) f_als) args_als
+  pure (AppExp (Apply f' args' loc) appres, res_als)
+  where
+    fname (Var v _ _) = Just v
+    fname (AppExp (Apply e _ _) _) = fname e
+    fname _ = Nothing
+    checkArg' (Info (d, p), e) = do
+      (e', e_als) <- checkArg (second (const d) (typeOf e)) e
+      pure ((Info (d, p), e'), e_als)
+--
+checkExp (AppExp (LetPat sizes p e body loc) appres) = do
+  (e', e_als) <- checkExp e
+  bindingPat p e_als $ do
+    (body', body_als) <- checkExp body
+    pure
+      ( AppExp (LetPat sizes p e' body' loc) appres,
+        body_als
+      )
+
+--
+checkExp (AppExp (If cond te fe loc) appres) = do
+  (cond', _) <- checkExp cond
+  ((te', te_als), te_cons) <- contain $ checkExp te
+  ((fe', fe_als), fe_cons) <- contain $ checkExp fe
+  let all_cons = te_cons <> fe_cons
+      notConsumed = not . (`M.member` all_cons) . aliasVar
+      comb_als = second (S.filter notConsumed) $ te_als `combineAliases` fe_als
+  consumed all_cons
+  pure
+    ( AppExp (If cond' te' fe' loc) appres,
+      appResType (unInfo appres) `setAliases` mempty `combineAliases` comb_als
+    )
+
+--
+checkExp (AppExp (Match cond cs loc) appres) = do
+  (cond', cond_als) <- checkExp cond
+  ((cs', cs_als), cs_cons) <- first NE.unzip . NE.unzip <$> mapM (checkCase cond_als) cs
+  let all_cons = fold cs_cons
+      notConsumed = not . (`M.member` all_cons) . aliasVar
+      comb_als = second (S.filter notConsumed) $ foldl1 combineAliases cs_als
+  consumed all_cons
+  pure
+    ( AppExp (Match cond' cs' loc) appres,
+      appResType (unInfo appres) `setAliases` mempty `combineAliases` comb_als
+    )
+  where
+    checkCase cond_als (CasePat p body caseloc) =
+      contain $ bindingPat p cond_als $ do
+        (body', body_als) <- checkExp body
+        pure (CasePat p body' caseloc, body_als)
+
+--
+checkExp (AppExp (LetFun fname (typarams, params, te, Info (RetType ext ret), funbody) letbody loc) appres) = do
+  (funbody', funbody_als) <- bindingParams params $ checkExp funbody
+  checkReturnAlias loc params ret funbody_als
+  checkGlobalAliases loc params funbody_als
+  let ret' = inferReturnUniqueness params ret funbody_als
+      ftype =
+        funType params (RetType ext ret')
+          `setAliases` S.map AliasBound (fvVars (freeInExp funbody))
+  (letbody', letbody_als) <- binding fname ftype $ checkExp letbody
+  pure
+    ( AppExp (LetFun fname (typarams, params, te, Info (RetType ext ret), funbody') letbody' loc) appres,
+      letbody_als
+    )
+
+--
+checkExp (AppExp (BinOp (op, oploc) opt (x, xp) (y, yp) loc) appres) = do
+  op_als <- observeVar (locOf oploc) (qualLeaf op) (unInfo opt)
+  let at1 : at2 : _ = fst $ unfoldFunType op_als
+  (x', x_als) <- checkArg at1 x
+  (y', y_als) <- checkArg at2 y
+  pure
+    ( AppExp (BinOp (op, oploc) opt (x', xp) (y', yp) loc) appres,
+      foldl applyArg op_als [x_als, y_als]
+    )
+
+--
+checkExp e@(Lambda params body te (Info (RetType ext ret)) loc) = do
+  (body', body_als) <- bindingParams params $ checkExp body
+  checkReturnAlias loc params ret body_als
+  checkGlobalAliases loc params body_als
+  vtable <- asks envVtable
+  let free_bound = S.filter (`M.member` vtable) $ fvVars (freeInExp e)
+      ret' = inferReturnUniqueness params ret body_als
+      als = aliases body_als <> S.map AliasBound free_bound
+  pure
+    ( Lambda params body' te (Info (RetType ext ret')) loc,
+      funType params (RetType ext ret') `setAliases` als
+    )
+
+--
+checkExp (AppExp (LetWith dst src slice ve body loc) appres) = do
+  src_als <- observeVar (locOf dst) (identName src) (unInfo $ identType src)
+  slice' <- checkSubExps slice
+  (ve', ve_als) <- checkExp ve
+  consume (locOf src) (identName src) (unInfo (identType src))
+  overlapCheck (locOf ve) (src, src_als) (ve', ve_als)
+  (body', body_als) <- bindingIdent Consume dst $ checkExp body
+  pure (AppExp (LetWith dst src slice' ve' body' loc) appres, body_als)
+
+--
+checkExp (Update src slice ve loc) = do
+  slice' <- checkSubExps slice
+  (src', src_als) <- checkExp src
+  (ve', ve_als) <- checkExp ve
+  overlapCheck (locOf ve) (src', src_als) (ve', ve_als)
+  consumeAliases (locOf loc) $ aliases src_als
+  pure (Update src' slice' ve' loc, second (const mempty) src_als)
+
+-- Cases that simply propagate aliases directly.
+checkExp (Var v (Info t) loc) = do
+  als <- observeVar (locOf loc) (qualLeaf v) t
+  observeAliases (locOf loc) (aliases als)
+  pure (Var v (Info t) loc, als)
+checkExp (OpSection v (Info t) loc) = do
+  als <- observeVar (locOf loc) (qualLeaf v) t
+  observeAliases (locOf loc) (aliases als)
+  pure (OpSection v (Info t) loc, als)
+checkExp (OpSectionLeft op ftype arg arginfo retinfo loc) = do
+  let (_, Info (pn, pt2)) = arginfo
+      (Info ret, _) = retinfo
+  als <- observeVar (locOf loc) (qualLeaf op) (unInfo ftype)
+  (arg', arg_als) <- checkExp arg
+  pure
+    ( OpSectionLeft op ftype arg' arginfo retinfo loc,
+      Scalar $ Arrow (aliases arg_als <> aliases als) pn (diet pt2) (toStruct pt2) ret
+    )
+checkExp (OpSectionRight op ftype arg arginfo retinfo loc) = do
+  let (Info (pn, pt2), _) = arginfo
+      Info ret = retinfo
+  als <- observeVar (locOf loc) (qualLeaf op) (unInfo ftype)
+  (arg', arg_als) <- checkExp arg
+  pure
+    ( OpSectionRight op ftype arg' arginfo retinfo loc,
+      Scalar $ Arrow (aliases arg_als <> aliases als) pn (diet pt2) (toStruct pt2) ret
+    )
+checkExp (IndexSection slice t loc) = do
+  slice' <- checkSubExps slice
+  pure (IndexSection slice' t loc, unInfo t `setAliases` mempty)
+checkExp (ProjectSection fs t loc) = do
+  pure (ProjectSection fs t loc, unInfo t `setAliases` mempty)
+checkExp (Coerce e te t loc) = do
+  (e', e_als) <- checkExp e
+  pure (Coerce e' te t loc, e_als)
+checkExp (Ascript e te loc) = do
+  (e', e_als) <- checkExp e
+  pure (Ascript e' te loc, e_als)
+checkExp (AppExp (Index v slice loc) appres) = do
+  (v', v_als) <- checkExp v
+  slice' <- checkSubExps slice
+  pure
+    ( AppExp (Index v' slice' loc) appres,
+      appResType (unInfo appres) `setAliases` aliases v_als
+    )
+checkExp (Assert e1 e2 t loc) = do
+  (e1', _) <- checkExp e1
+  (e2', e2_als) <- checkExp e2
+  pure (Assert e1' e2' t loc, e2_als)
+checkExp (Parens e loc) = do
+  (e', e_als) <- checkExp e
+  pure (Parens e' loc, e_als)
+checkExp (QualParens v e loc) = do
+  (e', e_als) <- checkExp e
+  pure (QualParens v e' loc, e_als)
+checkExp (Attr attr e loc) = do
+  (e', e_als) <- checkExp e
+  pure (Attr attr e' loc, e_als)
+checkExp (Project name e t loc) = do
+  (e', e_als) <- checkExp e
+  pure (Project name e' t loc, e_als)
+checkExp (TupLit es loc) = do
+  (es', es_als) <- mapAndUnzipM checkExp es
+  pure (TupLit es' loc, Scalar $ tupleRecord es_als)
+checkExp (Constr name es t loc) = do
+  (es', es_als) <- mapAndUnzipM checkExp es
+  pure
+    ( Constr name es' t loc,
+      case unInfo t of
+        Scalar (Sum cs) ->
+          Scalar . Sum . M.insert name es_als $
+            M.map (map (`setAliases` mempty)) cs
+        t' -> error $ "checkExp Constr: bad type " <> prettyString t'
+    )
+checkExp (RecordUpdate src fields ve t loc) = do
+  (src', src_als) <- checkExp src
+  (ve', ve_als) <- checkExp ve
+  pure
+    ( RecordUpdate src' fields ve' t loc,
+      setFieldAliases ve_als fields src_als
+    )
+checkExp (RecordLit fs loc) = do
+  (fs', fs_als) <- mapAndUnzipM checkField fs
+  pure (RecordLit fs' loc, Scalar $ Record $ M.fromList fs_als)
+  where
+    checkField (RecordFieldExplicit name e floc) = do
+      (e', e_als) <- checkExp e
+      pure (RecordFieldExplicit name e' floc, (name, e_als))
+    checkField (RecordFieldImplicit name t floc) = do
+      name_als <- observeVar (locOf floc) name $ unInfo t
+      pure (RecordFieldImplicit name t floc, (baseName name, name_als))
+
+-- Cases that create alias-free values.
+checkExp e@(AppExp Range {} _) = noAliases e
+checkExp e@IntLit {} = noAliases e
+checkExp e@FloatLit {} = noAliases e
+checkExp e@Literal {} = noAliases e
+checkExp e@StringLit {} = noAliases e
+checkExp e@ArrayLit {} = noAliases e
+checkExp e@Negate {} = noAliases e
+checkExp e@Not {} = noAliases e
+checkExp e@Hole {} = noAliases e
+checkExp (AppExp (DoLoop sparams pat args form body loc) appres) = do
+  ((pat', args', form', body'), als) <- checkLoop (locOf loc) (pat, args, form, body)
+  pure
+    ( AppExp (DoLoop sparams pat' args' form' body' loc) appres,
+      als
+    )
+
+checkGlobalAliases :: SrcLoc -> [Pat ParamType] -> TypeAliases -> CheckM ()
+checkGlobalAliases loc params body_t = do
+  vtable <- asks envVtable
+  let global = flip M.notMember vtable
+  unless (null params) $ forM_ (boundAliases $ arrayAliases body_t) $ \v ->
+    when (global v) . addError loc mempty . withIndexLink "alias-free-variable" $
+      "Function result aliases the free variable "
+        <> dquotes (prettyName v)
+        <> "."
+        </> "Use"
+        <+> dquotes "copy"
+        <+> "to break the aliasing."
+
+-- | Type-check a value definition.  This also infers a new return
+-- type that may be more unique than previously.
+checkValDef ::
+  (VName, [Pat ParamType], Exp, ResRetType, SrcLoc) ->
+  ((Exp, ResRetType), [TypeError])
+checkValDef (_fname, params, body, RetType ext ret, loc) = runCheckM $ do
+  (body', body_als) <- bindingParams params $ checkExp body
+  checkReturnAlias loc params ret body_als
+  checkGlobalAliases loc params body_als
+  when (null params && unique ret) $
+    addError loc mempty "A top-level constant cannot have a unique type."
+  pure (body', RetType ext $ inferReturnUniqueness params ret body_als)
+{-# NOINLINE checkValDef #-}

--- a/src/Language/Futhark/TypeChecker/Match.hs
+++ b/src/Language/Futhark/TypeChecker/Match.hs
@@ -49,7 +49,7 @@ pprMatch _ (MatchConstr (ConstrRecord fs) ps _) =
 instance Pretty (Match t) where
   pretty = pprMatch (-1)
 
-patternToMatch :: Pat -> Match StructType
+patternToMatch :: Pat StructType -> Match StructType
 patternToMatch (Id _ (Info t) _) = MatchWild $ toStruct t
 patternToMatch (Wildcard (Info t) _) = MatchWild $ toStruct t
 patternToMatch (PatParens p _) = patternToMatch p
@@ -174,7 +174,7 @@ findUnmatched _ _ = []
 {-# NOINLINE unmatched #-}
 
 -- | Find the unmatched cases.
-unmatched :: [Pat] -> [Match ()]
+unmatched :: [Pat StructType] -> [Match ()]
 unmatched orig_ps =
   -- The algorithm may find duplicate example, which we filter away
   -- here.

--- a/src/Language/Futhark/TypeChecker/Terms.hs
+++ b/src/Language/Futhark/TypeChecker/Terms.hs
@@ -22,7 +22,7 @@ import Data.Bifunctor
 import Data.Bitraversable
 import Data.Char (isAscii)
 import Data.Either
-import Data.List (find, foldl', genericLength, partition)
+import Data.List (find, genericLength, partition)
 import Data.List.NonEmpty qualified as NE
 import Data.Map.Strict qualified as M
 import Data.Maybe
@@ -32,6 +32,7 @@ import Futhark.Util.Pretty hiding (space)
 import Language.Futhark
 import Language.Futhark.Primitive (intByteSize)
 import Language.Futhark.Traversals
+import Language.Futhark.TypeChecker.Consumption qualified as Consumption
 import Language.Futhark.TypeChecker.Match
 import Language.Futhark.TypeChecker.Monad hiding (BoundV)
 import Language.Futhark.TypeChecker.Terms.DoLoop
@@ -65,12 +66,12 @@ overloadedTypeVars = mconcat . map f . M.elems
 -- Mismatched dimensions are turned into fresh rigid type variables.
 -- Causes a 'TypeError' if they fail to match, and otherwise returns
 -- one of them.
-unifyBranchTypes :: SrcLoc -> PatType -> PatType -> TermTypeM (PatType, [VName])
+unifyBranchTypes :: SrcLoc -> StructType -> StructType -> TermTypeM (StructType, [VName])
 unifyBranchTypes loc t1 t2 =
   onFailure (CheckingBranches (toStruct t1) (toStruct t2)) $
     unifyMostCommon (mkUsage loc "unification of branch results") t1 t2
 
-unifyBranches :: SrcLoc -> Exp -> Exp -> TermTypeM (PatType, [VName])
+unifyBranches :: SrcLoc -> Exp -> Exp -> TermTypeM (StructType, [VName])
 unifyBranches loc e1 e2 = do
   e1_t <- expTypeFully e1
   e2_t <- expTypeFully e2
@@ -78,14 +79,14 @@ unifyBranches loc e1 e2 = do
 
 sliceShape ::
   Maybe (SrcLoc, Rigidity) ->
-  [(DimIndex, Maybe Occurrence)] ->
+  [DimIndex] ->
   TypeBase Size as ->
   TermTypeM (TypeBase Size as, [VName])
-sliceShape r slice t@(Array als u (Shape orig_dims) et) =
+sliceShape r slice t@(Array u (Shape orig_dims) et) =
   runStateT (setDims <$> adjustDims slice orig_dims) []
   where
     setDims [] = stripArray (length orig_dims) t
-    setDims dims' = Array als u (Shape dims') et
+    setDims dims' = Array u (Shape dims') et
 
     -- If the result is supposed to be a nonrigid size variable, then
     -- don't bother trying to create non-existential sizes.  This is
@@ -117,52 +118,31 @@ sliceShape r slice t@(Array als u (Shape orig_dims) et) =
           | isJust i, isJust j = Nothing
           | otherwise = Just orig_d
 
-    warnIfConsumingOrBinding mOcc binds d i j stride size =
-      case (mOcc, binds) of
-        (Just occ, _) -> do
-          lift . warn (location occ) $
-            withIndexLink
-              "size-expression-consume"
-              "Size expression with consumption is replaced by unknown size."
-          (:) <$> sliceSize d i j stride
-        (_, True) -> do
-          lift . warn (srclocOf size) $
-            withIndexLink
-              "size-expression-bind"
-              "Size expression with binding is replaced by unknown size."
-          (:) <$> sliceSize d i j stride
-        (_, False) ->
-          pure (size :)
-
-    adjustDims ((DimFix {}, _) : idxes') (_ : dims) =
+    adjustDims (DimFix {} : idxes') (_ : dims) =
       adjustDims idxes' dims
     -- Pat match some known slices to be non-existential.
-    adjustDims ((DimSlice i j stride, mOcc) : idxes') (d : dims)
+    adjustDims (DimSlice i j stride : idxes') (d : dims)
       | refine_sizes,
         maybe True ((== Just 0) . isInt64) i,
         maybe True ((== Just 1) . isInt64) stride =
-          let j' = fromMaybe d j
-           in warnIfConsumingOrBinding mOcc (maybe False hasBinding j) d i j stride j'
-                <*> adjustDims idxes' dims
-    adjustDims ((DimSlice i j stride, mOcc) : idxes') (d : dims)
+          (fromMaybe d j :) <$> adjustDims idxes' dims
+    adjustDims ((DimSlice i j stride) : idxes') (d : dims)
       | refine_sizes,
         Just i' <- i, -- if i ~ 0, previous case
         maybe True ((== Just 1) . isInt64) stride =
           let j' = fromMaybe d j
-           in warnIfConsumingOrBinding mOcc (hasBinding j' || hasBinding i') d i j stride (sizeMinus j' i')
-                <*> adjustDims idxes' dims
+           in (sizeMinus j' i' :) <$> adjustDims idxes' dims
     -- stride == -1
-    adjustDims ((DimSlice Nothing Nothing stride, _) : idxes') (d : dims)
+    adjustDims ((DimSlice Nothing Nothing stride) : idxes') (d : dims)
       | refine_sizes,
         maybe True ((== Just (-1)) . isInt64) stride =
           (d :) <$> adjustDims idxes' dims
-    adjustDims ((DimSlice (Just i) (Just j) stride, mOcc) : idxes') (d : dims)
+    adjustDims ((DimSlice (Just i) (Just j) stride) : idxes') (_d : dims)
       | refine_sizes,
         maybe True ((== Just (-1)) . isInt64) stride =
-          warnIfConsumingOrBinding mOcc (hasBinding i || hasBinding j) d (Just i) (Just j) stride (sizeMinus i j)
-            <*> adjustDims idxes' dims
+          (sizeMinus i j :) <$> adjustDims idxes' dims
     -- existential
-    adjustDims ((DimSlice i j stride, _) : idxes') (d : dims) =
+    adjustDims ((DimSlice i j stride) : idxes') (d : dims) =
       (:) <$> sliceSize d i j stride <*> adjustDims idxes' dims
     adjustDims _ dims =
       pure dims
@@ -179,31 +159,16 @@ sliceShape r slice t@(Array als u (Shape orig_dims) et) =
         $ Info
         $ AppRes i64 []
     i64 = Scalar $ Prim $ Signed Int64
-    sizeBinOpInfo = Info $ foldFunType [(Observe, i64), (Observe, i64)] $ RetType [] i64
+    sizeBinOpInfo = Info $ foldFunType [i64, i64] $ RetType [] i64
 sliceShape _ _ t = pure (t, [])
 
 --- Main checkers
 
--- The closure of a lambda or local function are those variables that
--- it references, and which local to the current top-level function.
-lexicalClosure :: [Pat] -> Occurrences -> TermTypeM Aliasing
-lexicalClosure params closure = do
-  vtable <- asks $ scopeVtable . termScope
-  let isGlobal v = case v `M.lookup` vtable of
-        Just (BoundV Global _ _) -> True
-        Just EqualityF {} -> True
-        Just OverloadedF {} -> True
-        Just (BoundV Local _ _) -> False
-        Just (BoundV Nonlocal _ _) -> False
-        Nothing -> False
-  pure . S.map AliasBound . S.filter (not . isGlobal) $
-    allOccurring closure S.\\ mconcat (map patNames params)
-
-noAliasesIfOverloaded :: PatType -> TermTypeM PatType
-noAliasesIfOverloaded t@(Scalar (TypeVar _ u tn [])) = do
+noAliasesIfOverloaded :: StructType -> TermTypeM StructType
+noAliasesIfOverloaded t@(Scalar (TypeVar u tn [])) = do
   subst <- fmap snd . M.lookup (qualLeaf tn) <$> getConstraints
   case subst of
-    Just Overloaded {} -> pure $ Scalar $ TypeVar mempty u tn []
+    Just Overloaded {} -> pure $ Scalar $ TypeVar u tn []
     _ -> pure t
 noAliasesIfOverloaded t =
   pure t
@@ -218,8 +183,8 @@ checkAscript loc te e = do
   e' <- checkExp e
   e_t <- toStruct <$> expTypeFully e'
 
-  onFailure (CheckingAscription decl_t e_t) $
-    unify (mkUsage loc "type ascription") decl_t e_t
+  onFailure (CheckingAscription (toStruct decl_t) e_t) $
+    unify (mkUsage loc "type ascription") (toStruct decl_t) (toStruct e_t)
 
   pure (te', e')
 
@@ -235,8 +200,8 @@ checkCoerce loc te e = do
 
   te_t_nonrigid <- makeNonExtFresh ext te_t
 
-  onFailure (CheckingAscription te_t e_t) $
-    unify (mkUsage loc "size coercion") e_t te_t_nonrigid
+  onFailure (CheckingAscription (toStruct te_t) e_t) $
+    unify (mkUsage loc "size coercion") e_t (toStruct te_t_nonrigid)
 
   -- If the type expression had any anonymous dimensions, these will
   -- now be in 'ext'.  Those we keep nonrigid and unify with e_t.
@@ -244,7 +209,7 @@ checkCoerce loc te e = do
   -- dimension unknown.  Use of matchDims is sensible because the
   -- structure of e_t' will be fully known due to the unification, and
   -- te_t because type expressions are complete.
-  pure (te', te_t, e')
+  pure (te', toStruct te_t, e')
   where
     makeNonExtFresh ext = bitraverse onDim pure
       where
@@ -324,18 +289,18 @@ sizeFree tloc expKiller orig_t = do
       rl <- state $ partition (`notElem` old_bound)
       let dims' = dims <> rl
       pure $ Arrow as argName d argT' (RetType dims' retT')
-    onScalar (TypeVar as u v args) =
-      TypeVar as u v <$> mapM onTypeArg args
+    onScalar (TypeVar u v args) =
+      TypeVar u v <$> mapM onTypeArg args
       where
         onTypeArg (TypeArgDim d) = TypeArgDim <$> replacing d
         onTypeArg (TypeArgType ty) = TypeArgType <$> onType ty
     onScalar (Prim pt) = pure $ Prim pt
 
     onType ::
-      TypeBase Size as ->
-      ReaderT [(Exp, Exp)] (StateT [VName] TermTypeM) (TypeBase Size as) -- Precise the typing, else haskell refuse it
-    onType (Array as u shape scalar) =
-      Array as u <$> traverse replacing shape <*> onScalar scalar
+      TypeBase Size u ->
+      ReaderT [(Exp, Exp)] (StateT [VName] TermTypeM) (TypeBase Size u)
+    onType (Array u shape scalar) =
+      Array u <$> traverse replacing shape <*> onScalar scalar
     onType (Scalar ty) =
       Scalar <$> onScalar ty
 
@@ -346,8 +311,8 @@ sizeFree tloc expKiller orig_t = do
 -- unknown, which is then by let-generalisation turned into
 -- '?[z].[z]t'.
 unscopeUnknown ::
-  TypeBase Size as ->
-  TermTypeM (TypeBase Size as)
+  TypeBase Size u ->
+  TermTypeM (TypeBase Size u)
 unscopeUnknown t = do
   constraints <- getConstraints
   -- These sizes will be immediately turned into existentials, so we
@@ -362,32 +327,13 @@ unscopeUnknown t = do
     isUnknown _ _ = False
     (witnesses, _) = determineSizeWitnesses $ toStruct t
 
-unscopeTypeBase ::
+unscopeType ::
   SrcLoc ->
   S.Set VName ->
   TypeBase Size as ->
   TermTypeM (TypeBase Size as, [VName])
-unscopeTypeBase tloc unscoped =
+unscopeType tloc unscoped =
   sizeFree tloc $ S.lookupMin . S.intersection unscoped . fvVars . freeInExp
-
-unscopeStructType ::
-  SrcLoc ->
-  S.Set VName ->
-  StructType ->
-  TermTypeM (StructType, [VName])
-unscopeStructType = unscopeTypeBase
-
-unscopePatType ::
-  SrcLoc ->
-  S.Set VName ->
-  PatType ->
-  TermTypeM (PatType, [VName])
-unscopePatType tloc unscoped t = do
-  (t', m) <- unscopeTypeBase tloc unscoped t
-  pure (t' `addAliases` S.map unAlias, m)
-  where
-    unAlias (AliasBound v) | v `S.member` unscoped = AliasFree v
-    unAlias a = a
 
 reboundI64 ::
   ASTMappable (TypeBase Size as) =>
@@ -403,9 +349,8 @@ reboundI64 tloc unscoped =
         { mapOnExp,
           mapOnName = pure,
           mapOnStructType = astMap mapper,
-          mapOnPatType = astMap mapper,
-          mapOnStructRetType = astMap mapper,
-          mapOnPatRetType = astMap mapper
+          mapOnParamType = astMap mapper,
+          mapOnResRetType = astMap mapper
         }
 
     mapOnExp :: Exp -> StateT (M.Map VName VName) TermTypeM Exp
@@ -431,11 +376,11 @@ checkExp (StringLit vs loc) =
 checkExp (IntLit val NoInfo loc) = do
   t <- newTypeVar loc "t"
   mustBeOneOf anyNumberType (mkUsage loc "integer literal") t
-  pure $ IntLit val (Info $ fromStruct t) loc
+  pure $ IntLit val (Info t) loc
 checkExp (FloatLit val NoInfo loc) = do
   t <- newTypeVar loc "t"
   mustBeOneOf anyFloatType (mkUsage loc "float literal") t
-  pure $ FloatLit val (Info $ fromStruct t) loc
+  pure $ FloatLit val (Info t) loc
 checkExp (TupLit es loc) =
   TupLit <$> mapM checkExp es <*> pure loc
 checkExp (RecordLit fs loc) = do
@@ -472,17 +417,17 @@ checkExp (ArrayLit all_es _ loc) =
   case all_es of
     [] -> do
       et <- newTypeVar loc "t"
-      t <- arrayOfM loc et (Shape [sizeFromInteger 0 mempty]) Nonunique
+      t <- arrayOfM loc et (Shape [sizeFromInteger 0 mempty])
       pure $ ArrayLit [] (Info t) loc
     e : es -> do
       e' <- checkExp e
       et <- expType e'
       es' <- mapM (unifies "type of first array element" (toStruct et) <=< checkExp) es
       et' <- normTypeFully et
-      t <- arrayOfM loc et' (Shape [sizeFromInteger (genericLength all_es) mempty]) Nonunique
+      t <- arrayOfM loc et' (Shape [sizeFromInteger (genericLength all_es) mempty])
       pure $ ArrayLit (e' : es') (Info t) loc
 checkExp (AppExp (Range start maybe_step end loc) _) = do
-  (start', startOcc) <- tapOccurrences $ require "use in range expression" anySignedType =<< checkExp start
+  start' <- require "use in range expression" anySignedType =<< checkExp start
   start_t <- toStruct <$> expTypeFully start'
   maybe_step' <- case maybe_step of
     Nothing -> pure Nothing
@@ -495,7 +440,7 @@ checkExp (AppExp (Range start maybe_step end loc) _) = do
       Just <$> (unifies "use in range expression" start_t =<< checkExp step)
 
   let unifyRange e = unifies "use in range expression" start_t =<< checkExp e
-  (end', endOcc) <- tapOccurrences $ traverse unifyRange end
+  end' <- traverse unifyRange end
 
   end_t <- case end' of
     DownToExclusive e -> expType e
@@ -504,23 +449,15 @@ checkExp (AppExp (Range start maybe_step end loc) _) = do
 
   -- Special case some ranges to give them a known size.
   let warnIfConsumingOrBinding binds size =
-        case (anyConsumption (startOcc <> endOcc), binds) of
-          (Just occ, _) -> do
-            warn (location occ) $
-              withIndexLink
-                "size-expression-consume"
-                "Size expression with consumption is replaced by unknown size."
-            d <- newRigidDim loc RigidRange "range_dim"
-            pure (sizeFromName (qualName d) mempty, Just d)
-          (_, True) -> do
+        if binds
+          then do
             warn (srclocOf size) $
               withIndexLink
                 "size-expression-bind"
                 "Size expression with binding is replaced by unknown size."
             d <- newRigidDim loc RigidRange "range_dim"
             pure (sizeFromName (qualName d) mempty, Just d)
-          (_, False) ->
-            pure (size, Nothing)
+          else pure (size, Nothing)
   (dim, retext) <-
     case (isInt64 start', isInt64 <$> maybe_step', end') of
       (Just 0, Just (Just 1), UpToExclusive end'')
@@ -543,8 +480,8 @@ checkExp (AppExp (Range start maybe_step end loc) _) = do
         d <- newRigidDim loc RigidRange "range_dim"
         pure (sizeFromName (qualName d) mempty, Just d)
 
-  t <- arrayOfM loc start_t (Shape [dim]) Nonunique
-  let res = AppRes (t `setAliases` mempty) (maybeToList retext)
+  t <- arrayOfM loc start_t (Shape [dim])
+  let res = AppRes t (maybeToList retext)
 
   pure $ AppExp (Range start' maybe_step' end' loc) (Info res)
   where
@@ -563,14 +500,14 @@ checkExp (AppExp (Range start maybe_step end loc) _) = do
     mkAdd = mkBinOp "+" i64
     sizeMinus j i = j `mkSub` i
     sizeMinusInc j i = (j `mkSub` i) `mkAdd` sizeFromInteger 1 mempty
-    sizeBinOpInfo = Info $ foldFunType [(Observe, i64), (Observe, i64)] $ RetType [] i64
+    sizeBinOpInfo = Info $ foldFunType [i64, i64] $ RetType [] i64
 checkExp (Ascript e te loc) = do
   (te', e') <- checkAscript loc te e
   pure $ Ascript e' te' loc
 checkExp (Coerce e te NoInfo loc) = do
   (te', te_t, e') <- checkCoerce loc te e
   t <- expTypeFully e'
-  t' <- matchDims (const . const pure) t $ fromStruct te_t
+  t' <- matchDims (const . const pure) t te_t
   pure $ Coerce e' te' (Info t') loc
 checkExp (AppExp (BinOp (op, oploc) NoInfo (e1, _) (e2, _) loc) NoInfo) = do
   (op', ftype) <- lookupVar oploc op
@@ -597,27 +534,24 @@ checkExp (Project k e NoInfo loc) = do
   t <- expType e'
   kt <- mustHaveField (mkUsage loc $ docText $ "projection of field " <> dquotes (pretty k)) k t
   pure $ Project k e' (Info kt) loc
-checkExp (AppExp (If e1 e2 e3 loc) _) =
-  sequentially checkCond $ \e1' _ -> do
-    ((e2', e3'), dflow) <- tapOccurrences $ checkExp e2 `alternative` checkExp e3
+checkExp (AppExp (If e1 e2 e3 loc) _) = do
+  e1' <- checkExp e1
+  e2' <- checkExp e2
+  e3' <- checkExp e3
 
-    (brancht, retext) <- unifyBranches loc e2' e3'
-    let t' = addAliases brancht $ S.filter $ (`S.notMember` allConsumed dflow) . aliasVar
+  let bool = Scalar $ Prim Bool
+  e1_t <- toStruct <$> expType e1'
+  onFailure (CheckingRequired [bool] e1_t) $
+    unify (mkUsage e1' "use as 'if' condition") bool e1_t
 
-    zeroOrderType
-      (mkUsage loc "returning value of this type from 'if' expression")
-      "type returned from branch"
-      (toStruct t')
+  (brancht, retext) <- unifyBranches loc e2' e3'
 
-    pure $ AppExp (If e1' e2' e3' loc) (Info $ AppRes t' retext)
-  where
-    checkCond = do
-      e1' <- checkExp e1
-      let bool = Scalar $ Prim Bool
-      e1_t <- toStruct <$> expType e1'
-      onFailure (CheckingRequired [bool] e1_t) $
-        unify (mkUsage e1' "use as 'if' condition") bool e1_t
-      pure e1'
+  zeroOrderType
+    (mkUsage loc "returning value of this type from 'if' expression")
+    "type returned from branch"
+    (toStruct brancht)
+
+  pure $ AppExp (If e1' e2' e3' loc) (Info $ AppRes brancht retext)
 checkExp (Parens e loc) =
   Parens <$> checkExp e <*> pure loc
 checkExp (QualParens (modname, modnameloc) e loc) = do
@@ -687,102 +621,86 @@ checkExp (AppExp (Apply fe args loc) NoInfo) = do
         ( (i + 1, all_exts <> exts, rt),
           (Info (d1, argext), argExp arg')
         )
-checkExp (AppExp (LetPat sizes pat e body loc) _) =
-  sequentially (checkExp e) $ \e' e_occs -> do
-    -- Not technically an ascription, but we want the pattern to have
-    -- exactly the type of 'e'.
-    t <- expType e'
-    case anyConsumption e_occs of
-      Just c ->
-        zeroOrderType
-          (mkUsage loc "consumption in right-hand side of 'let'-binding")
-          ("type computed with consumption at " <> locText (location c))
-          (toStruct t)
-      _ -> pure ()
+checkExp (AppExp (LetPat sizes pat e body loc) _) = do
+  e' <- checkExp e
 
-    incLevel . bindingSizes sizes $ \sizes' ->
-      bindingPat sizes' pat (Ascribed t) $ \pat' -> do
-        body' <- checkExp body
-        let (i64, noni64) = S.partition i64Ident $ patIdents pat'
-        (body_t, retext) <-
-          reboundI64 loc (sizesMap sizes' <> S.map identName i64) =<< expTypeFully body'
-        (body_t', retext') <- unscopePatType loc (S.map identName noni64) body_t
+  -- Not technically an ascription, but we want the pattern to have
+  -- exactly the type of 'e'.
+  t <- expType e'
+  incLevel . bindingSizes sizes $ \sizes' ->
+    bindingPat sizes' pat (Ascribed t) $ \pat' -> do
+      body' <- checkExp body
+      let (i64, noni64) = S.partition i64Ident $ patIdents pat'
+      (body_t, retext) <-
+        reboundI64 loc (sizesMap sizes' <> S.map identName i64) =<< expTypeFully body'
+      (body_t', retext') <- unscopeType loc (S.map identName noni64) body_t
 
-        pure $ AppExp (LetPat sizes' pat' e' body' loc) (Info $ AppRes body_t' (retext <> retext'))
+      pure $
+        AppExp
+          (LetPat sizes' (fmap toStruct pat') e' body' loc)
+          (Info $ AppRes body_t' (retext <> retext'))
   where
     i64Ident (Ident _ ty _) =
       ty == Info (Scalar $ Prim $ Signed Int64)
     sizesMap = foldMap (S.singleton . sizeName)
-checkExp (AppExp (LetFun name (tparams, params, maybe_retdecl, NoInfo, e) body loc) _) =
-  sequentially (checkBinding (name, maybe_retdecl, tparams, params, e, loc)) $
-    \(tparams', params', maybe_retdecl', rettype, e') closure -> do
-      closure' <- lexicalClosure params' closure
+checkExp (AppExp (LetFun name (tparams, params, maybe_retdecl, NoInfo, e) body loc) _) = do
+  (tparams', params', maybe_retdecl', rettype, e') <-
+    checkBinding (name, maybe_retdecl, tparams, params, e, loc)
 
-      bindSpaced [(Term, name)] $ do
-        name' <- checkName Term name loc
+  bindSpaced [(Term, name)] $ do
+    name' <- checkName Term name loc
 
-        let ftype = funType params' rettype
-            entry = BoundV Local tparams' $ ftype `setAliases` closure'
-            bindF scope =
-              scope
-                { scopeVtable =
-                    M.insert name' entry $ scopeVtable scope,
-                  scopeNameMap =
-                    M.insert (Term, name) (qualName name') $
-                      scopeNameMap scope
-                }
-        body' <- localScope bindF $ checkExp body
+    let ftype = funType params' rettype
+        entry = BoundV Local tparams' ftype
+        bindF scope =
+          scope
+            { scopeVtable =
+                M.insert name' entry $ scopeVtable scope,
+              scopeNameMap =
+                M.insert (Term, name) (qualName name') $
+                  scopeNameMap scope
+            }
+    body' <- localScope bindF $ checkExp body
 
-        (body_t, ext) <-
-          unscopePatType loc (S.singleton name')
-            =<< expTypeFully body'
+    (body_t, ext) <-
+      unscopeType loc (S.singleton name')
+        =<< expTypeFully body'
 
-        pure $
-          AppExp
-            ( LetFun
-                name'
-                (tparams', params', maybe_retdecl', Info rettype, e')
-                body'
-                loc
-            )
-            (Info $ AppRes body_t ext)
-checkExp (AppExp (LetWith dest src slice ve body loc) _) =
-  sequentially ((,) <$> checkIdent src <*> checkSlice slice) $ \(src', slice') _ -> do
-    (t, _) <- newArrayType (mkUsage src "type of source array") "src" $ sliceDims slice'
-    unify (mkUsage loc "type of target array") t $ toStruct $ unInfo $ identType src'
+    pure $
+      AppExp
+        ( LetFun
+            name'
+            (tparams', params', maybe_retdecl', Info rettype, e')
+            body'
+            loc
+        )
+        (Info $ AppRes body_t ext)
+checkExp (AppExp (LetWith dest src slice ve body loc) _) = do
+  src' <- checkIdent src
+  slice' <- checkSlice slice
+  (t, _) <- newArrayType (mkUsage src "type of source array") "src" $ sliceDims slice'
+  unify (mkUsage loc "type of target array") t $ toStruct $ unInfo $ identType src'
 
-    -- Need the fully normalised type here to get the proper aliasing information.
-    src_t <- normTypeFully $ unInfo $ identType src'
+  -- Need the fully normalised type here to get the proper aliasing information.
+  src_t <- normTypeFully $ unInfo $ identType src'
 
-    (elemt, _) <- sliceShape (Just (loc, Nonrigid)) slice' =<< normTypeFully t
+  (elemt, _) <- sliceShape (Just (loc, Nonrigid)) slice' =<< normTypeFully t
 
-    sequentially (unifies "type of target array" (toStruct elemt) =<< checkExp ve) $ \ve' _ -> do
-      ve_t <- expTypeFully ve'
-      when (AliasBound (identName src') `S.member` aliases ve_t) $
-        badLetWithValue src ve loc
+  ve' <- unifies "type of target array" (toStruct elemt) =<< checkExp ve
 
-      bindingIdent dest (src_t `setAliases` S.empty) $ \dest' -> do
-        consume (srclocOf src) $ aliases src_t
-        body' <- checkExp body
-        (body_t, ext) <-
-          unscopePatType loc (S.singleton (identName dest'))
-            =<< expTypeFully body'
-        pure $ AppExp (LetWith dest' src' (map fst slice') ve' body' loc) (Info $ AppRes body_t ext)
+  bindingIdent dest src_t $ \dest' -> do
+    body' <- checkExp body
+    (body_t, ext) <-
+      unscopeType loc (S.singleton (identName dest'))
+        =<< expTypeFully body'
+    pure $ AppExp (LetWith dest' src' slice' ve' body' loc) (Info $ AppRes body_t ext)
 checkExp (Update src slice ve loc) = do
   slice' <- checkSlice slice
   (t, _) <- newArrayType (mkUsage' src) "src" $ sliceDims slice'
   (elemt, _) <- sliceShape (Just (loc, Nonrigid)) slice' =<< normTypeFully t
-
-  sequentially (checkExp ve >>= unifies "type of target array" elemt) $ \ve' _ ->
-    sequentially (checkExp src >>= unifies "type of target array" t) $ \src' _ -> do
-      src_t <- expTypeFully src'
-
-      let src_als = aliases src_t
-      ve_t <- expTypeFully ve'
-      unless (S.null $ src_als `S.intersection` aliases ve_t) $ badLetWithValue src ve loc
-
-      consume loc src_als
-      pure $ Update src' (map fst slice') ve' loc
+  ve' <- unifies "type of target array" elemt =<< checkExp ve
+  src' <- unifies "type of target array" t =<< checkExp src
+  pure $ Update src' slice' ve' loc
 
 -- Record updates are a bit hacky, because we do not have row typing
 -- (yet?).  For now, we only permit record updates where we know the
@@ -827,47 +745,39 @@ checkExp (AppExp (Index e slice loc) _) = do
   -- will certainly not be aliased.
   t'' <- noAliasesIfOverloaded t'
 
-  pure $ AppExp (Index e' (map fst slice') loc) (Info $ AppRes t'' retext)
+  pure $ AppExp (Index e' slice' loc) (Info $ AppRes t'' retext)
 checkExp (Assert e1 e2 NoInfo loc) = do
   e1' <- require "being asserted" [Bool] =<< checkExp e1
   e2' <- checkExp e2
   pure $ Assert e1' e2' (Info (prettyText e1)) loc
 checkExp (Lambda params body rettype_te NoInfo loc) = do
-  (params', body', body_t, rettype', Info (as, RetType dims ty)) <-
-    removeSeminullOccurrences . noUnique . incLevel . bindingParams [] params $ \_ params' -> do
+  (params', body', rettype', RetType dims ty) <-
+    incLevel . bindingParams [] params $ \_ params' -> do
       rettype_checked <- traverse checkTypeExpNonrigid rettype_te
       let declared_rettype =
             case rettype_checked of
               Just (_, st, _) -> Just st
               Nothing -> Nothing
-      (body', closure) <-
-        tapOccurrences $ checkFunBody params' body declared_rettype loc
+      body' <- checkFunBody params' body declared_rettype loc
       body_t <- expTypeFully body'
 
       params'' <- mapM updateTypes params'
 
       (rettype', rettype_st) <-
         case rettype_checked of
-          Just (te, st, ext) -> do
-            let st_structural = toStructural st
-            checkReturnAlias loc st_structural params'' body_t
+          Just (te, st, ext) ->
             pure (Just te, RetType ext st)
           Nothing -> do
-            ret <-
-              inferReturnSizes params'' . toStruct $
-                inferReturnUniqueness params'' body_t
+            ret <- inferReturnSizes params'' $ toRes Nonunique body_t
             pure (Nothing, ret)
 
-      closure' <- lexicalClosure params'' closure
+      pure (params'', body', rettype', rettype_st)
 
-      pure (params'', body', body_t, rettype', Info (closure', rettype_st))
-
-  checkGlobalAliases params' body_t loc
   verifyFunctionParams Nothing params'
 
-  (ty', dims') <- unscopeStructType loc (S.fromList dims) ty
+  (ty', dims') <- unscopeType loc (S.fromList dims) ty
 
-  pure $ Lambda params' body' rettype' (Info (as, RetType dims' ty')) loc
+  pure $ Lambda params' body' rettype' (Info (RetType dims' ty')) loc
   where
     -- Inferring the sizes of the return type of a lambda is a lot
     -- like let-generalisation.  We wish to remove any rigid sizes
@@ -880,7 +790,7 @@ checkExp (Lambda params body rettype_te NoInfo loc) = do
           named (Unnamed, _, _) = Nothing
           param_names = mapMaybe (named . patternParam) params'
           pos_sizes =
-            sizeNamesPos $ foldFunTypeFromParams params' $ RetType [] ret
+            sizeNamesPos $ funType params' $ RetType [] ret
           hide k (lvl, _) =
             lvl >= cur_lvl && k `notElem` param_names && k `S.notMember` pos_sizes
 
@@ -900,13 +810,13 @@ checkExp (OpSectionLeft op _ e _ _ loc) = do
   e_arg <- checkArg e
   (_, t1, rt, argext, retext) <- checkApply loc (Just op', 0) ftype e_arg
   case (ftype, rt) of
-    (Scalar (Arrow _ m1 _ _ _), Scalar (Arrow _ m2 _ t2 rettype)) ->
+    (Scalar (Arrow _ m1 d1 _ _), Scalar (Arrow _ m2 d2 t2 rettype)) ->
       pure $
         OpSectionLeft
           op'
           (Info ftype)
           (argExp e_arg)
-          (Info (m1, toStruct t1, argext), Info (m2, toStruct t2))
+          (Info (m1, toParam d1 t1, argext), Info (m2, toParam d2 t2))
           (Info rettype, Info retext)
           loc
     _ ->
@@ -916,12 +826,12 @@ checkExp (OpSectionRight op _ e _ NoInfo loc) = do
   (op', ftype) <- lookupVar loc op
   e_arg <- checkArg e
   case ftype of
-    Scalar (Arrow as1 m1 d1 t1 (RetType [] (Scalar (Arrow as2 m2 d2 t2 (RetType dims2 ret))))) -> do
+    Scalar (Arrow _ m1 d1 t1 (RetType [] (Scalar (Arrow _ m2 d2 t2 (RetType dims2 ret))))) -> do
       (_, t2', arrow', argext, _) <-
         checkApply
           loc
           (Just op', 1)
-          (Scalar $ Arrow as2 m2 d2 t2 $ RetType [] $ Scalar $ Arrow as1 m1 d1 t1 $ RetType dims2 ret)
+          (Scalar $ Arrow mempty m2 d2 t2 $ RetType [] $ Scalar $ Arrow Nonunique m1 d1 t1 $ RetType dims2 ret)
           e_arg
       case arrow' of
         Scalar (Arrow _ _ _ t1' (RetType dims2' ret')) ->
@@ -930,8 +840,8 @@ checkExp (OpSectionRight op _ e _ NoInfo loc) = do
               op'
               (Info ftype)
               (argExp e_arg)
-              (Info (m1, toStruct t1'), Info (m2, toStruct t2', argext))
-              (Info $ RetType dims2' $ addAliases ret' (<> aliases arrow'))
+              (Info (m1, toParam d1 t1'), Info (m2, toParam d2 t2', argext))
+              (Info $ RetType dims2' ret')
               loc
         _ -> error $ "OpSectionRight: impossible type\n" <> prettyString arrow'
     _ ->
@@ -941,14 +851,14 @@ checkExp (ProjectSection fields NoInfo loc) = do
   a <- newTypeVar loc "a"
   let usage = mkUsage loc "projection at"
   b <- foldM (flip $ mustHaveField usage) a fields
-  let ft = Scalar $ Arrow mempty Unnamed Observe (toStruct a) $ RetType [] b
+  let ft = Scalar $ Arrow mempty Unnamed Observe (toStruct a) $ RetType [] $ toRes Nonunique b
   pure $ ProjectSection fields (Info ft) loc
 checkExp (IndexSection slice NoInfo loc) = do
   slice' <- checkSlice slice
   (t, _) <- newArrayType (mkUsage' loc) "e" $ sliceDims slice'
   (t', retext) <- sliceShape Nothing slice' t
-  let ft = Scalar $ Arrow mempty Unnamed Observe t $ RetType retext $ fromStruct t'
-  pure $ IndexSection (map fst slice') (Info ft) loc
+  let ft = Scalar $ Arrow mempty Unnamed Observe t $ RetType retext $ toRes Nonunique t'
+  pure $ IndexSection slice' (Info ft) loc
 checkExp (AppExp (DoLoop _ mergepat mergeexp form loopbody loc) _) = do
   ((sparams, mergepat', mergeexp', form', loopbody'), appres) <-
     checkDoLoop checkExp (mergepat, mergeexp, form, loopbody) loc
@@ -961,52 +871,46 @@ checkExp (Constr name es NoInfo loc) = do
   es' <- mapM checkExp es
   ets <- mapM expTypeFully es'
   mustHaveConstr (mkUsage loc "use of constructor") name t (toStruct <$> ets)
-  -- A sum value aliases *anything* that went into its construction.
-  let als = foldMap aliases ets
-  pure $ Constr name es' (Info $ fromStruct t `addAliases` (<> als)) loc
-checkExp (AppExp (Match e cs loc) _) =
-  sequentially (checkExp e) $ \e' _ -> do
-    mt <- expTypeFully e'
-    (cs', t, retext) <- checkCases mt cs
-    zeroOrderType
-      (mkUsage loc "being returned 'match'")
-      "type returned from pattern match"
-      (toStruct t)
-    pure $ AppExp (Match e' cs' loc) (Info $ AppRes t retext)
+  pure $ Constr name es' (Info t) loc
+checkExp (AppExp (Match e cs loc) _) = do
+  e' <- checkExp e
+  mt <- expTypeFully e'
+  (cs', t, retext) <- checkCases mt cs
+  zeroOrderType
+    (mkUsage loc "being returned 'match'")
+    "type returned from pattern match"
+    (toStruct t)
+  pure $ AppExp (Match e' cs' loc) (Info $ AppRes t retext)
 checkExp (Attr info e loc) =
   Attr <$> checkAttr info <*> checkExp e <*> pure loc
 
 checkCases ::
-  PatType ->
+  StructType ->
   NE.NonEmpty (CaseBase NoInfo Name) ->
-  TermTypeM (NE.NonEmpty (CaseBase Info VName), PatType, [VName])
+  TermTypeM (NE.NonEmpty (CaseBase Info VName), StructType, [VName])
 checkCases mt rest_cs =
   case NE.uncons rest_cs of
     (c, Nothing) -> do
       (c', t, retext) <- checkCase mt c
       pure (NE.singleton c', t, retext)
     (c, Just cs) -> do
-      (((c', c_t, _), (cs', cs_t, _)), dflow) <-
-        tapOccurrences $ checkCase mt c `alternative` checkCases mt cs
+      ((c', c_t, _), (cs', cs_t, _)) <-
+        (,) <$> checkCase mt c <*> checkCases mt cs
       (brancht, retext) <- unifyBranchTypes (srclocOf c) c_t cs_t
-      let t =
-            addAliases
-              brancht
-              (`S.difference` S.map AliasBound (allConsumed dflow))
-      pure (NE.cons c' cs', t, retext)
+      pure (NE.cons c' cs', brancht, retext)
 
 checkCase ::
-  PatType ->
+  StructType ->
   CaseBase NoInfo Name ->
-  TermTypeM (CaseBase Info VName, PatType, [VName])
+  TermTypeM (CaseBase Info VName, StructType, [VName])
 checkCase mt (CasePat p e loc) =
   bindingPat [] p (Ascribed mt) $ \p' -> do
     e' <- checkExp e
     let (i64, noni64) = S.partition i64Ident $ patIdents p'
     (t, retext) <-
       reboundI64 loc (S.map identName i64) =<< expTypeFully e'
-    (t', retext') <- unscopePatType loc (S.map identName noni64) t
-    pure (CasePat p' e' loc, t', retext <> retext')
+    (t', retext') <- unscopeType loc (S.map identName noni64) t
+    pure (CasePat (fmap toStruct p') e' loc, t', retext <> retext')
   where
     i64Ident (Ident _ ty _) =
       ty == Info (Scalar $ Prim $ Signed Int64)
@@ -1020,7 +924,7 @@ data Unmatched p
   | Unmatched p
   deriving (Functor, Show)
 
-instance Pretty (Unmatched (PatBase Info VName)) where
+instance Pretty (Unmatched (Pat StructType)) where
   pretty um = case um of
     (UnmatchedNum p nums) -> pretty' p <+> "where p is not one of" <+> pretty nums
     (UnmatchedBool p) -> pretty' p
@@ -1039,20 +943,18 @@ instance Pretty (Unmatched (PatBase Info VName)) where
       pretty' (PatLit e _ _) = pretty e
       pretty' (PatConstr n _ ps _) = "#" <> pretty n <+> sep (map pretty' ps)
 
-checkIdent :: IdentBase NoInfo Name -> TermTypeM Ident
+checkIdent :: IdentBase NoInfo Name StructType -> TermTypeM (Ident StructType)
 checkIdent (Ident name _ loc) = do
   (QualName _ name', vt) <- lookupVar loc (qualName name)
   pure $ Ident name' (Info vt) loc
 
-checkSlice :: UncheckedSlice -> TermTypeM [(DimIndex, Maybe Occurrence)]
+checkSlice :: UncheckedSlice -> TermTypeM [DimIndex]
 checkSlice = mapM checkDimIndex
   where
     checkDimIndex (DimFix i) = do
-      (i', dflow) <- tapOccurrences (require "use as index" anySignedType =<< checkExp i)
-      pure (DimFix i', anyConsumption dflow)
-    checkDimIndex (DimSlice i j s) = do
-      (sl, dflow) <- tapOccurrences $ DimSlice <$> check i <*> check j <*> check s
-      pure (sl, anyConsumption dflow)
+      DimFix <$> (require "use as index" anySignedType =<< checkExp i)
+    checkDimIndex (DimSlice i j s) =
+      DimSlice <$> check i <*> check j <*> check s
 
     check =
       maybe (pure Nothing) $
@@ -1060,22 +962,22 @@ checkSlice = mapM checkDimIndex
 
 -- The number of dimensions affected by this slice (so the minimum
 -- rank of the array we are slicing).
-sliceDims :: [(DimIndex, Maybe Occurrence)] -> Int
+sliceDims :: [DimIndex] -> Int
 sliceDims = length
 
-type Arg = (Exp, PatType, Occurrences, SrcLoc)
+type Arg = (Exp, StructType, SrcLoc)
 
 argExp :: Arg -> Exp
-argExp (e, _, _, _) = e
+argExp (e, _, _) = e
 
-argType :: Arg -> PatType
-argType (_, t, _, _) = t
+argType :: Arg -> StructType
+argType (_, t, _) = t
 
 checkArg :: UncheckedExp -> TermTypeM Arg
 checkArg arg = do
-  (arg', dflow) <- collectOccurrences $ checkExp arg
+  arg' <- checkExp arg
   arg_t <- expType arg'
-  pure (arg', arg_t, dflow, srclocOf arg')
+  pure (arg', arg_t, srclocOf arg')
 
 instantiateDimsInReturnType ::
   SrcLoc ->
@@ -1100,9 +1002,9 @@ type ApplyOp = (Maybe (QualName VName), Int)
 
 -- | Extract all those names that are bound inside the type.
 boundInsideType :: TypeBase Size as -> S.Set VName
-boundInsideType (Array _ _ _ t) = boundInsideType (Scalar t)
+boundInsideType (Array _ _ t) = boundInsideType (Scalar t)
 boundInsideType (Scalar Prim {}) = mempty
-boundInsideType (Scalar (TypeVar _ _ _ targs)) = foldMap f targs
+boundInsideType (Scalar (TypeVar _ _ targs)) = foldMap f targs
   where
     f (TypeArgType t) = boundInsideType t
     f TypeArgDim {} = mempty
@@ -1117,7 +1019,7 @@ boundInsideType (Scalar (Arrow _ pn _ t1 (RetType dims t2))) =
 
 -- Returns the sizes of the immediate type produced,
 -- the sizes of parameter types, and the sizes of return types.
-dimUses :: StructType -> (Names, Names)
+dimUses :: TypeBase Size u -> (Names, Names)
 dimUses = flip execState mempty . traverseDims f
   where
     f bound _ (Var v _ _) | qualLeaf v `S.member` bound = pure ()
@@ -1128,14 +1030,14 @@ dimUses = flip execState mempty . traverseDims f
 checkApply ::
   SrcLoc ->
   ApplyOp ->
-  PatType ->
+  StructType ->
   Arg ->
-  TermTypeM (Diet, StructType, PatType, Maybe VName, [VName])
+  TermTypeM (Diet, StructType, StructType, Maybe VName, [VName])
 checkApply
   loc
   (fname, _)
-  (Scalar (Arrow as pname d1 tp1 tp2))
-  (argexp, argtype, dflow, argloc) =
+  (Scalar (Arrow _ pname d1 tp1 tp2))
+  (argexp, argtype, argloc) =
     onFailure (CheckingApply fname argexp tp1 (toStruct argtype)) $ do
       unify (mkUsage argloc "use as function argument") (toStruct tp1) (toStruct argtype)
 
@@ -1153,36 +1055,12 @@ checkApply
             </> indent 2 (pretty (RetType ext tp2'))
             </> textwrap "This is usually because a higher-order function is used with functional arguments that return existential sizes or locally named sizes, which are then used as parameters of other function arguments."
 
-      occur [observation as loc]
-
-      checkOccurrences dflow
-
-      case anyConsumption dflow of
-        Just c ->
-          let msg = "type of expression with consumption at " <> locText (location c)
-           in zeroOrderType (mkUsage argloc "potential consumption in expression") msg tp1
-        _ -> pure ()
-
-      arg_consumed <- consumedByArg (locOf argloc) argtype' d1
-      checkIfConsumable loc $ mconcat arg_consumed
-      occur $ dflow `seqOccurrences` map (`consumption` argloc) arg_consumed
-
       (argext, parsubst) <-
         case pname of
           Named pname'
             | S.member pname' (fvVars $ freeInType tp2') ->
-                case (isJust (anyConsumption dflow), hasBinding argexp) of
-                  (True, _) -> do
-                    warn (srclocOf argexp) $
-                      withIndexLink
-                        "size-expression-consume"
-                        "Size expression with consumption is replaced by unknown size."
-                    d <- newRigidDim argexp (RigidArg fname $ prettyTextOneLine $ bareExp argexp) "n"
-                    pure
-                      ( Just d,
-                        (`M.lookup` M.singleton pname' (ExpSubst $ sizeFromName (qualName d) $ srclocOf argexp))
-                      )
-                  (_, True) -> do
+                if hasBinding argexp
+                  then do
                     warn (srclocOf argexp) $
                       withIndexLink
                         "size-expression-bind"
@@ -1192,9 +1070,9 @@ checkApply
                       ( Just d,
                         (`M.lookup` M.singleton pname' (ExpSubst $ sizeFromName (qualName d) $ srclocOf argexp))
                       )
-                  (False, False) ->
-                    -- We strip the argument expression to make it
-                    -- nicer (in particular, to remove parens).
+                  else -- We strip the argument expression to make it
+                  -- nicer (in particular, to remove parens).
+
                     pure
                       ( Nothing,
                         ( `M.lookup`
@@ -1211,20 +1089,16 @@ checkApply
       -- uniqueness-error60.fut).
       v <- newID "internal_app_result"
       modify $ \s -> s {stateNames = M.insert v (NameAppRes fname loc) $ stateNames s}
-      let appres = S.singleton $ AliasFree v
-      let tp2'' = applySubst parsubst $ returnType appres tp2' d1 argtype'
+      let tp2'' = applySubst parsubst $ toStruct tp2'
 
       pure (d1, tp1', tp2'', argext, ext)
 checkApply loc fname tfun@(Scalar TypeVar {}) arg = do
   tv <- newTypeVar loc "b"
-  -- Change the uniqueness of the argument type because we never want
-  -- to infer that a function is consuming.
-  let argt_nonunique = toStruct (argType arg) `setUniqueness` Nonunique
   unify (mkUsage loc "use as function") (toStruct tfun) $
-    Scalar (Arrow mempty Unnamed Observe argt_nonunique $ RetType [] tv)
-  tfun' <- normPatType tfun
+    Scalar (Arrow mempty Unnamed Observe (toStruct (argType arg)) $ RetType [] $ paramToRes tv)
+  tfun' <- normType tfun
   checkApply loc fname tfun' arg
-checkApply loc (fname, prev_applied) ftype (argexp, _, _, _) = do
+checkApply loc (fname, prev_applied) ftype (argexp, _, _) = do
   let fname' = maybe "expression" (dquotes . pretty) fname
 
   typeError loc mempty $
@@ -1249,32 +1123,15 @@ checkApply loc (fname, prev_applied) ftype (argexp, _, _, _) = do
       | prev_applied == 1 = "argument"
       | otherwise = "arguments"
 
-aliasParts :: PatType -> [Aliasing]
-aliasParts (Scalar (Record ts)) = foldMap aliasParts $ M.elems ts
-aliasParts t = [aliases t]
-
-consumedByArg :: Loc -> PatType -> Diet -> TermTypeM [Aliasing]
-consumedByArg loc at Consume = do
-  let parts = aliasParts at
-  foldM_ check mempty parts
-  pure parts
-  where
-    check seen als
-      | any (`S.member` seen) als =
-          typeError loc mempty . withIndexLink "self-aliasing-arg" $
-            "Argument passed for consuming parameter is self-aliased."
-      | otherwise = pure $ als <> seen
-consumedByArg _ _ _ = pure []
-
 -- | Type-check a single expression in isolation.  This expression may
 -- turn out to be polymorphic, in which case the list of type
 -- parameters will be non-empty.
 checkOneExp :: UncheckedExp -> TypeM ([TypeParam], Exp)
-checkOneExp e = fmap fst . runTermTypeM checkExp $ do
+checkOneExp e = runTermTypeM checkExp $ do
   e' <- checkExp e
   let t = toStruct $ typeOf e'
   (tparams, _, _) <-
-    letGeneralise (nameFromString "<exp>") (srclocOf e) [] [] t
+    letGeneralise (nameFromString "<exp>") (srclocOf e) [] [] $ toRes Nonunique t
   fixOverloadedTypes $ typeVars t
   e'' <- updateTypes e'
   localChecks e''
@@ -1284,8 +1141,8 @@ checkOneExp e = fmap fst . runTermTypeM checkExp $ do
 -- | Type-check a single size expression in isolation.  This expression may
 -- turn out to be polymorphic, in which case it is unified with i64.
 checkSizeExp :: UncheckedExp -> TypeM Exp
-checkSizeExp e = fmap fst . runTermTypeM checkExp $ do
-  e' <- noUnique $ checkExp e
+checkSizeExp e = runTermTypeM checkExp $ do
+  e' <- checkExp e
   let t = toStruct $ typeOf e'
   when (hasBinding e') $
     typeError (srclocOf e') mempty . withIndexLink "size-expression-bind" $
@@ -1501,20 +1358,20 @@ checkFunDef ::
   ( Name,
     Maybe UncheckedTypeExp,
     [UncheckedTypeParam],
-    [UncheckedPat],
+    [UncheckedPat ParamType],
     UncheckedExp,
     SrcLoc
   ) ->
   TypeM
     ( VName,
       [TypeParam],
-      [Pat],
+      [Pat ParamType],
       Maybe (TypeExp Info VName),
-      StructRetType,
+      ResRetType,
       Exp
     )
 checkFunDef (fname, maybe_retdecl, tparams, params, body, loc) =
-  fmap fst . runTermTypeM checkExp $ do
+  runTermTypeM checkExp $ do
     (tparams', params', maybe_retdecl', RetType dims rettype', body') <-
       checkBinding (fname, maybe_retdecl, tparams, params, body, loc)
 
@@ -1541,7 +1398,12 @@ checkFunDef (fname, maybe_retdecl, tparams, params, body, loc) =
         typeError loc mempty . withIndexLink "may-not-be-redefined" $
           "The" <+> prettyName fname <+> "operator may not be redefined."
 
-      pure (fname', tparams', params'', maybe_retdecl'', RetType dims rettype'', body'')
+      let ((body''', updated_ret), errors) =
+            Consumption.checkValDef (fname', params'', body'', RetType dims rettype'', loc)
+
+      mapM_ throwError errors
+
+      pure (fname', tparams', params'', maybe_retdecl'', updated_ret, body''')
 
 -- | This is "fixing" as in "setting them", not "correcting them".  We
 -- only make very conservative fixing.
@@ -1551,17 +1413,13 @@ fixOverloadedTypes tyvars_at_toplevel =
   where
     fixOverloaded (v, Overloaded ots usage)
       | Signed Int32 `elem` ots = do
-          unify usage (Scalar (TypeVar () Nonunique (qualName v) [])) $
-            Scalar $
-              Prim $
-                Signed Int32
+          unify usage (Scalar (TypeVar mempty (qualName v) [])) $
+            Scalar (Prim $ Signed Int32)
           when (v `S.member` tyvars_at_toplevel) $
             warn usage "Defaulting ambiguous type to i32."
       | FloatType Float64 `elem` ots = do
-          unify usage (Scalar (TypeVar () Nonunique (qualName v) [])) $
-            Scalar $
-              Prim $
-                FloatType Float64
+          unify usage (Scalar (TypeVar mempty (qualName v) [])) $
+            Scalar (Prim $ FloatType Float64)
           when (v `S.member` tyvars_at_toplevel) $
             warn usage "Defaulting ambiguous type to f64."
       | otherwise =
@@ -1571,9 +1429,8 @@ fixOverloadedTypes tyvars_at_toplevel =
               </> "Add a type annotation to disambiguate the type."
     fixOverloaded (v, NoConstraint _ usage) = do
       -- See #1552.
-      unify usage (Scalar (TypeVar () Nonunique (qualName v) [])) $
-        Scalar $
-          tupleRecord []
+      unify usage (Scalar (TypeVar mempty (qualName v) [])) $
+        Scalar (tupleRecord [])
       when (v `S.member` tyvars_at_toplevel) $
         warn usage "Defaulting ambiguous type to ()."
     fixOverloaded (_, Equality usage) =
@@ -1600,7 +1457,7 @@ fixOverloadedTypes tyvars_at_toplevel =
         "Ambiguous size" <+> dquotes (prettyName v) <+> "arising from" <+> pretty u <> "."
     fixOverloaded _ = pure ()
 
-hiddenParamNames :: [Pat] -> Names
+hiddenParamNames :: [Pat ParamType] -> Names
 hiddenParamNames params = hidden
   where
     param_all_names = mconcat $ map patNames params
@@ -1610,75 +1467,34 @@ hiddenParamNames params = hidden
       S.fromList $ mapMaybe (named . patternParam) params
     hidden = param_all_names `S.difference` param_names
 
-inferredReturnType :: SrcLoc -> [Pat] -> PatType -> TermTypeM StructType
+inferredReturnType :: SrcLoc -> [Pat ParamType] -> StructType -> TermTypeM StructType
 inferredReturnType loc params t = do
   -- The inferred type may refer to names that are bound by the
   -- parameter patterns, but which will not be visible in the type.
   -- These we must turn into fresh type variables, which will be
   -- existential in the return type.
-  fmap (toStruct . fst) $
-    unscopePatType loc hidden_params $
-      inferReturnUniqueness params t
+  toStruct . fst <$> unscopeType loc hidden_params t
   where
     hidden_params = S.filter (`S.member` hidden) $ foldMap patNames params
     hidden = hiddenParamNames params
-
-checkReturnAlias :: SrcLoc -> TypeBase () () -> [Pat] -> PatType -> TermTypeM ()
-checkReturnAlias loc rettp params =
-  foldM_ (checkReturnAlias' params) S.empty . returnAliasing rettp
-  where
-    checkReturnAlias' params' seen (Unique, names)
-      | any (`S.member` S.map snd seen) $ S.toList names =
-          uniqueReturnAliased loc
-      | otherwise = do
-          notAliasingParam params' names
-          pure $ seen `S.union` tag Unique names
-    checkReturnAlias' _ seen (Nonunique, names)
-      | any (`S.member` seen) $ S.toList $ tag Unique names =
-          uniqueReturnAliased loc
-      | otherwise = pure $ seen `S.union` tag Nonunique names
-
-    notAliasingParam params' names =
-      forM_ params' $ \p ->
-        let consumedNonunique p' =
-              not (consumableParamType $ unInfo $ identType p') && (identName p' `S.member` names)
-         in case find consumedNonunique $ S.toList $ patIdents p of
-              Just p' ->
-                returnAliased (baseName $ identName p') loc
-              Nothing ->
-                pure ()
-
-    tag u = S.map (u,)
-
-    returnAliasing (Scalar (Record ets1)) (Scalar (Record ets2)) =
-      concat $ M.elems $ M.intersectionWith returnAliasing ets1 ets2
-    returnAliasing expected got =
-      [(uniqueness expected, S.map aliasVar $ aliases got)]
-
-    consumableParamType (Array _ u _ _) = u == Unique
-    consumableParamType (Scalar Prim {}) = True
-    consumableParamType (Scalar (TypeVar _ u _ _)) = u == Unique
-    consumableParamType (Scalar (Record fs)) = all consumableParamType fs
-    consumableParamType (Scalar (Sum fs)) = all (all consumableParamType) fs
-    consumableParamType (Scalar Arrow {}) = False
 
 checkBinding ::
   ( Name,
     Maybe UncheckedTypeExp,
     [UncheckedTypeParam],
-    [UncheckedPat],
+    [UncheckedPat ParamType],
     UncheckedExp,
     SrcLoc
   ) ->
   TermTypeM
     ( [TypeParam],
-      [Pat],
+      [Pat ParamType],
       Maybe (TypeExp Info VName),
-      StructRetType,
+      ResRetType,
       Exp
     )
 checkBinding (fname, maybe_retdecl, tparams, params, body, loc) =
-  noUnique . incLevel . bindingParams tparams params $ \tparams' params' -> do
+  incLevel . bindingParams tparams params $ \tparams' params' -> do
     maybe_retdecl' <- traverse checkTypeExpNonrigid maybe_retdecl
 
     body' <-
@@ -1693,28 +1509,20 @@ checkBinding (fname, maybe_retdecl, tparams, params, body, loc) =
 
     (maybe_retdecl'', rettype) <- case maybe_retdecl' of
       Just (retdecl', ret, _) -> do
-        let rettype_structural = toStructural ret
-        checkReturnAlias loc rettype_structural params'' body_t
-
-        when (null params) $ nothingMustBeUnique loc rettype_structural
-
         ret' <- normTypeFully ret
-
         pure (Just retdecl', ret')
       Nothing
         | null params ->
-            pure (Nothing, toStruct body_t)
+            pure (Nothing, toRes Nonunique body_t)
         | otherwise -> do
             body_t' <- inferredReturnType loc params'' body_t
-            pure (Nothing, body_t')
+            pure (Nothing, toRes Nonunique body_t')
 
     verifyFunctionParams (Just fname) params''
 
     (tparams'', params''', rettype') <-
       letGeneralise fname loc tparams' params''
         =<< unscopeUnknown rettype
-
-    checkGlobalAliases params'' body_t loc
 
     pure (tparams'', params''', maybe_retdecl'', rettype', body')
 
@@ -1726,83 +1534,12 @@ sizeNamesPos (Scalar (Arrow _ _ _ t1 (RetType _ t2))) = onParam t1 <> sizeNamesP
     onParam :: TypeBase Size als -> S.Set VName
     onParam (Scalar Arrow {}) = mempty
     onParam (Scalar (Record fs)) = mconcat $ map onParam $ M.elems fs
-    onParam (Scalar (TypeVar _ _ _ targs)) = mconcat $ map onTypeArg targs
+    onParam (Scalar (TypeVar _ _ targs)) = mconcat $ map onTypeArg targs
     onParam t = fvVars $ freeInType t
     onTypeArg (TypeArgDim (Var d _ _)) = S.singleton $ qualLeaf d
     onTypeArg (TypeArgDim _) = mempty
     onTypeArg (TypeArgType t) = onParam t
 sizeNamesPos _ = mempty
-
-checkGlobalAliases :: [Pat] -> PatType -> SrcLoc -> TermTypeM ()
-checkGlobalAliases params body_t loc = do
-  vtable <- asks $ scopeVtable . termScope
-  let isGlobal v = case v `M.lookup` vtable of
-        Just (BoundV Global _ _) -> True
-        _ -> False
-  let als =
-        filter isGlobal . S.toList $
-          boundArrayAliases body_t `S.difference` foldMap patNames params
-  unless (null params) $ case als of
-    v : _ ->
-      typeError loc mempty . withIndexLink "alias-free-variable" $
-        "Function result aliases the free variable "
-          <> dquotes (prettyName v)
-          <> "."
-          </> "Use"
-          <+> dquotes "copy"
-          <+> "to break the aliasing."
-    _ ->
-      pure ()
-
-inferReturnUniqueness :: [Pat] -> PatType -> PatType
-inferReturnUniqueness params t =
-  let forbidden = aliasesMultipleTimes t
-      uniques = uniqueParamNames params
-      delve (Scalar (Record fs)) =
-        Scalar $ Record $ M.map delve fs
-      delve (Scalar (Sum cs)) =
-        Scalar $ Sum $ M.map (map delve) cs
-      delve t'
-        | all (`S.member` uniques) (boundArrayAliases t'),
-          not $ any ((`S.member` forbidden) . aliasVar) (aliases t') =
-            t' `setUniqueness` Unique
-        | otherwise =
-            t' `setUniqueness` Nonunique
-   in delve t
-
--- An alias inhibits uniqueness if it is used in disjoint values.
-aliasesMultipleTimes :: PatType -> Names
-aliasesMultipleTimes = S.fromList . map fst . filter ((> 1) . snd) . M.toList . delve
-  where
-    delve (Scalar (Record fs)) =
-      foldl' (M.unionWith (+)) mempty $ map delve $ M.elems fs
-    delve t =
-      M.fromList $ zip (map aliasVar $ S.toList (aliases t)) $ repeat (1 :: Int)
-
-uniqueParamNames :: [Pat] -> Names
-uniqueParamNames =
-  S.map identName
-    . S.filter (unique . unInfo . identType)
-    . foldMap patIdents
-
-boundArrayAliases :: PatType -> S.Set VName
-boundArrayAliases (Array als _ _ _) = boundAliases als
-boundArrayAliases (Scalar Prim {}) = mempty
-boundArrayAliases (Scalar (Record fs)) = foldMap boundArrayAliases fs
-boundArrayAliases (Scalar (TypeVar als _ _ _)) = boundAliases als
-boundArrayAliases (Scalar Arrow {}) = mempty
-boundArrayAliases (Scalar (Sum fs)) =
-  mconcat $ concatMap (map boundArrayAliases) $ M.elems fs
-
-nothingMustBeUnique :: SrcLoc -> TypeBase () () -> TermTypeM ()
-nothingMustBeUnique loc = check
-  where
-    check (Array _ Unique _ _) = bad
-    check (Scalar (TypeVar _ Unique _ _)) = bad
-    check (Scalar (Record fs)) = mapM_ check fs
-    check (Scalar (Sum fs)) = mapM_ (mapM_ check) fs
-    check _ = pure ()
-    bad = typeError loc mempty "A top-level constant cannot have a unique type."
 
 -- | Verify certain restrictions on function parameters, and bail out
 -- on dubious constructions.
@@ -1810,7 +1547,7 @@ nothingMustBeUnique loc = check
 -- These restrictions apply to all functions (anonymous or otherwise).
 -- Top-level functions have further restrictions that are checked
 -- during let-generalisation.
-verifyFunctionParams :: Maybe Name -> [Pat] -> TermTypeM ()
+verifyFunctionParams :: Maybe Name -> [Pat ParamType] -> TermTypeM ()
 verifyFunctionParams fname params =
   onFailure (CheckingParams fname) $
     verifyParams (foldMap patNames params) =<< mapM updateTypes params
@@ -1849,19 +1586,20 @@ verifyFunctionParams fname params =
 -- @
 -- bool -> ?[n].[n]bool
 -- @
-injectExt :: [VName] -> StructType -> StructRetType
+injectExt :: [VName] -> TypeBase Size u -> RetTypeBase Size u
 injectExt [] ret = RetType [] ret
 injectExt ext ret = RetType ext_here $ deeper ret
   where
     (immediate, _) = dimUses ret
     (ext_here, ext_there) = partition (`S.member` immediate) ext
+    deeper :: TypeBase Size u -> TypeBase Size u
     deeper (Scalar (Prim t)) = Scalar $ Prim t
     deeper (Scalar (Record fs)) = Scalar $ Record $ M.map deeper fs
     deeper (Scalar (Sum cs)) = Scalar $ Sum $ M.map (map deeper) cs
     deeper (Scalar (Arrow als p d1 t1 (RetType t2_ext t2))) =
       Scalar $ Arrow als p d1 t1 $ injectExt (ext_there <> t2_ext) t2
-    deeper (Scalar (TypeVar as u tn targs)) =
-      Scalar $ TypeVar as u tn $ map deeperArg targs
+    deeper (Scalar (TypeVar u tn targs)) =
+      Scalar $ TypeVar u tn $ map deeperArg targs
     deeper t@Array {} = t
 
     deeperArg (TypeArgType t) = TypeArgType $ deeper t
@@ -1877,9 +1615,9 @@ closeOverTypes ::
   SrcLoc ->
   [TypeParam] ->
   [StructType] ->
-  StructType ->
+  ResType ->
   Constraints ->
-  TermTypeM ([TypeParam], StructRetType)
+  TermTypeM ([TypeParam], ResRetType)
 closeOverTypes defname defloc tparams paramts ret substs = do
   (more_tparams, retext) <-
     partitionEithers . catMaybes
@@ -1894,7 +1632,7 @@ closeOverTypes defname defloc tparams paramts ret substs = do
     )
   where
     -- Diet does not matter here.
-    t = foldFunType (zip (repeat Observe) paramts) $ RetType [] ret
+    t = foldFunType (map (toParam Observe) paramts) $ RetType [] ret
     to_close_over = M.filterWithKey (\k _ -> k `S.member` visible) substs
     visible = typeVars t <> fvVars (freeInType t)
 
@@ -1930,9 +1668,9 @@ letGeneralise ::
   Name ->
   SrcLoc ->
   [TypeParam] ->
-  [Pat] ->
-  StructType ->
-  TermTypeM ([TypeParam], [Pat], StructRetType)
+  [Pat ParamType] ->
+  ResType ->
+  TermTypeM ([TypeParam], [Pat ParamType], ResRetType)
 letGeneralise defname defloc tparams params rettype =
   onFailure (CheckingLetGeneralise defname) $ do
     now_substs <- getConstraints
@@ -1969,7 +1707,7 @@ letGeneralise defname defloc tparams params rettype =
     rettype'' <- updateTypes rettype'
 
     let used_sizes =
-          foldMap freeInType $ rettype'' : map patternStructType params
+          freeInType rettype'' <> foldMap (freeInType . patternType) params
     case filter ((`S.notMember` fvVars used_sizes) . typeParamName) $
       filter isSizeParam tparams' of
       [] -> pure ()
@@ -1982,9 +1720,9 @@ letGeneralise defname defloc tparams params rettype =
     pure (tparams', params, RetType ret_dims rettype'')
 
 checkFunBody ::
-  [Pat] ->
+  [Pat ParamType] ->
   UncheckedExp ->
-  Maybe StructType ->
+  Maybe ResType ->
   SrcLoc ->
   TermTypeM Exp
 checkFunBody params body maybe_rettype loc = do
@@ -1998,25 +1736,23 @@ checkFunBody params body maybe_rettype loc = do
       -- names into existential sizes instead.
       let hidden = hiddenParamNames params
       (body_t', _) <-
-        unscopePatType
+        unscopeType
           loc
           (S.filter (`S.member` hidden) $ foldMap patNames params)
           body_t
 
       let usage = mkUsage body "return type annotation"
       onFailure (CheckingReturn rettype (toStruct body_t')) $
-        unify usage rettype (toStruct body_t')
+        unify usage (toStruct rettype) (toStruct body_t')
     Nothing -> pure ()
 
   pure body'
 
 arrayOfM ::
-  (Pretty (Shape dim), Monoid as) =>
   SrcLoc ->
-  TypeBase dim as ->
-  Shape dim ->
-  Uniqueness ->
-  TermTypeM (TypeBase dim as)
-arrayOfM loc t shape u = do
+  StructType ->
+  Shape Size ->
+  TermTypeM StructType
+arrayOfM loc t shape = do
   arrayElemType (mkUsage loc "use as array element") "type used in array" t
-  pure $ arrayOf u shape t
+  pure $ arrayOf shape t

--- a/src/Language/Futhark/TypeChecker/Terms.hs
+++ b/src/Language/Futhark/TypeChecker/Terms.hs
@@ -687,14 +687,11 @@ checkExp (AppExp (LetWith dest src slice ve body loc) _) = do
   (t, _) <- newArrayType (mkUsage src "type of source array") "src" $ sliceDims slice'
   unify (mkUsage loc "type of target array") t $ toStruct $ unInfo $ identType src'
 
-  -- Need the fully normalised type here to get the proper aliasing information.
-  src_t <- normTypeFully $ unInfo $ identType src'
-
   (elemt, _) <- sliceShape (Just (loc, Nonrigid)) slice' =<< normTypeFully t
 
   ve' <- unifies "type of target array" (toStruct elemt) =<< checkExp ve
 
-  bindingIdent dest src_t $ \dest' -> do
+  bindingIdent dest (unInfo (identType src')) $ \dest' -> do
     body' <- checkExp body
     (body_t, ext) <-
       unscopeType loc (S.singleton (identName dest'))

--- a/src/Language/Futhark/TypeChecker/Terms/DoLoop.hs
+++ b/src/Language/Futhark/TypeChecker/Terms/DoLoop.hs
@@ -21,7 +21,7 @@ import Futhark.Util (nubOrd)
 import Futhark.Util.Pretty hiding (group, space)
 import Language.Futhark
 import Language.Futhark.TypeChecker.Monad hiding (BoundV)
-import Language.Futhark.TypeChecker.Terms.Monad hiding (consumed)
+import Language.Futhark.TypeChecker.Terms.Monad
 import Language.Futhark.TypeChecker.Terms.Pat
 import Language.Futhark.TypeChecker.Types
 import Language.Futhark.TypeChecker.Unify
@@ -285,8 +285,6 @@ checkDoLoop checkExp (mergepat, mergeexp, form, loopbody) loc = do
                 loopbody'
               )
 
-  merge_t' <- expTypeFully mergeexp'
-
   -- dim handling (4)
   wellTypedLoopArg Initial sparams mergepat' mergeexp'
 
@@ -297,16 +295,6 @@ checkDoLoop checkExp (mergepat, mergeexp, form, loopbody) loc = do
       "loop"
       sparams
       (patternType mergepat')
-  -- We set all of the uniqueness to be unique.  This is intentional,
-  -- and matches what happens for function calls.  Those arrays that
-  -- really *cannot* be consumed will alias something unconsumable,
-  -- and will be caught that way.
-  let bound_here = patNames mergepat' <> S.fromList sparams <> form_bound
-      form_bound =
-        case form' of
-          For v _ -> S.singleton $ identName v
-          ForIn forpat _ -> patNames forpat
-          While {} -> mempty
   pure
     ( (sparams, mergepat', mergeexp', form', loopbody'),
       AppRes (toStruct loopt) retext

--- a/src/Language/Futhark/TypeChecker/Terms/DoLoop.hs
+++ b/src/Language/Futhark/TypeChecker/Terms/DoLoop.hs
@@ -67,8 +67,8 @@ freshDimsInType ::
   Rigidity ->
   Name ->
   [VName] ->
-  TypeBase Size als ->
-  TermTypeM (TypeBase Size als, [VName])
+  TypeBase Size u ->
+  TermTypeM (TypeBase Size u, [VName])
 freshDimsInType usage r desc fresh t = do
   areSameSize <- getAreSame
   second (map snd) <$> runStateT (bitraverse (onDim areSameSize) pure t) mempty
@@ -84,105 +84,9 @@ freshDimsInType usage r desc fresh t = do
               pure $ sizeFromName (qualName v) $ srclocOf usage
     onDim _ d = pure d
 
--- | Mark bindings of names in "consumed" as Unique.
-uniquePat :: Names -> Pat -> Pat
-uniquePat consumed = recurse
-  where
-    recurse (Wildcard (Info t) wloc) =
-      Wildcard (Info $ t `setUniqueness` Nonunique) wloc
-    recurse (PatParens p ploc) =
-      PatParens (recurse p) ploc
-    recurse (PatAttr attr p ploc) =
-      PatAttr attr (recurse p) ploc
-    recurse (Id name (Info t) iloc)
-      | name `S.member` consumed =
-          let t' = t `setUniqueness` Unique `setAliases` mempty
-           in Id name (Info t') iloc
-      | otherwise =
-          let t' = t `setUniqueness` Nonunique
-           in Id name (Info t') iloc
-    recurse (TuplePat pats ploc) =
-      TuplePat (map recurse pats) ploc
-    recurse (RecordPat fs ploc) =
-      RecordPat (map (fmap recurse) fs) ploc
-    recurse (PatAscription p t ploc) =
-      PatAscription p t ploc
-    recurse p@PatLit {} = p
-    recurse (PatConstr n t ps ploc) =
-      PatConstr n t (map recurse ps) ploc
-
-convergePat :: SrcLoc -> Pat -> Names -> PatType -> Usage -> TermTypeM Pat
-convergePat loop_loc pat body_cons body_t body_loc = do
-  let -- Make the pattern unique where needed.
-      pat' = uniquePat (patNames pat `S.intersection` body_cons) pat
-
-  -- Check that the new values of consumed merge parameters do not
-  -- alias something bound outside the loop, AND that anything
-  -- returned for a unique merge parameter does not alias anything
-  -- else returned.  We also update the aliases for the pattern.
-  bound_outside <- asks $ S.fromList . M.keys . scopeVtable . termScope
-  let combAliases t1 t2 =
-        case t1 of
-          Scalar Record {} -> t1
-          _ -> t1 `addAliases` (<> aliases t2)
-
-      checkMergeReturn (Id pat_v (Info pat_v_t) patloc) t
-        | unique pat_v_t,
-          v : _ <-
-            S.toList $
-              S.map aliasVar (aliases t) `S.intersection` bound_outside =
-            lift . typeError loop_loc mempty $
-              "Return value for consuming loop parameter"
-                <+> dquotes (prettyName pat_v)
-                <+> "aliases"
-                <+> dquotes (prettyName v) <> "."
-        | otherwise = do
-            (cons, obs) <- get
-            unless (S.null $ aliases t `S.intersection` cons) $
-              lift . typeError loop_loc mempty $
-                "Return value for loop parameter"
-                  <+> dquotes (prettyName pat_v)
-                  <+> "aliases other consumed loop parameter."
-            when
-              ( unique pat_v_t
-                  && not (S.null (aliases t `S.intersection` (cons <> obs)))
-              )
-              $ lift . typeError loop_loc mempty
-              $ "Return value for consuming loop parameter"
-                <+> dquotes (prettyName pat_v)
-                <+> "aliases previously returned value."
-            if unique pat_v_t
-              then put (cons <> aliases t, obs)
-              else put (cons, obs <> aliases t)
-
-            pure $ Id pat_v (Info (combAliases pat_v_t t)) patloc
-      checkMergeReturn (Wildcard (Info pat_v_t) patloc) t =
-        pure $ Wildcard (Info (combAliases pat_v_t t)) patloc
-      checkMergeReturn (PatParens p _) t =
-        checkMergeReturn p t
-      checkMergeReturn (PatAscription p _ _) t =
-        checkMergeReturn p t
-      checkMergeReturn (RecordPat pfs patloc) (Scalar (Record tfs)) =
-        RecordPat . M.toList <$> sequence pfs' <*> pure patloc
-        where
-          pfs' = M.intersectionWith checkMergeReturn (M.fromList pfs) tfs
-      checkMergeReturn (TuplePat pats patloc) t
-        | Just ts <- isTupleRecord t =
-            TuplePat <$> zipWithM checkMergeReturn pats ts <*> pure patloc
-      checkMergeReturn p _ =
-        pure p
-
-  (pat'', (pat_cons, _)) <-
-    runStateT (checkMergeReturn pat' body_t) (mempty, mempty)
-
-  let body_cons' = body_cons <> S.map aliasVar pat_cons
-  if body_cons' == body_cons && patternType pat'' == patternType pat
-    then pure pat'
-    else convergePat loop_loc pat'' body_cons' body_t body_loc
-
 data ArgSource = Initial | BodyResult
 
-wellTypedLoopArg :: ArgSource -> [VName] -> Pat -> Exp -> TermTypeM ()
+wellTypedLoopArg :: ArgSource -> [VName] -> Pat ParamType -> Exp -> TermTypeM ()
 wellTypedLoopArg src sparams pat arg = do
   (merge_t, _) <-
     freshDimsInType (mkUsage arg desc) Nonrigid "loop" sparams $
@@ -198,16 +102,11 @@ wellTypedLoopArg src sparams pat arg = do
 
 -- | An un-checked loop.
 type UncheckedLoop =
-  (UncheckedPat, UncheckedExp, LoopFormBase NoInfo Name, UncheckedExp)
+  (UncheckedPat ParamType, UncheckedExp, LoopFormBase NoInfo Name, UncheckedExp)
 
 -- | A loop that has been type-checked.
 type CheckedLoop =
-  ([VName], Pat, Exp, LoopFormBase Info VName, Exp)
-
-loopReturnType :: Pat -> PatType -> PatType
-loopReturnType pat = returnType mempty pat_t (diet pat_t)
-  where
-    pat_t = patternType pat
+  ([VName], Pat ParamType, Exp, LoopFormBase Info VName, Exp)
 
 -- | Type-check a @loop@ expression, passing in a function for
 -- type-checking subexpressions.
@@ -216,224 +115,199 @@ checkDoLoop ::
   UncheckedLoop ->
   SrcLoc ->
   TermTypeM (CheckedLoop, AppRes)
-checkDoLoop checkExp (mergepat, mergeexp, form, loopbody) loc =
-  sequentially (checkExp mergeexp) $ \mergeexp' _ -> do
-    known_before <- M.keysSet <$> getConstraints
-    zeroOrderType
-      (mkUsage mergeexp "use as loop variable")
-      "type used as loop variable"
-      . toStruct
+checkDoLoop checkExp (mergepat, mergeexp, form, loopbody) loc = do
+  mergeexp' <- checkExp mergeexp
+  known_before <- M.keysSet <$> getConstraints
+  zeroOrderType
+    (mkUsage mergeexp "use as loop variable")
+    "type used as loop variable"
+    . toStruct
+    =<< expTypeFully mergeexp'
+
+  -- The handling of dimension sizes is a bit intricate, but very
+  -- similar to checking a function, followed by checking a call to
+  -- it.  The overall procedure is as follows:
+  --
+  -- (1) All empty dimensions in the merge pattern are instantiated
+  -- with nonrigid size variables.  All explicitly specified
+  -- dimensions are preserved.
+  --
+  -- (2) The body of the loop is type-checked.  The result type is
+  -- combined with the merge pattern type to determine which sizes are
+  -- variant, and these are turned into size parameters for the merge
+  -- pattern.
+  --
+  -- (3) We now conceptually have a function parameter type and
+  -- return type.  We check that it can be called with the body type
+  -- as argument.
+  --
+  -- (4) Similarly to (3), we check that the "function" can be
+  -- called with the initial merge values as argument.  The result
+  -- of this is the type of the loop as a whole.
+  --
+  -- (There is also a convergence loop for inferring uniqueness, but
+  -- that's orthogonal to the size handling.)
+
+  -- We don't want the loop parameters to alias their initial
+  -- values, so we blank them here.  We will actually check them
+  -- properly later.
+  (merge_t, new_dims_map) <-
+    -- dim handling (1)
+    allDimsFreshInType (mkUsage loc "loop parameter type inference") Nonrigid "loop_d"
       =<< expTypeFully mergeexp'
+  let new_dims_to_initial_dim = M.toList new_dims_map
+      new_dims = map fst new_dims_to_initial_dim
 
-    -- The handling of dimension sizes is a bit intricate, but very
-    -- similar to checking a function, followed by checking a call to
-    -- it.  The overall procedure is as follows:
-    --
-    -- (1) All empty dimensions in the merge pattern are instantiated
-    -- with nonrigid size variables.  All explicitly specified
-    -- dimensions are preserved.
-    --
-    -- (2) The body of the loop is type-checked.  The result type is
-    -- combined with the merge pattern type to determine which sizes are
-    -- variant, and these are turned into size parameters for the merge
-    -- pattern.
-    --
-    -- (3) We now conceptually have a function parameter type and
-    -- return type.  We check that it can be called with the body type
-    -- as argument.
-    --
-    -- (4) Similarly to (3), we check that the "function" can be
-    -- called with the initial merge values as argument.  The result
-    -- of this is the type of the loop as a whole.
-    --
-    -- (There is also a convergence loop for inferring uniqueness, but
-    -- that's orthogonal to the size handling.)
+  -- dim handling (2)
+  let checkLoopReturnSize mergepat' loopbody' = do
+        loopbody_t <- expTypeFully loopbody'
+        pat_t <-
+          someDimsFreshInType loc "loop" new_dims
+            =<< normTypeFully (patternType mergepat')
 
-    -- We don't want the loop parameters to alias their initial
-    -- values, so we blank them here.  We will actually check them
-    -- properly later.
-    (merge_t, new_dims_map) <-
-      -- dim handling (1)
-      allDimsFreshInType (mkUsage loc "loop parameter type inference") Nonrigid "loop_d"
-        . flip setAliases mempty
-        =<< expTypeFully mergeexp'
-    let new_dims_to_initial_dim = M.toList new_dims_map
-        new_dims = map fst new_dims_to_initial_dim
+        -- We are ignoring the dimensions here, because any mismatches
+        -- should be turned into fresh size variables.
+        onFailure (CheckingLoopBody (toStruct pat_t) (toStruct loopbody_t)) $
+          unify
+            (mkUsage loopbody "matching loop body to loop pattern")
+            (toStruct pat_t)
+            (toStruct loopbody_t)
 
-    -- dim handling (2)
-    let checkLoopReturnSize mergepat' loopbody' = do
-          loopbody_t <- expTypeFully loopbody'
-          pat_t <-
-            someDimsFreshInType loc "loop" new_dims
-              =<< normTypeFully (patternType mergepat')
+        -- Figure out which of the 'new_dims' dimensions are variant.
+        -- This works because we know that each dimension from
+        -- new_dims in the pattern is unique and distinct.
+        areSameSize <- getAreSame
+        let onDims _ x y
+              | x == y = pure x
+            onDims _ e d = do
+              forM_ (fvVars $ freeInExp e) $ \v -> do
+                case L.find (areSameSize v . fst) new_dims_to_initial_dim of
+                  Just (_, e') ->
+                    if e' == d
+                      then modify $ first $ M.insert v $ ExpSubst e'
+                      else
+                        unless (v `S.member` known_before) $
+                          modify (second (v :))
+                  _ ->
+                    pure ()
+              pure e
+        loopbody_t' <- normTypeFully loopbody_t
+        merge_t' <- normTypeFully merge_t
 
-          -- We are ignoring the dimensions here, because any mismatches
-          -- should be turned into fresh size variables.
-          onFailure (CheckingLoopBody (toStruct pat_t) (toStruct loopbody_t)) $
-            unify
-              (mkUsage loopbody "matching loop body to loop pattern")
-              (toStruct pat_t)
-              (toStruct loopbody_t)
+        let (init_substs, sparams) =
+              execState (matchDims onDims merge_t' loopbody_t') mempty
 
-          -- Figure out which of the 'new_dims' dimensions are variant.
-          -- This works because we know that each dimension from
-          -- new_dims in the pattern is unique and distinct.
-          areSameSize <- getAreSame
-          let onDims _ x y
-                | x == y = pure x
-              onDims _ e d = do
-                forM_ (fvVars $ freeInExp e) $ \v -> do
-                  case L.find (areSameSize v . fst) new_dims_to_initial_dim of
-                    Just (_, e') ->
-                      if e' == d
-                        then modify $ first $ M.insert v $ ExpSubst e'
-                        else
-                          unless (v `S.member` known_before) $
-                            modify (second (v :))
-                    _ ->
-                      pure ()
-                pure e
-          loopbody_t' <- normTypeFully loopbody_t
-          merge_t' <- normTypeFully merge_t
+        -- Make sure that any of new_dims that are invariant will be
+        -- replaced with the invariant size in the loop body.  Failure
+        -- to do this can cause type annotations to still refer to
+        -- new_dims.
+        let dimToInit (v, ExpSubst e) =
+              constrain v $ Size (Just e) (mkUsage loc "size of loop parameter")
+            dimToInit _ =
+              pure ()
+        mapM_ dimToInit $ M.toList init_substs
 
-          let (init_substs, sparams) =
-                execState (matchDims onDims merge_t' loopbody_t') mempty
+        mergepat'' <- applySubst (`M.lookup` init_substs) <$> updateTypes mergepat'
 
-          -- Make sure that any of new_dims that are invariant will be
-          -- replaced with the invariant size in the loop body.  Failure
-          -- to do this can cause type annotations to still refer to
-          -- new_dims.
-          let dimToInit (v, ExpSubst e) =
-                constrain v $ Size (Just e) (mkUsage loc "size of loop parameter")
-              dimToInit _ =
-                pure ()
-          mapM_ dimToInit $ M.toList init_substs
+        -- Eliminate those new_dims that turned into sparams so it won't
+        -- look like we have ambiguous sizes lying around.
+        modifyConstraints $ M.filterWithKey $ \k _ -> k `notElem` sparams
 
-          mergepat'' <- applySubst (`M.lookup` init_substs) <$> updateTypes mergepat'
+        -- dim handling (3)
+        --
+        -- The only trick here is that we have to turn any instances
+        -- of loop parameters in the type of loopbody' rigid,
+        -- because we are no longer in a position to change them,
+        -- really.
+        wellTypedLoopArg BodyResult sparams mergepat'' loopbody'
 
-          -- Eliminate those new_dims that turned into sparams so it won't
-          -- look like we have ambiguous sizes lying around.
-          modifyConstraints $ M.filterWithKey $ \k _ -> k `notElem` sparams
+        pure (nubOrd sparams, mergepat'')
 
-          -- dim handling (3)
-          --
-          -- The only trick here is that we have to turn any instances
-          -- of loop parameters in the type of loopbody' rigid,
-          -- because we are no longer in a position to change them,
-          -- really.
-          wellTypedLoopArg BodyResult sparams mergepat'' loopbody'
-
-          pure (nubOrd sparams, mergepat'')
-
-    -- First we do a basic check of the loop body to figure out which of
-    -- the merge parameters are being consumed.  For this, we first need
-    -- to check the merge pattern, which requires the (initial) merge
-    -- expression.
-    --
-    -- Play a little with occurences to ensure it does not look like
-    -- none of the merge variables are being used.
-    ((sparams, mergepat', form', loopbody'), bodyflow) <-
-      case form of
-        For i uboundexp -> do
-          uboundexp' <-
-            require "being the bound in a 'for' loop" anySignedType
-              =<< checkExp uboundexp
-          bound_t <- expTypeFully uboundexp'
-          bindingIdent i bound_t $ \i' ->
-            noUnique . bindingPat [] mergepat (Ascribed merge_t) $
-              \mergepat' -> tapOccurrences $ incLevel $ do
-                loopbody' <- checkExp loopbody
-                (sparams, mergepat'') <- checkLoopReturnSize mergepat' loopbody'
-                pure
-                  ( sparams,
-                    mergepat'',
-                    For i' uboundexp',
-                    loopbody'
-                  )
-        ForIn xpat e -> do
-          (arr_t, _) <- newArrayType (mkUsage' (srclocOf e)) "e" 1
-          e' <- unifies "being iterated in a 'for-in' loop" arr_t =<< checkExp e
-          t <- expTypeFully e'
-          case t of
-            _
-              | Just t' <- peelArray 1 t ->
-                  bindingPat [] xpat (Ascribed t') $ \xpat' ->
-                    noUnique . bindingPat [] mergepat (Ascribed merge_t) $
-                      \mergepat' -> tapOccurrences $ incLevel $ do
-                        loopbody' <- checkExp loopbody
-                        (sparams, mergepat'') <- checkLoopReturnSize mergepat' loopbody'
-                        pure
-                          ( sparams,
-                            mergepat'',
-                            ForIn xpat' e',
-                            loopbody'
-                          )
-              | otherwise ->
-                  typeError (srclocOf e) mempty $
-                    "Iteratee of a for-in loop must be an array, but expression has type"
-                      <+> pretty t
-        While cond ->
-          noUnique . bindingPat [] mergepat (Ascribed merge_t) $ \mergepat' ->
-            tapOccurrences
-              . incLevel
-              . sequentially
-                ( checkExp cond
-                    >>= unifies "being the condition of a 'while' loop" (Scalar $ Prim Bool)
+  -- First we do a basic check of the loop body to figure out which of
+  -- the merge parameters are being consumed.  For this, we first need
+  -- to check the merge pattern, which requires the (initial) merge
+  -- expression.
+  --
+  -- Play a little with occurences to ensure it does not look like
+  -- none of the merge variables are being used.
+  (sparams, mergepat', form', loopbody') <-
+    case form of
+      For i uboundexp -> do
+        uboundexp' <-
+          require "being the bound in a 'for' loop" anySignedType
+            =<< checkExp uboundexp
+        bound_t <- expTypeFully uboundexp'
+        bindingIdent i bound_t $ \i' ->
+          bindingPat [] mergepat (Ascribed merge_t) $
+            \mergepat' -> incLevel $ do
+              loopbody' <- checkExp loopbody
+              (sparams, mergepat'') <- checkLoopReturnSize mergepat' loopbody'
+              pure
+                ( sparams,
+                  mergepat'',
+                  For i' uboundexp',
+                  loopbody'
                 )
-              $ \cond' _ -> do
-                loopbody' <- checkExp loopbody
-                (sparams, mergepat'') <- checkLoopReturnSize mergepat' loopbody'
-                pure
-                  ( sparams,
-                    mergepat'',
-                    While cond',
-                    loopbody'
-                  )
+      ForIn xpat e -> do
+        (arr_t, _) <- newArrayType (mkUsage' (srclocOf e)) "e" 1
+        e' <- unifies "being iterated in a 'for-in' loop" arr_t =<< checkExp e
+        t <- expTypeFully e'
+        case t of
+          _
+            | Just t' <- peelArray 1 t ->
+                bindingPat [] xpat (Ascribed t') $ \xpat' ->
+                  bindingPat [] mergepat (Ascribed merge_t) $
+                    \mergepat' -> incLevel $ do
+                      loopbody' <- checkExp loopbody
+                      (sparams, mergepat'') <- checkLoopReturnSize mergepat' loopbody'
+                      pure
+                        ( sparams,
+                          mergepat'',
+                          ForIn (fmap toStruct xpat') e',
+                          loopbody'
+                        )
+            | otherwise ->
+                typeError (srclocOf e) mempty $
+                  "Iteratee of a for-in loop must be an array, but expression has type"
+                    <+> pretty t
+      While cond ->
+        bindingPat [] mergepat (Ascribed merge_t) $ \mergepat' ->
+          incLevel $ do
+            cond' <-
+              checkExp cond
+                >>= unifies "being the condition of a 'while' loop" (Scalar $ Prim Bool)
+            loopbody' <- checkExp loopbody
+            (sparams, mergepat'') <- checkLoopReturnSize mergepat' loopbody'
+            pure
+              ( sparams,
+                mergepat'',
+                While cond',
+                loopbody'
+              )
 
-    mergepat'' <- do
-      loopbody_t <- expTypeFully loopbody'
-      convergePat loc mergepat' (allConsumed bodyflow) loopbody_t $
-        mkUsage loopbody' "being (part of) the result of the loop body"
+  merge_t' <- expTypeFully mergeexp'
 
-    merge_t' <- expTypeFully mergeexp'
-    let consumeMerge (Id _ (Info pt) ploc) mt
-          | unique pt = consume ploc $ aliases mt
-        consumeMerge (TuplePat pats _) t
-          | Just ts <- isTupleRecord t =
-              zipWithM_ consumeMerge pats ts
-        consumeMerge (PatParens pat _) t =
-          consumeMerge pat t
-        consumeMerge (PatAscription pat _ _) t =
-          consumeMerge pat t
-        consumeMerge _ _ =
-          pure ()
-    consumeMerge mergepat'' merge_t'
+  -- dim handling (4)
+  wellTypedLoopArg Initial sparams mergepat' mergeexp'
 
-    -- dim handling (4)
-    wellTypedLoopArg Initial sparams mergepat'' mergeexp'
-
-    (loopt, retext) <-
-      freshDimsInType
-        (mkUsage loc "inference of loop result type")
-        (Rigid RigidLoop)
-        "loop"
-        sparams
-        $ loopReturnType mergepat'' merge_t'
-    -- We set all of the uniqueness to be unique.  This is intentional,
-    -- and matches what happens for function calls.  Those arrays that
-    -- really *cannot* be consumed will alias something unconsumable,
-    -- and will be caught that way.
-    let bound_here = patNames mergepat'' <> S.fromList sparams <> form_bound
-        form_bound =
-          case form' of
-            For v _ -> S.singleton $ identName v
-            ForIn forpat _ -> patNames forpat
-            While {} -> mempty
-        loopt' =
-          second (`S.difference` S.map AliasBound bound_here) $
-            loopt `setUniqueness` Unique
-
-    pure
-      ( (sparams, mergepat'', mergeexp', form', loopbody'),
-        AppRes loopt' retext
-      )
+  (loopt, retext) <-
+    freshDimsInType
+      (mkUsage loc "inference of loop result type")
+      (Rigid RigidLoop)
+      "loop"
+      sparams
+      (patternType mergepat')
+  -- We set all of the uniqueness to be unique.  This is intentional,
+  -- and matches what happens for function calls.  Those arrays that
+  -- really *cannot* be consumed will alias something unconsumable,
+  -- and will be caught that way.
+  let bound_here = patNames mergepat' <> S.fromList sparams <> form_bound
+      form_bound =
+        case form' of
+          For v _ -> S.singleton $ identName v
+          ForIn forpat _ -> patNames forpat
+          While {} -> mempty
+  pure
+    ( (sparams, mergepat', mergeexp', form', loopbody'),
+      AppRes (toStruct loopt) retext
+    )

--- a/src/Language/Futhark/TypeChecker/Terms/DoLoop.hs
+++ b/src/Language/Futhark/TypeChecker/Terms/DoLoop.hs
@@ -144,13 +144,7 @@ checkDoLoop checkExp (mergepat, mergeexp, form, loopbody) loc = do
   -- (4) Similarly to (3), we check that the "function" can be
   -- called with the initial merge values as argument.  The result
   -- of this is the type of the loop as a whole.
-  --
-  -- (There is also a convergence loop for inferring uniqueness, but
-  -- that's orthogonal to the size handling.)
 
-  -- We don't want the loop parameters to alias their initial
-  -- values, so we blank them here.  We will actually check them
-  -- properly later.
   (merge_t, new_dims_map) <-
     -- dim handling (1)
     allDimsFreshInType (mkUsage loc "loop parameter type inference") Nonrigid "loop_d"
@@ -223,13 +217,6 @@ checkDoLoop checkExp (mergepat, mergeexp, form, loopbody) loc = do
 
         pure (nubOrd sparams, mergepat'')
 
-  -- First we do a basic check of the loop body to figure out which of
-  -- the merge parameters are being consumed.  For this, we first need
-  -- to check the merge pattern, which requires the (initial) merge
-  -- expression.
-  --
-  -- Play a little with occurences to ensure it does not look like
-  -- none of the merge variables are being used.
   (sparams, mergepat', form', loopbody') <-
     case form of
       For i uboundexp -> do

--- a/src/Language/Futhark/TypeChecker/Terms/Monad.hs
+++ b/src/Language/Futhark/TypeChecker/Terms/Monad.hs
@@ -252,7 +252,8 @@ data SizeSource
 -- generating unique names, as these will be user-visible.
 data TermTypeState = TermTypeState
   { stateConstraints :: Constraints,
-    stateCounter :: !Int
+    stateCounter :: !Int,
+    stateUsed :: S.Set VName
   }
 
 newtype TermTypeM a
@@ -482,6 +483,7 @@ instance MonadTypeChecker TermTypeM where
         let (pts', rt') = instOverloaded argtype pts rt
         pure $ foldFunType (map (toParam Observe) pts') $ RetType [] $ toRes Nonunique rt'
 
+    modify $ \s -> s {stateUsed = S.insert (qualLeaf qn') $ stateUsed s}
     pure (qn', t)
     where
       instOverloaded argtype pts rt =
@@ -658,4 +660,4 @@ runTermTypeM checker (TermTypeM m) = do
             termLevel = 0,
             termChecker = checker
           }
-  evalStateT (runReaderT m initial_tenv) (TermTypeState mempty 0)
+  evalStateT (runReaderT m initial_tenv) (TermTypeState mempty 0 mempty)

--- a/src/Language/Futhark/TypeChecker/Terms/Monad.hs
+++ b/src/Language/Futhark/TypeChecker/Terms/Monad.hs
@@ -64,8 +64,6 @@ import Language.Futhark.TypeChecker.Types
 import Language.Futhark.TypeChecker.Unify
 import Prelude hiding (mod)
 
---- Uniqueness
-
 type Names = S.Set VName
 
 data ValBinding
@@ -74,14 +72,10 @@ data ValBinding
   | EqualityF
   deriving (Show)
 
---- Errors
-
 unusedSize :: (MonadTypeChecker m) => SizeBinder VName -> m a
 unusedSize p =
   typeError p mempty . withIndexLink "unused-size" $
     "Size" <+> pretty p <+> "unused in pattern."
-
---- Scope management
 
 data Inferred t
   = NoneInferred

--- a/src/Language/Futhark/TypeChecker/Terms/Monad.hs
+++ b/src/Language/Futhark/TypeChecker/Terms/Monad.hs
@@ -34,7 +34,6 @@ module Language.Futhark.TypeChecker.Terms.Monad
 
     -- * Sizes
     isInt64,
-    maybeDimFromExp,
 
     -- * Control flow
     incLevel,
@@ -615,12 +614,6 @@ isInt64 (IntLit k' _ _) = Just $ fromInteger k'
 isInt64 (Negate x _) = negate <$> isInt64 x
 isInt64 (Parens x _) = isInt64 x
 isInt64 _ = Nothing
-
-maybeDimFromExp :: Exp -> Maybe Size
-maybeDimFromExp (Var v typ loc) = Just $ Var v typ loc
-maybeDimFromExp (Parens e _) = maybeDimFromExp e
-maybeDimFromExp (QualParens _ e _) = maybeDimFromExp e
-maybeDimFromExp e = flip sizeFromInteger mempty . fromIntegral <$> isInt64 e
 
 -- Running
 

--- a/src/Language/Futhark/TypeChecker/Terms/Pat.hs
+++ b/src/Language/Futhark/TypeChecker/Terms/Pat.hs
@@ -6,7 +6,6 @@ module Language.Futhark.TypeChecker.Terms.Pat
     bindingIdent,
     bindingSizes,
     doNotShadow,
-    boundAliases,
   )
 where
 
@@ -48,48 +47,14 @@ nonrigidFor sizes t = evalStateT (bitraverse onDim pure t) mempty
               pure $ Var (qualName v') typ loc
     onDim d = pure d
 
--- | The set of in-scope variables that are being aliased.
-boundAliases :: Aliasing -> S.Set VName
-boundAliases = S.map aliasVar . S.filter bound
-  where
-    bound AliasBound {} = True
-    bound AliasFree {} = False
-
-checkIfUsed :: Bool -> Occurrences -> Ident -> TermTypeM ()
-checkIfUsed allow_consume occs v
-  | not allow_consume,
-    not $ consumable $ unInfo $ identType v,
-    Just occ <- find consumes occs =
-      typeError (srclocOf occ) mempty $
-        "Consuming"
-          <+> dquotes (prettyName $ identName v)
-          <+> textwrap ("which is a non-consumable parameter bound at " <> locText (locOf v) <> ".")
-  | not $ identName v `S.member` allOccurring occs,
-    not $ "_" `isPrefixOf` baseString (identName v) =
-      warn (srclocOf v) $
-        "Unused variable" <+> dquotes (prettyName $ identName v) <+> "."
-  | otherwise =
-      pure ()
-  where
-    consumes = maybe False (identName v `S.member`) . consumed
-
-    consumable (Scalar (Record fs)) = all consumable fs
-    consumable (Scalar (Sum cs)) = all (all consumable) cs
-    consumable (Scalar (TypeVar _ u _ _)) = u == Unique
-    consumable (Scalar Arrow {}) = True
-    consumable (Scalar Prim {}) = True
-    consumable (Array _ u _ _) = u == Unique
-
 -- | Bind these identifiers locally while running the provided action.
 -- Checks that the identifiers are used properly within the scope
 -- (e.g. consumption).
 binding ::
-  -- | Allow consumption, even if the type is not unique.
-  Bool ->
-  [Ident] ->
+  [Ident StructType] ->
   TermTypeM a ->
   TermTypeM a
-binding allow_consume idents = check . handleVars
+binding idents = handleVars
   where
     handleVars m =
       localScope (`bindVars` idents) $ do
@@ -103,46 +68,13 @@ binding allow_consume idents = check . handleVars
           constrain (identName ident) $ ParamSize $ srclocOf ident
         m
 
-    bindVars :: TermScope -> [Ident] -> TermScope
     bindVars = foldl bindVar
 
-    bindVar :: TermScope -> Ident -> TermScope
     bindVar scope (Ident name (Info tp) _) =
-      let tp' = tp `addAliases` S.insert (AliasBound name)
-       in scope
-            { scopeVtable =
-                M.insert name (BoundV Local [] tp') $ scopeVtable scope
-            }
-
-    -- Check whether the bound variables have been used correctly
-    -- within their scope.
-    check m = do
-      (a, usages) <- collectBindingsOccurrences m
-      checkOccurrences usages
-
-      mapM_ (checkIfUsed allow_consume usages) idents
-
-      pure a
-
-    -- Collect and remove all occurences of @idents@.  This relies
-    -- on the fact that no variables shadow any other.
-    collectBindingsOccurrences m = do
-      (x, usage) <- collectOccurrences m
-      let (relevant, rest) = split usage
-      occur rest
-      pure (x, relevant)
-      where
-        onOcc occ =
-          let (obs1, obs2) = divide $ observed occ
-              occ_cons = divide <$> consumed occ
-              con1 = fst <$> occ_cons
-              con2 = snd <$> occ_cons
-           in ( occ {observed = obs1, consumed = con1},
-                occ {observed = obs2, consumed = con2}
-              )
-        split = unzip . map onOcc
-        names = S.fromList $ map identName idents
-        divide s = (s `S.intersection` names, s `S.difference` names)
+      scope
+        { scopeVtable =
+            M.insert name (BoundV Local [] tp) $ scopeVtable scope
+        }
 
 bindingTypes ::
   [Either (VName, TypeBinding) (VName, Constraint)] ->
@@ -161,32 +93,32 @@ bindingTypes types m = do
 
 bindingTypeParams :: [TypeParam] -> TermTypeM a -> TermTypeM a
 bindingTypeParams tparams =
-  binding False (mapMaybe typeParamIdent tparams)
+  binding (mapMaybe typeParamIdent tparams)
     . bindingTypes (concatMap typeParamType tparams)
   where
     typeParamType (TypeParamType l v loc) =
-      [ Left (v, TypeAbbr l [] $ RetType [] $ Scalar (TypeVar () Nonunique (qualName v) [])),
+      [ Left (v, TypeAbbr l [] $ RetType [] $ Scalar (TypeVar mempty (qualName v) [])),
         Right (v, ParamType l loc)
       ]
     typeParamType (TypeParamDim v loc) =
       [Right (v, ParamSize loc)]
 
-typeParamIdent :: TypeParam -> Maybe Ident
+typeParamIdent :: TypeParam -> Maybe (Ident StructType)
 typeParamIdent (TypeParamDim v loc) =
   Just $ Ident v (Info $ Scalar $ Prim $ Signed Int64) loc
 typeParamIdent _ = Nothing
 
 -- | Bind a single term-level identifier.
 bindingIdent ::
-  IdentBase NoInfo Name ->
-  PatType ->
-  (Ident -> TermTypeM a) ->
+  IdentBase NoInfo Name StructType ->
+  StructType ->
+  (Ident StructType -> TermTypeM a) ->
   TermTypeM a
 bindingIdent (Ident v NoInfo vloc) t m =
   bindSpaced [(Term, v)] $ do
     v' <- checkName Term v vloc
     let ident = Ident v' (Info t) vloc
-    binding True [ident] $ m ident
+    binding [ident] $ m ident
 
 -- | Bind @let@-bound sizes.  This is usually followed by 'bindingPat'
 -- immediately afterwards.
@@ -196,7 +128,7 @@ bindingSizes sizes m = do
   foldM_ lookForDuplicates mempty sizes
   bindSpaced (map sizeWithSpace sizes) $ do
     sizes' <- mapM check sizes
-    binding False (map sizeWithType sizes') $ m sizes'
+    binding (map sizeWithType sizes') $ m sizes'
   where
     lookForDuplicates prev size
       | Just prevloc <- M.lookup (sizeName size) prev =
@@ -218,45 +150,25 @@ bindingSizes sizes m = do
 sizeBinderToParam :: SizeBinder VName -> UncheckedTypeParam
 sizeBinderToParam (SizeBinder v loc) = TypeParamDim (baseName v) loc
 
--- | Check and bind a @let@-pattern.
-bindingPat ::
-  [SizeBinder VName] ->
-  PatBase NoInfo Name ->
-  InferredType ->
-  (Pat -> TermTypeM a) ->
-  TermTypeM a
-bindingPat sizes p t m = do
-  checkPat sizes p t $ \p' -> binding True (S.toList $ patIdents p') $ do
-    -- Perform an observation of every declared dimension.  This
-    -- prevents unused-name warnings for otherwise unused dimensions.
-    let ident (SizeBinder v loc) =
-          Ident v (Info (Scalar $ Prim $ Signed Int64)) loc
-    mapM_ (observe . ident) sizes
-
-    let used_sizes = fvVars $ freeInType $ patternStructType p'
-    case filter ((`S.notMember` used_sizes) . sizeName) sizes of
-      [] -> m p'
-      size : _ -> unusedSize size
-
 -- All this complexity is just so we can handle un-suffixed numeric
 -- literals in patterns.
-patLitMkType :: PatLit -> SrcLoc -> TermTypeM StructType
+patLitMkType :: PatLit -> SrcLoc -> TermTypeM ParamType
 patLitMkType (PatLitInt _) loc = do
   t <- newTypeVar loc "t"
-  mustBeOneOf anyNumberType (mkUsage loc "integer literal") t
+  mustBeOneOf anyNumberType (mkUsage loc "integer literal") (toStruct t)
   pure t
 patLitMkType (PatLitFloat _) loc = do
   t <- newTypeVar loc "t"
-  mustBeOneOf anyFloatType (mkUsage loc "float literal") t
+  mustBeOneOf anyFloatType (mkUsage loc "float literal") (toStruct t)
   pure t
 patLitMkType (PatLitPrim v) _ =
   pure $ Scalar $ Prim $ primValueType v
 
 checkPat' ::
   [SizeBinder VName] ->
-  UncheckedPat ->
-  InferredType ->
-  TermTypeM Pat
+  UncheckedPat ParamType ->
+  Inferred ParamType ->
+  TermTypeM (Pat ParamType)
 checkPat' sizes (PatParens p loc) t =
   PatParens <$> checkPat' sizes p t <*> pure loc
 checkPat' sizes (PatAttr attr p loc) t =
@@ -286,7 +198,7 @@ checkPat' sizes (TuplePat ps loc) (Ascribed t)
         <*> pure loc
 checkPat' sizes p@(TuplePat ps loc) (Ascribed t) = do
   ps_t <- replicateM (length ps) (newTypeVar loc "t")
-  unify (mkUsage loc "matching a tuple pattern") (Scalar (tupleRecord ps_t)) $ toStruct t
+  unify (mkUsage loc "matching a tuple pattern") (Scalar (tupleRecord ps_t)) (toStruct t)
   t' <- normTypeFully t
   checkPat' sizes p $ Ascribed t'
 checkPat' sizes (TuplePat ps loc) NoneInferred =
@@ -310,7 +222,7 @@ checkPat' sizes p@(RecordPat fields loc) (Ascribed t) = do
     typeError loc mempty $
       "Duplicate fields in record pattern" <+> pretty p <> "."
 
-  unify (mkUsage loc "matching a record pattern") (Scalar (Record fields')) $ toStruct t
+  unify (mkUsage loc "matching a record pattern") (Scalar (Record fields')) (toStruct t)
   t' <- normTypeFully t
   checkPat' sizes p $ Ascribed t'
 checkPat' sizes (RecordPat fs loc) NoneInferred =
@@ -322,26 +234,25 @@ checkPat' sizes (PatAscription p t loc) maybe_outer_t = do
 
   case maybe_outer_t of
     Ascribed outer_t -> do
-      st_forunify <- nonrigidFor sizes st
+      st_forunify <- nonrigidFor sizes $ toStruct st
       unify (mkUsage loc "explicit type ascription") st_forunify (toStruct outer_t)
 
-      outer_t' <- normTypeFully outer_t
       PatAscription
-        <$> checkPat' sizes p (Ascribed (addAliasesFromType (fromStruct st) outer_t'))
+        <$> checkPat' sizes p (Ascribed (resToParam st))
         <*> pure t'
         <*> pure loc
     NoneInferred ->
       PatAscription
-        <$> checkPat' sizes p (Ascribed (fromStruct st))
+        <$> checkPat' sizes p (Ascribed (resToParam st))
         <*> pure t'
         <*> pure loc
 checkPat' _ (PatLit l NoInfo loc) (Ascribed t) = do
   t' <- patLitMkType l loc
-  unify (mkUsage loc "matching against literal") t' (toStruct t)
-  pure $ PatLit l (Info (fromStruct t')) loc
+  unify (mkUsage loc "matching against literal") (toStruct t') (toStruct t)
+  pure $ PatLit l (Info t') loc
 checkPat' _ (PatLit l NoInfo loc) NoneInferred = do
   t' <- patLitMkType l loc
-  pure $ PatLit l (Info (fromStruct t')) loc
+  pure $ PatLit l (Info t') loc
 checkPat' sizes (PatConstr n NoInfo ps loc) (Ascribed (Scalar (Sum cs)))
   | Just ts <- M.lookup n cs = do
       when (length ps /= length ts) $
@@ -357,8 +268,8 @@ checkPat' sizes (PatConstr n NoInfo ps loc) (Ascribed t) = do
   t' <- newTypeVar loc "t"
   ps' <- forM ps $ \p -> do
     p_t <- newTypeVar (srclocOf p) "t"
-    checkPat' sizes p $ Ascribed $ addAliasesFromType p_t t
-  mustHaveConstr usage n t' (patternStructType <$> ps')
+    checkPat' sizes p $ Ascribed p_t
+  mustHaveConstr usage n (toStruct t') (patternStructType <$> ps')
   unify usage t' (toStruct t)
   t'' <- normTypeFully t
   pure $ PatConstr n (Info t'') ps' loc
@@ -367,25 +278,22 @@ checkPat' sizes (PatConstr n NoInfo ps loc) (Ascribed t) = do
 checkPat' sizes (PatConstr n NoInfo ps loc) NoneInferred = do
   ps' <- mapM (\p -> checkPat' sizes p NoneInferred) ps
   t <- newTypeVar loc "t"
-  mustHaveConstr usage n t (patternStructType <$> ps')
-  pure $ PatConstr n (Info $ fromStruct t) ps' loc
+  mustHaveConstr usage n (toStruct t) (patternStructType <$> ps')
+  pure $ PatConstr n (Info t) ps' loc
   where
     usage = mkUsage loc "matching against constructor"
 
-patNameMap :: Pat -> NameMap
-patNameMap = M.fromList . map asTerm . S.toList . patNames
-  where
-    asTerm v = ((Term, baseName v), qualName v)
-
 checkPat ::
   [SizeBinder VName] ->
-  UncheckedPat ->
-  InferredType ->
-  (Pat -> TermTypeM a) ->
+  UncheckedPat (TypeBase Size u) ->
+  Inferred StructType ->
+  (Pat ParamType -> TermTypeM a) ->
   TermTypeM a
 checkPat sizes p t m = do
   checkForDuplicateNames (map sizeBinderToParam sizes) [p]
-  p' <- onFailure (CheckingPat p t) $ checkPat' sizes p t
+  p' <-
+    onFailure (CheckingPat (fmap toStruct p) (fmap toStruct t)) $
+      checkPat' sizes (fmap (toParam Observe) p) (fmap (toParam Observe) t)
 
   let explicit = mustBeExplicitInType $ patternStructType p'
 
@@ -398,23 +306,39 @@ checkPat sizes p t m = do
     [] ->
       bindNameMap (patNameMap p') $ m p'
 
+-- | Check and bind a @let@-pattern.
+bindingPat ::
+  [SizeBinder VName] ->
+  UncheckedPat (TypeBase Size u) ->
+  Inferred StructType ->
+  (Pat ParamType -> TermTypeM a) ->
+  TermTypeM a
+bindingPat sizes p t m = do
+  checkPat sizes p t $ \p' -> binding (S.toList $ patIdents (fmap toStruct p')) $ do
+    p'' <- updateTypes p'
+
+    let used_sizes = fvVars $ freeInPat p''
+    case filter ((`S.notMember` used_sizes) . sizeName) sizes of
+      [] -> m p''
+      size : _ -> unusedSize size
+
+patNameMap :: Pat t -> NameMap
+patNameMap = M.fromList . map asTerm . S.toList . patNames
+  where
+    asTerm v = ((Term, baseName v), qualName v)
+
 -- | Check and bind type and value parameters.
 bindingParams ::
   [UncheckedTypeParam] ->
-  [UncheckedPat] ->
-  ([TypeParam] -> [Pat] -> TermTypeM a) ->
+  [UncheckedPat ParamType] ->
+  ([TypeParam] -> [Pat ParamType] -> TermTypeM a) ->
   TermTypeM a
 bindingParams tps orig_ps m = do
   checkForDuplicateNames tps orig_ps
   checkTypeParams tps $ \tps' -> bindingTypeParams tps' $ do
     let descend ps' (p : ps) =
           checkPat [] p NoneInferred $ \p' ->
-            binding False (S.toList $ patIdents p') $ descend (p' : ps') ps
-        descend ps' [] = do
-          -- Perform an observation of every type parameter.  This
-          -- prevents unused-name warnings for otherwise unused
-          -- dimensions.
-          mapM_ observe $ mapMaybe typeParamIdent tps'
-          m tps' $ reverse ps'
+            binding (S.toList $ patIdents $ fmap toStruct p') $ descend (p' : ps') ps
+        descend ps' [] = m tps' $ reverse ps'
 
     descend [] orig_ps

--- a/src/Language/Futhark/TypeChecker/Terms/Pat.hs
+++ b/src/Language/Futhark/TypeChecker/Terms/Pat.hs
@@ -73,7 +73,7 @@ binding idents = handleVars
     bindVar scope (Ident name (Info tp) _) =
       scope
         { scopeVtable =
-            M.insert name (BoundV Local [] tp) $ scopeVtable scope
+            M.insert name (BoundV [] tp) $ scopeVtable scope
         }
 
 bindingTypes ::

--- a/src/Language/Futhark/TypeChecker/Terms/Pat.hs
+++ b/src/Language/Futhark/TypeChecker/Terms/Pat.hs
@@ -48,8 +48,6 @@ nonrigidFor sizes t = evalStateT (bitraverse onDim pure t) mempty
     onDim d = pure d
 
 -- | Bind these identifiers locally while running the provided action.
--- Checks that the identifiers are used properly within the scope
--- (e.g. consumption).
 binding ::
   [Ident StructType] ->
   TermTypeM a ->

--- a/src/Language/Futhark/TypeChecker/Terms/Pat.hs
+++ b/src/Language/Futhark/TypeChecker/Terms/Pat.hs
@@ -320,7 +320,7 @@ bindingPat ::
   (Pat ParamType -> TermTypeM a) ->
   TermTypeM a
 bindingPat sizes p t m = do
-  checkPat sizes p t $ \p' -> binding (S.toList $ patIdents (fmap toStruct p')) $ do
+  checkPat sizes p t $ \p' -> binding (patIdents (fmap toStruct p')) $ do
     p'' <- updateTypes p'
 
     let used_sizes = fvVars $ freeInPat p''
@@ -344,7 +344,7 @@ bindingParams tps orig_ps m = do
   checkTypeParams tps $ \tps' -> bindingTypeParams tps' $ do
     let descend ps' (p : ps) =
           checkPat [] p NoneInferred $ \p' ->
-            binding (S.toList $ patIdents $ fmap toStruct p') $ descend (p' : ps') ps
+            binding (patIdents $ fmap toStruct p') $ descend (p' : ps') ps
         descend ps' [] = m tps' $ reverse ps'
 
     descend [] orig_ps

--- a/src/Language/Futhark/TypeChecker/Types.hs
+++ b/src/Language/Futhark/TypeChecker/Types.hs
@@ -184,7 +184,7 @@ evalTypeExp (TEArrow (Just v) t1 t2 loc) = do
       pure
         ( TEArrow (Just v') t1' t2' loc,
           svars1 ++ dims1 ++ svars2,
-          RetType [] $ Scalar $ Arrow mempty (Named v') (diet $ resToParam st1) (toStruct st1) (RetType dims2 st2),
+          RetType [] $ Scalar $ Arrow Nonunique (Named v') (diet $ resToParam st1) (toStruct st1) (RetType dims2 st2),
           Lifted
         )
 --
@@ -195,7 +195,7 @@ evalTypeExp (TEArrow Nothing t1 t2 loc) = do
     ( TEArrow Nothing t1' t2' loc,
       svars1 ++ dims1 ++ svars2,
       RetType [] . Scalar $
-        Arrow mempty Unnamed (diet $ resToParam st1) (toStruct st1) $
+        Arrow Nonunique Unnamed (diet $ resToParam st1) (toStruct st1) $
           RetType dims2 st2,
       Lifted
     )

--- a/src/Language/Futhark/TypeChecker/Types.hs
+++ b/src/Language/Futhark/TypeChecker/Types.hs
@@ -452,20 +452,17 @@ typeParamToArg (TypeParamType _ v _) =
 
 -- | A type substitution may be a substitution or a yet-unknown
 -- substitution (but which is certainly an overloaded primitive
--- type!).  The latter is used to remove aliases from types that are
--- yet-unknown but that we know cannot carry aliases (see issue #682).
-data Subst t = Subst [TypeParam] t | PrimSubst | ExpSubst Exp
+-- type!).
+data Subst t = Subst [TypeParam] t | ExpSubst Exp
   deriving (Show)
 
 instance Pretty t => Pretty (Subst t) where
   pretty (Subst [] t) = pretty t
   pretty (Subst tps t) = mconcat (map pretty tps) <> colon <+> pretty t
-  pretty PrimSubst = "#<primsubst>"
   pretty (ExpSubst e) = pretty e
 
 instance Functor Subst where
   fmap f (Subst ps t) = Subst ps $ f t
-  fmap _ PrimSubst = PrimSubst
   fmap _ (ExpSubst e) = ExpSubst e
 
 -- | Create a type substitution corresponding to a type binding.
@@ -608,8 +605,6 @@ substTypesRet lookupSubst ot =
           RetType ext t <- freshDims rt
           modify (ext ++)
           pure $ second (<> u) $ applyType ps (second (const u) t) targs'
-        Just PrimSubst ->
-          pure $ Scalar $ TypeVar u v targs'
         _ ->
           pure $ Scalar $ TypeVar u v targs'
     onType (Scalar (Record ts)) =

--- a/src/Language/Futhark/TypeChecker/Types.hs
+++ b/src/Language/Futhark/TypeChecker/Types.hs
@@ -2,8 +2,6 @@
 module Language.Futhark.TypeChecker.Types
   ( checkTypeExp,
     renameRetType,
-    returnType,
-    addAliasesFromType,
     checkForDuplicateNames,
     checkTypeParams,
     typeParamToArg,
@@ -64,7 +62,7 @@ mustBeExplicitInBinding :: StructType -> S.Set VName
 mustBeExplicitInBinding bind_t =
   let (ts, ret) = unfoldFunType bind_t
       alsoRet = M.unionWith (&&) $ M.fromList $ zip (S.toList (fvVars (freeInType ret))) (repeat True)
-   in S.fromList $ M.keys $ M.filter id $ alsoRet $ foldl' onType mempty $ map snd ts
+   in S.fromList $ M.keys $ M.filter id $ alsoRet $ foldl' onType mempty $ map toStruct ts
   where
     onType uses t = uses <> mustBeExplicitAux t -- Left-biased union.
 
@@ -74,72 +72,9 @@ mustBeExplicitInBinding bind_t =
 mustBeExplicitInType :: StructType -> S.Set VName
 mustBeExplicitInType = snd . determineSizeWitnesses
 
--- | @returnType appres ret_type arg_diet arg_type@ gives result of applying
--- an argument the given types to a function with the given return
--- type, consuming the argument with the given diet.
-returnType :: Aliasing -> PatType -> Diet -> PatType -> PatType
-returnType _ (Array _ Unique et shape) _ _ =
-  Array mempty Nonunique et shape -- Intentional!
-returnType appres (Array als Nonunique et shape) d arg =
-  Array (appres <> als <> arg_als) Nonunique et shape
-  where
-    arg_als = aliases $ maskAliases arg d
-returnType appres (Scalar (Record fs)) d arg =
-  Scalar $ Record $ fmap (\et -> returnType appres et d arg) fs
-returnType _ (Scalar (Prim t)) _ _ =
-  Scalar $ Prim t
-returnType _ (Scalar (TypeVar _ Unique t targs)) _ _ =
-  Scalar $ TypeVar mempty Nonunique t targs -- Intentional!
-returnType appres (Scalar (TypeVar als Nonunique t targs)) d arg =
-  Scalar $ TypeVar (appres <> als <> arg_als) Unique t targs
-  where
-    arg_als = aliases $ maskAliases arg d
-returnType _ (Scalar (Arrow old_als v pd t1 (RetType dims t2))) d arg =
-  Scalar $ Arrow als v pd (t1 `setAliases` mempty) $ RetType dims $ t2 `setAliases` als
-  where
-    -- Make sure to propagate the aliases of an existing closure.
-    als = old_als <> aliases (maskAliases arg d)
-returnType appres (Scalar (Sum cs)) d arg =
-  Scalar $ Sum $ (fmap . fmap) (\et -> returnType appres et d arg) cs
-
--- @t `maskAliases` d@ removes aliases (sets them to 'mempty') from
--- the parts of @t@ that are denoted as consumed by the 'Diet' @d@.
-maskAliases ::
-  Monoid as =>
-  TypeBase shape as ->
-  Diet ->
-  TypeBase shape as
-maskAliases t Consume = t `setAliases` mempty
-maskAliases t Observe = t
-
--- | The two types are assumed to be approximately structurally equal,
--- but not necessarily regarding sizes.  Combines aliases.
-addAliasesFromType :: PatType -> PatType -> PatType
-addAliasesFromType (Array als1 u1 et1 shape1) t2 =
-  Array (als1 <> aliases t2) u1 et1 shape1
-addAliasesFromType (Scalar (TypeVar als1 u1 tv1 targs1)) t2 =
-  Scalar $ TypeVar (als1 <> aliases t2) u1 tv1 targs1
-addAliasesFromType (Scalar (Record ts1)) (Scalar (Record ts2))
-  | length ts1 == length ts2,
-    sort (M.keys ts1) == sort (M.keys ts2) =
-      Scalar $ Record $ M.intersectionWith addAliasesFromType ts1 ts2
-addAliasesFromType
-  (Scalar (Arrow als1 mn1 d1 pt1 (RetType dims1 rt1)))
-  (Scalar (Arrow als2 _ _ _ (RetType _ rt2))) =
-    Scalar (Arrow (als1 <> als2) mn1 d1 pt1 (RetType dims1 rt1'))
-    where
-      rt1' = addAliasesFromType rt1 rt2
-addAliasesFromType (Scalar (Sum cs1)) (Scalar (Sum cs2))
-  | length cs1 == length cs2,
-    sort (M.keys cs1) == sort (M.keys cs2) =
-      Scalar $ Sum $ M.intersectionWith (zipWith addAliasesFromType) cs1 cs2
-addAliasesFromType (Scalar (Prim t)) _ = Scalar $ Prim t
-addAliasesFromType t1 t2 =
-  error $ "addAliasesFromType invalid args: " ++ show (t1, t2)
-
 -- | Ensure that the dimensions of the RetType are unique by
 -- generating new names for them.  This is to avoid name capture.
-renameRetType :: MonadTypeChecker m => StructRetType -> m StructRetType
+renameRetType :: MonadTypeChecker m => ResRetType -> m ResRetType
 renameRetType (RetType dims st)
   | dims /= mempty = do
       dims' <- mapM newName dims
@@ -153,10 +88,10 @@ renameRetType (RetType dims st)
 evalTypeExp ::
   MonadTypeChecker m =>
   TypeExp NoInfo Name ->
-  m (TypeExp Info VName, [VName], StructRetType, Liftedness)
+  m (TypeExp Info VName, [VName], ResRetType, Liftedness)
 evalTypeExp (TEVar name loc) = do
   (name', ps, t, l) <- lookupType loc name
-  t' <- renameRetType t
+  t' <- renameRetType $ toResRet Nonunique t
   case ps of
     [] -> pure (TEVar name' loc, [], t', l)
     _ ->
@@ -200,7 +135,7 @@ evalTypeExp t@(TERecord fs loc) = do
 evalTypeExp (TEArray d t loc) = do
   (d_svars, d', d'') <- checkSizeExp d
   (t', svars, RetType dims st, l) <- evalTypeExp t
-  case (l, arrayOf Nonunique (Shape [d'']) st) of
+  case (l, arrayOfWithAliases Nonunique (Shape [d'']) st) of
     (Unlifted, st') ->
       pure
         ( TEArray d' t' loc,
@@ -244,12 +179,12 @@ evalTypeExp (TEArrow (Just v) t1 t2 loc) = do
   (t1', svars1, RetType dims1 st1, _) <- evalTypeExp t1
   bindSpaced [(Term, v)] $ do
     v' <- checkName Term v loc
-    bindVal v' (BoundV [] st1) $ do
+    bindVal v' (BoundV [] $ toStruct st1) $ do
       (t2', svars2, RetType dims2 st2, _) <- evalTypeExp t2
       pure
         ( TEArrow (Just v') t1' t2' loc,
           svars1 ++ dims1 ++ svars2,
-          RetType [] $ Scalar $ Arrow mempty (Named v') (diet st1) st1 (RetType dims2 st2),
+          RetType [] $ Scalar $ Arrow mempty (Named v') (diet $ resToParam st1) (toStruct st1) (RetType dims2 st2),
           Lifted
         )
 --
@@ -260,7 +195,7 @@ evalTypeExp (TEArrow Nothing t1 t2 loc) = do
     ( TEArrow Nothing t1' t2' loc,
       svars1 ++ dims1 ++ svars2,
       RetType [] . Scalar $
-        Arrow mempty Unnamed (diet st1) (st1 `setUniqueness` Nonunique) $
+        Arrow mempty Unnamed (diet $ resToParam st1) (toStruct st1) $
           RetType dims2 st2,
       Lifted
     )
@@ -270,7 +205,7 @@ evalTypeExp (TEDim dims t loc) = do
     dims' <- mapM (flip (checkName Term) loc) dims
     bindDims dims' $ do
       (t', svars, RetType t_dims st, l) <- evalTypeExp t
-      let (witnessed, _) = determineSizeWitnesses st
+      let (witnessed, _) = determineSizeWitnesses $ toStruct st
       case find (`S.notMember` witnessed) dims' of
         Just d ->
           typeError loc mempty . withIndexLink "unused-existential" $
@@ -315,7 +250,7 @@ evalTypeExp t@(TESum cs loc) = do
 evalTypeExp ote@TEApply {} = do
   (tname, tname_loc, targs) <- rootAndArgs ote
   (tname', ps, tname_t, l) <- lookupType tloc tname
-  RetType t_dims t <- renameRetType tname_t
+  RetType t_dims t <- renameRetType $ toResRet Nonunique tname_t
   if length ps /= length targs
     then
       typeError tloc mempty $
@@ -330,7 +265,8 @@ evalTypeExp ote@TEApply {} = do
       pure
         ( foldl (\x y -> TEApply x y tloc) (TEVar tname' tname_loc) targs',
           [],
-          RetType (t_dims ++ mconcat dims) $ applySubst (`M.lookup` mconcat substs) t,
+          RetType (t_dims ++ mconcat dims) $
+            applySubst (`M.lookup` mconcat substs) t,
           l
         )
   where
@@ -371,7 +307,7 @@ evalTypeExp ote@TEApply {} = do
       pure
         ( TypeArgExpType te',
           svars ++ dims,
-          M.singleton pv $ Subst [] $ RetType [] st
+          M.singleton pv $ Subst [] $ RetType [] $ toStruct st
         )
     checkArgApply p a =
       typeError tloc mempty $
@@ -389,14 +325,14 @@ evalTypeExp ote@TEApply {} = do
 checkTypeExp ::
   MonadTypeChecker m =>
   TypeExp NoInfo Name ->
-  m (TypeExp Info VName, [VName], StructRetType, Liftedness)
+  m (TypeExp Info VName, [VName], ResRetType, Liftedness)
 checkTypeExp te = do
   checkForDuplicateNamesInType te
   evalTypeExp te
 
 -- | Check for duplication of names inside a binding group.
 checkForDuplicateNames ::
-  MonadTypeChecker m => [UncheckedTypeParam] -> [UncheckedPat] -> m ()
+  MonadTypeChecker m => [UncheckedTypeParam] -> [UncheckedPat t] -> m ()
 checkForDuplicateNames tps pats = (`evalStateT` mempty) $ do
   mapM_ checkTypeParam tps
   mapM_ checkPat pats
@@ -512,7 +448,7 @@ typeParamToArg :: TypeParam -> StructTypeArg
 typeParamToArg (TypeParamDim v ploc) =
   TypeArgDim $ sizeFromName (qualName v) ploc
 typeParamToArg (TypeParamType _ v _) =
-  TypeArgType $ Scalar $ TypeVar () Nonunique (qualName v) []
+  TypeArgType $ Scalar $ TypeVar mempty (qualName v) []
 
 -- | A type substitution may be a substitution or a yet-unknown
 -- substitution (but which is certainly an overloaded primitive
@@ -527,6 +463,11 @@ instance Pretty t => Pretty (Subst t) where
   pretty PrimSubst = "#<primsubst>"
   pretty (ExpSubst e) = pretty e
 
+instance Functor Subst where
+  fmap f (Subst ps t) = Subst ps $ f t
+  fmap _ PrimSubst = PrimSubst
+  fmap _ (ExpSubst e) = ExpSubst e
+
 -- | Create a type substitution corresponding to a type binding.
 substFromAbbr :: TypeBinding -> Subst StructRetType
 substFromAbbr (TypeAbbr _ ps rt) = Subst ps rt
@@ -534,33 +475,31 @@ substFromAbbr (TypeAbbr _ ps rt) = Subst ps rt
 -- | Substitutions to apply in a type.
 type TypeSubs = VName -> Maybe (Subst StructRetType)
 
-instance Functor Subst where
-  fmap f (Subst ps t) = Subst ps $ f t
-  fmap _ PrimSubst = PrimSubst
-  fmap _ (ExpSubst e) = ExpSubst e
-
 -- | Class of types which allow for substitution of types with no
 -- annotations for type variable names.
 class Substitutable a where
   applySubst :: TypeSubs -> a -> a
 
-instance Substitutable (RetTypeBase Size ()) where
-  applySubst f (RetType dims t) =
-    let RetType more_dims t' = substTypesRet f t
-     in RetType (dims ++ more_dims) t'
-
-instance Substitutable (RetTypeBase Size Aliasing) where
+instance Substitutable (RetTypeBase Size Uniqueness) where
   applySubst f (RetType dims t) =
     let RetType more_dims t' = substTypesRet f' t
      in RetType (dims ++ more_dims) t'
     where
       f' = fmap (fmap (second (const mempty))) . f
 
-instance Substitutable (TypeBase Size ()) where
+instance Substitutable (RetTypeBase Size NoUniqueness) where
+  applySubst f (RetType dims t) =
+    let RetType more_dims t' = substTypesRet f t
+     in RetType (dims ++ more_dims) t'
+
+instance Substitutable StructType where
   applySubst = substTypesAny
 
-instance Substitutable (TypeBase Size Aliasing) where
-  applySubst = substTypesAny . (fmap (fmap (second (const mempty))) .)
+instance Substitutable ParamType where
+  applySubst f = substTypesAny $ fmap (fmap $ second $ const Observe) . f
+
+instance Substitutable (TypeBase Size Uniqueness) where
+  applySubst f = substTypesAny $ fmap (fmap $ second $ const Nonunique) . f
 
 instance Substitutable Exp where
   applySubst f = runIdentity . mapOnExp
@@ -574,15 +513,14 @@ instance Substitutable Exp where
           { mapOnExp,
             mapOnName = pure,
             mapOnStructType = pure . applySubst f,
-            mapOnPatType = pure . applySubst f,
-            mapOnStructRetType = pure . applySubst f,
-            mapOnPatRetType = pure . applySubst f
+            mapOnParamType = pure . applySubst f,
+            mapOnResRetType = pure . applySubst f
           }
 
 instance Substitutable d => Substitutable (Shape d) where
   applySubst f = fmap $ applySubst f
 
-instance Substitutable Pat where
+instance Substitutable (Pat StructType) where
   applySubst f = runIdentity . astMap mapper
     where
       mapper =
@@ -590,9 +528,20 @@ instance Substitutable Pat where
           { mapOnExp = pure . applySubst f,
             mapOnName = pure,
             mapOnStructType = pure . applySubst f,
-            mapOnPatType = pure . applySubst f,
-            mapOnStructRetType = pure . applySubst f,
-            mapOnPatRetType = pure . applySubst f
+            mapOnParamType = pure . applySubst f,
+            mapOnResRetType = pure . applySubst f
+          }
+
+instance Substitutable (Pat ParamType) where
+  applySubst f = runIdentity . astMap mapper
+    where
+      mapper =
+        ASTMapper
+          { mapOnExp = pure . applySubst f,
+            mapOnName = pure,
+            mapOnStructType = pure . applySubst f,
+            mapOnParamType = pure . applySubst f,
+            mapOnResRetType = pure . applySubst f
           }
 
 applyType ::
@@ -648,24 +597,21 @@ substTypesRet lookupSubst ot =
       TypeBase Size as ->
       State [VName] (TypeBase Size as)
 
-    onType (Array als u shape et) = do
-      t <- arrayOf u (applySubst lookupSubst' shape) <$> onType (Scalar et)
-      pure $ t `setAliases` als
+    onType (Array u shape et) =
+      arrayOfWithAliases u (applySubst lookupSubst' shape)
+        <$> onType (second (const mempty) $ Scalar et)
     onType (Scalar (Prim t)) = pure $ Scalar $ Prim t
-    onType (Scalar (TypeVar als u v targs)) = do
+    onType (Scalar (TypeVar u v targs)) = do
       targs' <- mapM subsTypeArg targs
       case lookupSubst $ qualLeaf v of
         Just (Subst ps rt) -> do
           RetType ext t <- freshDims rt
           modify (ext ++)
-          pure $
-            applyType ps (t `setAliases` mempty) targs'
-              `setUniqueness` u
-              `addAliases` (<> als)
+          pure $ second (<> u) $ applyType ps (second (const u) t) targs'
         Just PrimSubst ->
-          pure $ Scalar $ TypeVar mempty u v targs'
+          pure $ Scalar $ TypeVar u v targs'
         _ ->
-          pure $ Scalar $ TypeVar als u v targs'
+          pure $ Scalar $ TypeVar u v targs'
     onType (Scalar (Record ts)) =
       Scalar . Record <$> traverse onType ts
     onType (Scalar (Arrow als v d t1 t2)) =
@@ -691,7 +637,7 @@ substTypesRet lookupSubst ot =
     subsTypeArg (TypeArgDim v) =
       pure $ TypeArgDim $ applySubst lookupSubst' v
 
-    lookupSubst' = fmap (fmap $ second (const ())) . lookupSubst
+    lookupSubst' = fmap (fmap $ second (const NoUniqueness)) . lookupSubst
 
 -- | Perform substitutions, from type names to types, on a type. Works
 -- regardless of what shape and uniqueness information is attached to the type.

--- a/src/Language/Futhark/TypeChecker/Unify.hs
+++ b/src/Language/Futhark/TypeChecker/Unify.hs
@@ -154,7 +154,6 @@ type Constraints = M.Map VName (Level, Constraint)
 lookupSubst :: VName -> Constraints -> Maybe (Subst StructRetType)
 lookupSubst v constraints = case snd <$> M.lookup v constraints of
   Just (Constraint t _) -> Just $ Subst [] $ applySubst (`lookupSubst` constraints) t
-  Just Overloaded {} -> Just PrimSubst
   Just (Size (Just d) _) ->
     Just $ ExpSubst $ applySubst (`lookupSubst` constraints) d
   _ -> Nothing

--- a/src/Language/Futhark/TypeChecker/Unify.hs
+++ b/src/Language/Futhark/TypeChecker/Unify.hs
@@ -20,7 +20,7 @@ module Language.Futhark.TypeChecker.Unify
     mustHaveField,
     mustBeOneOf,
     equalityType,
-    normPatType,
+    normType,
     normTypeFully,
     unify,
     unifyMostCommon,
@@ -330,22 +330,12 @@ normTypeFully t = do
 
 -- | Replace any top-level type variable with its substitution.
 normType :: MonadUnify m => StructType -> m StructType
-normType t@(Scalar (TypeVar _ _ (QualName [] v) [])) = do
+normType t@(Scalar (TypeVar _ (QualName [] v) [])) = do
   constraints <- getConstraints
   case snd <$> M.lookup v constraints of
     Just (Constraint (RetType [] t') _) -> normType t'
     _ -> pure t
 normType t = pure t
-
--- | Replace any top-level type variable with its substitution.
-normPatType :: MonadUnify m => PatType -> m PatType
-normPatType t@(Scalar (TypeVar als u (QualName [] v) [])) = do
-  constraints <- getConstraints
-  case snd <$> M.lookup v constraints of
-    Just (Constraint (RetType [] t') _) ->
-      normPatType $ t' `setUniqueness` u `setAliases` als
-    _ -> pure t
-normPatType t = pure t
 
 rigidConstraint :: Constraint -> Bool
 rigidConstraint ParamType {} = True
@@ -445,15 +435,15 @@ unifyWith onDims usage = subunify False
                         ++ filter (`notElem` M.keys fs) (M.keys arg_fs)
                 unifyError usage mempty bcs $
                   "Unshared fields:" <+> commasep (map pretty missing) <> "."
-        ( Scalar (TypeVar _ _ (QualName _ tn) targs),
-          Scalar (TypeVar _ _ (QualName _ arg_tn) arg_targs)
+        ( Scalar (TypeVar _ (QualName _ tn) targs),
+          Scalar (TypeVar _ (QualName _ arg_tn) arg_targs)
           )
             | tn == arg_tn,
               length targs == length arg_targs -> do
                 let bcs' = breadCrumb (Matching "When matching type arguments.") bcs
                 zipWithM_ (unifyTypeArg bcs') targs arg_targs
-        ( Scalar (TypeVar _ _ (QualName [] v1) []),
-          Scalar (TypeVar _ _ (QualName [] v2) [])
+        ( Scalar (TypeVar _ (QualName [] v1) []),
+          Scalar (TypeVar _ (QualName [] v2) [])
           ) ->
             case (nonrigid v1, nonrigid v2) of
               (Nothing, Nothing) -> failure
@@ -462,10 +452,10 @@ unifyWith onDims usage = subunify False
               (Just lvl1, Just lvl2)
                 | lvl1 <= lvl2 -> link ord v1 lvl1 t2'
                 | otherwise -> link (not ord) v2 lvl2 t1'
-        (Scalar (TypeVar _ _ (QualName [] v1) []), _)
+        (Scalar (TypeVar _ (QualName [] v1) []), _)
           | Just lvl <- nonrigid v1 ->
               link ord v1 lvl t2'
-        (_, Scalar (TypeVar _ _ (QualName [] v2) []))
+        (_, Scalar (TypeVar _ (QualName [] v2) []))
           | Just lvl <- nonrigid v2 ->
               link (not ord) v2 lvl t1'
         ( Scalar (Arrow _ p1 d1 a1 (RetType b1_dims b1)),
@@ -509,8 +499,8 @@ unifyWith onDims usage = subunify False
                   ord
                   bound'
                   (breadCrumb (Matching "When matching return types.") bcs)
-                  b1'
-                  b2'
+                  (toStruct b1')
+                  (toStruct b2')
 
                 -- Delete the size variables we introduced to represent
                 -- the existential sizes.
@@ -576,7 +566,7 @@ unifySizes usage bcs _ _ e1 e2 = do
 
 -- | Unifies two types.
 unify :: MonadUnify m => Usage -> StructType -> StructType -> m ()
-unify usage = unifyWith (unifySizes usage) usage mempty noBreadCrumbs
+unify usage t1 t2 = unifyWith (unifySizes usage) usage mempty noBreadCrumbs (toStruct t1) (toStruct t2)
 
 -- | @expect super sub@ checks that @sub@ is a subtype of @super@.
 expect :: MonadUnify m => Usage -> StructType -> StructType -> m ()
@@ -694,7 +684,7 @@ linkVarToType onDims usage bound bcs vn lvl tp_unnorm = do
       | tp `notElem` map (Scalar . Prim) ts -> do
           link
           case tp of
-            Scalar (TypeVar _ _ (QualName [] v) [])
+            Scalar (TypeVar _ (QualName [] v) [])
               | not $ isRigid v constraints ->
                   linkVarToTypes usage v ts
             _ ->
@@ -720,7 +710,7 @@ linkVarToType onDims usage bound bcs vn lvl tp_unnorm = do
               modifyConstraints $
                 M.insert vn (lvl, Constraint (RetType ext tp') usage)
               unifySharedFields onDims usage bound bcs required_fields' tp_fields
-        Scalar (TypeVar _ _ (QualName [] v) []) -> do
+        Scalar (TypeVar _ (QualName [] v) []) -> do
           case M.lookup v constraints of
             Just (_, HasFields _ tp_fields _) ->
               unifySharedFields onDims usage bound bcs required_fields tp_fields
@@ -764,7 +754,7 @@ linkVarToType onDims usage bound bcs vn lvl tp_unnorm = do
               unifySharedConstructors onDims usage bound bcs required_cs ts
           | otherwise ->
               unsharedConstructors required_cs ts =<< typeVarNotes vn
-        Scalar (TypeVar _ _ (QualName [] v) []) -> do
+        Scalar (TypeVar _ (QualName [] v) []) -> do
           case M.lookup v constraints of
             Just (_, HasConstrs _ v_cs _) ->
               unifySharedConstructors onDims usage bound bcs required_cs v_cs
@@ -856,7 +846,7 @@ mustBeOneOf ts usage t = do
   let isRigid' v = isRigid v constraints
 
   case t' of
-    Scalar (TypeVar _ _ (QualName [] v) [])
+    Scalar (TypeVar _ (QualName [] v) [])
       | not $ isRigid' v -> linkVarToTypes usage v ts
     Scalar (Prim pt) | pt `elem` ts -> pure ()
     _ -> failure
@@ -903,9 +893,9 @@ linkVarToTypes usage vn ts = do
 
 -- | Assert that this type must support equality.
 equalityType ::
-  (MonadUnify m, Pretty (Shape dim), Monoid as) =>
+  (MonadUnify m, Pretty (Shape dim), Pretty u) =>
   Usage ->
-  TypeBase dim as ->
+  TypeBase dim u ->
   m ()
 equalityType usage t = do
   unless (orderZero t) $
@@ -916,7 +906,7 @@ equalityType usage t = do
     mustBeEquality vn = do
       constraints <- getConstraints
       case M.lookup vn constraints of
-        Just (_, Constraint (RetType [] (Scalar (TypeVar _ _ (QualName [] vn') []))) _) ->
+        Just (_, Constraint (RetType [] (Scalar (TypeVar _ (QualName [] vn') []))) _) ->
           mustBeEquality vn'
         Just (_, Constraint (RetType _ vn_t) cusage)
           | not $ orderZero vn_t ->
@@ -979,10 +969,10 @@ zeroOrderType usage desc =
     bc = Matching $ "When checking" <+> textwrap desc
 
 arrayElemTypeWith ::
-  (MonadUnify m, Pretty (Shape dim), Monoid as) =>
+  (MonadUnify m, Pretty (Shape dim), Pretty u) =>
   Usage ->
   BreadCrumbs ->
-  TypeBase dim as ->
+  TypeBase dim u ->
   m ()
 arrayElemTypeWith usage bcs t = do
   unless (orderZero t) $
@@ -1007,10 +997,10 @@ arrayElemTypeWith usage bcs t = do
 
 -- | Assert that this type must be valid as an array element.
 arrayElemType ::
-  (MonadUnify m, Pretty (Shape dim), Monoid as) =>
+  (MonadUnify m, Pretty (Shape dim), Pretty u) =>
   Usage ->
   T.Text ->
-  TypeBase dim as ->
+  TypeBase dim u ->
   m ()
 arrayElemType usage desc =
   arrayElemTypeWith usage $ breadCrumb bc noBreadCrumbs
@@ -1063,7 +1053,7 @@ mustHaveConstr ::
 mustHaveConstr usage c t fs = do
   constraints <- getConstraints
   case t of
-    Scalar (TypeVar _ _ (QualName _ tn) [])
+    Scalar (TypeVar _ (QualName _ tn) [])
       | Just (lvl, NoConstraint l _) <- M.lookup tn constraints -> do
           mapM_ (scopeCheck usage noBreadCrumbs tn lvl) fs
           modifyConstraints $ M.insert tn (lvl, HasConstrs l (M.singleton c fs) usage)
@@ -1097,18 +1087,17 @@ mustHaveFieldWith ::
   [VName] ->
   BreadCrumbs ->
   Name ->
-  PatType ->
-  m PatType
+  StructType ->
+  m StructType
 mustHaveFieldWith onDims usage bound bcs l t = do
   constraints <- getConstraints
   l_type <- newTypeVar (srclocOf usage) "t"
-  let l_type' = l_type `setAliases` aliases t
   case t of
-    Scalar (TypeVar _ _ (QualName _ tn) [])
+    Scalar (TypeVar _ (QualName _ tn) [])
       | Just (lvl, NoConstraint {}) <- M.lookup tn constraints -> do
           scopeCheck usage bcs tn lvl l_type
           modifyConstraints $ M.insert tn (lvl, HasFields Lifted (M.singleton l l_type) usage)
-          pure l_type'
+          pure l_type
       | Just (lvl, HasFields lifted fields _) <- M.lookup tn constraints -> do
           case M.lookup l fields of
             Just t' -> unifyWith onDims usage bound bcs l_type t'
@@ -1117,7 +1106,7 @@ mustHaveFieldWith onDims usage bound bcs l t = do
                 M.insert
                   tn
                   (lvl, HasFields lifted (M.insert l l_type fields) usage)
-          pure l_type'
+          pure l_type
     Scalar (Record fields)
       | Just t' <- M.lookup l fields -> do
           unify usage l_type $ toStruct t'
@@ -1130,15 +1119,15 @@ mustHaveFieldWith onDims usage bound bcs l t = do
               <+> pretty (toStructural t) <> "."
     _ -> do
       unify usage (toStruct t) $ Scalar $ Record $ M.singleton l l_type
-      pure l_type'
+      pure l_type
 
 -- | Assert that some type must have a field with this name and type.
 mustHaveField ::
   MonadUnify m =>
   Usage ->
   Name ->
-  PatType ->
-  m PatType
+  StructType ->
+  m StructType
 mustHaveField usage = mustHaveFieldWith (unifySizes usage) usage mempty noBreadCrumbs
 
 newDimOnMismatch ::
@@ -1170,9 +1159,9 @@ newDimOnMismatch loc t1 t2 = do
 unifyMostCommon ::
   MonadUnify m =>
   Usage ->
-  PatType ->
-  PatType ->
-  m (PatType, [VName])
+  StructType ->
+  StructType ->
+  m (StructType, [VName])
 unifyMostCommon usage t1 t2 = do
   -- We are ignoring the dimensions here, because any mismatches
   -- should be turned into fresh size variables.
@@ -1208,7 +1197,7 @@ instance MonadUnify UnifyM where
   newTypeVar loc name = do
     v <- newVar name
     modifyConstraints $ M.insert v (0, NoConstraint Lifted $ Usage Nothing loc)
-    pure $ Scalar $ TypeVar mempty Nonunique (qualName v) []
+    pure $ Scalar $ TypeVar mempty (qualName v) []
 
   newDimVar usage rigidity name = do
     dim <- newVar name

--- a/tests/accs/intrinsics.fut
+++ b/tests/accs/intrinsics.fut
@@ -5,7 +5,7 @@ type~ acc 't = intrinsics.acc t
 
 def scatter_stream [k] 'a 'b
                    (dest: *[k]a)
-                   (f: *acc ([k]a) -> b -> *acc ([k]a))
+                   (f: *acc ([k]a) -> b -> acc ([k]a))
                    (bs: []b)
                  : *[k]a =
   intrinsics.scatter_stream dest f bs :> *[k]a
@@ -14,7 +14,7 @@ def reduce_by_index_stream [k] 'a 'b
                    (dest: *[k]a)
                    (op: a -> a -> a)
                    (ne: a)
-                   (f: *acc ([k]a) -> b -> *acc ([k]a))
+                   (f: *acc ([k]a) -> b -> acc ([k]a))
                    (bs: []b)
                  : *[k]a =
   intrinsics.hist_stream dest op ne f bs :> *[k]a

--- a/tests/fusion/Vers2.0/mapomap0.fut
+++ b/tests/fusion/Vers2.0/mapomap0.fut
@@ -14,6 +14,5 @@
 def main(arr: []f64): ([]f64,[]f64,[]f64) =
     let x = map     (+ 1.0) arr
     let y = map2    (+) x arr
-    let r = map     (+ 5.0) arr in
-    (r,x,y)
-
+    let r = map     (+ 5.0) arr
+    in (r,x,y)

--- a/tests/issue1749.fut
+++ b/tests/issue1749.fut
@@ -1,5 +1,5 @@
 -- ==
--- error: "consume".*"Test.empty"
+-- error: Consuming.*"empty"
 
 module Test = {
     let empty = []

--- a/tests/issue596.fut
+++ b/tests/issue596.fut
@@ -1,5 +1,5 @@
 -- ==
--- error: Consuming "xs"
+-- error: Consuming.*"xs"
 
 def consume (xs: *[]i32) = xs
 

--- a/tests/issue844.fut
+++ b/tests/issue844.fut
@@ -1,5 +1,5 @@
 -- ==
--- error: Consuming "xs"
+-- error: Consuming.*"xs"
 
 module type mt = {
   type~ t

--- a/tests/issue879.fut
+++ b/tests/issue879.fut
@@ -1,5 +1,5 @@
 -- ==
--- error: Consuming "s"
+-- error: Consuming.*"s"
 
 def f (xs: [10]i32) : [10]i32 = xs
 

--- a/tests/issue880.fut
+++ b/tests/issue880.fut
@@ -1,5 +1,5 @@
 -- ==
--- error: Consuming "xs"
+-- error: Consuming.*"xs"
 
 type t = {xs: [10]i32}
 

--- a/tests/migration/intrinsics.fut
+++ b/tests/migration/intrinsics.fut
@@ -20,7 +20,7 @@ type~ acc 't = intrinsics.acc t
 
 def scatter_stream [k] 'a 'b
                    (dest: *[k]a)
-                   (f: *acc ([k]a) -> b -> *acc ([k]a))
+                   (f: *acc ([k]a) -> b -> acc ([k]a))
                    (bs: []b)
                  : *[k]a =
   intrinsics.scatter_stream dest f bs :> *[k]a
@@ -29,7 +29,7 @@ def reduce_by_index_stream [k] 'a 'b
                    (dest: *[k]a)
                    (op: a -> a -> a)
                    (ne: a)
-                   (f: *acc ([k]a) -> b -> *acc ([k]a))
+                   (f: *acc ([k]a) -> b -> acc ([k]a))
                    (bs: []b)
                  : *[k]a =
   intrinsics.hist_stream dest op ne f bs :> *[k]a

--- a/tests/modules/ascription-error3.fut
+++ b/tests/modules/ascription-error3.fut
@@ -2,5 +2,5 @@
 -- ==
 -- error: \*\[d\]i32
 
-module type mt = { val f : i32 -> ?[d].*[d]i32 }
-module m = { def f (n: i32): []i32 = [n] } : mt
+module type mt = { val f [n] : [n]i32 -> ?[d].*[d]i32 }
+module m = { def f (ns: []i32): []i32 = ns } : mt

--- a/tests/shapes/range3.fut
+++ b/tests/shapes/range3.fut
@@ -1,8 +1,0 @@
--- Ranges with unknown size produce warnings
--- ==
--- warning: with consumption
-
-def consume (xs: *[]i64): i64 = xs[0]
-
-def main (xs:*[]i64) =
-  0..<(consume xs)

--- a/tests/sumtypes/sumtype21.fut
+++ b/tests/sumtypes/sumtype21.fut
@@ -2,10 +2,10 @@
 -- ==
 -- error: "xs".*consumed
 
-type^ sum = #foo ([]i32) | #bar ([]i32)
+type sum [n] = #foo ([n]i32) | #bar ([n]i32)
 
-def main (xs: *[]i32) =
-  let v : sum = #foo xs
+def main [n] (xs: *[n]i32) =
+  let v : sum [n] = #foo xs
   let xs[0] = 0
   let v' = v
   in 0

--- a/tests/types/inference32.fut
+++ b/tests/types/inference32.fut
@@ -1,7 +1,7 @@
 -- Inferring a unique type is never allowed - it must always be put
 -- there explicitly!
 -- ==
--- error: Consuming "xs"
+-- error: Consuming.*"xs"
 
 def consume (xs: *[]i32) = xs
 

--- a/tests/uniqueness/uniqueness-error0.fut
+++ b/tests/uniqueness/uniqueness-error0.fut
@@ -1,6 +1,6 @@
 -- Type ascription should not hide aliases.
 -- ==
--- error: "b".*consumed
+-- error: "a".*consumed
 
 def main(): i64 =
   let a = iota(10)

--- a/tests/uniqueness/uniqueness-error1.fut
+++ b/tests/uniqueness/uniqueness-error1.fut
@@ -1,7 +1,7 @@
 -- Test whether multiple references within the same sequence are
 -- detected.
 -- ==
--- error: "b".*consumed
+-- error: "a".*consumed
 
 def main(): i32 =
     let n = 10

--- a/tests/uniqueness/uniqueness-error12.fut
+++ b/tests/uniqueness/uniqueness-error12.fut
@@ -5,8 +5,7 @@
 def f(a: *[]i64) (i: i64): []i64 =
   let a[i] = 0 in a
 
-def main(): [][]i32 =
-    let n = 10
+def main n =
     let a = iota(n)
     let b = iota(n) in
     map (f (a)) b -- Bad, because a may be consumed many times.

--- a/tests/uniqueness/uniqueness-error14.fut
+++ b/tests/uniqueness/uniqueness-error14.fut
@@ -3,7 +3,7 @@
 -- ==
 -- error: "arr" aliases "barr"
 
-def main(): i32 =
+def main(): i64 =
   let arr = copy(iota(10))
   let barr = copy(iota(10)) in
   let arr = loop arr for i < 10 do

--- a/tests/uniqueness/uniqueness-error17.fut
+++ b/tests/uniqueness/uniqueness-error17.fut
@@ -3,8 +3,7 @@
 -- ==
 -- error: .*consumed.*
 
-def main(): i32 =
-  let n = 10
+def main n =
   let a = iota(n)
   let c = if 2==2 then iota(n) else a -- c aliases a.
   let c[0] = 4 in -- Consume c and a.

--- a/tests/uniqueness/uniqueness-error2.fut
+++ b/tests/uniqueness/uniqueness-error2.fut
@@ -3,7 +3,7 @@
 -- ==
 -- error: .*consumed.*
 
-def main(): []i32 =
+def main(): []i64 =
     let n = 10
     let a = replicate n (iota n) -- Note that a is 2-dimensional
     let b = a[0] -- Now b aliases a.

--- a/tests/uniqueness/uniqueness-error21.fut
+++ b/tests/uniqueness/uniqueness-error21.fut
@@ -1,7 +1,7 @@
 -- This benchmark tests whether aliasing is tracked even deep inside
 -- loops.
 -- ==
--- error: consume.*"D"
+-- error: "DT".*consumed
 
 def floydSbsImp(N: i32, D: *[][]i32): [][]i32 =
     let DT = transpose(D) -- DT aliases D.

--- a/tests/uniqueness/uniqueness-error21.fut
+++ b/tests/uniqueness/uniqueness-error21.fut
@@ -1,7 +1,7 @@
 -- This benchmark tests whether aliasing is tracked even deep inside
 -- loops.
 -- ==
--- error: "D".*consumed
+-- error: consume.*"D"
 
 def floydSbsImp(N: i32, D: *[][]i32): [][]i32 =
     let DT = transpose(D) -- DT aliases D.

--- a/tests/uniqueness/uniqueness-error22.fut
+++ b/tests/uniqueness/uniqueness-error22.fut
@@ -1,6 +1,6 @@
 -- Test that we cannot consume anything inside an anonymous function.
 -- ==
--- error: Would consume variable "a"
+-- error: Consuming variable "a"
 
 def f(a: *[]i64) = a[0]
 

--- a/tests/uniqueness/uniqueness-error27.fut
+++ b/tests/uniqueness/uniqueness-error27.fut
@@ -1,7 +1,7 @@
 -- You may not consume a free variable inside of a lambda.
 --
 -- ==
--- error: Would consume variable "a"
+-- error: Consuming variable "a"
 
 def consume(a: *[]i32): []i32 = a
 

--- a/tests/uniqueness/uniqueness-error3.fut
+++ b/tests/uniqueness/uniqueness-error3.fut
@@ -1,8 +1,7 @@
 -- ==
 -- error: "a".*consumed
 
-def main(): i32 =
-    let n = 10
+def main n =
     let a = iota(n)
     let b = a -- b and a alias each other.
     let (i,j) = (2,5) in

--- a/tests/uniqueness/uniqueness-error35.fut
+++ b/tests/uniqueness/uniqueness-error35.fut
@@ -1,5 +1,5 @@
 -- Loop parameters must respect uniqueness.
 -- ==
--- error: consume.*"x"
+-- error: Consuming.*"x"
 
 def main (x: []i32) = loop (x: *[]i32) for i < 10 do x

--- a/tests/uniqueness/uniqueness-error35.fut
+++ b/tests/uniqueness/uniqueness-error35.fut
@@ -1,5 +1,5 @@
 -- Loop parameters must respect uniqueness.
 -- ==
--- error: Consuming "x"
+-- error: consume.*"x"
 
 def main (x: []i32) = loop (x: *[]i32) for i < 10 do x

--- a/tests/uniqueness/uniqueness-error46.fut
+++ b/tests/uniqueness/uniqueness-error46.fut
@@ -3,8 +3,6 @@
 -- ==
 -- error: "f".*which is not consumable
 
-def g (_: *[]i32) = true
-
 def f (f: i32 -> []i32): i32 =
   let xs = f 1
   let xs[0] = xs[0] + 2

--- a/tests/uniqueness/uniqueness-error49.fut
+++ b/tests/uniqueness/uniqueness-error49.fut
@@ -1,6 +1,6 @@
 -- Do not let ascription screw up uniqueness/aliasing.
 -- ==
--- error: Consuming "xs"
+-- error: consume.*"xs"
 
 def f 't (x: t) = id (x : t)
 def main (xs: []i32) = f xs with [0] = 0

--- a/tests/uniqueness/uniqueness-error49.fut
+++ b/tests/uniqueness/uniqueness-error49.fut
@@ -1,6 +1,6 @@
 -- Do not let ascription screw up uniqueness/aliasing.
 -- ==
--- error: consume.*"xs"
+-- error: Consuming.*"xs"
 
 def f 't (x: t) = id (x : t)
 def main (xs: []i32) = f xs with [0] = 0

--- a/tests/uniqueness/uniqueness-error5.fut
+++ b/tests/uniqueness/uniqueness-error5.fut
@@ -2,8 +2,7 @@
 -- error: .*consumed.*
 def f(a: *[][]i64): i64 = a[0,0]
 
-def main(): i32 =
-    let n = 10
+def main n =
     let a = replicate n (iota n)
     let c = transpose a in -- Rearrange creates an alias.
     f(a) + c[0,0] -- f(a) consumes both a and c, so error.

--- a/tests/uniqueness/uniqueness-error51.fut
+++ b/tests/uniqueness/uniqueness-error51.fut
@@ -1,6 +1,6 @@
 -- Type inference should not eliminate uniqueness checking.
 -- ==
--- error: consume.*"xs"
+-- error: Consuming.*"xs"
 
 def f {xs: []i32} : {xs: []i32} = {xs}
 

--- a/tests/uniqueness/uniqueness-error51.fut
+++ b/tests/uniqueness/uniqueness-error51.fut
@@ -1,6 +1,6 @@
 -- Type inference should not eliminate uniqueness checking.
 -- ==
--- error: Consuming "xs"
+-- error: consume.*"xs"
 
 def f {xs: []i32} : {xs: []i32} = {xs}
 

--- a/tests/uniqueness/uniqueness-error63.fut
+++ b/tests/uniqueness/uniqueness-error63.fut
@@ -1,0 +1,10 @@
+-- Issue #1975
+-- ==
+-- error: aliased to some other component
+
+def main n : (*[]i64, *[]i64) =
+  let (foo,bar) =
+    loop _ = (iota 10,iota 10) for i < n do
+    let arr = iota 10
+    in (arr,arr)
+  in (foo,bar)

--- a/tests/uniqueness/uniqueness-error7.fut
+++ b/tests/uniqueness/uniqueness-error7.fut
@@ -1,9 +1,8 @@
 -- ==
 -- error: "a".*consumed
 
-def main(): i32 =
-    let n = 10
+def main n =
     let a = iota(n)
     let b = iota(n)
     let i = 0 in
-    (let b=a in b[i]) + (let a[i]=b[i] in a[i]) -- Bad because of parallel consume-observe collision.
+    (let a[i]=b[i] in a[i]) + (let b=a in b[i])  -- Bad because of parallel consume-observe collision.

--- a/tests/uniqueness/uniqueness-error9.fut
+++ b/tests/uniqueness/uniqueness-error9.fut
@@ -7,8 +7,7 @@ def f(x: (i32, i32), t: (i32, i32, []i64)): []i64 =
     let (x, y, a) = t in
     a
 
-def main(): []i32 =
-    let n = 10
+def main n =
     let a = iota(n)
     let t = (3, 4, a)
     let b = f((1,2), t)

--- a/tests/uniqueness/uniqueness-warn0.fut
+++ b/tests/uniqueness/uniqueness-warn0.fut
@@ -1,7 +1,0 @@
--- It is bad to give consuming argument that is used in size
--- but it is accepted
--- ==
--- warning: with consumption
-
-def consume (xs: *[]i64): i64 = xs[0]
-def f [n] (ns: *[n]i64) = iota (consume ns)

--- a/tests/uniqueness/uniqueness-warn1.fut
+++ b/tests/uniqueness/uniqueness-warn1.fut
@@ -1,9 +1,0 @@
--- Bad to consume in slices, but accepted
--- ==
--- warning: with consumption
-
-def consume (xs: *[]i64): i64 = xs[0]
-
-def main (n:i64) (xs:*[n]i64) =
-  let t = iota n
-  in t[:consume xs]

--- a/tests/uniqueness/uniqueness57.fut
+++ b/tests/uniqueness/uniqueness57.fut
@@ -1,5 +1,5 @@
 -- ==
--- error: Using variable "xs", but this was consumed
+-- error: "f".*consumed
 
 def main [n] (xs: *[n]i32) =
   let f i = xs[i]

--- a/unittests/Language/Futhark/SyntaxTests.hs
+++ b/unittests/Language/Futhark/SyntaxTests.hs
@@ -3,6 +3,7 @@
 module Language.Futhark.SyntaxTests (tests) where
 
 import Control.Applicative hiding (many, some)
+import Data.Bifunctor
 import Data.Char (isAlpha)
 import Data.Functor
 import Data.Map qualified as M
@@ -119,63 +120,70 @@ pSize =
         flip sizeFromName mempty <$> pQualName
       ]
 
-pScalarNonFun :: Parser (ScalarTypeBase Size ())
+pScalarNonFun :: Parser (ScalarTypeBase Size Uniqueness)
 pScalarNonFun =
   choice
     [ Prim <$> pPrimType,
       pTypeVar,
-      tupleRecord <$> parens (pStructType `sepBy` lexeme ","),
+      tupleRecord <$> parens (pType `sepBy` lexeme ","),
       Record . M.fromList <$> braces (pField `sepBy1` lexeme ",")
     ]
   where
-    pField = (,) <$> pName <* lexeme ":" <*> pStructType
-    pTypeVar = TypeVar () <$> pUniqueness <*> pQualName <*> many pTypeArg
+    pField = (,) <$> pName <* lexeme ":" <*> pType
+    pTypeVar = TypeVar <$> pUniqueness <*> pQualName <*> many pTypeArg
     pTypeArg =
       choice
         [ TypeArgDim <$> pSize,
-          TypeArgType <$> pTypeArgType
+          TypeArgType . second (const NoUniqueness) <$> pTypeArgType
         ]
     pTypeArgType =
       choice
         [ Scalar . Prim <$> pPrimType,
-          parens pStructType
+          parens pType
         ]
 
-pArrayType :: Parser StructType
+pArrayType :: Parser ResType
 pArrayType =
-  Array () <$> pUniqueness <*> (Shape <$> some pSize) <*> pScalarNonFun
+  Array
+    <$> pUniqueness
+    <*> (Shape <$> some pSize)
+    <*> (second (const NoUniqueness) <$> pScalarNonFun)
 
-pNonFunType :: Parser StructType
+pNonFunType :: Parser ResType
 pNonFunType =
-  choice [try pArrayType, try $ parens pStructType, Scalar <$> pScalarNonFun]
+  choice
+    [ try pArrayType,
+      try $ parens pType,
+      Scalar <$> pScalarNonFun
+    ]
 
-pScalarType :: Parser (ScalarTypeBase Size ())
+pScalarType :: Parser (ScalarTypeBase Size Uniqueness)
 pScalarType = choice [try pFun, pScalarNonFun]
   where
     pFun =
-      pParam <* lexeme "->" <*> pStructRetType
+      pParam <* lexeme "->" <*> pRetType
     pParam =
       choice
         [ try pNamedParam,
           do
             t <- pNonFunType
-            pure $ Arrow () Unnamed (diet t) t
+            pure $ Arrow Nonunique Unnamed (diet $ resToParam t) (toStruct t)
         ]
     pNamedParam = parens $ do
       v <- pVName <* lexeme ":"
-      t <- pStructType
-      pure $ Arrow () (Named v) (diet t) t
+      t <- pType
+      pure $ Arrow Nonunique (Named v) (diet $ resToParam t) (toStruct t)
 
-pStructRetType :: Parser StructRetType
-pStructRetType =
+pRetType :: Parser ResRetType
+pRetType =
   choice
-    [ lexeme "?" *> (RetType <$> some (brackets pVName) <* lexeme "." <*> pStructType),
-      RetType [] <$> pStructType
+    [ lexeme "?" *> (RetType <$> some (brackets pVName) <* lexeme "." <*> pType),
+      RetType [] <$> pType
     ]
 
-pStructType :: Parser StructType
-pStructType =
-  choice [try $ Scalar <$> pScalarType, pArrayType, parens pStructType]
+pType :: Parser ResType
+pType =
+  choice [try $ Scalar <$> pScalarType, pArrayType, parens pType]
 
 fromStringParse :: Parser a -> String -> String -> a
 fromStringParse p what s =
@@ -184,11 +192,17 @@ fromStringParse p what s =
     onError e =
       error $ "not a " <> what <> ": " <> s <> "\n" <> errorBundlePretty e
 
-instance IsString (ScalarTypeBase Size ()) where
-  fromString = fromStringParse pScalarType "ScalarType"
+instance IsString (ScalarTypeBase Size NoUniqueness) where
+  fromString =
+    fromStringParse (second (const NoUniqueness) <$> pScalarType) "ScalarType"
 
 instance IsString StructType where
-  fromString = fromStringParse pStructType "StructType"
+  fromString =
+    fromStringParse (second (const NoUniqueness) <$> pType) "StructType"
 
 instance IsString StructRetType where
-  fromString = fromStringParse pStructRetType "StructRetType"
+  fromString =
+    fromStringParse (second (pure NoUniqueness) <$> pRetType) "StructRetType"
+
+instance IsString ResRetType where
+  fromString = fromStringParse pRetType "ResRetType"

--- a/unittests/Language/Futhark/TypeChecker/TypesTests.hs
+++ b/unittests/Language/Futhark/TypeChecker/TypesTests.hs
@@ -1,6 +1,6 @@
 module Language.Futhark.TypeChecker.TypesTests (tests) where
 
-import Data.Bifunctor (first)
+import Data.Bifunctor
 import Data.List (isInfixOf)
 import Data.Map qualified as M
 import Data.Text qualified as T
@@ -16,7 +16,7 @@ import Language.Futhark.TypeChecker.Types
 import Test.Tasty
 import Test.Tasty.HUnit
 
-evalTest :: TypeExp NoInfo Name -> Either String ([VName], StructRetType) -> TestTree
+evalTest :: TypeExp NoInfo Name -> Either String ([VName], ResRetType) -> TestTree
 evalTest te expected =
   testCase (prettyString te) $
     case (fmap (extract . fst) (run (checkTypeExp te)), expected) of


### PR DESCRIPTION
This significantly simplifies the type checker, and also fixes known
(and future) bugs related to tracking aliases of an incompletely typed
term.

This also allows us to provide better error messages, although it's
possible that they are currently slightly worse, as the aliasing
checking does not use the "context" mechanism of the term-level type
checker.

The AST itself is simplified because it no longer has to embed alias
information (which wasn't correct anyway, and was not actually used).

There is one user-visible change: lambdas that *must* return an
alias-free result will now require a return type annotation.  We may
loosen this in the future, but it is a very rare case in practice.

Closes #1872.