### PR TITLE
Remove simplifyPatFromExpS machinery.

### DIFF
--- a/src/Futhark/Optimise/Simplify/Engine.hs
+++ b/src/Futhark/Optimise/Simplify/Engine.hs
@@ -136,10 +136,6 @@ data SimpleOps rep = SimpleOps
     -- actually be used.
     protectHoistedOpS :: Protect (Builder (Wise rep)),
     opUsageS :: Op (Wise rep) -> UT.UsageTable,
-    simplifyPatFromExpS ::
-      Pat (LetDec rep) ->
-      Exp (Wise rep) ->
-      SimpleM rep (Pat (LetDec rep)),
     simplifyOpS :: SimplifyOp rep (Op (Wise rep))
   }
 
@@ -148,12 +144,11 @@ bindableSimpleOps ::
   SimplifyOp rep (Op (Wise rep)) ->
   SimpleOps rep
 bindableSimpleOps =
-  SimpleOps mkExpDecS' mkBodyS' protectHoistedOpS' (const mempty) simplifyPatFromExp
+  SimpleOps mkExpDecS' mkBodyS' protectHoistedOpS' (const mempty)
   where
     mkExpDecS' _ pat e = pure $ mkExpDec pat e
     mkBodyS' _ stms res = pure $ mkBody stms res
     protectHoistedOpS' _ _ _ = Nothing
-    simplifyPatFromExp pat _ = traverse simplify pat
 
 newtype SimpleM rep a
   = SimpleM
@@ -438,9 +433,8 @@ nonrecSimplifyStm ::
   SimpleM rep (Stm (Wise rep))
 nonrecSimplifyStm (Let pat (StmAux cs attrs (_, dec)) e) = do
   cs' <- simplify cs
+  (pat', pat_cs) <- collectCerts $ traverse simplify $ removePatWisdom pat
   e' <- simplifyExpBase e
-  simplifyPat <- asks $ simplifyPatFromExpS . fst
-  (pat', pat_cs) <- collectCerts $ simplifyPat (removePatWisdom pat) e'
   let aux' = StmAux (cs' <> pat_cs) attrs dec
   pure $ mkWiseStm pat' aux' e'
 

--- a/src/Futhark/Pass/ExplicitAllocations.hs
+++ b/src/Futhark/Pass/ExplicitAllocations.hs
@@ -1135,7 +1135,7 @@ simplifiable ::
   ) ->
   SimpleOps rep
 simplifiable innerUsage simplifyInnerOp =
-  SimpleOps mkExpDecS' mkBodyS' protectOp opUsage simplifyPat (simplifyMemOp simplifyInnerOp)
+  SimpleOps mkExpDecS' mkBodyS' protectOp opUsage (simplifyMemOp simplifyInnerOp)
   where
     mkExpDecS' _ pat e =
       pure $ Engine.mkWiseExpDec pat () e
@@ -1158,26 +1158,6 @@ simplifiable innerUsage simplifyInnerOp =
       mempty
     opUsage (Inner inner) =
       innerUsage inner
-
-    simplifyPat (Pat pes) e = do
-      rets <- fromMaybe (error "simplifyPat: ill-typed") <$> expReturns e
-      Pat <$> zipWithM update pes rets
-      where
-        names = map patElemName pes
-        update
-          (PatElem pe_v (MemArray pt shape u (ArrayIn mem _)))
-          (MemArray _ _ _ (Just (ReturnsInBlock _ ixfun)))
-            | Just ixfun' <- traverse (traverse inst) ixfun =
-                PatElem pe_v
-                  <$> ( MemArray pt
-                          <$> Engine.simplify shape
-                          <*> pure u
-                          <*> (ArrayIn <$> Engine.simplify mem <*> pure ixfun')
-                      )
-            where
-              inst (Ext i) = maybeNth i names
-              inst (Free v) = Just v
-        update pe _ = traverse Engine.simplify pe
 
 data ExpHint
   = NoHint


### PR DESCRIPTION
This was a somewhat complicated fix for #1309, but with the arrival of single-LMAD index functions, it may no longer be necessary.