### PR TITLE
Use own stream in CUDA backend.

### DIFF
--- a/rts/c/backends/cuda.h
+++ b/rts/c/backends/cuda.h
@@ -308,8 +308,8 @@ static int cuda_device_setup(struct futhark_context *ctx) {
   struct futhark_context_config *cfg = ctx->cfg;
   char name[256];
   int count, chosen = -1, best_cc = -1;
-  int cc_major_best, cc_minor_best;
-  int cc_major, cc_minor;
+  int cc_major_best = 0, cc_minor_best = 0;
+  int cc_major = 0, cc_minor = 0;
   CUdevice dev;
 
   CUDA_SUCCEED_FATAL(cuDeviceGetCount(&count));

--- a/src/Futhark/CodeGen/Backends/CCUDA/Boilerplate.hs
+++ b/src/Futhark/CodeGen/Backends/CCUDA/Boilerplate.hs
@@ -37,17 +37,17 @@ errorMsgNumArgs = length . errorMsgArgTypes
 profilingEnclosure :: Name -> ([C.BlockItem], [C.BlockItem])
 profilingEnclosure name =
   ( [C.citems|
-      typename cudaEvent_t *pevents = NULL;
+      typename CUevent *pevents = NULL;
       if (ctx->profiling && !ctx->profiling_paused) {
         pevents = cuda_get_events(ctx,
                                   &ctx->program->$id:(kernelRuns name),
                                   &ctx->program->$id:(kernelRuntime name));
-        CUDA_SUCCEED_FATAL(cudaEventRecord(pevents[0], 0));
+        CUDA_SUCCEED_FATAL(cuEventRecord(pevents[0], ctx->stream));
       }
       |],
     [C.citems|
       if (pevents != NULL) {
-        CUDA_SUCCEED_FATAL(cudaEventRecord(pevents[1], 0));
+        CUDA_SUCCEED_FATAL(cuEventRecord(pevents[1], ctx->stream));
       }
       |]
   )


### PR DESCRIPTION
Previously we always used the "default stream", which might also be used by others.

The ultimate goal of this is to make it possible for the user to provide their own stream.