### PR TITLE
Check that dst is unused when short-circuiting function args

### DIFF
--- a/src/Futhark/Optimise/ArrayShortCircuiting/ArrayCoalescing.hs
+++ b/src/Futhark/Optimise/ArrayShortCircuiting/ArrayCoalescing.hs
@@ -1180,9 +1180,9 @@ mkCoalsTabStm _ (Let pat _ (BasicOp Update {})) _ _ =
 mkCoalsTabStm lutab stm@(Let pat aux (Op op)) td_env bu_env = do
   -- Process body
   on_op <- asks onOp
-  activeCoals' <- mkCoalsHelper3PatternMatch stm lutab td_env bu_env
-  let bu_env' = bu_env {activeCoals = activeCoals'}
-  on_op lutab pat (stmAuxCerts aux) op td_env bu_env'
+  bu_env' <- on_op lutab pat (stmAuxCerts aux) op td_env bu_env
+  activeCoals' <- mkCoalsHelper3PatternMatch stm lutab td_env bu_env'
+  pure $ bu_env' {activeCoals = activeCoals'}
 mkCoalsTabStm lutab stm@(Let pat _ e) td_env bu_env = do
   --   i) Filter @activeCoals@ by the 3rd safety condition:
   --      this is now relaxed by use of LMAD eqs:

--- a/src/Futhark/Optimise/ArrayShortCircuiting/ArrayCoalescing.hs
+++ b/src/Futhark/Optimise/ArrayShortCircuiting/ArrayCoalescing.hs
@@ -612,7 +612,9 @@ fixPointCoalesce lutab fpar bdy topenv = do
       handleFunctionParams (a, i, s) (_, u, MemBlock _ _ m ixf) =
         case (u, M.lookup m a) of
           (Unique, Just entry)
-            | dstind entry == ixf ->
+            | dstind entry == ixf,
+              Set dst_uses <- dstrefs (memrefs entry),
+              dst_uses == mempty ->
                 let (a', s') = markSuccessCoal (a, s) m entry
                  in (a', i, s')
           _ ->

--- a/src/Futhark/Optimise/ArrayShortCircuiting/ArrayCoalescing.hs
+++ b/src/Futhark/Optimise/ArrayShortCircuiting/ArrayCoalescing.hs
@@ -1436,7 +1436,7 @@ genSSPointInfoSeqMem _ _ _ _ _ _ =
 -- | For 'SegOp', we currently only handle 'SegMap', and only under the following
 -- circumstances:
 --
---  1. The 'SegMap' has only one return/pattern value.
+--  1. The 'SegMap' has only one return/pattern value, which is a 'Returns'.
 --
 --  2. The 'KernelBody' contains an 'Index' statement that is indexing an array using
 --  only the values from the 'SegSpace'.
@@ -1464,7 +1464,7 @@ genSSPointInfoSegOp
   scopetab
   (Pat [PatElem dst (_, MemArray dst_pt _ _ (ArrayIn dst_mem dst_ixf))])
   certs
-  (SegMap _ space _ kernel_body)
+  (SegMap _ space _ kernel_body@KernelBody {kernelBodyResult = [Returns {}]})
     | (src, MemBlock src_pt shp src_mem src_ixf) : _ <-
         mapMaybe getPotentialMapShortCircuit $
           stmsToList $

--- a/src/Futhark/Optimise/ArrayShortCircuiting/ArrayCoalescing.hs
+++ b/src/Futhark/Optimise/ArrayShortCircuiting/ArrayCoalescing.hs
@@ -1465,11 +1465,11 @@ genSSPointInfoSegOp
   (Pat [PatElem dst (_, MemArray dst_pt _ _ (ArrayIn dst_mem dst_ixf))])
   certs
   (SegMap _ space _ kernel_body)
-    | (src, MemBlock _ shp src_mem src_ixf) : _ <-
+    | (src, MemBlock src_pt shp src_mem src_ixf) : _ <-
         mapMaybe getPotentialMapShortCircuit $
           stmsToList $
             kernelBodyStms kernel_body =
-        Just [(MapCoal, id, dst, dst_mem, dst_ixf, src, src_mem, src_ixf, dst_pt, shp, certs)]
+        Just [(MapCoal, id, dst, dst_mem, dst_ixf, src, src_mem, src_ixf, src_pt, shp, certs)]
     where
       iterators = map fst $ unSegSpace space
       frees = freeIn kernel_body

--- a/tests/memory-block-merging/coalescing/issue-2010.fut
+++ b/tests/memory-block-merging/coalescing/issue-2010.fut
@@ -1,0 +1,30 @@
+-- partition2.fut
+-- ==
+-- input { [1i32,2i32,3i32,4i32,5i32,6i32,7i32]
+-- }
+-- output {
+--   3i64
+--   [2i32,4i32,6i32,1i32,3i32,5i32,7i32]
+-- }
+
+let partition2 't [n]  (dummy: t)
+      (cond: t -> bool) (X: [n]t) :
+                      (i64, *[n]t) =
+ let cs = map cond X
+ let tfs= map (\ f->if f then 1i64
+                         else 0i64) cs
+ let isT= scan (+) 0 tfs
+ let i  = isT[n-1]
+
+ let ffs= map (\f->if f then 0
+                        else 1) cs
+ let isF= map (+i) <| scan (+) 0 ffs
+ let inds=map (\(c,iT,iF) ->
+                  if c then iT-1
+                       else iF-1
+              ) (zip3 cs isT isF)
+ let tmp = replicate n dummy
+ in (i, scatter tmp inds X)
+
+let main [n] (arr: *[n]i32) : (i64,*[n]i32) =
+  partition2 0i32 (\(x:i32) -> (x & 1i32) == 0i32) arr

--- a/tests/memory-block-merging/coalescing/lud/lud_internal1-16.fut
+++ b/tests/memory-block-merging/coalescing/lud/lud_internal1-16.fut
@@ -1,5 +1,5 @@
 -- ==
--- structure gpu-mem { Alloc 3 }
+-- structure gpu-mem { Alloc 2 }
 -- structure seq-mem { Alloc 1 }
 
 let lud_internal [m] (top_per: [m][16][16]f32) (lft_per: [m][16][16]f32) (mat_slice: [m][m][16][16]f32): *[m][m][16][16]f32 =

--- a/tests/memory-block-merging/coalescing/lud/lud_internal1.fut
+++ b/tests/memory-block-merging/coalescing/lud/lud_internal1.fut
@@ -1,5 +1,5 @@
 -- ==
--- structure gpu-mem { Alloc 3 }
+-- structure gpu-mem { Alloc 2 }
 -- structure seq-mem { Alloc 1 }
 
 let lud_internal [m][b] (top_per: [m][b][b]f32) (lft_per: [m][b][b]f32) (mat_slice: [m][m][b][b]f32): *[m][m][b][b]f32 =

--- a/tests/memory-block-merging/coalescing/lud/lud_internal3.fut
+++ b/tests/memory-block-merging/coalescing/lud/lud_internal3.fut
@@ -1,5 +1,5 @@
 -- ==
--- structure gpu-mem { Alloc 15 }
+-- structure gpu-mem { Alloc 14 }
 -- structure seq-mem { Alloc 1 }
 
 let lud_internal [m][b] (top_per: [m][b][b]f32) (lft_per: [m][b][b]f32) (mat_slice: [m][m][b][b]f32): *[m][m][b][b]f32 =

--- a/tests/memory-block-merging/coalescing/lud/lud_internal4.fut
+++ b/tests/memory-block-merging/coalescing/lud/lud_internal4.fut
@@ -1,7 +1,7 @@
 -- ==
 -- compiled random input { [16][16][8][8]f32 }
 -- auto output
--- structure gpu-mem { Alloc 3 }
+-- structure gpu-mem { Alloc 2 }
 
 let lud_internal [b][m] (top_per: [m][b][b]f32) (lft_per: [m][b][b]f32) (mat_slice: [m][m][b][b]f32): *[m][m][b][b]f32 =
   let top_slice = map transpose top_per in

--- a/tests/memory-block-merging/coalescing/map/map12.fut
+++ b/tests/memory-block-merging/coalescing/map/map12.fut
@@ -1,7 +1,7 @@
 -- ==
 -- input { [[1,2,3,4]] }
 -- auto output
--- structure gpu-mem { Alloc 3 }
+-- structure gpu-mem { Alloc 2 }
 
 def main [n][m] (xs: [n][m]i32) =
   #[incremental_flattening(only_intra)]

--- a/tests/memory-block-merging/coalescing/map/map15.fut
+++ b/tests/memory-block-merging/coalescing/map/map15.fut
@@ -1,0 +1,9 @@
+-- ==
+-- input { [1,2,3] }
+-- output { [2.0f32, 3.0f32, 4.0f32] }
+-- structure gpu-mem { Alloc 0 }
+
+let main [n] (xs: *[n]i32): *[n]f32 =
+  let xs = opaque (map (+1) xs)
+  let ys = map (f32.i32) xs
+  in ys


### PR DESCRIPTION
When short-circuiting with a function argument as the source, we should verify that the destination is never used in-between the short-circuiting point and the start of the function, because the source is live in all that code.  Instead of
checking for memory overlap, we can simply check that the destination is unused, because we already enforce that the index function of the destination must match the index function of the function argument.

Fixes #2010

This PR also contains a fix to another issue, which caused map short-circuits to incorrectly process the map body after adding the short-circuit target and destination to the current short-circuiting attempt. This led to us to reject some otherwise sound short-circuitings.

Combined with the fix in handling function arguments as short-circuiting sources, this erroneous behaviour caused e.g. tests/memory-block-merging/coalescing/map/map.fut to fail:

```futhark
-- ==
-- input { [1,2,3] }
-- output { [2,3,4] }
-- structure gpu-mem { Alloc 0 }
-- structure seq-mem { Alloc 1 }

let main [n] (xs: *[n]i32): *[n]i32 =
  map (+1) xs
```

Trying to short-circuit `xs` (the source) into the result of the map (the destination), the problem was that the (+1) (and resulting kernel body) resulted in a destination use that interfered with the source. Since the function argument is essentially "written to" at the start of the function, this caused map.fut to not short-circuit.

Incidentally, this commit also reduces the number of allocations needed in a handful of other tests.
