### PR TITLE
Copy strings passed to API functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+* The various C API functions that accept strings now perform a copy,
+  meaning the caller does not have to keep the strings alive.
+
 ### Removed
 
 ### Changed

--- a/docs/c-api.rst
+++ b/docs/c-api.rst
@@ -22,6 +22,11 @@ non-zero value on error, as documented below.  Others return a
 ``NULL`` pointer.  Use :c:func:`futhark_context_get_error` to get a
 (possibly) more precise error message.
 
+Some functions take a C string (``const char*``) as argument.  Unless
+otherwise indicated, the string will be copied if necessary, meaning
+the argument string can always be modified (or freed) after the
+function returns.
+
 .. c:macro:: FUTHARK_BACKEND_foo
 
    A preprocessor macro identifying that the backend *foo* was used to

--- a/rts/c/context.h
+++ b/rts/c/context.h
@@ -96,6 +96,7 @@ struct futhark_context_config* futhark_context_config_new(void) {
 void futhark_context_config_free(struct futhark_context_config* cfg) {
   assert(!cfg->in_use);
   backend_context_config_teardown(cfg);
+  free(cfg->cache_fname);
   free(cfg->tuning_params);
   free(cfg);
 }
@@ -138,6 +139,7 @@ void futhark_context_free(struct futhark_context* ctx) {
   free_all_in_free_list(ctx);
   free_list_destroy(&ctx->free_list);
   free(ctx->constants);
+  free(ctx->error);
   free_lock(&ctx->lock);
   free_lock(&ctx->error_lock);
   ctx->cfg->in_use = 0;

--- a/src/Futhark/CodeGen/Backends/GenericC.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC.hs
@@ -614,7 +614,7 @@ generateCommonLibFuns memreport = do
   publicDef_ "context_config_set_cache_file" MiscDecl $ \s ->
     ( [C.cedecl|void $id:s($ty:cfg* cfg, const char *f);|],
       [C.cedecl|void $id:s($ty:cfg* cfg, const char *f) {
-                 cfg->cache_fname = f;
+                 cfg->cache_fname = strdup(f);
                }|]
     )
 


### PR DESCRIPTION
This simplifies the life of the user, at a small extra copying overhead.

It is particularly useful when calling these functions through an FFI from a garbage collected language, where managing the lifetime of a C string can be quite annoying and error-prone.