### PR TITLE
Fix issue of failed run 'make install' in macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@
 
 PREFIX?=$(HOME)/.local
 
+UNAME:=$(shell uname)
+
 # Disable all implicit rules.
 .SUFFIXES:
 
@@ -23,7 +25,12 @@ build:
 	cabal build
 
 install: build
+ifeq ($(UNAME), Darwin)
+	install -d $(PREFIX)/bin/futhark
+	install "$$(cabal -v0 list-bin exe:futhark)" $(PREFIX)/bin/futhark
+else
 	install -D "$$(cabal -v0 list-bin exe:futhark)" $(PREFIX)/bin/futhark
+endif
 
 docs:
 	cabal haddock \


### PR DESCRIPTION
The command 'make install' should call install command with option '-D', but in macOS, the install command hasn't option '-D'. So, I add a condition at install target in Makefile to detect operate system, if the operate system is macOS, then call install command with option '-d' to create installed directory.