### PR TITLE
Remove base from index functions

### DIFF
--- a/src/Futhark/IR/Mem/LMAD.hs
+++ b/src/Futhark/IR/Mem/LMAD.hs
@@ -544,16 +544,16 @@ isDirect :: (Eq num, IntegralExp num) => LMAD num -> Bool
 isDirect lmad = lmad == iota 0 (map ldShape $ dims lmad)
 {-# NOINLINE isDirect #-}
 
--- | The largest possible linear address reachable by this LMAD. If
--- you add one to this number (and multiply it with the element size),
--- you get the amount of bytes you need to allocate for an array with
--- this LMAD.
+-- | The largest possible linear address reachable by this LMAD, not
+-- counting the offset. If you add one to this number (and multiply it
+-- with the element size), you get the amount of bytes you need to
+-- allocate for an array with this LMAD (assuming zero offset).
 range :: (Pretty num) => LMAD (TPrimExp Int64 num) -> TPrimExp Int64 num
 range lmad =
-  -- The idea is that the largest possible offset must be the offset
-  -- plus the sum of the maximum offsets reachable in each dimension,
-  -- which must be at either the minimum or maximum index.
-  offset lmad + sum (map dimRange $ dims lmad)
+  -- The idea is that the largest possible offset must be the sum of
+  -- the maximum offsets reachable in each dimension, which must be at
+  -- either the minimum or maximum index.
+  sum (map dimRange $ dims lmad)
   where
     dimRange LMADDim {ldStride, ldShape} =
       0 `sMax64` ((0 `sMax64` (ldShape - 1)) * ldStride)

--- a/src/Futhark/IR/Mem/Simplify.hs
+++ b/src/Futhark/IR/Mem/Simplify.hs
@@ -11,12 +11,12 @@ where
 
 import Control.Monad
 import Data.List (find)
-import Data.Maybe (isJust)
 import Futhark.Analysis.SymbolTable qualified as ST
 import Futhark.Analysis.UsageTable qualified as UT
 import Futhark.Construct
 import Futhark.IR.Mem
 import Futhark.IR.Mem.IxFun qualified as IxFun
+import Futhark.IR.Mem.LMAD qualified as LMAD
 import Futhark.IR.Prop.Aliases (AliasedOp)
 import Futhark.Optimise.Simplify qualified as Simplify
 import Futhark.Optimise.Simplify.Engine qualified as Engine
@@ -128,7 +128,7 @@ memRuleBook =
 unExistentialiseMemory :: (SimplifyMemory rep inner) => TopDownRuleMatch (Wise rep)
 unExistentialiseMemory vtable pat _ (cond, cases, defbody, ifdec)
   | ST.simplifyMemory vtable,
-    fixable <- foldl hasConcretisableMemory mempty $ zip [0 ..] $ patElems pat,
+    fixable <- foldl hasConcretisableMemory mempty $ patElems pat,
     not $ null fixable = Simplify $ do
       -- Create non-existential memory blocks big enough to hold the
       -- arrays.
@@ -167,7 +167,7 @@ unExistentialiseMemory vtable pat _ (cond, cases, defbody, ifdec)
     knownSize (Var v) = not $ inContext v
     inContext = (`elem` patNames pat)
 
-    hasConcretisableMemory fixable (i, pat_elem)
+    hasConcretisableMemory fixable pat_elem
       | (_, MemArray pt shape _ (ArrayIn mem ixfun)) <- patElemDec pat_elem,
         Just (j, Mem space) <-
           fmap patElemType
@@ -180,24 +180,11 @@ unExistentialiseMemory vtable pat _ (cond, cases, defbody, ifdec)
         all knownSize (shapeDims shape),
         not $ freeIn ixfun `namesIntersect` namesFromList (patNames pat),
         any (defbody_se /=) cases_ses,
-        all (notIndex i) (defbody : map caseBody cases) =
+        LMAD.offset (IxFun.ixfunLMAD ixfun) == 0 =
           let mem_size = untyped $ primByteSize pt * (1 + IxFun.range ixfun)
            in (pat_elem, mem_size, mem, space) : fixable
       | otherwise =
           fixable
-
-    -- Check if the i'th result is not an index; see #1325. This is a
-    -- rather crude check, but this is also a rather crude
-    -- simplification rule. We only need to keep it around until
-    -- memory expansion can handle existential memory generally.
-    notIndex i body
-      | Just (SubExpRes _ (Var v)) <- maybeNth (i :: Int) $ bodyResult body =
-          not $ any (bad v) $ bodyStms body
-      where
-        bad v (Let index_pat _ (BasicOp (Index _ slice))) =
-          (v `elem` patNames index_pat) && any (isJust . dimFix) (unSlice slice)
-        bad _ _ = False
-    notIndex _ _ = True
 unExistentialiseMemory _ _ _ _ = Skip
 
 -- If an allocation is statically known to be safe, then we can remove

--- a/src/Futhark/IR/Parse.hs
+++ b/src/Futhark/IR/Parse.hs
@@ -963,10 +963,7 @@ pMCOp pr pOther =
 
 pIxFunBase :: Parser a -> Parser (IxFun.IxFun a)
 pIxFunBase pNum =
-  braces $ do
-    base <- pLab "base" $ brackets (pNum `sepBy` pComma) <* pSemi
-    lmad <- pLab "LMAD" pLMAD
-    pure $ IxFun.IxFun lmad base
+  IxFun.IxFun <$> pLMAD
   where
     pLab s m = keyword s *> pColon *> m
     pLMAD = braces $ do

--- a/src/Futhark/Optimise/ArrayShortCircuiting/ArrayCoalescing.hs
+++ b/src/Futhark/Optimise/ArrayShortCircuiting/ArrayCoalescing.hs
@@ -1257,7 +1257,7 @@ mkCoalsTabStm lutab stm@(Let pat _ e) td_env bu_env = do
                         _ -> (failed, s_acc) -- fail!
 
 ixfunToAccessSummary :: IxFun.IxFun (TPrimExp Int64 VName) -> AccessSummary
-ixfunToAccessSummary (IxFun.IxFun lmad _) = Set $ S.singleton lmad
+ixfunToAccessSummary (IxFun.IxFun lmad) = Set $ S.singleton lmad
 
 -- | Check safety conditions 2 and 5 and update new substitutions:
 -- called on the pat-elements of loop and if-then-else expressions.

--- a/src/Futhark/Optimise/ArrayShortCircuiting/MemRefAggreg.hs
+++ b/src/Futhark/Optimise/ArrayShortCircuiting/MemRefAggreg.hs
@@ -252,7 +252,7 @@ recordMemRefUses td_env bu_env stm =
         <> fromMaybe mempty (M.lookup m (m_alias td_env))
     mbLmad indfun
       | Just subs <- freeVarSubstitutions (scope td_env) (scals bu_env) indfun,
-        (IxFun.IxFun lmad _) <- IxFun.substituteInIxFun subs indfun =
+        (IxFun.IxFun lmad) <- IxFun.substituteInIxFun subs indfun =
           Just lmad
     mbLmad _ = Nothing
     addLmads wrts uses etry =

--- a/src/Futhark/Optimise/BlkRegTiling.hs
+++ b/src/Futhark/Optimise/BlkRegTiling.hs
@@ -141,7 +141,7 @@ kkLoopBody
         | [slc_X'] <- patNames pat,
           slc_X == slc_X',
           Just ixf_fn <- M.lookup x ixfn_env,
-          (IxFun.IxFun lmad _) <- ixf_fn =
+          (IxFun.IxFun lmad) <- ixf_fn =
             innerHasStride1 lmad
       isInnerCoal _ _ _ =
         error "kkLoopBody.isInnerCoal: not an error, but I would like to know why!"

--- a/src/Futhark/Pass/ExpandAllocations.hs
+++ b/src/Futhark/Pass/ExpandAllocations.hs
@@ -796,7 +796,7 @@ offsetMemoryInExp :: RebaseMap -> Exp GPUMem -> OffsetM (Exp GPUMem)
 offsetMemoryInExp offsets = mapExpM recurse
   where
     recurse =
-      identityMapper
+      (identityMapper @GPUMem)
         { mapOnBody = \bscope -> localScope bscope . offsetMemoryInBody offsets,
           mapOnBranchType = offsetMemoryInBodyReturns offsets,
           mapOnOp = onOp

--- a/tests/distribution/loop2.fut
+++ b/tests/distribution/loop2.fut
@@ -16,7 +16,8 @@
 
 def main [n][m][k] (a: [n][m][k]i32): [n][k]i32 =
   map (\(a_r: [m][k]i32): [k]i32  ->
-        let acc = a_r[0] in
+         let acc = a_r[0] in
+         #[sequential]
         loop(acc) for i < m do
           map2 (+) acc (a_r[i])
      ) a

--- a/tests/memory-block-merging/coalescing/copy/pos5.fut
+++ b/tests/memory-block-merging/coalescing/copy/pos5.fut
@@ -25,8 +25,8 @@
 --        }
 -- compiled random input { [256][256][256]i32 1i64 [256]i32 }
 -- auto output
--- structure seq-mem { Alloc 2 }
--- structure gpu-mem { Alloc 2 }
+-- structure seq-mem { /Alloc 1 }
+-- structure gpu-mem { /Alloc 0 }
 
 let main [n] (t1: *[n][n][n]i32) (i: i64) (xs: [n]i32): *[n][n][n]i32 =
   #[incremental_flattening(only_intra)]

--- a/tests/memory-block-merging/coalescing/hoisting/copy-in-if.fut
+++ b/tests/memory-block-merging/coalescing/hoisting/copy-in-if.fut
@@ -3,7 +3,7 @@
 --
 -- It is perhaps a pretty far-out case.
 -- ==
--- structure seq-mem { Alloc 3 }
+-- structure seq-mem { Alloc 2 }
 -- structure gpu-mem { Alloc 3 }
 
 let main (cond: bool, lengths: []i64, index: i64): []i64 =

--- a/tests/memory-block-merging/coalescing/hoisting/copy-in-if.fut
+++ b/tests/memory-block-merging/coalescing/hoisting/copy-in-if.fut
@@ -4,7 +4,7 @@
 -- It is perhaps a pretty far-out case.
 -- ==
 -- structure seq-mem { Alloc 2 }
--- structure gpu-mem { Alloc 3 }
+-- structure gpu-mem { Alloc 2 }
 
 let main (cond: bool, lengths: []i64, index: i64): []i64 =
   if cond

--- a/tests/memory-block-merging/coalescing/lud/lud.fut
+++ b/tests/memory-block-merging/coalescing/lud/lud.fut
@@ -1,7 +1,7 @@
 -- Parallel blocked LU-decomposition.
 --
 -- ==
--- structure gpu-mem { Alloc 34 }
+-- structure gpu-mem { Alloc 32 }
 -- structure seq-mem { Alloc 20 }
 
 def block_size: i64 = 32

--- a/tests/memory-block-merging/coalescing/lud/lud.fut
+++ b/tests/memory-block-merging/coalescing/lud/lud.fut
@@ -1,7 +1,7 @@
 -- Parallel blocked LU-decomposition.
 --
 -- ==
--- structure gpu-mem { Alloc 32 }
+-- structure gpu-mem { Alloc 30 }
 -- structure seq-mem { Alloc 20 }
 
 def block_size: i64 = 32


### PR DESCRIPTION
With this PR, index functions are now just LMADs, with no extra information.

This results in an overall reduction of copies.

However, some of those copies turn out to be load-bearing, so we need
fixes elsewhere, in particular memory expansion.

My hope is that this will lead to the memory handling being simpler
and more intentionally (instead of accidentally) correct.