### PR TITLE
Remove unExistentialiseMemory.

### DIFF
--- a/src/Futhark/IR/Mem/Simplify.hs
+++ b/src/Futhark/IR/Mem/Simplify.hs
@@ -9,13 +9,10 @@ module Futhark.IR.Mem.Simplify
   )
 where
 
-import Control.Monad
-import Data.List (find)
 import Futhark.Analysis.SymbolTable qualified as ST
 import Futhark.Analysis.UsageTable qualified as UT
 import Futhark.Construct
 import Futhark.IR.Mem
-import Futhark.IR.Mem.LMAD qualified as LMAD
 import Futhark.IR.Prop.Aliases (AliasedOp)
 import Futhark.Optimise.Simplify qualified as Simplify
 import Futhark.Optimise.Simplify.Engine qualified as Engine
@@ -24,7 +21,6 @@ import Futhark.Optimise.Simplify.Rule
 import Futhark.Optimise.Simplify.Rules
 import Futhark.Pass
 import Futhark.Pass.ExplicitAllocations (simplifiable)
-import Futhark.Util
 
 -- | Some constraints that must hold for the simplification rules to work.
 type SimplifyMemory rep inner =
@@ -115,76 +111,9 @@ memRuleBook :: (SimplifyMemory rep inner) => RuleBook (Wise rep)
 memRuleBook =
   standardRules
     <> ruleBook
-      [ RuleMatch unExistentialiseMemory,
-        RuleOp decertifySafeAlloc
+      [ RuleOp decertifySafeAlloc
       ]
       []
-
--- | If a branch is returning some existential memory, but the size of
--- the array is not existential, and the index function of the array
--- does not refer to any names in the pattern, then we can create a
--- block of the proper size and always return there.
-unExistentialiseMemory :: (SimplifyMemory rep inner) => TopDownRuleMatch (Wise rep)
-unExistentialiseMemory vtable pat _ (cond, cases, defbody, ifdec)
-  | ST.simplifyMemory vtable,
-    fixable <- foldl hasConcretisableMemory mempty $ patElems pat,
-    not $ null fixable = Simplify $ do
-      -- Create non-existential memory blocks big enough to hold the
-      -- arrays.
-      (arr_to_mem, oldmem_to_mem) <-
-        fmap unzip $
-          forM fixable $ \(arr_pe, mem_size, oldmem, space) -> do
-            size <- toSubExp "unext_mem_size" mem_size
-            mem <- letExp "unext_mem" $ Op $ Alloc size space
-            pure ((patElemName arr_pe, mem), (oldmem, mem))
-
-      -- Update the branches to contain Copy expressions putting the
-      -- arrays where they are expected.
-      let updateBody body = buildBody_ $ do
-            res <- bodyBind body
-            zipWithM updateResult (patElems pat) res
-          updateResult pat_elem (SubExpRes cs (Var v))
-            | Just mem <- lookup (patElemName pat_elem) arr_to_mem,
-              (_, MemArray pt shape u (ArrayIn _ lmad)) <- patElemDec pat_elem = do
-                v_copy <- newVName $ baseString v <> "_nonext_copy"
-                let v_pat =
-                      Pat [PatElem v_copy $ MemArray pt shape u $ ArrayIn mem lmad]
-                addStm $ mkWiseStm v_pat (defAux ()) $ BasicOp $ Replicate mempty $ Var v
-                pure $ SubExpRes cs $ Var v_copy
-            | Just mem <- lookup (patElemName pat_elem) oldmem_to_mem =
-                pure $ SubExpRes cs $ Var mem
-          updateResult _ se =
-            pure se
-      cases' <- mapM (traverse updateBody) cases
-      defbody' <- updateBody defbody
-      letBind pat $ Match cond cases' defbody' ifdec
-  where
-    onlyUsedIn name here =
-      not . any ((name `nameIn`) . freeIn) . filter ((/= here) . patElemName) $
-        patElems pat
-    knownSize Constant {} = True
-    knownSize (Var v) = not $ inContext v
-    inContext = (`elem` patNames pat)
-
-    hasConcretisableMemory fixable pat_elem
-      | (_, MemArray pt shape _ (ArrayIn mem lmad)) <- patElemDec pat_elem,
-        Just (j, Mem space) <-
-          fmap patElemType
-            <$> find
-              ((mem ==) . patElemName . snd)
-              (zip [(0 :: Int) ..] $ patElems pat),
-        Just cases_ses <- mapM (maybeNth j . bodyResult . caseBody) cases,
-        Just defbody_se <- maybeNth j $ bodyResult defbody,
-        mem `onlyUsedIn` patElemName pat_elem,
-        all knownSize (shapeDims shape),
-        not $ freeIn lmad `namesIntersect` namesFromList (patNames pat),
-        any (defbody_se /=) cases_ses,
-        LMAD.offset lmad == 0 =
-          let mem_size = untyped $ primByteSize pt * (1 + LMAD.range lmad)
-           in (pat_elem, mem_size, mem, space) : fixable
-      | otherwise =
-          fixable
-unExistentialiseMemory _ _ _ _ = Skip
 
 -- If an allocation is statically known to be safe, then we can remove
 -- the certificates on it.  This can help hoist things that would


### PR DESCRIPTION
This rather complicated and dubiously sound simplification rule has long been necessary as a workaround for deficiencies elsewhere in the compiler. With the recent improvements to double buffering and memory expansion (and the general simplification of the memory representation), it may no longer be necessary. Performance impact of the removal is unclear, but the test suite works.