### PR TITLE
Fix #2106.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * A concatenation simplification would sometimes mess up sizes.
   (#2104)
 
+* But related to monomorphisation of polymorphic local functions
+  (#2106).
+
 ## [0.25.13]
 
 ### Added

--- a/futhark.cabal
+++ b/futhark.cabal
@@ -284,6 +284,7 @@ library
       Futhark.IR.TypeCheck
       Futhark.Internalise
       Futhark.Internalise.AccurateSizes
+      Futhark.Internalise.ApplyTypeAbbrs
       Futhark.Internalise.Bindings
       Futhark.Internalise.Defunctionalise
       Futhark.Internalise.Defunctorise

--- a/src/Futhark/Internalise.hs
+++ b/src/Futhark/Internalise.hs
@@ -19,6 +19,15 @@
 -- * The core IR has no modules.  These are removed in
 --   "Futhark.Internalise.Defunctorise".
 --
+-- * The core IR has no type abbreviations.  These are removed in
+--   "Futhark.Internalise.ApplyTypeAbbrs".
+--
+-- * The core IR has little syntactic niceties. A lot of syntactic
+--   sugar is removed in "Futhark.Internalise.FullNormalise".
+--
+-- * Lambda lifting is performed by "Futhark.Internalise.LiftLambdas",
+-- * mostly to make the job of later passes simpler.
+--
 -- * The core IR is monomorphic.  Polymorphic functions are monomorphised in
 --   "Futhark.Internalise.Monomorphise"
 --
@@ -42,6 +51,7 @@ module Futhark.Internalise (internaliseProg) where
 import Data.Text qualified as T
 import Futhark.Compiler.Config
 import Futhark.IR.SOACS as I hiding (stmPat)
+import Futhark.Internalise.ApplyTypeAbbrs as ApplyTypeAbbrs
 import Futhark.Internalise.Defunctionalise as Defunctionalise
 import Futhark.Internalise.Defunctorise as Defunctorise
 import Futhark.Internalise.Entry (visibleTypes)
@@ -63,19 +73,19 @@ internaliseProg ::
   m (I.Prog SOACS)
 internaliseProg config prog = do
   maybeLog "Defunctorising"
-  prog_decs <- Defunctorise.transformProg prog
+  prog_decs0 <- ApplyTypeAbbrs.transformProg =<< Defunctorise.transformProg prog
   maybeLog "Full Normalising"
-  prog_decs' <- FullNormalise.transformProg prog_decs
-  maybeLog "Monomorphising"
-  prog_decs'' <- Monomorphise.transformProg prog_decs'
-  maybeLog "Replacing records"
-  prog_decs''' <- ReplaceRecords.transformProg prog_decs''
+  prog_decs1 <- FullNormalise.transformProg prog_decs0
   maybeLog "Lifting lambdas"
-  prog_decs'''' <- LiftLambdas.transformProg prog_decs'''
+  prog_decs2 <- LiftLambdas.transformProg prog_decs1
+  maybeLog "Monomorphising"
+  prog_decs3 <- Monomorphise.transformProg prog_decs2
+  maybeLog "Replacing records"
+  prog_decs4 <- ReplaceRecords.transformProg prog_decs3
   maybeLog "Defunctionalising"
-  prog_decs''''' <- Defunctionalise.transformProg prog_decs''''
+  prog_decs5 <- Defunctionalise.transformProg prog_decs4
   maybeLog "Converting to core IR"
-  Exps.transformProg (futharkSafe config) (visibleTypes prog) prog_decs'''''
+  Exps.transformProg (futharkSafe config) (visibleTypes prog) prog_decs5
   where
     verbose = fst (futharkVerbose config) > NotVerbose
     maybeLog s

--- a/src/Futhark/Internalise/ApplyTypeAbbrs.hs
+++ b/src/Futhark/Internalise/ApplyTypeAbbrs.hs
@@ -1,0 +1,85 @@
+-- | A minor cleanup pass that runs after defunctorisation and applies
+-- any type abbreviations. After this, the program consists entirely
+-- value bindings.
+module Futhark.Internalise.ApplyTypeAbbrs (transformProg) where
+
+import Control.Monad.Identity
+import Data.Map.Strict qualified as M
+import Data.Maybe (mapMaybe)
+import Language.Futhark
+import Language.Futhark.Semantic (TypeBinding (..))
+import Language.Futhark.Traversals
+import Language.Futhark.TypeChecker.Types
+
+type Types = M.Map VName (Subst StructRetType)
+
+getTypes :: Types -> [Dec] -> Types
+getTypes types [] = types
+getTypes types (TypeDec typebind : ds) = do
+  let (TypeBind name l tparams _ (Info (RetType dims t)) _ _) = typebind
+      tbinding = TypeAbbr l tparams $ RetType dims $ applySubst (`M.lookup` types) t
+      types' = M.insert name (substFromAbbr tbinding) types
+  getTypes types' ds
+getTypes types (_ : ds) =
+  getTypes types ds
+
+-- Perform a given substitution on the types in a pattern.
+substPat :: (t -> t) -> Pat t -> Pat t
+substPat f pat = case pat of
+  TuplePat pats loc -> TuplePat (map (substPat f) pats) loc
+  RecordPat fs loc -> RecordPat (map substField fs) loc
+    where
+      substField (n, p) = (n, substPat f p)
+  PatParens p loc -> PatParens (substPat f p) loc
+  PatAttr attr p loc -> PatAttr attr (substPat f p) loc
+  Id vn (Info tp) loc -> Id vn (Info $ f tp) loc
+  Wildcard (Info tp) loc -> Wildcard (Info $ f tp) loc
+  PatAscription p _ _ -> substPat f p
+  PatLit e (Info tp) loc -> PatLit e (Info $ f tp) loc
+  PatConstr n (Info tp) ps loc -> PatConstr n (Info $ f tp) ps loc
+
+removeTypeVariablesInType :: Types -> StructType -> StructType
+removeTypeVariablesInType types =
+  applySubst (`M.lookup` types)
+
+substEntry :: Types -> EntryPoint -> EntryPoint
+substEntry types (EntryPoint params ret) =
+  EntryPoint (map onEntryParam params) (onEntryType ret)
+  where
+    onEntryParam (EntryParam v t) =
+      EntryParam v $ onEntryType t
+    onEntryType (EntryType t te) =
+      EntryType (removeTypeVariablesInType types t) te
+
+-- Remove all type variables and type abbreviations from a value binding.
+removeTypeVariables :: Types -> ValBind -> ValBind
+removeTypeVariables types valbind = do
+  let (ValBind entry _ _ (Info (RetType dims rettype)) _ pats body _ _ _) = valbind
+      mapper =
+        ASTMapper
+          { mapOnExp = onExp,
+            mapOnName = pure,
+            mapOnStructType = pure . applySubst (`M.lookup` types),
+            mapOnParamType = pure . applySubst (`M.lookup` types),
+            mapOnResRetType = pure . applySubst (`M.lookup` types)
+          }
+      onExp = astMap mapper
+
+  let body' = runIdentity $ onExp body
+
+  valbind
+    { valBindRetType = Info (applySubst (`M.lookup` types) $ RetType dims rettype),
+      valBindParams = map (substPat $ applySubst (`M.lookup` types)) pats,
+      valBindEntryPoint = fmap (substEntry types) <$> entry,
+      valBindBody = body'
+    }
+
+-- | Apply type abbreviations from a list of top-level declarations. A
+-- module-free input program is expected, so only value declarations
+-- and type declaration are accepted.
+transformProg :: (Monad m) => [Dec] -> m [ValBind]
+transformProg decs =
+  let types = getTypes mempty decs
+      onDec (ValDec valbind) = Just $ removeTypeVariables types valbind
+      onDec _ = Nothing
+   in pure $ mapMaybe onDec decs

--- a/src/Futhark/Internalise/FullNormalise.hs
+++ b/src/Futhark/Internalise/FullNormalise.hs
@@ -2,13 +2,19 @@
 -- module-free Futhark program into an equivalent with only simple expresssions.
 -- Notably, all non-trivial expression are converted into a list of
 -- let-bindings to make them simpler, with no nested apply, nested lets...
--- This module only performs synthatic operations.
+-- This module only performs syntactic operations.
 --
--- Also, it performs desugaring that is:
--- * Turn operator section into lambda
--- * turn BinOp into application (&& and || are converted to if structure)
--- * turn `let x [i] = e1` into `let x = x with [i] = e1`
--- * binds all implicit sizes
+-- Also, it performs various kinds of desugaring:
+--
+-- * Turns operator sections into explicit lambdas.
+--
+-- * Rewrites BinOp nodes to Apply nodes (&& and || are converted to conditionals).
+--
+-- * Turns `let x [i] = e1` into `let x = x with [i] = e1`.
+--
+-- * Binds all implicit sizes.
+--
+-- * Turns implicit record fields into explicit record fields.
 --
 -- This is currently not done for expressions inside sizes, this processing
 -- still needed in monomorphisation for now.
@@ -164,7 +170,8 @@ getOrdering _ (RecordLit fs loc) = do
     f (RecordFieldExplicit n e floc) = do
       e' <- getOrdering False e
       pure $ RecordFieldExplicit n e' floc
-    f field@RecordFieldImplicit {} = pure field
+    f (RecordFieldImplicit v t _) =
+      f $ RecordFieldExplicit (baseName v) (Var (qualName v) t loc) loc
 getOrdering _ (ArrayLit es ty loc) = do
   es' <- mapM (getOrdering False) es
   pure $ ArrayLit es' ty loc
@@ -349,11 +356,10 @@ transformBody e = do
     f body (FunBind vn infos) =
       AppExp (LetFun vn infos body mempty) appRes
 
-transformDec :: (MonadFreshNames m) => Dec -> m Dec
-transformDec (ValDec valbind) = do
+transformValBind :: (MonadFreshNames m) => ValBind -> m ValBind
+transformValBind valbind = do
   body' <- transformBody $ valBindBody valbind
-  pure $ ValDec (valbind {valBindBody = body'})
-transformDec d = pure d
+  pure $ valbind {valBindBody = body'}
 
-transformProg :: (MonadFreshNames m) => [Dec] -> m [Dec]
-transformProg = mapM transformDec
+transformProg :: (MonadFreshNames m) => [ValBind] -> m [ValBind]
+transformProg = mapM transformValBind

--- a/src/Futhark/Internalise/LiftLambdas.hs
+++ b/src/Futhark/Internalise/LiftLambdas.hs
@@ -18,7 +18,7 @@ import Language.Futhark
 import Language.Futhark.Traversals
 
 data Env = Env
-  { envReplace :: M.Map VName Exp,
+  { envReplace :: M.Map VName (StructType -> Exp),
     envVtable :: M.Map VName StructType
   }
 
@@ -53,7 +53,7 @@ addValBind vb = modify $ \s ->
       stateGlobal = foldl' (flip S.insert) (stateGlobal s) (valBindBound vb)
     }
 
-replacing :: VName -> Exp -> LiftM a -> LiftM a
+replacing :: VName -> (StructType -> Exp) -> LiftM a -> LiftM a
 replacing v e = local $ \env ->
   env {envReplace = M.insert v e $ envReplace env}
 
@@ -85,7 +85,7 @@ bindingForm While {} = id
 toRet :: TypeBase Size u -> TypeBase Size Uniqueness
 toRet = second (const Nonunique)
 
-liftFunction :: VName -> [TypeParam] -> [Pat ParamType] -> ResRetType -> Exp -> LiftM Exp
+liftFunction :: VName -> [TypeParam] -> [Pat ParamType] -> ResRetType -> Exp -> LiftM (StructType -> Exp)
 liftFunction fname tparams params (RetType dims ret) funbody = do
   -- Find free variables
   vtable <- asks envVtable
@@ -124,22 +124,22 @@ liftFunction fname tparams params (RetType dims ret) funbody = do
         valBindEntryPoint = Nothing
       }
 
-  pure
-    $ apply
-      (Var (qualName fname) (Info (augType free_ts)) mempty)
-    $ free_dims ++ free_nondims
+  pure $ \orig_type ->
+    apply
+      orig_type
+      (Var (qualName fname) (Info (augType free_ts orig_type)) mempty)
+      $ free_dims ++ free_nondims
   where
-    orig_type = funType params $ RetType dims ret
     mkParam (v, t) = Id v (Info (toParam Observe t)) mempty
     freeVar (v, t) = Var (qualName v) (Info t) mempty
-    augType rem_free = funType (map mkParam rem_free) $ RetType [] $ toRet orig_type
+    augType rem_free orig_type = funType (map mkParam rem_free) $ RetType [] $ toRet orig_type
 
-    apply :: Exp -> [(VName, StructType)] -> Exp
-    apply f [] = f
-    apply f (p : rem_ps) =
-      let inner_ret = AppRes (augType rem_ps) mempty
+    apply :: StructType -> Exp -> [(VName, StructType)] -> Exp
+    apply _ f [] = f
+    apply orig_type f (p : rem_ps) =
+      let inner_ret = AppRes (augType rem_ps orig_type) mempty
           inner = mkApply f [(Nothing, freeVar p)] inner_ret
-       in apply inner rem_ps
+       in apply orig_type inner rem_ps
 
 transformSubExps :: ASTMapper LiftM
 transformSubExps = identityMapper {mapOnExp = transformExp}
@@ -150,10 +150,10 @@ transformExp (AppExp (LetFun fname (tparams, params, _, Info ret, funbody) body 
   fname' <- newVName $ "lifted_" ++ baseString fname
   lifted_call <- liftFunction fname' tparams params ret funbody'
   replacing fname lifted_call $ transformExp body
-transformExp (Lambda params body _ (Info ret) _) = do
+transformExp e@(Lambda params body _ (Info ret) _) = do
   body' <- bindingParams [] params $ transformExp body
   fname <- newVName "lifted_lambda"
-  liftFunction fname [] params ret body'
+  liftFunction fname [] params ret body' <*> pure (typeOf e)
 transformExp (AppExp (LetPat sizes pat e body loc) appres) = do
   e' <- transformExp e
   body' <- bindingLetPat (map sizeName sizes) pat $ transformExp body
@@ -173,10 +173,10 @@ transformExp (AppExp (Loop sizes pat args form body loc) appres) = do
     form' <- astMap transformSubExps form
     body' <- bindingForm form' $ transformExp body
     pure $ AppExp (Loop sizes pat args' form' body' loc) appres
-transformExp e@(Var v _ _) =
+transformExp e@(Var v (Info t) _) =
   -- Note that function-typed variables can only occur in expressions,
   -- not in other places where VNames/QualNames can occur.
-  asks (fromMaybe e . M.lookup (qualLeaf v) . envReplace)
+  asks $ maybe e ($ t) . M.lookup (qualLeaf v) . envReplace
 transformExp e = astMap transformSubExps e
 
 transformValBind :: ValBind -> LiftM ()

--- a/tests/issue2106.fut
+++ b/tests/issue2106.fut
@@ -1,0 +1,11 @@
+-- ==
+-- input { 2i64 }
+-- output { [0i64, 0i64] }
+
+def f'' 'a (n: i64) (f: a -> i64) (a: a): [n]i64 = replicate n (f a)
+
+def f (s: {n: i64}): [s.n]i64 =
+  let f' 'a (f: a -> i64) (a: a): [s.n]i64 = f'' s.n f a
+  in f' id 0
+
+entry main (n: i64) = f {n}


### PR DESCRIPTION
This looks a lot more complicated than it ought to. The real bug was a mishandling of local polymorphic functions in monomorphisation. I reasoned that there is no reason monomorphisation should ever encounter those - we should lambda lift those before we monomorphise. However, that created the need for a bunch of other modifications, including a new (very small) pass (ApplyTypeAbbrs) that runs just after defunctorisation.

IT is overall a conceptual simplification, but the code changes look quite large for such a small bug.