### PR TITLE
Fix the problem that files compiled by windows CI are not added to the download list.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -666,3 +666,4 @@ jobs:
         files: |
           futhark-nightly-linux-x86_64.tar.xz
           futhark-nightly-macos-x86_64.tar.xz
+          futhark-nightly-windows-x86_64.zip


### PR DESCRIPTION
Fix the problem that files compiled by windows CI are not added to the download list.
Should be no problem this time. Thanks.