### PR TITLE
Replace some memory fences with "atomic writes".

### DIFF
--- a/src/Futhark/CodeGen/ImpCode/GPU.hs
+++ b/src/Futhark/CodeGen/ImpCode/GPU.hs
@@ -183,9 +183,10 @@ data KernelOp
     ErrorSync Fence
   deriving (Show)
 
--- | Atomic operations return the value stored before the update.
--- This old value is stored in the first 'VName'.  The second 'VName'
--- is the memory block to update.  The 'Exp' is the new value.
+-- | Atomic operations return the value stored before the update. This
+-- old value is stored in the first 'VName' (except for
+-- 'AtomicWrite'). The second 'VName' is the memory block to update.
+-- The 'Exp' is the new value.
 data AtomicOp
   = AtomicAdd IntType VName VName (Count Elements (TExp Int64)) Exp
   | AtomicFAdd FloatType VName VName (Count Elements (TExp Int64)) Exp
@@ -198,6 +199,9 @@ data AtomicOp
   | AtomicXor IntType VName VName (Count Elements (TExp Int64)) Exp
   | AtomicCmpXchg PrimType VName VName (Count Elements (TExp Int64)) Exp Exp
   | AtomicXchg PrimType VName VName (Count Elements (TExp Int64)) Exp
+  | -- | Corresponds to a write followed by a memory fence. The old
+    -- value is not read.
+    AtomicWrite PrimType VName (Count Elements (TExp Int64)) Exp
   deriving (Show)
 
 instance FreeIn AtomicOp where
@@ -212,6 +216,7 @@ instance FreeIn AtomicOp where
   freeIn' (AtomicXor _ _ arr i x) = freeIn' arr <> freeIn' i <> freeIn' x
   freeIn' (AtomicCmpXchg _ _ arr i x y) = freeIn' arr <> freeIn' i <> freeIn' x <> freeIn' y
   freeIn' (AtomicXchg _ _ arr i x) = freeIn' arr <> freeIn' i <> freeIn' x
+  freeIn' (AtomicWrite _ arr i x) = freeIn' arr <> freeIn' i <> freeIn' x
 
 instance Pretty KernelOp where
   pretty (GetBlockId dest i) =
@@ -311,6 +316,10 @@ instance Pretty KernelOp where
     pretty old
       <+> "<-"
       <+> "atomic_xchg"
+      <> pretty t
+      <> parens (commasep [pretty arr <> brackets (pretty ind), pretty x])
+  pretty (Atomic _ (AtomicWrite t arr ind x)) =
+    "atomic_write"
       <> pretty t
       <> parens (commasep [pretty arr <> brackets (pretty ind), pretty x])
 

--- a/src/Futhark/CodeGen/ImpGen.hs
+++ b/src/Futhark/CodeGen/ImpGen.hs
@@ -44,6 +44,7 @@ module Futhark.CodeGen.ImpGen
     -- * Lookups
     lookupVar,
     lookupArray,
+    lookupArraySpace,
     lookupMemory,
     lookupAcc,
     askAttrs,
@@ -1368,6 +1369,7 @@ lookupMemory name = do
     MemVar _ entry -> pure entry
     _ -> error $ "Unknown memory block: " ++ prettyString name
 
+-- | In which memory space is this array allocated?
 lookupArraySpace :: VName -> ImpM rep r op Space
 lookupArraySpace =
   fmap entryMemSpace . lookupMemory

--- a/src/Futhark/CodeGen/ImpGen/GPU/Base.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/Base.hs
@@ -686,10 +686,15 @@ writeAtomic dst dst_is src src_is = do
   sLoopSpace (map pe64 (arrayDims t)) $ \is -> do
     let pt = elemType t
     (dst_mem, dst_space, dst_offset) <- fullyIndexArray dst (dst_is ++ is)
-    tmp <- dPrimSV "tmp" pt
-    copyDWIMFix (tvVar tmp) [] src (src_is ++ is)
-    sOp . Imp.Atomic dst_space $
-      Imp.AtomicWrite pt dst_mem dst_offset (untyped (tvExp tmp))
+    case src_is ++ is of
+      [] ->
+        sOp . Imp.Atomic dst_space $
+          Imp.AtomicWrite pt dst_mem dst_offset (toExp' pt src)
+      _ -> do
+        tmp <- dPrimSV "tmp" pt
+        copyDWIMFix (tvVar tmp) [] src (src_is ++ is)
+        sOp . Imp.Atomic dst_space $
+          Imp.AtomicWrite pt dst_mem dst_offset (untyped (tvExp tmp))
 
 -- | Locking strategy used for an atomic update.
 data Locking = Locking

--- a/src/Futhark/CodeGen/ImpGen/GPU/SegRed.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/SegRed.hs
@@ -928,8 +928,7 @@ reductionStageTwo segred_pes tblock_id segment_gtids first_block_for_segment blo
   sComment "first thread in block saves block result to global memory" $
     sWhen (ltid32 .==. 0) $ do
       forM_ (take (length nes) $ zip block_res_arrs (slugAccs slug)) $ \(v, (acc, acc_is)) ->
-        copyDWIMFix v [0, sExt64 tblock_id] (Var acc) acc_is
-      sOp $ Imp.MemFence Imp.FenceGlobal
+        writeAtomic v [0, sExt64 tblock_id] (Var acc) acc_is
       -- Increment the counter, thus stating that our result is
       -- available.
       sOp

--- a/src/Futhark/CodeGen/ImpGen/GPU/ToOpenCL.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/ToOpenCL.hs
@@ -736,11 +736,11 @@ inKernelOperations env mode body =
       doAtomicXchg s t old arr ind val [C.cty|int|]
     atomicOps s (AtomicWrite t arr ind val) = do
       ind' <- GC.compileExp $ untyped $ unCount ind
-      val' <- GC.compileExp val
+      val' <- toStorage t <$> GC.compileExp val
       let quals = case s of
             Space sid -> pointerQuals sid
             _ -> pointerQuals "global"
-      GC.stm [C.cstm|(($tyquals:quals $ty:(primTypeToCType t)*)$id:arr)[$exp:ind'] = $exp:val';|]
+      GC.stm [C.cstm|(($tyquals:quals $ty:(primStorageType t)*)$id:arr)[$exp:ind'] = $exp:val';|]
       GC.stm $
         case s of
           Space "shared" -> [C.cstm|mem_fence_local();|]

--- a/src/Futhark/CodeGen/ImpGen/GPU/ToOpenCL.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/ToOpenCL.hs
@@ -734,6 +734,17 @@ inKernelOperations env mode body =
       doAtomicCmpXchg s t old arr ind cmp val [C.cty|int|]
     atomicOps s (AtomicXchg t old arr ind val) =
       doAtomicXchg s t old arr ind val [C.cty|int|]
+    atomicOps s (AtomicWrite t arr ind val) = do
+      ind' <- GC.compileExp $ untyped $ unCount ind
+      val' <- GC.compileExp val
+      let quals = case s of
+            Space sid -> pointerQuals sid
+            _ -> pointerQuals "global"
+      GC.stm [C.cstm|(($tyquals:quals $ty:(primTypeToCType t)*)$id:arr)[$exp:ind'] = $exp:val';|]
+      GC.stm $
+        case s of
+          Space "shared" -> [C.cstm|mem_fence_local();|]
+          _ -> [C.cstm|mem_fence_global();|]
 
     cannotAllocate :: GC.Allocate KernelOp KernelState
     cannotAllocate _ =


### PR DESCRIPTION
On our current backends, an atomic write is just a write followed by a memory fence, but on some future ones (e.g. the WebGPU one), fences supported only implicitly through use of atomic data types. It turns out that in most (all?) cases, we only need fences for these "atomic writes". The possible exception is single pass scan, but we will not use that for the WebGPU backend anyway.