### PR TITLE
Another ImpCode int type fix

### DIFF
--- a/src/Futhark/CodeGen/ImpGen/GPU/SegRed.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/SegRed.hs
@@ -960,7 +960,7 @@ reductionStageTwo segred_pes tblock_id segment_gtids first_block_for_segment blo
         Imp.Atomic DefaultSpace $
           Imp.AtomicAdd Int32 (tvVar old_counter) counter_mem counter_offset $
             untyped $
-              negate blocks_per_segment
+              sExt32 (negate blocks_per_segment)
 
     sLoopNest (slugShape slug) $ \vec_is -> do
       unless (null $ slugShape slug) $


### PR DESCRIPTION
Found another one. `blocks_per_segment` is already `sExt32`'d a couple lines above, so I assume this fix is fine?