### PR TITLE
OpenCL backend: pass -cl-fp32-correctly-rounded-divide-sqrt.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+* The `opencl` backend now always passes
+  `-cl-fp32-correctly-rounded-divide-sqrt` to the kernel compiler, in
+  order to match CUDA and HIP behaviour.
+
 ## [0.25.18]
 
 ### Added

--- a/rts/c/backends/opencl.h
+++ b/rts/c/backends/opencl.h
@@ -657,6 +657,12 @@ static char* mk_compile_opts(struct futhark_context *ctx,
     w += snprintf(compile_opts+w, compile_opts_size-w, "-DEMULATE_F16 ");
   }
 
+  // By default, OpenCL allows imprecise (but faster) division and
+  // square root operations. For equivalence with other backends, ask
+  // for correctly rounded ones here.
+  w += snprintf(compile_opts+w, compile_opts_size-w,
+                "-cl-fp32-correctly-rounded-divide-sqrt");
+
   free(macro_names);
   free(macro_vals);
 


### PR DESCRIPTION
Closes #2155.