### PR TITLE
More efficient floating-point addition in OpenCL backend.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Trailing commas are now allowed for arrays, records, and tuples in
   the textual value format and in FutharkScript.
 
+* Faster floating-point atomics with OpenCL backend on AMD and NVIDIA
+  GPUs. This affects histogram workloads.
+
 ### Removed
 
 ### Changed

--- a/rts/c/atomics.h
+++ b/rts/c/atomics.h
@@ -78,16 +78,29 @@ SCALAR_FUN_ATTR int32_t atomic_add_i32_shared(volatile __local int32_t *p, int32
 SCALAR_FUN_ATTR float atomic_fadd_f32_global(volatile __global float *p, float x) {
 #if defined(FUTHARK_CUDA) || defined(FUTHARK_HIP)
   return atomicAdd((float*)p, x);
+  // On OpenCL, use technique from
+  // https://pipinspace.github.io/blog/atomic-float-addition-in-opencl.html
+#elif defined(cl_nv_pragma_unroll)
+  // use hardware-supported atomic addition on Nvidia GPUs with inline
+  // PTX assembly
+  float ret;
+  asm volatile("atom.global.add.f32 %0,[%1],%2;":"=f"(ret):"l"(p),"f"(x):"memory");
+  return ret;
+#elif defined(__opencl_c_ext_fp32_global_atomic_add)
+  // use hardware-supported atomic addition on some Intel GPUs
+  return atomic_fetch_add_explicit((volatile __global atomic_float*)p,
+                                   x,
+                                   memory_order_relaxed);
+#elif __has_builtin(__builtin_amdgcn_global_atomic_fadd_f32)
+  // use hardware-supported atomic addition on some AMD GPUs
+  return __builtin_amdgcn_global_atomic_fadd_f32(p, x);
 #else
-  union { int32_t i; float f; } old;
-  union { int32_t i; float f; } assumed;
-  old.f = *p;
-  do {
-    assumed.f = old.f;
-    old.f = old.f + x;
-    old.i = atomic_cmpxchg_i32_global((volatile __global int32_t*)p, assumed.i, old.i);
-  } while (assumed.i != old.i);
-  return old.f;
+  // fallback emulation:
+  // https://forums.developer.nvidia.com/t/atomicadd-float-float-atomicmul-float-float/14639/5
+  float old = x;
+  float ret;
+  while ((old=atomic_xchg(p, ret=atomic_xchg(p, 0.0f)+old))!=0.0f);
+  return ret;
 #endif
 }
 
@@ -306,16 +319,32 @@ SCALAR_FUN_ATTR int64_t atomic_add_i64_shared(volatile __local int64_t *p, int64
 SCALAR_FUN_ATTR double atomic_fadd_f64_global(volatile __global double *p, double x) {
 #if defined(FUTHARK_CUDA) && __CUDA_ARCH__ >= 600 || defined(FUTHARK_HIP)
   return atomicAdd((double*)p, x);
+  // On OpenCL, use technique from
+  // https://pipinspace.github.io/blog/atomic-float-addition-in-opencl.html
+#elif defined(cl_nv_pragma_unroll)
+  // use hardware-supported atomic addition on Nvidia GPUs with inline
+  // PTX assembly
+  double ret;
+  asm volatile("atom.global.add.f64 %0,[%1],%2;":"=d"(ret):"l"(p),"d"(x):"memory");
+  return ret;
+#elif __has_builtin(__builtin_amdgcn_global_atomic_fadd_f64)
+  // use hardware-supported atomic addition on some AMD GPUs
+  return __builtin_amdgcn_global_atomic_fadd_f64(p, x);
 #else
-  union { int64_t i; double f; } old;
-  union { int64_t i; double f; } assumed;
-  old.f = *p;
-  do {
-    assumed.f = old.f;
-    old.f = old.f + x;
-    old.i = atomic_cmpxchg_i64_global((volatile __global int64_t*)p, assumed.i, old.i);
-  } while (assumed.i != old.i);
-  return old.f;
+  // fallback emulation:
+  // https://forums.developer.nvidia.com/t/atomicadd-float-float-atomicmul-float-float/14639/5
+  union {int64_t i; double f;} old;
+  union {int64_t i; double f;} ret;
+  old.f = x;
+  while (1) {
+    ret.i = atom_xchg((volatile __global int64_t*)p, (int64_t)0);
+    ret.f += old.f;
+    old.i = atom_xchg((volatile __global int64_t*)p, ret.i);
+    if (old.i == 0) {
+      break;
+    }
+  }
+  return ret.f;
 #endif
 }
 

--- a/src/Futhark/CodeGen/ImpGen/GPU.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU.hs
@@ -45,6 +45,7 @@ openclAtomics, cudaAtomics :: AtomicBinOp
   where
     opencl64 =
       [ (Add Int64 OverflowUndef, Imp.AtomicAdd Int64),
+        (FAdd Float64, Imp.AtomicFAdd Float64),
         (SMax Int64, Imp.AtomicSMax Int64),
         (SMin Int64, Imp.AtomicSMin Int64),
         (UMax Int64, Imp.AtomicUMax Int64),
@@ -55,6 +56,7 @@ openclAtomics, cudaAtomics :: AtomicBinOp
       ]
     opencl32 =
       [ (Add Int32 OverflowUndef, Imp.AtomicAdd Int32),
+        (FAdd Float32, Imp.AtomicFAdd Float32),
         (SMax Int32, Imp.AtomicSMax Int32),
         (SMin Int32, Imp.AtomicSMin Int32),
         (UMax Int32, Imp.AtomicUMax Int32),
@@ -64,11 +66,7 @@ openclAtomics, cudaAtomics :: AtomicBinOp
         (Xor Int32, Imp.AtomicXor Int32)
       ]
     opencl = opencl32 ++ opencl64
-    cuda =
-      opencl
-        ++ [ (FAdd Float32, Imp.AtomicFAdd Float32),
-             (FAdd Float64, Imp.AtomicFAdd Float64)
-           ]
+    cuda = opencl
 
 compileProg ::
   (MonadFreshNames m) =>


### PR DESCRIPTION
Based on the technique described by PipInSpace at
https://pipinspace.github.io/blog/atomic-float-addition-in-opencl.html