### PR TITLE
Add missing newline

### DIFF
--- a/rts/c/tuning.h
+++ b/rts/c/tuning.h
@@ -2,7 +2,7 @@
 
 
 int is_blank_line_or_comment(const char *s) {
-  size_t i = strspn(s, " \t");
+  size_t i = strspn(s, " \t\n");
   return s[i] == '\0' || // Line is blank.
          strncmp(s + i, "--", 2) == 0; // Line is comment.
 }


### PR DESCRIPTION
This PR now allows completely blank lines in tuning files, by correcting my own mistake in which I had neglected to account for `fgets` storing terminating newlines (if any).