### PR TITLE
Add negation as a primitive unop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+* Negation of floating-point positive zero now produces a negative
+  zero.
+
 ## [0.25.23]
 
 ### Added

--- a/src/Futhark/AD/Derivatives.hs
+++ b/src/Futhark/AD/Derivatives.hs
@@ -26,7 +26,10 @@ untyped2 = bimap untyped untyped
 pdUnOp :: UnOp -> PrimExp VName -> PrimExp VName
 pdUnOp (Abs it) a = UnOpExp (SSignum it) a
 pdUnOp (FAbs ft) a = UnOpExp (FSignum ft) a
-pdUnOp Not x = x
+pdUnOp (Neg Bool) x = x
+pdUnOp (Neg Unit) x = x
+pdUnOp (Neg (IntType it)) _ = iConst it (-1)
+pdUnOp (Neg (FloatType ft)) _ = fConst ft (-1)
 pdUnOp (Complement it) x = UnOpExp (Complement it) x
 pdUnOp (SSignum it) _ = iConst it 0
 pdUnOp (USignum it) _ = iConst it 0

--- a/src/Futhark/Analysis/PrimExp.hs
+++ b/src/Futhark/Analysis/PrimExp.hs
@@ -230,7 +230,7 @@ constFoldPrimExp (BinOpExp LogOr x y)
   | zeroIshExp y = x
 constFoldPrimExp (UnOpExp Abs {} x)
   | not $ negativeIshExp x = x
-constFoldPrimExp (UnOpExp Not {} (ValueExp (BoolValue x))) =
+constFoldPrimExp (UnOpExp (Neg _) (ValueExp (BoolValue x))) =
   ValueExp $ BoolValue $ not x
 constFoldPrimExp (BinOpExp UMod {} x y)
   | sameIshExp x y,
@@ -642,7 +642,7 @@ fromBool b = if b then true else false
 
 -- | Boolean negation smart constructor.
 bNot :: TPrimExp Bool v -> TPrimExp Bool v
-bNot = TPrimExp . UnOpExp Not . untyped
+bNot = TPrimExp . UnOpExp (Neg Bool) . untyped
 
 -- | SMax on 32-bit integers.
 sMax32 :: TPrimExp Int32 v -> TPrimExp Int32 v -> TPrimExp Int32 v

--- a/src/Futhark/CodeGen/Backends/GenericC/Code.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC/Code.hs
@@ -56,15 +56,18 @@ compilePrimExp f (LeafExp v _) =
 compilePrimExp f (UnOpExp Complement {} x) = do
   x' <- compilePrimExp f x
   pure [C.cexp|~$exp:x'|]
-compilePrimExp f (UnOpExp Not {} x) = do
-  x' <- compilePrimExp f x
-  pure [C.cexp|!$exp:x'|]
 compilePrimExp f (UnOpExp SSignum {} x) = do
   x' <- compilePrimExp f x
   pure [C.cexp|($exp:x' > 0 ? 1 : 0) - ($exp:x' < 0 ? 1 : 0)|]
 compilePrimExp f (UnOpExp USignum {} x) = do
   x' <- compilePrimExp f x
   pure [C.cexp|($exp:x' > 0 ? 1 : 0) - ($exp:x' < 0 ? 1 : 0) != 0|]
+compilePrimExp f (UnOpExp (Neg Bool) x) = do
+  x' <- compilePrimExp f x
+  pure [C.cexp|!$exp:x'|]
+compilePrimExp f (UnOpExp Neg {} x) = do
+  x' <- compilePrimExp f x
+  pure [C.cexp|-$exp:x'|]
 compilePrimExp f (UnOpExp op x) = do
   x' <- compilePrimExp f x
   pure [C.cexp|$id:(prettyString op)($exp:x')|]

--- a/src/Futhark/CodeGen/Backends/GenericPython.hs
+++ b/src/Futhark/CodeGen/Backends/GenericPython.hs
@@ -992,7 +992,8 @@ toMicroseconds x =
 compileUnOp :: Imp.UnOp -> String
 compileUnOp op =
   case op of
-    Not -> "not"
+    Neg Imp.Bool -> "not"
+    Neg _ -> "-"
     Complement {} -> "~"
     Abs {} -> "abs"
     FAbs {} -> "abs"

--- a/src/Futhark/CodeGen/Backends/MulticoreISPC.hs
+++ b/src/Futhark/CodeGen/Backends/MulticoreISPC.hs
@@ -415,9 +415,12 @@ compileExp (LeafExp v _) =
 compileExp (UnOpExp Complement {} x) = do
   x' <- compileExp x
   pure [C.cexp|~$exp:x'|]
-compileExp (UnOpExp Not {} x) = do
+compileExp (UnOpExp (Neg Bool) x) = do
   x' <- compileExp x
   pure [C.cexp|!$exp:x'|]
+compileExp (UnOpExp Neg {} x) = do
+  x' <- compileExp x
+  pure [C.cexp|-$exp:x'|]
 compileExp (UnOpExp (FAbs Float32) x) = do
   x' <- compileExp x
   pure [C.cexp|(float)fabs($exp:x')|]

--- a/src/Futhark/Internalise/Exps.hs
+++ b/src/Futhark/Internalise/Exps.hs
@@ -316,7 +316,7 @@ internaliseAppExp desc _ (E.Range start maybe_second end loc) = do
     letSubExp "range_invalid" $
       I.BasicOp $
         I.BinOp I.LogOr step_invalid bounds_invalid
-  valid <- letSubExp "valid" $ I.BasicOp $ I.UnOp I.Not invalid
+  valid <- letSubExp "valid" $ I.BasicOp $ I.UnOp (I.Neg I.Bool) invalid
   cs <- assert "range_valid_c" valid errmsg loc
 
   step_i64 <- asIntS Int64 step
@@ -720,11 +720,9 @@ internaliseExp desc (E.Negate e _) = do
   e' <- internaliseExp1 "negate_arg" e
   et <- subExpType e'
   case et of
-    I.Prim (I.IntType t) ->
-      letTupExp' desc $ I.BasicOp $ I.BinOp (I.Sub t I.OverflowWrap) (I.intConst t 0) e'
-    I.Prim (I.FloatType t) ->
-      letTupExp' desc $ I.BasicOp $ I.BinOp (I.FSub t) (I.floatConst t 0) e'
-    _ -> error "Futhark.Internalise.internaliseExp: non-numeric type in Negate"
+    I.Prim pt ->
+      letTupExp' desc $ I.BasicOp $ I.UnOp (I.Neg pt) e'
+    _ -> error "Futhark.Internalise.internaliseExp: non-primitive type in Negate"
 internaliseExp desc (E.Not e _) = do
   e' <- internaliseExp1 "not_arg" e
   et <- subExpType e'
@@ -732,7 +730,7 @@ internaliseExp desc (E.Not e _) = do
     I.Prim (I.IntType t) ->
       letTupExp' desc $ I.BasicOp $ I.UnOp (I.Complement t) e'
     I.Prim I.Bool ->
-      letTupExp' desc $ I.BasicOp $ I.UnOp I.Not e'
+      letTupExp' desc $ I.BasicOp $ I.UnOp (I.Neg I.Bool) e'
     _ ->
       error "Futhark.Internalise.internaliseExp: non-int/bool type in Not"
 internaliseExp desc (E.Update src slice ve loc) = do
@@ -1083,7 +1081,7 @@ internaliseDimIndex w (E.DimSlice i j s) = do
   n <- letSubExp "n" =<< divRounding (toExp j_m_i) (toExp s')
 
   zero_stride <- letSubExp "zero_stride" $ I.BasicOp $ I.CmpOp (CmpEq int64) s_sign zero
-  nonzero_stride <- letSubExp "nonzero_stride" $ I.BasicOp $ I.UnOp I.Not zero_stride
+  nonzero_stride <- letSubExp "nonzero_stride" $ I.BasicOp $ I.UnOp (I.Neg I.Bool) zero_stride
 
   -- Bounds checks depend on whether we are slicing forwards or
   -- backwards.  If forwards, we must check '0 <= i && i <= j'.  If
@@ -1320,7 +1318,7 @@ certifyingNonzero loc t x m = do
     letSubExp "zero" $
       I.BasicOp $
         CmpOp (CmpEq (IntType t)) x (intConst t 0)
-  nonzero <- letSubExp "nonzero" $ I.BasicOp $ UnOp I.Not zero
+  nonzero <- letSubExp "nonzero" $ I.BasicOp $ UnOp (I.Neg I.Bool) zero
   c <- assert "nonzero_cert" nonzero "division by zero" loc
   certifying c m
 
@@ -1427,7 +1425,7 @@ internaliseBinOp _ desc E.Equal x y t _ =
   simpleCmpOp desc (I.CmpEq $ internalisePrimType t) x y
 internaliseBinOp _ desc E.NotEqual x y t _ = do
   eq <- letSubExp (desc ++ "true") $ I.BasicOp $ I.CmpOp (I.CmpEq $ internalisePrimType t) x y
-  fmap pure $ letSubExp desc $ I.BasicOp $ I.UnOp I.Not eq
+  fmap pure $ letSubExp desc $ I.BasicOp $ I.UnOp (I.Neg I.Bool) eq
 internaliseBinOp _ desc E.Less x y (E.Signed t) _ =
   simpleCmpOp desc (I.CmpSlt t) x y
 internaliseBinOp _ desc E.Less x y (E.Unsigned t) _ =
@@ -1552,7 +1550,7 @@ isOverloadedFunction qname desc loc = do
           cmp_f =<< letSubExp "eq" =<< eAll rs
       where
         isEqlOp "!=" = Just $ \eq ->
-          letTupExp' desc $ I.BasicOp $ I.UnOp I.Not eq
+          letTupExp' desc $ I.BasicOp $ I.UnOp (I.Neg I.Bool) eq
         isEqlOp "==" = Just $ \eq ->
           pure [eq]
         isEqlOp _ = Nothing

--- a/src/Futhark/Optimise/ArrayLayout/Layout.hs
+++ b/src/Futhark/Optimise/ArrayLayout/Layout.hs
@@ -87,7 +87,7 @@ reduceStrideAndOffset (BinOpExp oper a b) = case (a, b) of
           Sub _ _ -> Just (s, o - valueIntegral v)
           Mul _ _ -> Just (s * valueIntegral v, o * valueIntegral v)
           _ -> Nothing
-    reduce _ (UnOpExp Not _) = Nothing
+    reduce _ (UnOpExp (Neg Bool) _) = Nothing
     reduce _ (UnOpExp (Complement _) _) = Nothing
     reduce _ (UnOpExp (Abs _) _) = Nothing
     reduce _ (UnOpExp _ sub_op) = reduceStrideAndOffset sub_op

--- a/src/Futhark/Optimise/Simplify/Engine.hs
+++ b/src/Futhark/Optimise/Simplify/Engine.hs
@@ -297,7 +297,7 @@ protectIf _ _ taken (Let pat aux (Match [cond] [Case [Just (BoolValue True)] tak
     Match [cond'] [Case [Just (BoolValue True)] taken_body] untaken_body $
       MatchDec if_ts MatchFallback
 protectIf _ _ taken (Let pat aux (BasicOp (Assert cond msg loc))) = do
-  not_taken <- letSubExp "loop_not_taken" $ BasicOp $ UnOp Not taken
+  not_taken <- letSubExp "loop_not_taken" $ BasicOp $ UnOp (Neg Bool) taken
   cond' <- letSubExp "protect_assert_disj" $ BasicOp $ BinOp LogOr not_taken cond
   auxing aux $ letBind pat $ BasicOp $ Assert cond' msg loc
 protectIf protect _ taken (Let pat aux (Op op))
@@ -380,7 +380,7 @@ matchingExactlyThis ses prior this = do
   letSubExp "matching_just_this"
     =<< eBinOp
       LogAnd
-      (eUnOp Not (eAny prior_matches))
+      (eUnOp (Neg Bool) (eAny prior_matches))
       (eSubExp =<< matching (zip ses this))
 
 -- | We are willing to hoist potentially unsafe statements out of

--- a/src/Futhark/Optimise/Simplify/Rules/BasicOp.hs
+++ b/src/Futhark/Optimise/Simplify/Rules/BasicOp.hs
@@ -224,7 +224,7 @@ ruleBasicOp vtable pat _ (CmpOp (CmpEq t) se1 se2)
           p_and_eq_x_y <-
             letSubExp "p_and_eq_x_y" $ BasicOp $ BinOp LogAnd p eq_x_y
           not_p <-
-            letSubExp "not_p" $ BasicOp $ UnOp Not p
+            letSubExp "not_p" $ BasicOp $ UnOp (Neg Bool) p
           not_p_and_eq_x_z <-
             letSubExp "p_and_eq_x_y" $ BasicOp $ BinOp LogAnd not_p eq_x_z
           letBind pat $

--- a/src/Futhark/Optimise/Simplify/Rules/Match.hs
+++ b/src/Futhark/Optimise/Simplify/Rules/Match.hs
@@ -80,7 +80,7 @@ ruleMatch _ pat _ ([cond], [Case [Just (BoolValue True)] tb], fb, MatchDec ts _)
           (pure $ BasicOp $ BinOp LogAnd cond tres)
           ( eBinOp
               LogAnd
-              (pure $ BasicOp $ UnOp Not cond)
+              (pure $ BasicOp $ UnOp (Neg Bool) cond)
               (pure $ BasicOp $ SubExp fres)
           )
       certifying (tcs <> fcs) $ letBind pat e
@@ -102,7 +102,7 @@ ruleMatch _ pat _ ([cond], [Case [Just (BoolValue True)] tb], fb, _)
         else
           if zeroIshInt t && oneIshInt f
             then Simplify $ do
-              cond_neg <- letSubExp "cond_neg" $ BasicOp $ UnOp Not cond
+              cond_neg <- letSubExp "cond_neg" $ BasicOp $ UnOp (Neg Bool) cond
               letBind pat $ BasicOp $ ConvOp (BToI (intValueType t)) cond_neg
             else Skip
 -- Simplify

--- a/src/Futhark/Optimise/Simplify/Rules/Simple.hs
+++ b/src/Futhark/Optimise/Simplify/Rules/Simple.hs
@@ -51,7 +51,7 @@ simplifyCmpOp look _ (CmpOp CmpEq {} (Constant (IntValue x)) (Var v))
   | Just (BasicOp (ConvOp BToI {} b), cs) <- look v =
       case valueIntegral x :: Int of
         1 -> Just (SubExp b, cs)
-        0 -> Just (UnOp Not b, cs)
+        0 -> Just (UnOp (Neg Bool) b, cs)
         _ -> Just (SubExp (Constant (BoolValue False)), cs)
 simplifyCmpOp _ _ _ = Nothing
 
@@ -176,11 +176,11 @@ simplifyBinOp defOf _ (BinOp LogAnd e1 e2)
   | isCt1 e1 = resIsSubExp e2
   | isCt1 e2 = resIsSubExp e1
   | Var v <- e1,
-    Just (BasicOp (UnOp Not e1'), v_cs) <- defOf v,
+    Just (BasicOp (UnOp (Neg Bool) e1'), v_cs) <- defOf v,
     e1' == e2 =
       Just (SubExp $ Constant $ BoolValue False, v_cs)
   | Var v <- e2,
-    Just (BasicOp (UnOp Not e2'), v_cs) <- defOf v,
+    Just (BasicOp (UnOp (Neg Bool) e2'), v_cs) <- defOf v,
     e2' == e1 =
       Just (SubExp $ Constant $ BoolValue False, v_cs)
 simplifyBinOp defOf _ (BinOp LogOr e1 e2)
@@ -189,11 +189,11 @@ simplifyBinOp defOf _ (BinOp LogOr e1 e2)
   | isCt1 e1 = constRes $ BoolValue True
   | isCt1 e2 = constRes $ BoolValue True
   | Var v <- e1,
-    Just (BasicOp (UnOp Not e1'), v_cs) <- defOf v,
+    Just (BasicOp (UnOp (Neg Bool) e1'), v_cs) <- defOf v,
     e1' == e2 =
       Just (SubExp $ Constant $ BoolValue True, v_cs)
   | Var v <- e2,
-    Just (BasicOp (UnOp Not e2'), v_cs) <- defOf v,
+    Just (BasicOp (UnOp (Neg Bool) e2'), v_cs) <- defOf v,
     e2' == e1 =
       Just (SubExp $ Constant $ BoolValue True, v_cs)
 simplifyBinOp defOf _ (BinOp (SMax it) e1 e2)
@@ -226,8 +226,8 @@ resIsSubExp = Just . (,mempty) . SubExp
 simplifyUnOp :: SimpleRule rep
 simplifyUnOp _ _ (UnOp op (Constant v)) =
   constRes =<< doUnOp op v
-simplifyUnOp defOf _ (UnOp Not (Var v))
-  | Just (BasicOp (UnOp Not v2), v_cs) <- defOf v =
+simplifyUnOp defOf _ (UnOp (Neg Bool) (Var v))
+  | Just (BasicOp (UnOp (Neg Bool) v2), v_cs) <- defOf v =
       Just (SubExp v2, v_cs)
 simplifyUnOp _ _ _ =
   Nothing

--- a/src/Language/Futhark/Prop.hs
+++ b/src/Language/Futhark/Prop.hs
@@ -1065,12 +1065,20 @@ intrinsics =
             )
           ++
           -- This overrides the ! from Primitive.
-
-          -- This overrides the ! from Primitive.
           [ ( "!",
               IntrinsicOverloadedFun
                 ( map Signed [minBound .. maxBound]
                     ++ map Unsigned [minBound .. maxBound]
+                    ++ [Bool]
+                )
+                [Nothing]
+                Nothing
+            ),
+            ( "neg",
+              IntrinsicOverloadedFun
+                ( map Signed [minBound .. maxBound]
+                    ++ map Unsigned [minBound .. maxBound]
+                    ++ map FloatType [minBound .. maxBound]
                     ++ [Bool]
                 )
                 [Nothing]

--- a/tests/ad/negate.fut
+++ b/tests/ad/negate.fut
@@ -1,6 +1,7 @@
 -- ==
 -- entry: fwd rev
 -- input { 1f32 } output { -1f32 }
+-- input { 3f32 } output { -1f32 }
 
 def f x : f32 = -x
 

--- a/tests/primitive/f16.fut
+++ b/tests/primitive/f16.fut
@@ -7,17 +7,17 @@
 
 -- ==
 -- entry: testNaN
--- input { [1f16, -1f16, -1f16] [0f16, 0f16, 1f16] }
+-- input { [1f16, -1f16, -1f16] }
 -- output { [false, true, true] }
 
 -- ==
 -- entry: testToBits
--- input { [1f16, -1f16, -1f16] [0f16, 0f16, 1f16] }
+-- input { [1f16, -1f16, -1f16] }
 -- output { [0x3c00u16, 0xbc00u16, 0xbc00u16] }
 
 -- ==
 -- entry: testFromBits
--- input { [1f16, -1f16, -1f16] [0f16, 0f16, 1f16] }
+-- input { [1f16, -1f16, -1f16] }
 -- output { [1f16, -1f16, -1f16] }
 
 -- ==
@@ -25,8 +25,14 @@
 -- input { [1f16, f16.inf, -f16.inf, f16.nan] }
 -- output { [-1f16, -f16.inf, f16.inf, f16.nan] }
 
+-- ==
+-- entry: testNegBits
+-- input { [0u16, 0x8000u16] }
+-- output { [0x8000u16, 0u16] }
+
 entry testInf (xs: []f16) (ys: []f16) = map2 (\x y -> f16.isinf(x/y)) xs ys
-entry testNaN (xs: []f16) (ys: []f16) = map (\x -> f16.isnan(f16.sqrt(x))) xs
-entry testToBits (xs: []f16) (ys: []f16) = map f16.to_bits xs
-entry testFromBits (xs: []f16) (ys: []f16) = map (\x -> f16.from_bits(f16.to_bits(x))) xs
+entry testNaN (xs: []f16) = map (\x -> f16.isnan(f16.sqrt(x))) xs
+entry testToBits (xs: []f16) = map f16.to_bits xs
+entry testFromBits (xs: []f16) = map (\x -> f16.from_bits(f16.to_bits(x))) xs
 entry testNeg = map f16.neg
+entry testNegBits = map (f16.from_bits >-> f16.neg >-> f16.to_bits)

--- a/tests/primitive/f32.fut
+++ b/tests/primitive/f32.fut
@@ -7,17 +7,17 @@
 
 -- ==
 -- entry: testNaN
--- input { [1f32, -1f32, -1f32] [0f32, 0f32, 1f32] }
+-- input { [1f32, -1f32, -1f32] }
 -- output { [false, true, true] }
 
 -- ==
 -- entry: testToBits
--- input { [1f32, -1f32, -1f32] [0f32, 0f32, 1f32] }
+-- input { [1f32, -1f32, -1f32] }
 -- output { [0x3f800000u32, 0xbf800000u32, 0xbf800000u32] }
 
 -- ==
 -- entry: testFromBits
--- input { [1f32, -1f32, -1f32] [0f32, 0f32, 1f32] }
+-- input { [1f32, -1f32, -1f32] }
 -- output { [1f32, -1f32, -1f32] }
 
 -- ==
@@ -25,8 +25,14 @@
 -- input { [1f32, f32.inf, -f32.inf, f32.nan] }
 -- output { [-1f32, -f32.inf, f32.inf, f32.nan] }
 
+-- ==
+-- entry: testNegBits
+-- input { [0u32, 0x80000000u32] }
+-- output { [0x80000000u32, 0u32] }
+
 entry testInf (xs: []f32) (ys: []f32) = map2 (\x y -> f32.isinf(x/y)) xs ys
-entry testNaN (xs: []f32) (ys: []f32) = map (\x -> f32.isnan(f32.sqrt(x))) xs
-entry testToBits (xs: []f32) (ys: []f32) = map f32.to_bits xs
-entry testFromBits (xs: []f32) (ys: []f32) = map (\x -> f32.from_bits(f32.to_bits(x))) xs
+entry testNaN (xs: []f32) = map (\x -> f32.isnan(f32.sqrt(x))) xs
+entry testToBits (xs: []f32) = map f32.to_bits xs
+entry testFromBits (xs: []f32) = map (\x -> f32.from_bits(f32.to_bits(x))) xs
 entry testNeg = map f32.neg
+entry testNegBits = map (f32.from_bits >-> f32.neg >-> f32.to_bits)

--- a/tests/primitive/f64.fut
+++ b/tests/primitive/f64.fut
@@ -7,17 +7,17 @@
 
 -- ==
 -- entry: testNaN
--- input { [1f64, -1f64, -1f64] [0f64, 0f64, 1f64] }
+-- input { [1f64, -1f64, -1f64] }
 -- output { [false, true, true] }
 
 -- ==
 -- entry: testToBits
--- input { [1f64, -1f64, -1f64] [0f64, 0f64, 1f64] }
+-- input { [1f64, -1f64, -1f64] }
 -- output { [0x3ff0000000000000u64, 0xbff0000000000000u64, 0xbff0000000000000u64] }
 
 -- ==
 -- entry: testFromBits
--- input { [1f64, -1f64, -1f64] [0f64, 0f64, 1f64] }
+-- input { [1f64, -1f64, -1f64] }
 -- output { [1f64, -1f64, -1f64] }
 
 -- ==
@@ -25,8 +25,15 @@
 -- input { [1f64, f64.inf, -f64.inf, f64.nan] }
 -- output { [-1f64, -f64.inf, f64.inf, f64.nan] }
 
+-- ==
+-- entry: testNegBits
+-- input { [0u64, 0x8000000000000000u64] }
+-- output { [0x8000000000000000u64, 0u64] }
+
+
 entry testInf (xs: []f64) (ys: []f64) = map2 (\x y -> f64.isinf(x/y)) xs ys
-entry testNaN (xs: []f64) (ys: []f64) = map (\x -> f64.isnan(f64.sqrt(x))) xs
-entry testToBits (xs: []f64) (ys: []f64) = map f64.to_bits xs
-entry testFromBits (xs: []f64) (ys: []f64) = map (\x -> f64.from_bits(f64.to_bits(x))) xs
+entry testNaN (xs: []f64) = map (\x -> f64.isnan(f64.sqrt(x))) xs
+entry testToBits (xs: []f64) = map f64.to_bits xs
+entry testFromBits (xs: []f64) = map (\x -> f64.from_bits(f64.to_bits(x))) xs
 entry testNeg = map f64.neg
+entry testNegBits = map (f64.from_bits >-> f64.neg >-> f64.to_bits)


### PR DESCRIPTION
Previously -x was defined as 0-x, but this is wrong when x==0.

This commit also consolidates numerical and logical negation, so there is no longer a 'not' unop.