### PR TITLE
Raise type var subscripts in type checker (error) messages

### DIFF
--- a/src/Language/Futhark/TypeChecker/Monad.hs
+++ b/src/Language/Futhark/TypeChecker/Monad.hs
@@ -578,9 +578,7 @@ topLevelNameMap = M.filterWithKey (\k _ -> available k) intrinsicsNameMap
 -- consumption but the machine does not care).
 mkTypeVarName :: Name -> Int -> Name
 mkTypeVarName desc i =
-  desc <> nameFromString (mapMaybe subscript (show i))
-  where
-    subscript = flip lookup $ zip "0123456789" "₀₁₂₃₄₅₆₇₈₉"
+  desc <> nameFromString ("_" ++ show i)
 
 -- | Type-check an attribute.
 checkAttr :: (MonadTypeChecker m) => AttrInfo VName -> m (AttrInfo VName)


### PR DESCRIPTION
Type variable names with subscripted tags are pretty, but if a user (in this case, a group of PMPH students trying to debug a bunch of size type mismatches) happens to use a unicode-incompatible terminal/editor (or is missing correct unicode fonts) then error messages can be confusing, especially if the missing unicode characters are shown as blank characters.

This small change makes type checker error messages universally printable/legible while preserving type variable names.

I do not know if there are other places/passes in the compiler which may print non-ascii characters (?).