### PR TITLE
Use monadic definition of Fmt.

### DIFF
--- a/src/Futhark/Fmt/Monad.hs
+++ b/src/Futhark/Fmt/Monad.hs
@@ -78,17 +78,20 @@ infixr 6 </>
 
 infixr 4 <|>
 
-type Fmt = P.Doc ()
+type Fmt = FmtM (P.Doc ())
+
+instance Located Fmt where
+  locOf _ = NoLoc -- FIXME: This is nonsense.
 
 -- | This function allows to inspect the layout of an expression @a@ and if it
 -- is singleline line then use format @s@ and if it is multiline format @m@.
 fmtByLayout ::
-  (Located a, Format s, Format m) => a -> s -> m -> FmtM Fmt
+  (Located a) => a -> Fmt -> Fmt -> Fmt
 fmtByLayout a s m =
   s
     <|> ( case lineLayout a of
-            Just SingleLine -> fmt s
-            _any -> fmt m
+            Just SingleLine -> s
+            _any -> m
         )
 
 -- | This function determines the Layout of @a@ and if it is singleline then it
@@ -118,19 +121,19 @@ localLayoutList a m = do
 -- accordance with if @a@ is singleline or multiline using 'localLayout'. At last
 -- it internally sets the state of the 'FmtM' monad to consider trailing
 -- comments if they exists. This function should be always used when possible to
--- wrap FmtM Fmt around. It currently does not handle trailing comment perfectly.
+-- wrap Fmt around. It currently does not handle trailing comment perfectly.
 -- See tests/fmt/traillingComments1.fut or the other test.
-addComments :: (Located a, Format b) => a -> b -> FmtM Fmt
+addComments :: (Located a) => a -> Fmt -> Fmt
 addComments a b = localLayout a $ do
   c <- fmtComments a
-  f <- fmt b
+  f <- b
   setTrailingComment a
   pure $ c <> f
 
-prependSepComments :: (Located a, Format b) => a -> b -> FmtM Fmt
+prependSepComments :: (Located a) => a -> Fmt -> Fmt
 prependSepComments a b = do
   fmcs <- fcs
-  b' <- fmt b
+  b' <- b
   pure $ fromMaybe mempty fmcs <> b'
   where
     fcs = do
@@ -176,20 +179,14 @@ data Layout = MultiLine | SingleLine deriving (Show, Eq)
 type FmtM a = ReaderT Layout (State FmtState) a
 
 -- | A typeclass that defines how an type can be formatted.
-class (Located a) => Format a where
-  fmt :: a -> FmtM Fmt
-
-instance Located (FmtM Fmt) where
-  locOf _ = NoLoc
-
-instance Format (FmtM Fmt) where
-  fmt = id
+class Format a where
+  fmt :: a -> Fmt
 
 instance Format Comment where
   fmt = comment . commentText
 
 -- | Prepends comments.
-fmtComments :: (Located a) => a -> FmtM Fmt
+fmtComments :: (Located a) => a -> Fmt
 fmtComments a = do
   s <- get
   case comments s of
@@ -248,15 +245,15 @@ lineLayoutList as =
         NoLoc -> [] -- error "Formatting term without location"
 
 -- | Retrieves the last comments from the monad and concatenates them together.
-popComments :: FmtM Fmt
+popComments :: Fmt
 popComments = do
   cs <- gets comments
   modify (\s -> s {comments = []})
-  sep nil cs
+  sep nil $ map fmt cs
 
 -- | Using the location of @a@ get the segment of text in the original file to
--- create a @FmtM Fmt@.
-fmtCopyLoc :: (Located a) => a -> FmtM Fmt
+-- create a @Fmt@.
+fmtCopyLoc :: (Located a) => a -> Fmt
 fmtCopyLoc a = do
   f <- gets file
   case locOf a of
@@ -284,21 +281,21 @@ runFormat format cs file = evalState (runReaderT format e) s
     e = MultiLine
 
 -- | An empty input.
-nil :: FmtM Fmt
+nil :: Fmt
 nil = pure mempty
 
 -- | Indents everything after a line occurs if in multiline and if in singleline
 -- then indent.
-nest :: (Format a) => Int -> a -> FmtM Fmt
-nest i a = fmt a <|> (P.nest i <$> fmt a)
+nest :: Int -> Fmt -> Fmt
+nest i a = a <|> (P.nest i <$> a)
 
 -- | A space.
-space :: FmtM Fmt
+space :: Fmt
 space = modify (\s -> s {lastOutput = Just Space}) >> pure P.space
 
 -- | Forces a line to be used regardless of layout, this should ideally not be
 -- used.
-hardline :: FmtM Fmt
+hardline :: Fmt
 hardline = do
   pc <- gets pendingComments
   case pc of
@@ -314,20 +311,20 @@ hardline = do
       pure P.line
 
 -- | A line or a space depending on layout.
-line :: FmtM Fmt
+line :: Fmt
 line = space <|> hardline
 
 -- | A comment.
-comment :: T.Text -> FmtM Fmt
+comment :: T.Text -> Fmt
 comment c = do
   modify (\s -> s {lastOutput = Just Line})
   pure $ P.pretty c <> P.line
 
 -- in order to handle trailing comments its VERY important to
 -- evaluate the seperator after each element in the list.
-sep :: (Format a, Format b) => a -> [b] -> FmtM Fmt
+sep :: Fmt -> [Fmt] -> Fmt
 sep _ [] = nil
-sep s (a : as) = auxiliary (fmt a) as
+sep s (a : as) = auxiliary a as
   where
     auxiliary acc [] = acc
     auxiliary acc (x : xs) =
@@ -335,122 +332,119 @@ sep s (a : as) = auxiliary (fmt a) as
 
 -- | Seperates element by a @s@ followed by a space in singleline layout and
 -- seperates by a line followed by a @s@ in multine layout.
-sepLine :: (Format a, Format b) => a -> [b] -> FmtM Fmt
+sepLine :: Fmt -> [Fmt] -> Fmt
 sepLine s = sep (s <:> space <|> hardline <:> s)
 
 -- | This is used for function arguments. It seperates multiline arguments by
 -- lines and singleline arguments by spaces.
-sepArgs :: (Format a) => [a] -> FmtM Fmt
+sepArgs :: [Fmt] -> Fmt
 sepArgs [] = nil
 sepArgs ls
   | any ((== Just MultiLine) . lineLayout) ls =
       sep nil $ zipWith3 auxiliary [0 :: Int ..] los ls
   | otherwise = align $ sep line ls
   where
-    auxiliary 0 _ x = fmt x
+    auxiliary 0 _ x = x
     auxiliary _ (Just SingleLine) x = space <:> x
     auxiliary _ _ x = hardline <:> x
     los = lineLayout <$> ls
 
 -- | Nest but with the standard value of two spaces.
-stdNest :: (Format a) => a -> FmtM Fmt
+stdNest :: Fmt -> Fmt
 stdNest = nest 2
 
 -- | Aligns line by line.
-align :: (Format a) => a -> FmtM Fmt
-align a = P.align <$> fmt a
+align :: Fmt -> Fmt
+align a = P.align <$> a
 
 -- | Indents everything by @i@, should never be used.
-hardIndent :: (Format a) => Int -> a -> FmtM Fmt
-hardIndent i a = P.indent i <$> fmt a
+hardIndent :: Int -> Fmt -> Fmt
+hardIndent i a = P.indent i <$> a
 
 -- | Indents if in multiline by @i@ if in singleline it does not indent.
-indent :: (Format a) => Int -> a -> FmtM Fmt
-indent i a = fmt a <|> hardIndent i a
+indent :: Int -> Fmt -> Fmt
+indent i a = a <|> hardIndent i a
 
 -- | Hard indents with the standard size of two.
-hardStdIndent :: (Format a) => a -> FmtM Fmt
+hardStdIndent :: Fmt -> Fmt
 hardStdIndent = hardIndent 2
 
 -- | Idents with the standard size of two.
-stdIndent :: (Format a) => a -> FmtM Fmt
+stdIndent :: Fmt -> Fmt
 stdIndent = indent 2
 
 -- | Creates a piece of text, it should not contain any new lines.
-text :: T.Text -> FmtM Fmt
+text :: T.Text -> Fmt
 text t = do
   modify (\s -> s {lastOutput = Just Text})
   pure $ P.pretty t
 
 -- | Adds brackets.
-brackets :: (Format a) => a -> FmtM Fmt
-brackets a = text "[" <:> fmt a <:> text "]"
+brackets :: Fmt -> Fmt
+brackets a = text "[" <:> a <:> text "]"
 
 -- | Adds braces.
-braces :: (Format a) => a -> FmtM Fmt
-braces a = text "{" <:> fmt a <:> text "}"
+braces :: Fmt -> Fmt
+braces a = text "{" <:> a <:> text "}"
 
 -- | Add parenthesis.
-parens :: (Format a) => a -> FmtM Fmt
-parens a = text "(" <:> fmt a <:> text ")"
+parens :: Fmt -> Fmt
+parens a = text "(" <:> a <:> text ")"
 
 -- | Depending on if @b@ is multiline then add a line between them and an indent
 -- to @b@. If singleline then just seperate by a single space.
-(<+/>) :: (Format a, Format b) => a -> b -> FmtM Fmt
+(<+/>) :: (Format b, Located b) => Fmt -> b -> Fmt
 (<+/>) a b =
   case lineLayout b of
-    Just MultiLine -> a </> hardStdIndent b
-    Just SingleLine -> a <+> b
+    Just MultiLine -> a </> hardStdIndent (fmt b)
+    Just SingleLine -> a <+> fmt b
     Nothing -> do
       lo <- ask
       case lo of
-        MultiLine -> a </> hardStdIndent b
-        SingleLine -> a <+> b
+        MultiLine -> a </> hardStdIndent (fmt b)
+        SingleLine -> a <+> fmt b
 
 -- | If in a singleline layout then concatenate with 'nil' and in multiline
 -- concatenate by a line.
-(<:/>) :: (Format a, Format b) => a -> b -> FmtM Fmt
+(<:/>) :: Fmt -> Fmt -> Fmt
 a <:/> b = a <:> (nil <|> hardline) <:> b
 
 -- | Concatenates @a@ and @b@.
-(<:>) :: (Format a, Format b) => a -> b -> FmtM Fmt
+(<:>) :: Fmt -> Fmt -> Fmt
 a <:> b = do
   c <- fmtComments a
-  a' <- fmt a
+  a' <- a
   setTrailingComment a
-  b' <- fmt b
+  b' <- b
   pure $ c <> a' <> b'
 
 -- | Concatenate with a space between.
-(<+>) :: (Format a, Format b) => a -> b -> FmtM Fmt
+(<+>) :: Fmt -> Fmt -> Fmt
 a <+> b = a <:> space <:> b
 
 -- | Concatenate with a space if in singleline layout and concatenate by a
 -- line in multiline.
-(</>) :: (Format a, Format b) => a -> b -> FmtM Fmt
+(</>) :: Fmt -> Fmt -> Fmt
 a </> b = a <:> line <:> b
 
 -- | If in a singleline layout then choose @a@, if in a multiline layout choose
 -- @b@.
-(<|>) :: (Format a, Format b) => a -> b -> FmtM Fmt
+(<|>) :: Fmt -> Fmt -> Fmt
 a <|> b = do
   lo <- ask
   if lo == SingleLine
-    then fmt a
-    else fmt b
+    then a
+    else b
 
 -- | If in singleline layout seperate by spaces. In a multiline layout seperate
 -- by a single line if two neighbouring elements are singleline. Otherwise
 -- sepereate by two lines.
-sepDecs ::
-  (Format a) =>
-  [a] ->
-  FmtM Fmt
+sepDecs :: [Fmt] -> Fmt
 sepDecs [] = nil
 sepDecs as@(x : xs) = sep space as <|> (x <:> auxiliary x xs)
   where
     auxiliary _ [] = nil
-    auxiliary prev (y : ys) = p <:> fmt y <:> auxiliary y ys
+    auxiliary prev (y : ys) = p <:> y <:> auxiliary y ys
       where
         p =
           case (lineLayout y, lineLayout prev) of
@@ -460,5 +454,5 @@ sepDecs as@(x : xs) = sep space as <|> (x <:> auxiliary x xs)
 layoutOpts :: P.LayoutOptions
 layoutOpts = P.LayoutOptions P.Unbounded
 
-pretty :: Fmt -> T.Text
+pretty :: P.Doc () -> T.Text
 pretty = renderStrict . P.layoutPretty layoutOpts

--- a/src/Futhark/Fmt/Printer.hs
+++ b/src/Futhark/Fmt/Printer.hs
@@ -13,15 +13,15 @@ import Language.Futhark.Parser
   )
 import Prettyprinter.Internal (Pretty)
 
-fmtName :: Name -> FmtM Fmt
+fmtName :: Name -> Fmt
 fmtName = text . nameToText
 
-fmtNameParen :: Name -> FmtM Fmt
+fmtNameParen :: Name -> Fmt
 fmtNameParen name
   | operatorName name = parens $ fmtName name
   | otherwise = fmtName name
 
-fmtPretty :: (Pretty a) => a -> FmtM Fmt
+fmtPretty :: (Pretty a) => a -> Fmt
 fmtPretty = text . prettyText
 
 instance Format (Maybe DocComment) where
@@ -32,38 +32,38 @@ instance Format (Maybe DocComment) where
       prefixes (l : ls) = comment ("-- | " <> l) : map (comment . ("-- " <>)) ls
   fmt Nothing = nil
 
-fmtFieldType :: (Name, UncheckedTypeExp) -> FmtM Fmt
-fmtFieldType (name', t) = fmtName name' <:> text ":" <+> t
+fmtFieldType :: (Name, UncheckedTypeExp) -> Fmt
+fmtFieldType (name', t) = fmtName name' <:> text ":" <+> fmt t
 
-fmtParamType :: Maybe Name -> UncheckedTypeExp -> FmtM Fmt
+fmtParamType :: Maybe Name -> UncheckedTypeExp -> Fmt
 fmtParamType (Just n) te =
-  parens $ fmtName n <:> text ":" <+> te
+  parens $ fmtName n <:> text ":" <+> fmt te
 fmtParamType Nothing te = fmt te
 
-fmtSumTypeConstr :: (Name, [UncheckedTypeExp]) -> FmtM Fmt
+fmtSumTypeConstr :: (Name, [UncheckedTypeExp]) -> Fmt
 fmtSumTypeConstr (name, fs) =
-  text "#" <:> fmtName name <+> sep space fs
+  text "#" <:> fmtName name <+> sep space (map fmt fs)
 
 instance Format UncheckedTypeExp where
   fmt (TEVar v loc) = addComments loc $ fmtQualName v
   fmt (TETuple ts loc) =
-    addComments loc $ parens $ sepLine (text ",") ts
-  fmt (TEParens te loc) = addComments loc $ parens te
+    addComments loc $ parens $ sepLine (text ",") $ map fmt ts
+  fmt (TEParens te loc) = addComments loc $ parens $ fmt te
   fmt (TERecord fs loc) =
     addComments loc $ braces $ sepLine (text ",") fields
     where
       fields = fmtFieldType <$> fs
-  fmt (TEArray se te loc) = addComments loc $ se <:> te
-  fmt (TEUnique te loc) = addComments loc $ text "*" <:> te
-  fmt (TEApply te tArgE loc) = addComments loc $ te <+> tArgE
+  fmt (TEArray se te loc) = addComments loc $ fmt se <:> fmt te
+  fmt (TEUnique te loc) = addComments loc $ text "*" <:> fmt te
+  fmt (TEApply te tArgE loc) = addComments loc $ fmt te <+> fmt tArgE
   fmt (TEArrow name te0 te1 loc) =
-    addComments loc $ fmtParamType name te0 <+> text "->" </> stdIndent te1
+    addComments loc $ fmtParamType name te0 <+> text "->" </> stdIndent (fmt te1)
   fmt (TESum tes loc) =
     addComments loc $
       sep (line <:> text "|" <:> space) $
         map fmtSumTypeConstr tes
   fmt (TEDim dims te loc) =
-    addComments loc $ text "?" <:> dims' <:> text "." <:> te
+    addComments loc $ text "?" <:> dims' <:> text "." <:> fmt te
     where
       dims' = sep nil $ map (brackets . fmtName) dims
 
@@ -74,14 +74,14 @@ instance Format (TypeArgExp UncheckedExp Name) where
 instance Format UncheckedTypeBind where
   fmt (TypeBind name l ps e NoInfo dc loc) =
     addComments loc $
-      dc
+      fmt dc
         <:> text "type"
-        <:> l
+        <:> fmt l
         <+> fmtName name
         <:> (if null ps then nil else space)
-        <:> localLayoutList ps (align $ sep line ps)
+        <:> localLayoutList ps (align $ sep line $ map fmt ps)
         <+> text "="
-        </> stdIndent e
+        </> stdIndent (fmt e)
 
 instance Located (AttrAtom a) where
   locOf _ = NoLoc
@@ -111,36 +111,33 @@ instance Format Liftedness where
   fmt Lifted = text "^"
 
 instance Format UncheckedTypeParam where
-  fmt (TypeParamDim name loc) = addComments loc $ brackets $ fmtName name
-  fmt (TypeParamType l name loc) = addComments loc $ text "'" <:> l <:> fmtName name
+  fmt (TypeParamDim name loc) =
+    addComments loc $ brackets $ fmtName name
+  fmt (TypeParamType l name loc) =
+    addComments loc $ text "'" <:> fmt l <:> fmtName name
 
 instance Format (UncheckedPat t) where
   fmt (TuplePat pats loc) =
-    addComments loc $
-      parens $
-        sepLine (text ",") pats
+    addComments loc $ parens $ sepLine (text ",") $ map fmt pats
   fmt (RecordPat pats loc) =
-    addComments loc $
-      braces $
-        sepLine (text ",") $
-          map fmtFieldPat pats
+    addComments loc $ braces $ sepLine (text ",") $ map fmtFieldPat pats
     where
       -- Currently it always adds the fields it seems.
-      fmtFieldPat (name, t) = fmtName name <+> text "=" <+> t
+      fmtFieldPat (name, t) = fmtName name <+> text "=" <+> fmt t
   fmt (PatParens pat loc) =
-    addComments loc $ text "(" <:> align pat <:/> text ")"
+    addComments loc $ text "(" <:> align (fmt pat) <:/> text ")"
   fmt (Id name _ loc) = addComments loc $ fmtNameParen name
   fmt (Wildcard _t loc) = addComments loc $ text "_"
-  fmt (PatAscription pat t loc) = addComments loc $ pat <:> text ":" <+> t
+  fmt (PatAscription pat t loc) = addComments loc $ fmt pat <:> text ":" <+> fmt t
   fmt (PatLit _e _ loc) = addComments loc $ fmtCopyLoc loc
   fmt (PatConstr n _ pats loc) =
     addComments loc $
-      text "#" <:> fmtName n </> align (sep line pats)
-  fmt (PatAttr attr pat loc) = addComments loc $ attr <+> pat
+      text "#" <:> fmtName n </> align (sep line (map fmt pats))
+  fmt (PatAttr attr pat loc) = addComments loc $ fmt attr <+> fmt pat
 
 instance Format (FieldBase NoInfo Name) where
   fmt (RecordFieldExplicit name e loc) =
-    addComments loc $ fmtName name <+> text "=" </> stdIndent e
+    addComments loc $ fmtName name <+> text "=" </> stdIndent (fmt e)
   fmt (RecordFieldImplicit name _ loc) = addComments loc $ fmtName name
 
 instance Located PrimValue where
@@ -148,16 +145,16 @@ instance Located PrimValue where
 
 instance Format PrimValue where
   fmt (UnsignedValue (Int8Value v)) =
-    fmt $ fmtPretty (show (fromIntegral v :: Word8)) <:> text "u8"
+    fmtPretty (show (fromIntegral v :: Word8)) <:> text "u8"
   fmt (UnsignedValue (Int16Value v)) =
-    fmt $ fmtPretty (show (fromIntegral v :: Word16)) <:> text "u16"
+    fmtPretty (show (fromIntegral v :: Word16)) <:> text "u16"
   fmt (UnsignedValue (Int32Value v)) =
-    fmt $ fmtPretty (show (fromIntegral v :: Word32)) <:> text "u32"
+    fmtPretty (show (fromIntegral v :: Word32)) <:> text "u32"
   fmt (UnsignedValue (Int64Value v)) =
-    fmt $ fmtPretty (show (fromIntegral v :: Word64)) <:> text "u64"
+    fmtPretty (show (fromIntegral v :: Word64)) <:> text "u64"
   fmt (SignedValue v) = fmtPretty v
-  fmt (BoolValue True) = fmt $ text "true"
-  fmt (BoolValue False) = fmt $ text "false"
+  fmt (BoolValue True) = text "true"
+  fmt (BoolValue False) = text "false"
   fmt (FloatValue v) = fmtPretty v
 
 instance Located UncheckedDimIndex where
@@ -166,18 +163,18 @@ instance Located UncheckedDimIndex where
 instance Format UncheckedDimIndex where
   fmt (DimFix e) = fmt e
   fmt (DimSlice i j (Just s)) =
-    maybe (fmt nil) fmt i
+    maybe nil fmt i
       <:> text ":"
-      <:> maybe (fmt nil) fmt j
+      <:> maybe nil fmt j
       <:> text ":"
       <:> fmt s
   fmt (DimSlice i (Just j) s) =
-    maybe (fmt nil) fmt i
+    maybe nil fmt i
       <:> text ":"
       <:> fmt j
       <:> maybe nil ((text ":" <:>) . fmt) s
   fmt (DimSlice i Nothing Nothing) =
-    maybe (fmt nil) fmt i <:> text ":"
+    maybe nil fmt i <:> text ":"
 
 operatorName :: Name -> Bool
 operatorName = (`elem` opchars) . T.head . nameToText
@@ -189,73 +186,65 @@ instance Format UncheckedExp where
   fmt (Var name _ loc) = addComments loc $ fmtQualName name
   fmt (Hole _ loc) = addComments loc $ text "???"
   fmt (Parens e loc) =
-    addComments loc $ text "(" <:> stdNest e <:/> text ")"
+    addComments loc $ text "(" <:> stdNest (fmt e) <:/> text ")"
   fmt (QualParens (v, _qLoc) e loc) =
     addComments loc $
-      fmtQualName v <:> text "." <:> text "(" <:> align e <:/> text ")"
-  fmt (Ascript e t loc) = addComments loc $ e <:> text ":" <+> t
-  fmt (Coerce e t _ loc) = addComments loc $ e <+> text ":>" <+> t
+      fmtQualName v <:> text "." <:> text "(" <:> align (fmt e) <:/> text ")"
+  fmt (Ascript e t loc) = addComments loc $ fmt e <:> text ":" <+> fmt t
+  fmt (Coerce e t _ loc) = addComments loc $ fmt e <+> text ":>" <+> fmt t
   fmt (Literal _v loc) = addComments loc $ fmtCopyLoc loc
   fmt (IntLit _v _ loc) = addComments loc $ fmtCopyLoc loc
   fmt (FloatLit _v _ loc) = addComments loc $ fmtCopyLoc loc
   fmt (TupLit es loc) =
-    addComments loc $
-      parens $
-        sepLine (text ",") es
+    addComments loc $ parens $ sepLine (text ",") $ map fmt es
   fmt (RecordLit fs loc) =
-    addComments loc $
-      braces $
-        sepLine (text ",") fs
+    addComments loc $ braces $ sepLine (text ",") $ map fmt fs
   fmt (ArrayVal vs _ loc) =
-    addComments loc $
-      brackets $
-        sepLine (text ",") vs
+    addComments loc $ brackets $ sepLine (text ",") $ map fmt vs
   fmt (ArrayLit es _ loc) =
-    addComments loc $
-      brackets $
-        sepLine (text ",") es
+    addComments loc $ brackets $ sepLine (text ",") $ map fmt es
   fmt (StringLit _s loc) = addComments loc $ fmtCopyLoc loc
-  fmt (Project k e _ loc) = addComments loc $ e <:> text "." <:> fmtPretty k
-  fmt (Negate e loc) = addComments loc $ text "-" <:> e
-  fmt (Not e loc) = addComments loc $ text "!" <:> e
+  fmt (Project k e _ loc) = addComments loc $ fmt e <:> text "." <:> fmtPretty k
+  fmt (Negate e loc) = addComments loc $ text "-" <:> fmt e
+  fmt (Not e loc) = addComments loc $ text "!" <:> fmt e
   fmt (Update src idxs ve loc) =
     addComments loc $
-      src <+> text "with" <+> idxs' <+> stdNest (text "=" </> ve)
+      fmt src <+> text "with" <+> idxs' <+> stdNest (text "=" </> fmt ve)
     where
-      idxs' = brackets $ sep (text "," <:> space) idxs
+      idxs' = brackets $ sep (text "," <:> space) $ map fmt idxs
   fmt (RecordUpdate src fs ve _ loc) =
     addComments loc $
-      src <+> text "with" <+> fs' <+> stdNest (text "=" </> ve)
+      fmt src <+> text "with" <+> fs' <+> stdNest (text "=" </> fmt ve)
     where
       fs' = sep (text ".") $ fmtName <$> fs
   fmt (Assert e1 e2 _ loc) =
-    addComments loc $ text "assert" <+> e1 <+> e2
+    addComments loc $ text "assert" <+> fmt e1 <+> fmt e2
   fmt (Lambda params body rettype _ loc) =
     addComments loc $
-      text "\\" <:> sep space params <:> ascript <+> stdNest (text "->" </> body)
+      text "\\" <:> sep space (map fmt params) <:> ascript <+> stdNest (text "->" </> fmt body)
     where
-      ascript = maybe nil (text ": " <:>) rettype
+      ascript = maybe nil ((text ": " <:>) . fmt) rettype
   fmt (OpSection binop _ loc) =
     addComments loc $
       if operatorName (qualLeaf binop)
         then fmtQualName binop
         else parens $ text "`" <:> fmtQualName binop <:> text "`"
   fmt (OpSectionLeft binop _ x _ _ loc) =
-    addComments loc $ parens $ x <+> fmtBinOp binop
+    addComments loc $ parens $ fmt x <+> fmtBinOp binop
   fmt (OpSectionRight binop _ x _ _ loc) =
-    addComments loc $ parens $ fmtBinOp binop <+> x
+    addComments loc $ parens $ fmtBinOp binop <+> fmt x
   fmt (ProjectSection fields _ loc) =
     addComments loc $ parens $ text "." <:> sep (text ".") (fmtName <$> fields)
   fmt (IndexSection idxs _ loc) =
     addComments loc $ parens (text "." <:> idxs')
     where
-      idxs' = brackets $ sep (text "," <:> space) idxs
+      idxs' = brackets $ sep (text "," <:> space) $ map fmt idxs
   fmt (Constr n cs _ loc) =
-    addComments loc $ text "#" <:> fmtName n <+> align (sep line cs)
-  fmt (Attr attr e loc) = addComments loc $ align (attr </> e)
+    addComments loc $ text "#" <:> fmtName n <+> align (sep line $ map fmt cs)
+  fmt (Attr attr e loc) = addComments loc $ align $ fmt attr </> fmt e
   fmt (AppExp e _) = fmt e
 
-fmtQualName :: QualName Name -> FmtM Fmt
+fmtQualName :: QualName Name -> Fmt
 fmtQualName (QualName names name)
   | operatorName name = parens $ pre <:> fmtName name
   | otherwise = pre <:> fmtName name
@@ -267,22 +256,22 @@ fmtQualName (QualName names name)
 
 instance Format UncheckedCase where
   fmt (CasePat p e loc) =
-    addComments loc $ text "case" <+> p <+> text "->" </> stdIndent e
+    addComments loc $ text "case" <+> fmt p <+> text "->" </> stdIndent (fmt e)
 
 instance Format (AppExpBase NoInfo Name) where
   fmt (BinOp (bop, _) _ (x, _) (y, _) loc) =
-    addComments loc $ x </> fmtBinOp bop <+> y
+    addComments loc $ fmt x </> fmtBinOp bop <+> fmt y
   fmt (Match e cs loc) =
-    addComments loc $ text "match" <+> e </> sep line (toList cs)
+    addComments loc $ text "match" <+> fmt e </> sep line (map fmt $ toList cs)
   -- need some way to omit the inital value expression, when this it's trivial
   fmt (Loop sizeparams pat (LoopInitImplicit NoInfo) form loopbody loc) =
     addComments loc $
       ( (text "loop" `op` sizeparams')
           <+/> pat
       )
-        <+> form
+        <+> fmt form
         <+> text "do"
-        </> stdIndent loopbody
+        </> stdIndent (fmt loopbody)
     where
       op = if null sizeparams then (<:>) else (<+>)
       sizeparams' = sep nil $ brackets . fmtName . toName <$> sizeparams
@@ -293,17 +282,14 @@ instance Format (AppExpBase NoInfo Name) where
           <+> text "="
       )
         <+/> initexp
-        <+> form
+        <+> fmt form
         <+> text "do"
-        </> stdIndent loopbody
+        </> stdIndent (fmt loopbody)
     where
       op = if null sizeparams then (<:>) else (<+>)
       sizeparams' = sep nil $ brackets . fmtName . toName <$> sizeparams
   fmt (Index e idxs loc) =
-    addComments loc $
-      (e <:>) $
-        brackets $
-          sepLine (text ",") idxs
+    addComments loc $ (fmt e <:>) $ brackets $ sepLine (text ",") $ map fmt idxs
   fmt (LetPat sizes pat e body loc) =
     addComments loc $
       ( text "let"
@@ -313,7 +299,7 @@ instance Format (AppExpBase NoInfo Name) where
         <+/> e
         </> letBody body
     where
-      sizes' = sep nil sizes
+      sizes' = sep nil $ map fmt sizes
       sub
         | null sizes = fmt pat
         | otherwise = sizes' <+> fmt pat
@@ -328,11 +314,11 @@ instance Format (AppExpBase NoInfo Name) where
         <+/> e
         </> letBody body
     where
-      tparams' = sep space tparams
-      params' = sep space params
+      tparams' = sep space $ map fmt tparams
+      params' = sep space $ map fmt params
       retdecl' =
         case retdecl of
-          Just a -> text ":" <+> a <:> space
+          Just a -> text ":" <+> fmt a <:> space
           Nothing -> space
       sub
         | null tparams && null params = nil
@@ -343,7 +329,7 @@ instance Format (AppExpBase NoInfo Name) where
     | dest == src =
         addComments loc $
           ( text "let"
-              <+> dest
+              <+> fmt dest
               <:> idxs'
               <+> text "="
           )
@@ -352,44 +338,43 @@ instance Format (AppExpBase NoInfo Name) where
     | otherwise =
         addComments loc $
           ( text "let"
-              <+> dest
+              <+> fmt dest
               <+> text "="
-              <+> src
+              <+> fmt src
               <+> text "with"
               <+> idxs'
           )
             <+/> ve
             </> letBody body
     where
-      idxs' = brackets $ sep (text ", ") idxs
+      idxs' = brackets $ sep (text ", ") $ map fmt idxs
   fmt (Range start maybe_step end loc) =
-    addComments loc $ start <:> step <:> end'
+    addComments loc $ fmt start <:> step <:> end'
     where
       end' =
         case end of
-          DownToExclusive e -> text "..>" <:> e
-          ToInclusive e -> text "..." <:> e
-          UpToExclusive e -> text "..<" <:> e
-      step = maybe nil (text ".." <:>) maybe_step
+          DownToExclusive e -> text "..>" <:> fmt e
+          ToInclusive e -> text "..." <:> fmt e
+          UpToExclusive e -> text "..<" <:> fmt e
+      step = maybe nil ((text ".." <:>) . fmt) maybe_step
   fmt (If c t f loc) =
     addComments loc $
       text "if"
-        <+> c
+        <+> fmt c
         <+> text "then"
-        </> stdIndent t
+        </> stdIndent (fmt t)
         </> text "else"
-        </> stdIndent f
+        </> stdIndent (fmt f)
   fmt (Apply f args loc) =
-    addComments loc $
-      f <+> align fmt_args
+    addComments loc $ fmt f <+> align fmt_args
     where
-      fmt_args = sepArgs $ map snd (toList args)
+      fmt_args = sepArgs $ map (fmt . snd) (toList args)
 
-letBody :: UncheckedExp -> FmtM Fmt
+letBody :: UncheckedExp -> Fmt
 letBody body@(AppExp LetPat {} _) = fmt body
 letBody body@(AppExp LetFun {} _) = fmt body
 letBody body@(AppExp LetWith {} _) = fmt body
-letBody body = addComments body $ text "in" <+> align body
+letBody body = addComments body $ text "in" <+> align (fmt body)
 
 instance Format (SizeBinder Name) where
   fmt (SizeBinder v loc) = addComments loc $ brackets $ fmtName v
@@ -401,15 +386,12 @@ instance Located (LoopFormBase NoInfo Name) where
   locOf _ = NoLoc
 
 instance Format (LoopFormBase NoInfo Name) where
-  fmt (For i ubound) =
-    text "for" <+> i <+> text "<" <+> ubound
-  fmt (ForIn x e) =
-    text "for" <+> x <+> text "in" <+> e
-  fmt (While cond) = do
-    text "while" <+> cond
+  fmt (For i ubound) = text "for" <+> fmt i <+> text "<" <+> fmt ubound
+  fmt (ForIn x e) = text "for" <+> fmt x <+> text "in" <+> fmt e
+  fmt (While cond) = text "while" <+> fmt cond
 
 -- | This should always be simplified by location.
-fmtBinOp :: QualName Name -> FmtM Fmt
+fmtBinOp :: QualName Name -> Fmt
 fmtBinOp bop =
   case leading of
     Backtick -> text "`" <:> fmtQualName bop <:> text "`"
@@ -420,21 +402,21 @@ fmtBinOp bop =
 instance Format UncheckedValBind where
   fmt (ValBind entry name retdecl _rettype tparams args body docs attrs loc) =
     addComments loc $
-      docs
+      fmt docs
         <:> (if null attrs then nil else attrs' <:> space)
         <:> fun
         <+> fmtNameParen name
         <:> sub
         <:> retdecl'
         <:> text "="
-        </> stdIndent body
+        </> stdIndent (fmt body)
     where
-      attrs' = sep space attrs
-      tparams' = localLayoutList tparams $ align $ sep line tparams
-      args' = localLayoutList args $ align $ sep line args
+      attrs' = sep space $ map fmt attrs
+      tparams' = localLayoutList tparams $ align $ sep line $ map fmt tparams
+      args' = localLayoutList args $ align $ sep line $ map fmt args
       retdecl' =
         case retdecl of
-          Just a -> text ":" <+> a <:> space
+          Just a -> text ":" <+> fmt a <:> space
           Nothing -> space
       sub
         | null tparams && null args = nil
@@ -447,63 +429,68 @@ instance Format UncheckedValBind where
           _any -> text "def"
 
 instance Format (SizeExp UncheckedExp) where
-  fmt (SizeExp d loc) = addComments loc $ brackets d
+  fmt (SizeExp d loc) = addComments loc $ brackets $ fmt d
   fmt (SizeExpAny loc) = addComments loc $ brackets nil
 
 instance Format UncheckedSpec where
   fmt (TypeAbbrSpec tpsig) = fmt tpsig
   fmt (TypeSpec l name ps doc loc) =
     addComments loc $
-      doc <:> text "type" <+> l <:> sub
+      fmt doc <:> text "type" <+> fmt l <:> sub
     where
       sub
         | null ps = fmtName name
-        | otherwise = fmtName name </> align (sep line ps)
+        | otherwise = fmtName name </> align (sep line $ map fmt ps)
   fmt (ValSpec name ps te _ doc loc) =
     addComments loc $
-      doc
+      fmt doc
         <:> text "val"
         <+> sub
         <:> text ":"
-        <+> te
+        <+> fmt te
     where
       sub
         | null ps = fmtName name
-        | otherwise = fmtName name </> align (sep line ps)
+        | otherwise = fmtName name </> align (sep line $ map fmt ps)
   fmt (ModSpec name mte doc loc) =
-    addComments loc $ doc <:> text "module" <+> fmtName name <:> text ":" <+> mte
-  fmt (IncludeSpec mte loc) = addComments loc $ text "include" <+> mte
+    addComments loc $ fmt doc <:> text "module" <+> fmtName name <:> text ":" <+> fmt mte
+  fmt (IncludeSpec mte loc) = addComments loc $ text "include" <+> fmt mte
 
 instance Format UncheckedModTypeExp where
   fmt (ModTypeVar v _ loc) = addComments loc $ fmtPretty v
   fmt (ModTypeParens mte loc) =
-    addComments loc $ text "(" <:> align mte <:/> text ")"
+    addComments loc $ text "(" <:> align (fmt mte) <:/> text ")"
   fmt (ModTypeSpecs sbs loc) =
-    addComments loc $ text "{" <:/> stdIndent (sep line sbs) <:/> text "}"
+    addComments loc $ text "{" <:/> stdIndent (sep line $ map fmt sbs) <:/> text "}"
   fmt (ModTypeWith mte (TypeRef v ps td _) loc) =
     addComments loc $
-      mte <+> text "with" <+> fmtPretty v `ps_op` sep space ps <+> text "=" <+> td
+      fmt mte
+        <+> text "with"
+        <+> fmtPretty v
+        `ps_op` sep space (map fmt ps)
+        <+> text "="
+        <+> fmt td
     where
       ps_op = if null ps then (<:>) else (<+>)
   fmt (ModTypeArrow (Just v) te0 te1 loc) =
     addComments loc $
-      parens (fmtName v <:> text ":" <+> te0) <+> align (text "->" </> te1)
+      parens (fmtName v <:> text ":" <+> fmt te0) <+> align (text "->" </> fmt te1)
   fmt (ModTypeArrow Nothing te0 te1 loc) =
-    addComments loc $ te0 <+> text "->" <+> te1
+    addComments loc $ fmt te0 <+> text "->" <+> fmt te1
 
 instance Format UncheckedModTypeBind where
   fmt (ModTypeBind pName pSig doc loc) =
     addComments loc $
-      doc <:> text "module type" <+> fmtName pName <+> text "=" <+> pSig
+      fmt doc <:> text "module type" <+> fmtName pName <+> text "=" <+> fmt pSig
 
 instance Format (ModParamBase NoInfo Name) where
   fmt (ModParam pName pSig _f loc) =
-    addComments loc $ parens $ fmtName pName <:> text ":" <+> pSig
+    addComments loc $ parens $ fmtName pName <:> text ":" <+> fmt pSig
 
 instance Format UncheckedModBind where
   fmt (ModBind name ps sig te doc loc) =
     addComments loc $
-      doc
+      fmt doc
         <:> text "module"
         <+> fmtName name
         <:> ps'
@@ -511,43 +498,43 @@ instance Format UncheckedModBind where
         <:> text "="
         <:> te'
     where
-      te' = fmtByLayout te (line <:> stdIndent te) (space <:> te)
+      te' = fmtByLayout te (line <:> stdIndent (fmt te)) (space <:> fmt te)
       sig' = fmtSig sig
       fmtSig Nothing = space
-      fmtSig (Just (s', _f)) = text ":" <+> s' <:> space
+      fmtSig (Just (s', _f)) = text ":" <+> fmt s' <:> space
       ps' =
         case ps of
           [] -> nil
-          _any -> space <:> localLayoutList ps (align $ sep line ps)
+          _any -> space <:> localLayoutList ps (align $ sep line $ map fmt ps)
 
 -- All of these should probably be "extra" indented
 instance Format UncheckedModExp where
   fmt (ModVar v loc) = addComments loc $ fmtQualName v
   fmt (ModParens f loc) =
-    addComments loc $ text "(" <:/> stdIndent f <:/> text ")"
+    addComments loc $ text "(" <:/> stdIndent (fmt f) <:/> text ")"
   fmt (ModImport path _f loc) =
     addComments loc $ text "import \"" <:> fmtPretty path <:> text "\""
   fmt (ModDecs decs loc) =
     addComments loc $
-      text "{" <:/> stdIndent (sepDecs decs) <:/> text "}"
-  fmt (ModApply f a _f0 _f1 loc) = addComments loc $ f <+> a
-  fmt (ModAscript me se _f loc) = addComments loc $ align (me <:> text ":" </> se)
+      text "{" <:/> stdIndent (sepDecs $ map fmt decs) <:/> text "}"
+  fmt (ModApply f a _f0 _f1 loc) = addComments loc $ fmt f <+> fmt a
+  fmt (ModAscript me se _f loc) = addComments loc $ align (fmt me <:> text ":" </> fmt se)
   fmt (ModLambda param maybe_sig body loc) =
     addComments loc $
-      text "\\" <:> param <:> sig <+> text "->" </> stdIndent body
+      text "\\" <:> fmt param <:> sig <+> text "->" </> stdIndent (fmt body)
     where
       sig =
         case maybe_sig of
           Nothing -> nil
-          Just (sig', _) -> text ":" <+> parens sig'
+          Just (sig', _) -> text ":" <+> parens (fmt sig')
 
 instance Format UncheckedDec where
   fmt (ValDec t) = fmt t
   fmt (TypeDec tb) = fmt tb
   fmt (ModTypeDec tb) = fmt tb
   fmt (ModDec tb) = fmt tb
-  fmt (OpenDec tb loc) = addComments loc $ text "open" <+> tb
-  fmt (LocalDec tb loc) = addComments loc $ text "local" <+> tb
+  fmt (OpenDec tb loc) = addComments loc $ text "open" <+> fmt tb
+  fmt (LocalDec tb loc) = addComments loc $ text "local" <+> fmt tb
   fmt (ImportDec path _tb loc) =
     addComments loc $ text "import \"" <:> fmtPretty path <:> text "\""
 
@@ -556,7 +543,7 @@ instance Located UncheckedProg where
 
 instance Format UncheckedProg where
   fmt (Prog dc decs) =
-    fmt $ dc <:> sepDecs decs </> popComments
+    fmt dc <:> sepDecs (map fmt decs) </> popComments
 
 -- | Given a filename and a futhark program, formats the program.
 fmtText :: String -> T.Text -> Either SyntaxError T.Text


### PR DESCRIPTION
This moves around the uses of 'fmt' to be explicit in the printer itself rather than in the combinators. I propose this as a more explicit design.

The one exception is (<+/>), which I think is a symptom that something is wrong.

As long as Fmt must be an instance of Located, then there will be bugs.