### PR TITLE
Call abortServer on test timeout.

### DIFF
--- a/futhark.cabal
+++ b/futhark.cabal
@@ -443,6 +443,7 @@ library
       aeson >=2.0.0.0
     , ansi-terminal >=0.6.3.1
     , array >=0.4
+    , async >=2.0
     , base >=4.15 && <5
     , base16-bytestring
     , binary >=0.8.3


### PR DESCRIPTION
An example of what this change does from Debian's ROCm CI: https://ci.rocm.debian.net/packages/h/haskell-futhark/unstable/amd64+gfx1034/39652/#S12 (from line 2354 onwards).