### PR TITLE
Fix inc. ranges with start == end and negative step

### DIFF
--- a/src/Futhark/Internalise/Exps.hs
+++ b/src/Futhark/Internalise/Exps.hs
@@ -245,7 +245,7 @@ internaliseAppExp desc _ (E.Range start maybe_second end loc) = do
   bounds_invalid_downwards <-
     letSubExp "bounds_invalid_downwards" $
       I.BasicOp $
-        I.CmpOp le_op start' end'
+        I.CmpOp lt_op start' end'
   bounds_invalid_upwards <-
     letSubExp "bounds_invalid_upwards" $
       I.BasicOp $

--- a/src/Futhark/Internalise/Exps.hs
+++ b/src/Futhark/Internalise/Exps.hs
@@ -213,8 +213,8 @@ internaliseAppExp desc _ (E.Range start maybe_second inclusiveness loc) = do
             ++ [ErrorVal int64 end'_i64, " is invalid."]
 
   let it = case E.typeOf start of
-             E.Scalar (E.Prim (E.Signed start_t)) -> start_t
-             start_t -> error $ "Start value in range has type " ++ prettyString start_t
+        E.Scalar (E.Prim (E.Signed start_t)) -> start_t
+        start_t -> error $ "Start value in range has type " ++ prettyString start_t
   let lt_op = CmpSlt it
 
   let zero = intConst it 0
@@ -224,10 +224,11 @@ internaliseAppExp desc _ (E.Range start maybe_second inclusiveness loc) = do
       letSubExp "subtracted_step" $
         I.BasicOp $
           I.BinOp (I.Sub it I.OverflowWrap) second' start'
-    Nothing -> pure $ intConst it $ -- use default step of 1 or -1.
-      case inclusiveness of
-        DownToExclusive {} -> -1
-        _ -> 1
+    Nothing -> pure $
+      intConst it $ -- use default step of 1 or -1.
+        case inclusiveness of
+          DownToExclusive {} -> -1
+          _ -> 1
 
   step_zero <-
     letSubExp "step_zero" $
@@ -241,10 +242,10 @@ internaliseAppExp desc _ (E.Range start maybe_second inclusiveness loc) = do
           I.BinOp (Sub it I.OverflowWrap) end' start'
     distance_exclusive_i64 <-
       asIntS Int64
-        =<< ( letSubExp "distance_exclusive" $
-                I.BasicOp $
-                  I.UnOp (Abs it) difference
-            )
+        =<< letSubExp
+          "distance_exclusive"
+          (I.BasicOp $ I.UnOp (Abs it) difference)
+
     case inclusiveness of
       ToInclusive {} ->
         letSubExp "distance_inclusive" $

--- a/src/Futhark/Internalise/Exps.hs
+++ b/src/Futhark/Internalise/Exps.hs
@@ -215,10 +215,10 @@ internaliseAppExp desc _ (E.Range start maybe_second end loc) = do
                )
             ++ [ErrorVal int64 end'_i64, " is invalid."]
 
-  (it, le_op, lt_op) <-
+  (it, lt_op) <-
     case E.typeOf start of
-      E.Scalar (E.Prim (E.Signed it)) -> pure (it, CmpSle it, CmpSlt it)
-      E.Scalar (E.Prim (E.Unsigned it)) -> pure (it, CmpUle it, CmpUlt it)
+      E.Scalar (E.Prim (E.Signed it)) -> pure (it, CmpSlt it)
+      E.Scalar (E.Prim (E.Unsigned it)) -> pure (it, CmpUlt it)
       start_t -> error $ "Start value in range has type " ++ prettyString start_t
 
   let one = intConst it 1

--- a/tests/range0.fut
+++ b/tests/range0.fut
@@ -5,8 +5,6 @@
 -- input { 1 5 } output { [1i32, 2i32, 3i32, 4i32, 5i32] }
 -- input { 5 1 } error: 5...1
 -- input { 5 0 } error: 5...0
--- input { 0 5 } output { [0i32, 1i32, 2i32,
--- 3i32, 4i32, 5i32] }
 
 -- ==
 -- entry: test1
@@ -14,7 +12,6 @@
 -- input { 1 5 } output { [1i32, 2i32, 3i32, 4i32] }
 -- input { 5 1 } error: 5..<1
 -- input { 5 0 } error: 5..<0
--- input { 0 5 } output { [0i32, 1i32, 2i32, 3i32, 4i32] }
 
 -- ==
 -- entry: test2
@@ -22,7 +19,6 @@
 -- input { 1 5 } error: 1..>5
 -- input { 5 1 } output { [5i32, 4i32, 3i32, 2i32] }
 -- input { 5 0 } output { [5i32, 4i32, 3i32, 2i32, 1i32] }
--- input { 0 5 } error: 0..>5
 
 -- ==
 -- entry: test3
@@ -31,6 +27,9 @@
 -- input { 5 4 1 } output { [5i32, 4i32, 3i32, 2i32, 1i32] }
 -- input { 5 0 0 } output { [5i32, 0i32] }
 -- input { 0 2 5 } output { [0i32, 2i32, 4i32] }
+-- input { 1 1 5 } error: 1..1...5
+-- input { 1 0 1 } output { [1i32] }
+-- input { 1 2 1 } output { [1i32] }
 
 -- ==
 -- entry: test4


### PR DESCRIPTION
There is a discrepancy in certain cases of inclusive ranges between the interpreter and the compiled backends. I do not know which of the two is intended, but from a quick glance I assume the interpreter has intended behavior.

So:

This changes behavior of inclusive ranges for the case where `start == end` and ~`start != second`~ `start > second`, for compiled programs only. In this case the result is now `[start]` rather than a runtime error.

Example: `1..0...1` now produces `[1]` rather than an "invalid range" runtime error.

This makes behavior for compiled programs similar to that of the Futhark interpreter (and e.g. Haskell ranges), for at least this particular case (I have not looked for other discrepancies).