### PR TITLE
Fix inc. ranges with start == end and negative step (2)

### DIFF
--- a/src/Futhark/Internalise/Exps.hs
+++ b/src/Futhark/Internalise/Exps.hs
@@ -245,7 +245,7 @@ internaliseAppExp desc _ (E.Range start maybe_second end loc) = do
   bounds_invalid_downwards <-
     letSubExp "bounds_invalid_downwards" $
       I.BasicOp $
-        I.CmpOp le_op start' end'
+        I.CmpOp lt_op start' end'
   bounds_invalid_upwards <-
     letSubExp "bounds_invalid_upwards" $
       I.BasicOp $

--- a/src/Futhark/Internalise/Exps.hs
+++ b/src/Futhark/Internalise/Exps.hs
@@ -215,10 +215,10 @@ internaliseAppExp desc _ (E.Range start maybe_second end loc) = do
                )
             ++ [ErrorVal int64 end'_i64, " is invalid."]
 
-  (it, le_op, lt_op) <-
+  (it, lt_op) <-
     case E.typeOf start of
-      E.Scalar (E.Prim (E.Signed it)) -> pure (it, CmpSle it, CmpSlt it)
-      E.Scalar (E.Prim (E.Unsigned it)) -> pure (it, CmpUle it, CmpUlt it)
+      E.Scalar (E.Prim (E.Signed it)) -> pure (it, CmpSlt it)
+      E.Scalar (E.Prim (E.Unsigned it)) -> pure (it, CmpUlt it)
       start_t -> error $ "Start value in range has type " ++ prettyString start_t
 
   let one = intConst it 1

--- a/tests/range0.fut
+++ b/tests/range0.fut
@@ -5,8 +5,6 @@
 -- input { 1 5 } output { [1i32, 2i32, 3i32, 4i32, 5i32] }
 -- input { 5 1 } error: 5...1
 -- input { 5 0 } error: 5...0
--- input { 0 5 } output { [0i32, 1i32, 2i32,
--- 3i32, 4i32, 5i32] }
 
 -- ==
 -- entry: test1
@@ -14,7 +12,6 @@
 -- input { 1 5 } output { [1i32, 2i32, 3i32, 4i32] }
 -- input { 5 1 } error: 5..<1
 -- input { 5 0 } error: 5..<0
--- input { 0 5 } output { [0i32, 1i32, 2i32, 3i32, 4i32] }
 
 -- ==
 -- entry: test2
@@ -22,7 +19,6 @@
 -- input { 1 5 } error: 1..>5
 -- input { 5 1 } output { [5i32, 4i32, 3i32, 2i32] }
 -- input { 5 0 } output { [5i32, 4i32, 3i32, 2i32, 1i32] }
--- input { 0 5 } error: 0..>5
 
 -- ==
 -- entry: test3
@@ -31,6 +27,9 @@
 -- input { 5 4 1 } output { [5i32, 4i32, 3i32, 2i32, 1i32] }
 -- input { 5 0 0 } output { [5i32, 0i32] }
 -- input { 0 2 5 } output { [0i32, 2i32, 4i32] }
+-- input { 1 1 5 } error: 1..1...5
+-- input { 1 0 1 } output { [1i32] }
+-- input { 1 2 1 } output { [1i32] }
 
 -- ==
 -- entry: test4


### PR DESCRIPTION
This PR is similar to #2194, which ran a little off-topic. I thought it easier to open a new one with just the pertinent commits.

There is a discrepancy in certain cases of inclusive ranges between the interpreter and the compiled backends for inclusive ranges with `start == end` and negative step. In particular, the range `1..0...1` gives `[1]` from the interpreter and an "invalid range" runtime error from compiled backends. This PR assimilates behavior of compiled code to that of the interpreter, for this single case at least. There may or may not be other discrepancies.