### PR TITLE
Be slightly more context aware of what is a doc comment and what isn't

### DIFF
--- a/src/Language/Futhark/Parser/Lexer.x
+++ b/src/Language/Futhark/Parser/Lexer.x
@@ -48,7 +48,7 @@ $opchar = [\+\-\*\/\%\=\!\>\<\|\&\^\.]
 @qualbinop = (@identifier ".")+ @binop
 
 @space = [\ \t\f\v]
-@doc = "-- |".*(\n@space*"--".*)*
+@doc = "-- |"[^>].*(\n@space*"--".*)*
 
 tokens :-
 

--- a/tests/dash_dash_fwd_pipe_is_not_a_doc_comment.fut
+++ b/tests/dash_dash_fwd_pipe_is_not_a_doc_comment.fut
@@ -1,0 +1,5 @@
+-- ==
+entry main (xs: []i32) =
+  xs
+  -- |> map (+1)
+  |> map (*2)

--- a/tests/doc_comments_may_only_precede_declarations.fut
+++ b/tests/doc_comments_may_only_precede_declarations.fut
@@ -1,0 +1,7 @@
+-- ==
+-- error: Documentation comments.*only permitted when preceding declarations
+entry main (x: i32) =
+  let y =
+     | 1337
+     -- | 42
+  in y


### PR DESCRIPTION
This PR is a QoL change which I hope will benefit more people besides just myself.

I often find myself commenting out lines beginning with a forward pipe, e.g. in a chained pipe expression such as this simple (but real) example:

```fut
def xs `filterBy` ps =
  zip xs ps
  |> filter (.1)
  |> map (.0)
  -- |> unzip
  -- |> (.0)
```

which will give a parsing error because lines 5 and 6 will have been lexed as doc comments -- in this case, an "unexpected EOF" error because a declaration is expected after line 6, but the error message on unexpected doc comments can also be e.g. "unexpected token" or "Doc comments can only precede declarations" in other contexts (as a side-note, it would be cool to uniformize the error messages given on unexpected doc comment lines).
EDIT: if the next token is a declaration then no error is thrown, but the comment will parse as a doc comment to the succeeding declaration. This is perhaps the trickiest case.

I'd like to be able to quickly comment out such lines without having to change my code comment plugin rules (which is easier but not so portable) -- this PR imlements the easy solution, which is to not lex as a doc comment if the `|` is followed immediately by a `>`. This is compatible with `futhark-doc` since that tool uses the same parser.
This change does not cover other (more or less plausible) cases, such as a code line starting with a vertical bar (bitwise OR) -- a better solution is perhaps to parse as a doc comment only if the lookahead is a declaration (but I don't know how to implement that).