### PR TITLE
Add irregular concat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+* Some Windows compatibility quirks (#2200, #2201).
+
+## [0.25.25]
+
+### Added
+
+* Improvements to `futhark fmt`.
+
+### Fixed
+
 * Sizes that go out of scope due to use of higher order functions will
   now work in more cases by adding existentials. (#2193)
 
@@ -26,6 +36,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   produces `[1]` rather than an invalid range error.
 
 * Inconsistent handling of types in lambda lifting (#2197).
+
+* Invalid primal results from `vjp2` in interpreter (#2199).
 
 ## [0.25.24]
 

--- a/rts/c/timing.h
+++ b/rts/c/timing.h
@@ -14,6 +14,10 @@ static int64_t get_wall_time(void) {
   return ((double)time.QuadPart / freq.QuadPart) * 1000000;
 }
 
+static int64_t get_wall_time_ns(void) {
+  return get_wall_time() * 1000;
+}
+
 #else
 // Assuming POSIX
 

--- a/src/Futhark/CodeGen/Backends/MulticoreC.hs
+++ b/src/Futhark/CodeGen/Backends/MulticoreC.hs
@@ -53,7 +53,7 @@ compileProg version =
         mempty
         operations
         generateBoilerplate
-        ""
+        "#include <pthread.h>\n"
         (DefaultSpace, [DefaultSpace])
         cliOptions
     )

--- a/src/Futhark/CodeGen/Backends/MulticoreISPC.hs
+++ b/src/Futhark/CodeGen/Backends/MulticoreISPC.hs
@@ -78,7 +78,7 @@ compileProg version prog = do
               generateBoilerplate
               mapM_ compileBuiltinFun funs
           )
-          mempty
+          "#include <pthread.h>\n"
           (DefaultSpace, [DefaultSpace])
           MC.cliOptions
       )

--- a/src/Futhark/Fmt/Printer.hs
+++ b/src/Futhark/Fmt/Printer.hs
@@ -226,6 +226,29 @@ instance Format PrimValue where
       BoolValue False -> "false"
       FloatValue v -> prettyText v
 
+updates ::
+  UncheckedExp ->
+  (UncheckedExp, [(Fmt, Fmt)])
+updates (RecordUpdate src fs ve _ _) = second (++ [(fs', ve')]) $ updates src
+  where
+    fs' = sep "." $ fmt <$> fs
+    ve' = fmt ve
+updates (Update src is ve _) = second (++ [(is', ve')]) $ updates src
+  where
+    is' = brackets $ sep ("," <> space) $ map fmt is
+    ve' = fmt ve
+updates e = (e, [])
+
+fmtUpdate :: UncheckedExp -> Fmt
+fmtUpdate e =
+  -- Special case multiple chained Updates/RecordUpdates.
+  let (root, us) = updates e
+      loc = srclocOf e
+   in addComments loc . localLayout loc $
+        fmt root <+> align (sep line (map fmtWith us))
+  where
+    fmtWith (fs', v) = "with" <+> fs' <+> "=" <+> v
+
 instance Format UncheckedExp where
   fmt (Var name _ loc) = addComments loc $ fmtQualName name
   fmt (Hole _ loc) = addComments loc "???"
@@ -246,16 +269,8 @@ instance Format UncheckedExp where
   fmt (Project k e _ loc) = addComments loc $ fmt e <> "." <> fmt k
   fmt (Negate e loc) = addComments loc $ "-" <> fmt e
   fmt (Not e loc) = addComments loc $ "!" <> fmt e
-  fmt (Update src idxs ve loc) =
-    addComments loc $
-      fmt src <+> "with" <+> idxs' <+> stdNest ("=" </> fmt ve)
-    where
-      idxs' = brackets $ sep ("," <> space) $ map fmt idxs
-  fmt (RecordUpdate src fs ve _ loc) =
-    addComments loc $
-      fmt src <+> "with" <+> fs' <+> stdNest ("=" </> fmt ve)
-    where
-      fs' = sep "." $ fmt <$> fs
+  fmt e@Update {} = fmtUpdate e
+  fmt e@RecordUpdate {} = fmtUpdate e
   fmt (Assert e1 e2 _ loc) =
     addComments loc $ "assert" <+> fmt e1 <+> fmt e2
   fmt (Lambda params body rettype _ loc) =
@@ -303,7 +318,7 @@ instance Format UncheckedCase where
 
 instance Format (AppExpBase NoInfo Name) where
   fmt (BinOp (bop, _) _ (x, _) (y, _) loc) =
-    addComments loc $ fmt x </> fmtBinOp bop <+> fmt y
+    addComments loc $ align (fmt x) </> fmtBinOp bop <+> align (fmt y)
   fmt (Match e cs loc) =
     addComments loc $ "match" <+> fmt e </> sep line (map fmt $ toList cs)
   -- need some way to omit the inital value expression, when this it's trivial

--- a/src/Language/Futhark/Interpreter.hs
+++ b/src/Language/Futhark/Interpreter.hs
@@ -2010,7 +2010,7 @@ initialCtx =
         let drvs = M.map (Just . putAD) $ M.unionsWith add $ map snd m
 
         -- Extract the output values, and the partial derivatives
-        let ov = modifyValue (\i _ -> fst $ m !! i) o
+        let ov = modifyValue (\i _ -> fst $ m !! (length m - 1 - i)) o
         let od =
               fromMaybe (error "vjp: differentiation failed") $
                 modifyValueM (\i vo -> M.findWithDefault (ValuePrim . putV . P.blankPrimValue . P.primValueType . AD.primitive <$> getAD vo) i drvs) v

--- a/tests/ad/issue2199.fut
+++ b/tests/ad/issue2199.fut
@@ -1,0 +1,14 @@
+-- ==
+-- entry: test_primal test_rev
+-- input { [1.0,2.0] [3.0,4.0] [5.0, 6.0] }
+-- output { 3.0 7.0 11.0 }
+
+def op (x0, y0, z0) (x1, y1, z1) : (f64, f64, f64) = (x0 + x1, y0 + y1, z0 + z1)
+def ne = (0f64, 0f64, 0f64)
+
+def primal xs = reduce_comm op ne xs
+
+entry test_primal as bs cs = primal (zip3 as bs cs)
+
+entry test_rev as bs cs =
+  (vjp2 (\(as, bs, cs) -> test_primal as bs cs) (as, bs, cs) (1, 1, 1)).0

--- a/tests/types/level1.fut
+++ b/tests/types/level1.fut
@@ -3,6 +3,6 @@
 -- error: "b".*scope
 
 def f x =
-  let g 'b (y: b) = if true then y else x.1
+  let g 'b (y: b) = if true then y else x.0
   let (_, _: i32) = x
   in g

--- a/tests_fmt/expected/with.fut
+++ b/tests_fmt/expected/with.fut
@@ -1,0 +1,7 @@
+def record (x: (f32, f32)) =
+  x with 0 = 42
+    with 1 = 1337
+
+def array (x: *[]f32) =
+  x with [0] = 42
+    with [1] = 1337

--- a/tests_fmt/with.fut
+++ b/tests_fmt/with.fut
@@ -1,0 +1,7 @@
+def record (x: (f32, f32)) =
+  x with 0 = 42
+       with 1 = 1337
+
+def array (x: *[]f32) =
+  x with [0] = 42 with
+  [1] = 1337

--- a/tools/data2png.py
+++ b/tools/data2png.py
@@ -9,6 +9,7 @@
 #  [height][width]u32
 #
 #  [height][width]f32
+#  [height][width]f64
 #
 #  [height][width][3]i8
 #  [height][width][3]u8
@@ -23,6 +24,10 @@ import sys
 import struct
 import numpy as np
 import png
+
+if "purepng" not in png.__file__:
+    print("data2png works only with purepng, not pypng.", file=sys.stderr)
+    sys.exit(1)
 
 
 def read_image(f):
@@ -93,7 +98,6 @@ if __name__ == "__main__":
 
     with open(infile, "rb") as f_in:
         width, height, img = read_image(f_in)
-
         with open(outfile, "wb") as f_out:
             w = png.Writer(width=width, height=height, alpha=False)
             w.write(f_out, img)


### PR DESCRIPTION
Add irregular concat to the flattening pass and tests for the implementation.
The implementation adds support for concat of dimension 0, such as the following:
```futhark
entry validate_flattening (ns: []i64) : []i64 =
    map (\n -> i64.sum (opaque (iota n `concat` iota n))) ns
```


Co-authored-by: Timmovich <Timmovich@users.noreply.github.com>
Co-authored-by: Vonutne <Vonutne@users.noreply.github.com>