### PR TITLE
Scan Scatter Fusion

### DIFF
--- a/src/Futhark/IR/Parse.hs
+++ b/src/Futhark/IR/Parse.hs
@@ -710,6 +710,7 @@ pSOAC pr =
       keyword "redomap" *> pScrema pRedomapForm,
       keyword "scanomap" *> pScrema pScanomapForm,
       keyword "screma" *> pScrema pScremaForm,
+      pScanScatter,
       keyword "vjp" *> pVJP,
       keyword "jvp" *> pJVP,
       pScatter,
@@ -811,6 +812,22 @@ pSOAC pr =
           <*> braces (pSubExp `sepBy` pComma)
           <* pComma
           <*> pLambda pr
+    pScanScatter =
+      keyword "scanscatter"
+        *> parens
+          ( SOAC.ScanScatter
+              <$> pSubExp
+              <* pComma
+              <*> braces (pVName `sepBy` pComma)
+              <* pComma
+              <*> pLambda pr
+              <* pComma
+              <*> pScan pr
+              <* pComma
+              <*> pLambda pr
+              <* pComma
+              <*> braces (pVName `sepBy` pComma)
+          )
 
 pSizeClass :: Parser GPU.SizeClass
 pSizeClass =

--- a/src/Futhark/IR/Parse.hs
+++ b/src/Futhark/IR/Parse.hs
@@ -758,9 +758,8 @@ pSOAC pr =
               <*> many (pDest <* pComma)
               <*> pLambda pr
           )
-      where
-        pDest =
-          parens $ (,,) <$> pShape <* pComma <*> pInt <* pComma <*> pVName
+    pDest =
+      parens $ (,,) <$> pShape <* pComma <*> pInt <* pComma <*> pVName
     pHist =
       keyword "hist"
         *> parens
@@ -824,9 +823,8 @@ pSOAC pr =
               <* pComma
               <*> pScan pr
               <* pComma
+              <*> many (pDest <* pComma)
               <*> pLambda pr
-              <* pComma
-              <*> braces (pVName `sepBy` pComma)
           )
 
 pSizeClass :: Parser GPU.SizeClass

--- a/src/Futhark/IR/SOACS/SOAC.hs
+++ b/src/Futhark/IR/SOACS/SOAC.hs
@@ -131,6 +131,9 @@ data SOAC rep
   | -- | A combination of scan, reduction, and map.  The first
     -- t'SubExp' is the size of the input arrays.
     Screma SubExp [VName] (ScremaForm rep)
+  | -- | @ScanScatter <width> <arrays> <map-lambda> <scan>
+    -- <scatter-lambda> <dest-arrays>
+    ScanScatter SubExp [VName] (Lambda rep) (Scan rep) (Lambda rep) [VName]
   deriving (Eq, Ord, Show)
 
 -- | Information about computing a single histogram.

--- a/temp_test_examples/temp.fut_soacs
+++ b/temp_test_examples/temp.fut_soacs
@@ -1,0 +1,31 @@
+types {
+
+}
+
+
+
+entry("main",
+      {xs: []i32},
+      {[]i32})
+  entry_main (n_5232 : i64,
+              xs_5233 : [n_5232]i32)
+  : {[n_5232]i32#([1], [0])} = {
+  let {defunc_0_scan_res_5256 : [n_5232]i32} =
+    scanscatter(n_5232,
+             {xs_5233},
+             \ {x_5252 : i32}
+               : {i32} ->
+               {x_5252},
+             \ {eta_p_5253 : i32,
+                 eta_p_5254 : i32}
+               : {i32} ->
+               let {defunc_0_op_res_5255 : i32} =
+                 add32(eta_p_5253, eta_p_5254)
+               in {defunc_0_op_res_5255},
+             {0i32},
+             \ {x_5252 : i32}
+               : {i32} ->
+               {x_5252},
+             {xs_5233})
+  in {defunc_0_scan_res_5256}
+}


### PR DESCRIPTION
This pull request aims to extend Futharks fusion algebra such that it is able to fuse a single pass scan followed by a scatter into a single kernel. The scan scatter kernel should allow for the ability to keep the scans output in shared memory and use the output for the scatter. The goal with this fusion rule is it will improve the performance of common operations such as filters, partition and segmented reduce.
