### PR TITLE
Implement pi variants of trigonometric functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * New math functions: `f16.rsqrt`, `f32.rsqrt`, `f64.rsqrt`.
 
+* New math functions: `cospi`, `sinpi`, `tanpi`, `acospi`, `asinpi`,
+  `atanpi`, `atan2pi`, in each of the `f16`/`f32`/`f64` modules. (#2243)
+
 * Slight improvements in the ability of the fusion engine to fuse
   across `map` nests separated by `reshape` operations. Only works if
   the innermost return type is purely scalar.

--- a/prelude/math.fut
+++ b/prelude/math.fut
@@ -162,9 +162,25 @@ module type real = {
   val cos : t -> t
   val tan : t -> t
 
+  -- | `sin(pi*x)` - depending on backing, may be faster or more
+  -- accurate.
+  val sinpi : t -> t
+
+  -- | `cos(pi*x)` - depending on backing, may be faster or more
+  -- accurate.
+  val cospi : t -> t
+
+  -- | `tan(pi*x)` - depending on backing, may be faster or more
+  -- accurate.
+  val tanpi : t -> t
+
   val asin : t -> t
   val acos : t -> t
   val atan : t -> t
+
+  val asinpi : t -> t
+  val acospi : t -> t
+  val atanpi : t -> t
 
   val sinh : t -> t
   val cosh : t -> t
@@ -175,6 +191,7 @@ module type real = {
   val atanh : t -> t
 
   val atan2 : t -> t -> t
+  val atan2pi : t -> t -> t
 
   -- | Compute the length of the hypotenuse of a right-angled
   -- triangle.  That is, `hypot x y` computes *√(x²+y²)*.  Put another
@@ -982,9 +999,15 @@ module f64 : (float with t = f64 with int_t = u64) = {
   def sin (x: f64) = intrinsics.sin64 x
   def cos (x: f64) = intrinsics.cos64 x
   def tan (x: f64) = intrinsics.tan64 x
+  def sinpi (x: f64) = intrinsics.sinpi64 x
+  def cospi (x: f64) = intrinsics.cospi64 x
+  def tanpi (x: f64) = intrinsics.tanpi64 x
   def acos (x: f64) = intrinsics.acos64 x
   def asin (x: f64) = intrinsics.asin64 x
   def atan (x: f64) = intrinsics.atan64 x
+  def acospi (x: f64) = intrinsics.acospi64 x
+  def asinpi (x: f64) = intrinsics.asinpi64 x
+  def atanpi (x: f64) = intrinsics.atanpi64 x
   def sinh (x: f64) = intrinsics.sinh64 x
   def cosh (x: f64) = intrinsics.cosh64 x
   def tanh (x: f64) = intrinsics.tanh64 x
@@ -992,6 +1015,7 @@ module f64 : (float with t = f64 with int_t = u64) = {
   def asinh (x: f64) = intrinsics.asinh64 x
   def atanh (x: f64) = intrinsics.atanh64 x
   def atan2 (x: f64) (y: f64) = intrinsics.atan2_64 (x, y)
+  def atan2pi (x: f64) (y: f64) = intrinsics.atan2pi_64 (x, y)
   def hypot (x: f64) (y: f64) = intrinsics.hypot64 (x, y)
   def gamma = intrinsics.gamma64
   def lgamma = intrinsics.lgamma64
@@ -1100,9 +1124,15 @@ module f32 : (float with t = f32 with int_t = u32) = {
   def sin (x: f32) = intrinsics.sin32 x
   def cos (x: f32) = intrinsics.cos32 x
   def tan (x: f32) = intrinsics.tan32 x
+  def sinpi (x: f32) = intrinsics.sinpi32 x
+  def cospi (x: f32) = intrinsics.cospi32 x
+  def tanpi (x: f32) = intrinsics.tanpi32 x
   def acos (x: f32) = intrinsics.acos32 x
   def asin (x: f32) = intrinsics.asin32 x
   def atan (x: f32) = intrinsics.atan32 x
+  def acospi (x: f32) = intrinsics.acospi32 x
+  def asinpi (x: f32) = intrinsics.asinpi32 x
+  def atanpi (x: f32) = intrinsics.atanpi32 x
   def sinh (x: f32) = intrinsics.sinh32 x
   def cosh (x: f32) = intrinsics.cosh32 x
   def tanh (x: f32) = intrinsics.tanh32 x
@@ -1110,6 +1140,7 @@ module f32 : (float with t = f32 with int_t = u32) = {
   def asinh (x: f32) = intrinsics.asinh32 x
   def atanh (x: f32) = intrinsics.atanh32 x
   def atan2 (x: f32) (y: f32) = intrinsics.atan2_32 (x, y)
+  def atan2pi (x: f32) (y: f32) = intrinsics.atan2pi_32 (x, y)
   def hypot (x: f32) (y: f32) = intrinsics.hypot32 (x, y)
   def gamma = intrinsics.gamma32
   def lgamma = intrinsics.lgamma32
@@ -1222,9 +1253,15 @@ module f16 : (float with t = f16 with int_t = u16) = {
   def sin (x: f16) = intrinsics.sin16 x
   def cos (x: f16) = intrinsics.cos16 x
   def tan (x: f16) = intrinsics.tan16 x
+  def sinpi (x: f16) = intrinsics.sinpi16 x
+  def cospi (x: f16) = intrinsics.cospi16 x
+  def tanpi (x: f16) = intrinsics.tanpi16 x
   def acos (x: f16) = intrinsics.acos16 x
   def asin (x: f16) = intrinsics.asin16 x
   def atan (x: f16) = intrinsics.atan16 x
+  def acospi (x: f16) = intrinsics.acospi16 x
+  def asinpi (x: f16) = intrinsics.asinpi16 x
+  def atanpi (x: f16) = intrinsics.atanpi16 x
   def sinh (x: f16) = intrinsics.sinh16 x
   def cosh (x: f16) = intrinsics.cosh16 x
   def tanh (x: f16) = intrinsics.tanh16 x
@@ -1232,6 +1269,7 @@ module f16 : (float with t = f16 with int_t = u16) = {
   def asinh (x: f16) = intrinsics.asinh16 x
   def atanh (x: f16) = intrinsics.atanh16 x
   def atan2 (x: f16) (y: f16) = intrinsics.atan2_16 (x, y)
+  def atan2pi (x: f16) (y: f16) = intrinsics.atan2pi_16 (x, y)
   def hypot (x: f16) (y: f16) = intrinsics.hypot16 (x, y)
   def gamma = intrinsics.gamma16
   def lgamma = intrinsics.lgamma16

--- a/rts/c/scalar.h
+++ b/rts/c/scalar.h
@@ -17,6 +17,10 @@
 // Double-precision definitions are only included if the preprocessor
 // macro FUTHARK_F64_ENABLED is set.
 
+#ifndef M_PI
+#define M_PI 3.141592653589793
+#endif
+
 SCALAR_FUN_ATTR int32_t futrts_to_bits32(float x);
 SCALAR_FUN_ATTR float futrts_from_bits32(int32_t x);
 
@@ -1801,24 +1805,48 @@ SCALAR_FUN_ATTR float futrts_cos32(float x) {
   return cos(x);
 }
 
+SCALAR_FUN_ATTR float futrts_cospi32(float x) {
+  return cospi(x);
+}
+
 SCALAR_FUN_ATTR float futrts_sin32(float x) {
   return sin(x);
+}
+
+SCALAR_FUN_ATTR float futrts_sinpi32(float x) {
+  return sinpi(x);
 }
 
 SCALAR_FUN_ATTR float futrts_tan32(float x) {
   return tan(x);
 }
 
+SCALAR_FUN_ATTR float futrts_tanpi32(float x) {
+  return tanpi(x);
+}
+
 SCALAR_FUN_ATTR float futrts_acos32(float x) {
   return acos(x);
+}
+
+SCALAR_FUN_ATTR float futrts_acospi32(float x) {
+  return acospi(x);
 }
 
 SCALAR_FUN_ATTR float futrts_asin32(float x) {
   return asin(x);
 }
 
+SCALAR_FUN_ATTR float futrts_asinpi32(float x) {
+  return asinpi(x);
+}
+
 SCALAR_FUN_ATTR float futrts_atan32(float x) {
   return atan(x);
+}
+
+SCALAR_FUN_ATTR float futrts_atanpi32(float x) {
+  return atanpi(x);
 }
 
 SCALAR_FUN_ATTR float futrts_cosh32(float x) {
@@ -1847,6 +1875,10 @@ SCALAR_FUN_ATTR float futrts_atanh32(float x) {
 
 SCALAR_FUN_ATTR float futrts_atan2_32(float x, float y) {
   return atan2(x, y);
+}
+
+SCALAR_FUN_ATTR float futrts_atan2pi_32(float x, float y) {
+  return atan2pi(x, y);
 }
 
 SCALAR_FUN_ATTR float futrts_hypot32(float x, float y) {
@@ -1956,25 +1988,50 @@ SCALAR_FUN_ATTR float futrts_cos32(float x) {
   return cos(x);
 }
 
+SCALAR_FUN_ATTR float futrts_cospi32(float x) {
+  return cos((float)M_PI*x);
+}
+
 SCALAR_FUN_ATTR float futrts_sin32(float x) {
   return sin(x);
+}
+
+SCALAR_FUN_ATTR float futrts_sinpi32(float x) {
+  return sin(M_PI*x);
 }
 
 SCALAR_FUN_ATTR float futrts_tan32(float x) {
   return tan(x);
 }
 
+SCALAR_FUN_ATTR float futrts_tanpi32(float x) {
+  return tan((float)M_PI*x);
+}
+
 SCALAR_FUN_ATTR float futrts_acos32(float x) {
   return acos(x);
+}
+
+SCALAR_FUN_ATTR float futrts_acospi32(float x) {
+  return acos(x)/(float)M_PI;
 }
 
 SCALAR_FUN_ATTR float futrts_asin32(float x) {
   return asin(x);
 }
 
+SCALAR_FUN_ATTR float futrts_asinpi32(float x) {
+  return asin(x)/(float)M_PI;
+}
+
 SCALAR_FUN_ATTR float futrts_atan32(float x) {
   return atan(x);
 }
+
+SCALAR_FUN_ATTR float futrts_atanpi32(float x) {
+  return atan(x)/(float)M_PI;
+}
+
 
 SCALAR_FUN_ATTR float futrts_cosh32(float x) {
   return (exp(x)+exp(-x)) / 2.0f;
@@ -2011,6 +2068,11 @@ SCALAR_FUN_ATTR float futrts_atanh32(float x) {
 SCALAR_FUN_ATTR float futrts_atan2_32(float x, float y) {
   return (x == 0.0f && y == 0.0f) ? 0.0f : atan2(x, y);
 }
+
+SCALAR_FUN_ATTR float futrts_atan2pi_32(float x, float y) {
+  return (x == 0.0f && y == 0.0f) ? 0.0f : atan2(x, y) / (float)M_PI;
+}
+
 
 SCALAR_FUN_ATTR float futrts_hypot32(float x, float y) {
   if (futrts_isfinite32(x) && futrts_isfinite32(y)) {
@@ -2170,24 +2232,56 @@ SCALAR_FUN_ATTR float futrts_cos32(float x) {
   return cosf(x);
 }
 
+SCALAR_FUN_ATTR float futrts_cospi32(float x) {
+#if defined(__CUDA_ARCH__)
+  return cospif(x);
+#else
+  return cosf(((float)M_PI)*x);
+#endif
+}
+
 SCALAR_FUN_ATTR float futrts_sin32(float x) {
   return sinf(x);
+}
+
+SCALAR_FUN_ATTR float futrts_sinpi32(float x) {
+#if defined(__CUDA_ARCH__)
+  return sinpif(x);
+#else
+  return sinf((float)M_PI*x);
+#endif
 }
 
 SCALAR_FUN_ATTR float futrts_tan32(float x) {
   return tanf(x);
 }
 
+SCALAR_FUN_ATTR float futrts_tanpi32(float x) {
+  return tanf((float)M_PI*x);
+}
+
 SCALAR_FUN_ATTR float futrts_acos32(float x) {
   return acosf(x);
+}
+
+SCALAR_FUN_ATTR float futrts_acospi32(float x) {
+  return acosf(x)/(float)M_PI;
 }
 
 SCALAR_FUN_ATTR float futrts_asin32(float x) {
   return asinf(x);
 }
 
+SCALAR_FUN_ATTR float futrts_asinpi32(float x) {
+  return asinf(x)/(float)M_PI;
+}
+
 SCALAR_FUN_ATTR float futrts_atan32(float x) {
   return atanf(x);
+}
+
+SCALAR_FUN_ATTR float futrts_atanpi32(float x) {
+  return atanf(x)/(float)M_PI;
 }
 
 SCALAR_FUN_ATTR float futrts_cosh32(float x) {
@@ -2216,6 +2310,10 @@ SCALAR_FUN_ATTR float futrts_atanh32(float x) {
 
 SCALAR_FUN_ATTR float futrts_atan2_32(float x, float y) {
   return atan2f(x, y);
+}
+
+SCALAR_FUN_ATTR float futrts_atan2pi_32(float x, float y) {
+  return atan2f(x, y) / (float)M_PI;
 }
 
 SCALAR_FUN_ATTR float futrts_hypot32(float x, float y) {
@@ -2449,24 +2547,48 @@ SCALAR_FUN_ATTR double futrts_cos64(double x) {
   return cos(x);
 }
 
+SCALAR_FUN_ATTR double futrts_cospi64(double x) {
+  return cos(M_PI*x);
+}
+
 SCALAR_FUN_ATTR double futrts_sin64(double x) {
   return sin(x);
+}
+
+SCALAR_FUN_ATTR double futrts_sinpi64(double x) {
+  return sin(M_PI*x);
 }
 
 SCALAR_FUN_ATTR double futrts_tan64(double x) {
   return tan(x);
 }
 
+SCALAR_FUN_ATTR double futrts_tanpi64(double x) {
+  return tan(M_PI*x);
+}
+
 SCALAR_FUN_ATTR double futrts_acos64(double x) {
   return acos(x);
+}
+
+SCALAR_FUN_ATTR double futrts_acospi64(double x) {
+  return acos(x)/M_PI;
 }
 
 SCALAR_FUN_ATTR double futrts_asin64(double x) {
   return asin(x);
 }
 
+SCALAR_FUN_ATTR double futrts_asinpi64(double x) {
+  return asin(x)/M_PI;
+}
+
 SCALAR_FUN_ATTR double futrts_atan64(double x) {
   return atan(x);
+}
+
+SCALAR_FUN_ATTR double futrts_atanpi64(double x) {
+  return atan(x)/M_PI;
 }
 
 SCALAR_FUN_ATTR double futrts_cosh64(double x) {
@@ -2497,11 +2619,14 @@ SCALAR_FUN_ATTR double futrts_atanh64(double x) {
   double f = (1.0d+x)/(1.0d-x);
   if(futrts_isfinite64(f)) return log(f)/2.0d;
   return f;
-
 }
 
 SCALAR_FUN_ATTR double futrts_atan2_64(double x, double y) {
   return atan2(x, y);
+}
+
+SCALAR_FUN_ATTR double futrts_atan2pi_64(double x, double y) {
+  return atan2(x, y) / M_PI;
 }
 
 extern "C" unmasked uniform double hypot(uniform double x, uniform double y);
@@ -2828,24 +2953,76 @@ SCALAR_FUN_ATTR double futrts_cos64(double x) {
   return cos(x);
 }
 
+SCALAR_FUN_ATTR double futrts_cospi64(double x) {
+#ifdef __OPENCL_VERSION__
+  return cospi(x);
+#elif defined(__CUDA_ARCH__)
+  return cospi(x);
+#else
+  return cos(M_PI*x);
+#endif
+}
+
 SCALAR_FUN_ATTR double futrts_sin64(double x) {
   return sin(x);
+}
+
+SCALAR_FUN_ATTR double futrts_sinpi64(double x) {
+#ifdef __OPENCL_VERSION__
+  return sinpi(x);
+#elif defined(__CUDA_ARCH__)
+  return sinpi(x);
+#else
+  return sin(M_PI*x);
+#endif
 }
 
 SCALAR_FUN_ATTR double futrts_tan64(double x) {
   return tan(x);
 }
 
+SCALAR_FUN_ATTR double futrts_tanpi64(double x) {
+#ifdef __OPENCL_VERSION__
+  return tanpi(x);
+#else
+  return tan(M_PI*x);
+#endif
+}
+
 SCALAR_FUN_ATTR double futrts_acos64(double x) {
   return acos(x);
+}
+
+SCALAR_FUN_ATTR double futrts_acospi64(double x) {
+#ifdef __OPENCL_VERSION__
+  return acospi(x);
+#else
+  return acos(x) / M_PI;
+#endif
 }
 
 SCALAR_FUN_ATTR double futrts_asin64(double x) {
   return asin(x);
 }
 
+SCALAR_FUN_ATTR double futrts_asinpi64(double x) {
+#ifdef __OPENCL_VERSION__
+  return asinpi(x);
+#else
+  return asin(x) / M_PI;
+#endif
+}
+
 SCALAR_FUN_ATTR double futrts_atan64(double x) {
   return atan(x);
+}
+
+SCALAR_FUN_ATTR double futrts_atanpi64(double x) {
+#ifdef __OPENCL_VERSION__
+  return atanpi(x);
+#else
+  return atan(x) / M_PI;
+#endif
 }
 
 SCALAR_FUN_ATTR double futrts_cosh64(double x) {
@@ -2874,6 +3051,14 @@ SCALAR_FUN_ATTR double futrts_atanh64(double x) {
 
 SCALAR_FUN_ATTR double futrts_atan2_64(double x, double y) {
   return atan2(x, y);
+}
+
+SCALAR_FUN_ATTR double futrts_atan2pi_64(double x, double y) {
+#ifdef __OPENCL_VERSION__
+  return atan2pi(x, y);
+#else
+  return atan2(x, y) / M_PI;
+#endif
 }
 
 SCALAR_FUN_ATTR double futrts_hypot64(double x, double y) {

--- a/rts/c/scalar_f16.h
+++ b/rts/c/scalar_f16.h
@@ -242,24 +242,48 @@ SCALAR_FUN_ATTR f16 futrts_cos16(f16 x) {
   return cos(x);
 }
 
+SCALAR_FUN_ATTR f16 futrts_cospi16(f16 x) {
+  return cospi(x);
+}
+
 SCALAR_FUN_ATTR f16 futrts_sin16(f16 x) {
   return sin(x);
+}
+
+SCALAR_FUN_ATTR f16 futrts_sinpi16(f16 x) {
+  return sinpi(x);
 }
 
 SCALAR_FUN_ATTR f16 futrts_tan16(f16 x) {
   return tan(x);
 }
 
+SCALAR_FUN_ATTR f16 futrts_tanpi16(f16 x) {
+  return tanpi(x);
+}
+
 SCALAR_FUN_ATTR f16 futrts_acos16(f16 x) {
   return acos(x);
+}
+
+SCALAR_FUN_ATTR f16 futrts_acospi16(f16 x) {
+  return acospi(x);
 }
 
 SCALAR_FUN_ATTR f16 futrts_asin16(f16 x) {
   return asin(x);
 }
 
+SCALAR_FUN_ATTR f16 futrts_asinpi16(f16 x) {
+  return asinpi(x);
+}
+
 SCALAR_FUN_ATTR f16 futrts_atan16(f16 x) {
   return atan(x);
+}
+
+SCALAR_FUN_ATTR f16 futrts_atanpi16(f16 x) {
+  return atanpi(x);
 }
 
 SCALAR_FUN_ATTR f16 futrts_cosh16(f16 x) {
@@ -288,6 +312,10 @@ SCALAR_FUN_ATTR f16 futrts_atanh16(f16 x) {
 
 SCALAR_FUN_ATTR f16 futrts_atan2_16(f16 x, f16 y) {
   return atan2(x, y);
+}
+
+SCALAR_FUN_ATTR f16 futrts_atan2pi_16(f16 x, f16 y) {
+  return atan2pi(x, y);
 }
 
 SCALAR_FUN_ATTR f16 futrts_hypot16(f16 x, f16 y) {
@@ -386,24 +414,48 @@ SCALAR_FUN_ATTR f16 futrts_cos16(f16 x) {
   return (float16)cos((float)x);
 }
 
+SCALAR_FUN_ATTR f16 futrts_cospi16(f16 x) {
+  return (float16)cos((float)M_PI*(float)x);
+}
+
 SCALAR_FUN_ATTR f16 futrts_sin16(f16 x) {
   return (float16)sin((float)x);
+}
+
+SCALAR_FUN_ATTR f16 futrts_sinpi16(f16 x) {
+  return (float16)sin((float)M_PI*(float)x);
 }
 
 SCALAR_FUN_ATTR f16 futrts_tan16(f16 x) {
   return (float16)tan((float)x);
 }
 
+SCALAR_FUN_ATTR f16 futrts_tanpi16(f16 x) {
+  return (float16)(tan((float)M_PI*(float)x));
+}
+
 SCALAR_FUN_ATTR f16 futrts_acos16(f16 x) {
   return (float16)acos((float)x);
+}
+
+SCALAR_FUN_ATTR f16 futrts_acospi16(f16 x) {
+  return (float16)(acos((float)x)/(float)M_PI);
 }
 
 SCALAR_FUN_ATTR f16 futrts_asin16(f16 x) {
   return (float16)asin((float)x);
 }
 
+SCALAR_FUN_ATTR f16 futrts_asinpi16(f16 x) {
+  return (float16)(asin((float)x)/(float)M_PI);
+}
+
 SCALAR_FUN_ATTR f16 futrts_atan16(f16 x) {
   return (float16)atan((float)x);
+}
+
+SCALAR_FUN_ATTR f16 futrts_atanpi16(f16 x) {
+  return (float16)(atan((float)x)/(float)M_PI);
 }
 
 SCALAR_FUN_ATTR f16 futrts_cosh16(f16 x) {
@@ -438,6 +490,10 @@ SCALAR_FUN_ATTR f16 futrts_atanh16(f16 x) {
 
 SCALAR_FUN_ATTR f16 futrts_atan2_16(f16 x, f16 y) {
   return (float16)atan2((float)x, (float)y);
+}
+
+SCALAR_FUN_ATTR f16 futrts_atan2pi_16(f16 x, f16 y) {
+  return (float16)(atan2((float)x, (float)y)/(float)M_PI);
 }
 
 SCALAR_FUN_ATTR f16 futrts_hypot16(f16 x, f16 y) {
@@ -557,24 +613,48 @@ SCALAR_FUN_ATTR f16 futrts_cos16(f16 x) {
   return hcos(x);
 }
 
+SCALAR_FUN_ATTR f16 futrts_cospi16(f16 x) {
+  return hcos((f16)M_PI*x);
+}
+
 SCALAR_FUN_ATTR f16 futrts_sin16(f16 x) {
   return hsin(x);
+}
+
+SCALAR_FUN_ATTR f16 futrts_sinpi16(f16 x) {
+  return hsin((f16)M_PI*x);
 }
 
 SCALAR_FUN_ATTR f16 futrts_tan16(f16 x) {
   return tanf(x);
 }
 
+SCALAR_FUN_ATTR f16 futrts_tanpi16(f16 x) {
+  return tanf((f16)M_PI*x);
+}
+
 SCALAR_FUN_ATTR f16 futrts_acos16(f16 x) {
   return acosf(x);
+}
+
+SCALAR_FUN_ATTR f16 futrts_acospi16(f16 x) {
+  return (f16)acosf(x)/(f16)M_PI;
 }
 
 SCALAR_FUN_ATTR f16 futrts_asin16(f16 x) {
   return asinf(x);
 }
 
+SCALAR_FUN_ATTR f16 futrts_asinpi16(f16 x) {
+  return (f16)asinf(x)/(f16)M_PI;
+}
+
 SCALAR_FUN_ATTR f16 futrts_atan16(f16 x) {
-  return atanf(x);
+  return (f16)atanf(x);
+}
+
+SCALAR_FUN_ATTR f16 futrts_atanpi16(f16 x) {
+  return (f16)atanf(x)/(f16)M_PI;
 }
 
 SCALAR_FUN_ATTR f16 futrts_cosh16(f16 x) {
@@ -602,7 +682,11 @@ SCALAR_FUN_ATTR f16 futrts_atanh16(f16 x) {
 }
 
 SCALAR_FUN_ATTR f16 futrts_atan2_16(f16 x, f16 y) {
-  return atan2f(x, y);
+  return (f16)atan2f(x, y);
+}
+
+SCALAR_FUN_ATTR f16 futrts_atan2pi_16(f16 x, f16 y) {
+  return (f16)atan2f(x, y)/(f16)M_PI;
 }
 
 SCALAR_FUN_ATTR f16 futrts_hypot16(f16 x, f16 y) {
@@ -771,24 +855,48 @@ SCALAR_FUN_ATTR f16 futrts_cos16(f16 x) {
   return futrts_cos32(x);
 }
 
+SCALAR_FUN_ATTR f16 futrts_cospi16(f16 x) {
+  return futrts_cospi32(x);
+}
+
 SCALAR_FUN_ATTR f16 futrts_sin16(f16 x) {
   return futrts_sin32(x);
+}
+
+SCALAR_FUN_ATTR f16 futrts_sinpi16(f16 x) {
+  return futrts_sinpi32(x);
 }
 
 SCALAR_FUN_ATTR f16 futrts_tan16(f16 x) {
   return futrts_tan32(x);
 }
 
+SCALAR_FUN_ATTR f16 futrts_tanpi16(f16 x) {
+  return futrts_tanpi32(x);
+}
+
 SCALAR_FUN_ATTR f16 futrts_acos16(f16 x) {
   return futrts_acos32(x);
+}
+
+SCALAR_FUN_ATTR f16 futrts_acospi16(f16 x) {
+  return futrts_acospi32(x);
 }
 
 SCALAR_FUN_ATTR f16 futrts_asin16(f16 x) {
   return futrts_asin32(x);
 }
 
+SCALAR_FUN_ATTR f16 futrts_asinpi16(f16 x) {
+  return futrts_asinpi32(x);
+}
+
 SCALAR_FUN_ATTR f16 futrts_atan16(f16 x) {
   return futrts_atan32(x);
+}
+
+SCALAR_FUN_ATTR f16 futrts_atanpi16(f16 x) {
+  return futrts_atanpi32(x);
 }
 
 SCALAR_FUN_ATTR f16 futrts_cosh16(f16 x) {
@@ -817,6 +925,10 @@ SCALAR_FUN_ATTR f16 futrts_atanh16(f16 x) {
 
 SCALAR_FUN_ATTR f16 futrts_atan2_16(f16 x, f16 y) {
   return futrts_atan2_32(x, y);
+}
+
+SCALAR_FUN_ATTR f16 futrts_atan2pi_16(f16 x, f16 y) {
+  return futrts_atan2pi_32(x, y);
 }
 
 SCALAR_FUN_ATTR f16 futrts_hypot16(f16 x, f16 y) {

--- a/rts/python/scalar.py
+++ b/rts/python/scalar.py
@@ -4,6 +4,10 @@ import numpy as np
 import math
 import struct
 
+pi16 = np.float16(np.pi)
+pi32 = np.float32(np.pi)
+pi64 = np.float64(np.pi)
+
 
 def intlit(t, x):
     if t == np.int8:
@@ -612,24 +616,48 @@ def futhark_cos64(x):
     return np.cos(x)
 
 
+def futhark_cospi64(x):
+    return np.cos(pi64 * x)
+
+
 def futhark_sin64(x):
     return np.sin(x)
+
+
+def futhark_sinpi64(x):
+    return np.sin(pi64 * x)
 
 
 def futhark_tan64(x):
     return np.tan(x)
 
 
+def futhark_tanpi64(x):
+    return np.tan(pi64 * x)
+
+
 def futhark_acos64(x):
     return np.arccos(x)
+
+
+def futhark_acospi64(x):
+    return np.arccos(x) / pi64
 
 
 def futhark_asin64(x):
     return np.arcsin(x)
 
 
+def futhark_asinpi64(x):
+    return np.arcsin(x) / pi64
+
+
 def futhark_atan64(x):
     return np.arctan(x)
+
+
+def futhark_atanpi64(x):
+    return np.arctan(x) / pi64
 
 
 def futhark_cosh64(x):
@@ -658,6 +686,10 @@ def futhark_atanh64(x):
 
 def futhark_atan2_64(x, y):
     return np.arctan2(x, y)
+
+
+def futhark_atan2pi_64(x, y):
+    return np.arctan2(x, y) / pi64
 
 
 def futhark_hypot64(x, y):
@@ -750,24 +782,48 @@ def futhark_cos32(x):
     return np.cos(x)
 
 
+def futhark_cospi32(x):
+    return np.cos(pi32 * x)
+
+
 def futhark_sin32(x):
     return np.sin(x)
+
+
+def futhark_sinpi32(x):
+    return np.sin(pi32 * x)
 
 
 def futhark_tan32(x):
     return np.tan(x)
 
 
+def futhark_tanpi32(x):
+    return np.tan(pi32 * x)
+
+
 def futhark_acos32(x):
     return np.arccos(x)
+
+
+def futhark_acospi32(x):
+    return np.arccos(x) / pi32
 
 
 def futhark_asin32(x):
     return np.arcsin(x)
 
 
+def futhark_asinpi32(x):
+    return np.arcsin(x) / pi32
+
+
 def futhark_atan32(x):
     return np.arctan(x)
+
+
+def futhark_atanpi32(x):
+    return np.arctan(x) / pi32
 
 
 def futhark_cosh32(x):
@@ -796,6 +852,10 @@ def futhark_atanh32(x):
 
 def futhark_atan2_32(x, y):
     return np.arctan2(x, y)
+
+
+def futhark_atan2pi_32(x, y):
+    return np.arctan2(x, y) / pi32
 
 
 def futhark_hypot32(x, y):
@@ -888,24 +948,48 @@ def futhark_cos16(x):
     return np.cos(x)
 
 
+def futhark_cospi16(x):
+    return np.cos(pi16 * x)
+
+
 def futhark_sin16(x):
     return np.sin(x)
+
+
+def futhark_sinpi16(x):
+    return np.sin(pi16 * x)
 
 
 def futhark_tan16(x):
     return np.tan(x)
 
 
+def futhark_tanpi16(x):
+    return np.tan(pi16 * x)
+
+
 def futhark_acos16(x):
     return np.arccos(x)
+
+
+def futhark_acospi16(x):
+    return np.arccos(x) / pi16
 
 
 def futhark_asin16(x):
     return np.arcsin(x)
 
 
+def futhark_asinpi16(x):
+    return np.arcsin(x) / pi16
+
+
 def futhark_atan16(x):
     return np.arctan(x)
+
+
+def futhark_atanpi16(x):
+    return np.arctan(x) / pi16
 
 
 def futhark_cosh16(x):
@@ -934,6 +1018,10 @@ def futhark_atanh16(x):
 
 def futhark_atan2_16(x, y):
     return np.arctan2(x, y)
+
+
+def futhark_atan2pi_16(x, y):
+    return np.arctan2(x, y) / pi16
 
 
 def futhark_hypot16(x, y):

--- a/src/Futhark/AD/Derivatives.hs
+++ b/src/Futhark/AD/Derivatives.hs
@@ -213,6 +213,12 @@ pdBuiltin "sin32" [x] =
   Just [untyped $ cos (isF32 x)]
 pdBuiltin "sin64" [x] =
   Just [untyped $ cos (isF64 x)]
+pdBuiltin "sinpi16" [x] =
+  Just [untyped $ pi * cos (pi * isF16 x)]
+pdBuiltin "sinpi32" [x] =
+  Just [untyped $ pi * cos (pi * isF32 x)]
+pdBuiltin "sinpi64" [x] =
+  Just [untyped $ pi * cos (pi * isF64 x)]
 pdBuiltin "sinh16" [x] =
   Just [untyped $ cosh (isF16 x)]
 pdBuiltin "sinh32" [x] =
@@ -225,6 +231,12 @@ pdBuiltin "cos32" [x] =
   Just [untyped $ -sin (isF32 x)]
 pdBuiltin "cos64" [x] =
   Just [untyped $ -sin (isF64 x)]
+pdBuiltin "cospi16" [x] =
+  Just [untyped $ -pi * sin (pi * isF16 x)]
+pdBuiltin "cospi32" [x] =
+  Just [untyped $ -pi * sin (pi * isF32 x)]
+pdBuiltin "cospi64" [x] =
+  Just [untyped $ -pi * sin (pi * isF64 x)]
 pdBuiltin "cosh16" [x] =
   Just [untyped $ sinh (isF16 x)]
 pdBuiltin "cosh32" [x] =
@@ -237,12 +249,24 @@ pdBuiltin "tan32" [x] =
   Just [untyped $ 1 / (cos (isF32 x) * cos (isF32 x))]
 pdBuiltin "tan64" [x] =
   Just [untyped $ 1 / (cos (isF64 x) * cos (isF64 x))]
+pdBuiltin "tanpi16" [x] =
+  Just [untyped $ pi * (1 / (cos (pi * isF16 x) * cos (pi * isF16 x)))]
+pdBuiltin "tanpi32" [x] =
+  Just [untyped $ pi * (1 / (cos (pi * isF32 x) * cos (pi * isF32 x)))]
+pdBuiltin "tanpi64" [x] =
+  Just [untyped $ pi * (1 / (cos (pi * isF64 x) * cos (pi * isF64 x)))]
 pdBuiltin "asin16" [x] =
   Just [untyped $ 1 / sqrt (1 - isF16 x * isF16 x)]
 pdBuiltin "asin32" [x] =
   Just [untyped $ 1 / sqrt (1 - isF32 x * isF32 x)]
 pdBuiltin "asin64" [x] =
   Just [untyped $ 1 / sqrt (1 - isF64 x * isF64 x)]
+pdBuiltin "asinpi16" [x] =
+  Just [untyped $ 1 / (pi * sqrt (1 - isF16 x * isF16 x))]
+pdBuiltin "asinpi32" [x] =
+  Just [untyped $ 1 / (pi * sqrt (1 - isF32 x * isF32 x))]
+pdBuiltin "asinpi64" [x] =
+  Just [untyped $ 1 / (pi * sqrt (1 - isF64 x * isF64 x))]
 pdBuiltin "asinh16" [x] =
   Just [untyped $ 1 / sqrt (1 + isF16 x * isF16 x)]
 pdBuiltin "asinh32" [x] =
@@ -255,6 +279,12 @@ pdBuiltin "acos32" [x] =
   Just [untyped $ -1 / sqrt (1 - isF32 x * isF32 x)]
 pdBuiltin "acos64" [x] =
   Just [untyped $ -1 / sqrt (1 - isF64 x * isF64 x)]
+pdBuiltin "acospi16" [x] =
+  Just [untyped $ -1 / (pi * sqrt (1 - isF16 x * isF16 x))]
+pdBuiltin "acospi32" [x] =
+  Just [untyped $ -1 / (pi * sqrt (1 - isF32 x * isF32 x))]
+pdBuiltin "acospi64" [x] =
+  Just [untyped $ -1 / (pi * sqrt (1 - isF64 x * isF64 x))]
 pdBuiltin "acosh16" [x] =
   Just [untyped $ 1 / sqrt (isF16 x * isF16 x - 1)]
 pdBuiltin "acosh32" [x] =
@@ -266,6 +296,12 @@ pdBuiltin "atan16" [x] =
 pdBuiltin "atan32" [x] =
   Just [untyped $ 1 / (1 + isF32 x * isF32 x)]
 pdBuiltin "atan64" [x] =
+  Just [untyped $ 1 / (pi * (1 + isF64 x * isF64 x))]
+pdBuiltin "atanpi16" [x] =
+  Just [untyped $ 1 / (pi * (1 + isF16 x * isF16 x))]
+pdBuiltin "atanpi32" [x] =
+  Just [untyped $ 1 / (pi * (1 + isF32 x * isF32 x))]
+pdBuiltin "atanpi64" [x] =
   Just [untyped $ 1 / (1 + isF64 x * isF64 x)]
 pdBuiltin "atanh16" [x] =
   Just [untyped $ cosh (isF16 x) * cosh (isF16 x)]
@@ -287,6 +323,21 @@ pdBuiltin "atan2_64" [x, y] =
   Just
     [ untyped $ -isF64 y / (isF64 x * isF64 x + isF64 y * isF64 y),
       untyped $ -isF64 x / (isF64 x * isF64 x + isF64 y * isF64 y)
+    ]
+pdBuiltin "atan2pi_16" [x, y] =
+  Just
+    [ untyped $ -isF16 y / (pi * (isF16 x * isF16 x + isF16 y * isF16 y)),
+      untyped $ -isF16 x / (pi * (isF16 x * isF16 x + isF16 y * isF16 y))
+    ]
+pdBuiltin "atan2pi_32" [x, y] =
+  Just
+    [ untyped $ -isF32 y / (pi * (isF32 x * isF32 x + isF32 y * isF32 y)),
+      untyped $ -isF32 x / (pi * (isF32 x * isF32 x + isF32 y * isF32 y))
+    ]
+pdBuiltin "atan2pi_64" [x, y] =
+  Just
+    [ untyped $ -isF64 y / (pi * (isF64 x * isF64 x + isF64 y * isF64 y)),
+      untyped $ -isF64 x / (pi * (isF64 x * isF64 x + isF64 y * isF64 y))
     ]
 pdBuiltin "tanh16" [x] =
   Just [untyped $ 1 - tanh (isF16 x) * tanh (isF16 x)]

--- a/src/Language/Futhark/Primitive.hs
+++ b/src/Language/Futhark/Primitive.hs
@@ -1242,6 +1242,10 @@ primFuns =
       f32 "sin32" sin,
       f64 "sin64" sin,
       --
+      f16 "sinpi16" $ sin . (pi *),
+      f32 "sinpi32" $ sin . (pi *),
+      f64 "sinpi64" $ sin . (pi *),
+      --
       f16 "sinh16" sinh,
       f32 "sinh32" sinh,
       f64 "sinh64" sinh,
@@ -1249,6 +1253,10 @@ primFuns =
       f16 "cos16" cos,
       f32 "cos32" cos,
       f64 "cos64" cos,
+      --
+      f16 "cospi16" $ cos . (pi *),
+      f32 "cospi32" $ cos . (pi *),
+      f64 "cospi64" $ cos . (pi *),
       --
       f16 "cosh16" cosh,
       f32 "cosh32" cosh,
@@ -1258,6 +1266,10 @@ primFuns =
       f32 "tan32" tan,
       f64 "tan64" tan,
       --
+      f16 "tanpi16" $ tan . (pi *),
+      f32 "tanpi32" $ tan . (pi *),
+      f64 "tanpi64" $ tan . (pi *),
+      --
       f16 "tanh16" tanh,
       f32 "tanh32" tanh,
       f64 "tanh64" tanh,
@@ -1265,6 +1277,10 @@ primFuns =
       f16 "asin16" asin,
       f32 "asin32" asin,
       f64 "asin64" asin,
+      --
+      f16 "asinpi16" $ (/ pi) . asin,
+      f32 "asinpi32" $ (/ pi) . asin,
+      f64 "asinpi64" $ (/ pi) . asin,
       --
       f16 "asinh16" asinh,
       f32 "asinh32" asinh,
@@ -1274,6 +1290,10 @@ primFuns =
       f32 "acos32" acos,
       f64 "acos64" acos,
       --
+      f16 "acospi16" $ (/ pi) . acos,
+      f32 "acospi32" $ (/ pi) . acos,
+      f64 "acospi64" $ (/ pi) . acos,
+      --
       f16 "acosh16" acosh,
       f32 "acosh32" acosh,
       f64 "acosh64" acosh,
@@ -1281,6 +1301,10 @@ primFuns =
       f16 "atan16" atan,
       f32 "atan32" atan,
       f64 "atan64" atan,
+      --
+      f16 "atanpi16" $ (/ pi) . atan,
+      f32 "atanpi32" $ (/ pi) . atan,
+      f64 "atanpi64" $ (/ pi) . atan,
       --
       f16 "atanh16" atanh,
       f32 "atanh32" atanh,
@@ -1404,6 +1428,33 @@ primFuns =
           \case
             [FloatValue (Float64Value x), FloatValue (Float64Value y)] ->
               Just $ FloatValue $ Float64Value $ atan2 x y
+            _ -> Nothing
+        )
+      ),
+      ( "atan2pi_16",
+        ( [FloatType Float16, FloatType Float16],
+          FloatType Float16,
+          \case
+            [FloatValue (Float16Value x), FloatValue (Float16Value y)] ->
+              Just $ FloatValue $ Float16Value $ atan2 x y / pi
+            _ -> Nothing
+        )
+      ),
+      ( "atan2pi_32",
+        ( [FloatType Float32, FloatType Float32],
+          FloatType Float32,
+          \case
+            [FloatValue (Float32Value x), FloatValue (Float32Value y)] ->
+              Just $ FloatValue $ Float32Value $ atan2 x y / pi
+            _ -> Nothing
+        )
+      ),
+      ( "atan2pi_64",
+        ( [FloatType Float64, FloatType Float64],
+          FloatType Float64,
+          \case
+            [FloatValue (Float64Value x), FloatValue (Float64Value y)] ->
+              Just $ FloatValue $ Float64Value $ atan2 x y / pi
             _ -> Nothing
         )
       ),

--- a/tests/primitive/acospi.fut
+++ b/tests/primitive/acospi.fut
@@ -1,0 +1,18 @@
+-- ==
+-- entry: acospi64
+-- input { [1.0, 0f64, -1.0] }
+-- output { [0f64, 0.5f64, 1f64 ] }
+
+-- ==
+-- entry: acospi32
+-- input { [1.0f32, 0f32, -1.0f32] }
+-- output { [0f32, 0.5f32, 1f32 ] }
+
+-- ==
+-- entry: acospi16
+-- input { [1.0f16, 0f16, -1.0f16] }
+-- output { [0f16, 0.5f16, 1f16 ] }
+
+entry acospi64 = map f64.acospi
+entry acospi32 = map f32.acospi
+entry acospi16 = map f16.acospi

--- a/tests/primitive/asinpi.fut
+++ b/tests/primitive/asinpi.fut
@@ -1,0 +1,18 @@
+-- ==
+-- entry: asinpi64
+-- input { [0.0f64, 1f64, -1f64, -1.0f64] }
+-- output { [0f64, 0.5f64, -0.5f64, -0.5f64 ] }
+
+-- ==
+-- entry: asinpi32
+-- input { [0.0f32, 1f32, -1f32, -1.0f32] }
+-- output { [0f32, 0.5f32, -0.5f32, -0.5f32 ] }
+
+-- ==
+-- entry: asinpi16
+-- input { [0.0f16, 1f16, -1f16, -1.0f16] }
+-- output { [0f16, 0.5f16, -0.5f16, -0.5f16 ] }
+
+entry asinpi64 = map f64.asinpi
+entry asinpi32 = map f32.asinpi
+entry asinpi16 = map f16.asinpi

--- a/tests/primitive/atan2pi.fut
+++ b/tests/primitive/atan2pi.fut
@@ -1,0 +1,18 @@
+-- ==
+-- entry: atan2pi64
+-- input { [0f64, 1f64, 1f64, 0f64, -1f64, 1f64, -1f64] [0f64, 0f64, 1f64, 1f64, 1f64, -1f64, -1f64] }
+-- output { [0.0f64, 0.5f64, 0.25f64, 0.0f64, -0.25f64, 0.75f64, -0.75f64] }
+
+-- ==
+-- entry: atan2pi32
+-- input { [0f32, 1f32, 1f32, 0f32, -1f32, 1f32, -1f32] [0f32, 0f32, 1f32, 1f32, 1f32, -1f32, -1f32] }
+-- output { [0.0f32, 0.5f32, 0.25f32, 0.0f32, -0.25f32, 0.75f32, -0.75f32] }
+
+-- ==
+-- entry: atan2pi16
+-- input { [1f16, 1f16, 0f16, -1f16, 1f16, -1f16] [0f16, 1f16, 1f16, 1f16, -1f16, -1f16] }
+-- output { [0.5f16, 0.25f16, 0.0f16, -0.25f16, 0.75f16, -0.75f16] }
+
+entry atan2pi64 = map2 f64.atan2pi
+entry atan2pi32 = map2 f32.atan2pi
+entry atan2pi16 = map2 f16.atan2pi

--- a/tests/primitive/atanpi.fut
+++ b/tests/primitive/atanpi.fut
@@ -1,0 +1,18 @@
+-- ==
+-- entry: atanpi64
+-- input { [0f64, 1.633123935319537e16f64, 5.443746451065123e15f64] }
+-- output { [0f64, 0.5f64, 0.5f64 ] }
+
+-- ==
+-- entry: atanpi32
+-- input { [0f32, -2.2877334e7f32, -8.385828e7f32] }
+-- output { [0f32, -0.49999997f32, -0.49999997f32 ] }
+
+-- ==
+-- entry: atanpi16
+-- input { [0f16, 2066f16, 689f16 ] }
+-- output { [0f16, 0.5f16, 0.5f16 ] }
+
+entry atanpi64 = map f64.atanpi
+entry atanpi32 = map f32.atanpi
+entry atanpi16 = map f16.atanpi

--- a/tests/primitive/cospi.fut
+++ b/tests/primitive/cospi.fut
@@ -1,0 +1,18 @@
+-- ==
+-- entry: cospi64
+-- input { [0f64, 0.5f64, 1f64, 2f64, -1f64 ] }
+-- output { [1.0, 0f64, -1.0, 1.0, -1.0] }
+
+-- ==
+-- entry: cospi32
+-- input { [0f32, 0.5f32, 1f32, 2f32, -1f32 ] }
+-- output { [1.0f32, 0f32, -1.0f32, 1.0f32, -1.0f32] }
+
+-- ==
+-- entry: cospi16
+-- input { [0f16, 0.5f16, 1f16, 2f16, -1f16 ] }
+-- output { [1.0f16, 0f16, -1.0f16, 1.0f16, -1.0f16] }
+
+entry cospi64 = map f64.cospi
+entry cospi32 = map f32.cospi
+entry cospi16 = map f16.cospi

--- a/tests/primitive/sinpi.fut
+++ b/tests/primitive/sinpi.fut
@@ -1,0 +1,18 @@
+-- ==
+-- entry: sinpi64
+-- input { [0f64, 0.5f64, 1f64, 1.5f64, 2f64, -0.5f64 ] }
+-- output { [0.0f64, 1f64, 0f64, -1f64, 0f64, -1.0f64] }
+
+-- ==
+-- entry: sinpi32
+-- input { [0f32, 0.5f32, 1f32, 1.5f32, 2f32, -0.5f32 ] }
+-- output { [0.0f32, 1f32, 0f32, -1f32, 0f32, -1.0f32] }
+
+-- ==
+-- entry: sinpi16
+-- input { [0f16, 0.5f16, 1f16, 1.5f16, 2f16, -0.5f16 ] }
+-- output { [0.0f16, 1f16, 0f16, -1f16, 0f16, -1.0f16] }
+
+entry sinpi64 = map f64.sinpi
+entry sinpi32 = map f32.sinpi
+entry sinpi16 = map f16.sinpi

--- a/tests/primitive/tanpi.fut
+++ b/tests/primitive/tanpi.fut
@@ -1,0 +1,18 @@
+-- ==
+-- entry: tanpi64
+-- input { [0f64, 0.1f64, 1f64, 2f64 ] }
+-- output { [0f64, 0.3249196962329063f64, 0f64, 0f64] }
+
+-- ==
+-- entry: tanpi32
+-- input { [0f32, 0.1f32, 1f32, 2f32 ] }
+-- output { [0f32, 0.3249197f32, 0f32, 0f32] }
+
+-- ==
+-- entry: tanpi16
+-- input { [0f16, 0.1f16, 1f16, 2f16 ] }
+-- output { [0f16, 0.32470703f16, 0f16, 0f16 ] }
+
+entry tanpi64 = map f64.tanpi
+entry tanpi32 = map f32.tanpi
+entry tanpi16 = map f16.tanpi


### PR DESCRIPTION
These map to intrinsics on OpenCL, HIP, and CUDA, but are expressed in terms of the normal functions on other platforms.

Closes #2243.