### PR TITLE
Use more compact coding style in scalar.h/scalar_f64.h

### DIFF
--- a/rts/c/scalar.h
+++ b/rts/c/scalar.h
@@ -24,53 +24,20 @@
 SCALAR_FUN_ATTR int32_t futrts_to_bits32(float x);
 SCALAR_FUN_ATTR float futrts_from_bits32(int32_t x);
 
-SCALAR_FUN_ATTR uint8_t add8(uint8_t x, uint8_t y) {
-  return x + y;
-}
+SCALAR_FUN_ATTR uint8_t   add8(uint8_t x, uint8_t y)   { return x + y; }
+SCALAR_FUN_ATTR uint16_t add16(uint16_t x, uint16_t y) { return x + y; }
+SCALAR_FUN_ATTR uint32_t add32(uint32_t x, uint32_t y) { return x + y; }
+SCALAR_FUN_ATTR uint64_t add64(uint64_t x, uint64_t y) { return x + y; }
 
-SCALAR_FUN_ATTR uint16_t add16(uint16_t x, uint16_t y) {
-  return x + y;
-}
+SCALAR_FUN_ATTR uint8_t   sub8(uint8_t x, uint8_t y)   { return x - y; }
+SCALAR_FUN_ATTR uint16_t sub16(uint16_t x, uint16_t y) { return x - y; }
+SCALAR_FUN_ATTR uint32_t sub32(uint32_t x, uint32_t y) { return x - y; }
+SCALAR_FUN_ATTR uint64_t sub64(uint64_t x, uint64_t y) { return x - y; }
 
-SCALAR_FUN_ATTR uint32_t add32(uint32_t x, uint32_t y) {
-  return x + y;
-}
-
-SCALAR_FUN_ATTR uint64_t add64(uint64_t x, uint64_t y) {
-  return x + y;
-}
-
-SCALAR_FUN_ATTR uint8_t sub8(uint8_t x, uint8_t y) {
-  return x - y;
-}
-
-SCALAR_FUN_ATTR uint16_t sub16(uint16_t x, uint16_t y) {
-  return x - y;
-}
-
-SCALAR_FUN_ATTR uint32_t sub32(uint32_t x, uint32_t y) {
-  return x - y;
-}
-
-SCALAR_FUN_ATTR uint64_t sub64(uint64_t x, uint64_t y) {
-  return x - y;
-}
-
-SCALAR_FUN_ATTR uint8_t mul8(uint8_t x, uint8_t y) {
-  return x * y;
-}
-
-SCALAR_FUN_ATTR uint16_t mul16(uint16_t x, uint16_t y) {
-  return x * y;
-}
-
-SCALAR_FUN_ATTR uint32_t mul32(uint32_t x, uint32_t y) {
-  return x * y;
-}
-
-SCALAR_FUN_ATTR uint64_t mul64(uint64_t x, uint64_t y) {
-  return x * y;
-}
+SCALAR_FUN_ATTR uint8_t   mul8(uint8_t x, uint8_t y)   { return x * y; }
+SCALAR_FUN_ATTR uint16_t mul16(uint16_t x, uint16_t y) { return x * y; }
+SCALAR_FUN_ATTR uint32_t mul32(uint32_t x, uint32_t y) { return x * y; }
+SCALAR_FUN_ATTR uint64_t mul64(uint64_t x, uint64_t y) { return x * y; }
 
 #if defined(ISPC)
 
@@ -80,1030 +47,514 @@ SCALAR_FUN_ATTR uint8_t udiv8(uint8_t x, uint8_t y) {
   // have 0-valued divisors. It ensures that any inactive lane instead
   // has a divisor of 1. https://github.com/ispc/ispc/issues/2292
   uint8_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return x / ys;
 }
 
 SCALAR_FUN_ATTR uint16_t udiv16(uint16_t x, uint16_t y) {
   uint16_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return x / ys;
 }
 
 SCALAR_FUN_ATTR uint32_t udiv32(uint32_t x, uint32_t y) {
   uint32_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
-
+  foreach_active(i) { ys = y; }
   return x / ys;
 }
 
 SCALAR_FUN_ATTR uint64_t udiv64(uint64_t x, uint64_t y) {
   uint64_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
-
+  foreach_active(i) { ys = y; }
   return x / ys;
 }
 
 SCALAR_FUN_ATTR uint8_t udiv_up8(uint8_t x, uint8_t y) {
   uint8_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
-
+  foreach_active(i) { ys = y; }
   return (x + y - 1) / ys;
 }
 
 SCALAR_FUN_ATTR uint16_t udiv_up16(uint16_t x, uint16_t y) {
   uint16_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return (x + y - 1) / ys;
 }
 
 SCALAR_FUN_ATTR uint32_t udiv_up32(uint32_t x, uint32_t y) {
   uint32_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return (x + y - 1) / ys;
 }
 
 SCALAR_FUN_ATTR uint64_t udiv_up64(uint64_t x, uint64_t y) {
   uint64_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return (x + y - 1) / ys;
 }
 
 SCALAR_FUN_ATTR uint8_t umod8(uint8_t x, uint8_t y) {
   uint8_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return x % ys;
 }
 
 SCALAR_FUN_ATTR uint16_t umod16(uint16_t x, uint16_t y) {
   uint16_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
-
+  foreach_active(i) { ys = y; }
   return x % ys;
 }
 
 SCALAR_FUN_ATTR uint32_t umod32(uint32_t x, uint32_t y) {
   uint32_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return x % ys;
 }
 
 SCALAR_FUN_ATTR uint64_t umod64(uint64_t x, uint64_t y) {
   uint64_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return x % ys;
 }
 
 SCALAR_FUN_ATTR uint8_t udiv_safe8(uint8_t x, uint8_t y) {
   uint8_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return y == 0 ? 0 : x / ys;
 }
 
 SCALAR_FUN_ATTR uint16_t udiv_safe16(uint16_t x, uint16_t y) {
   uint16_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return y == 0 ? 0 : x / ys;
 }
 
 SCALAR_FUN_ATTR uint32_t udiv_safe32(uint32_t x, uint32_t y) {
   uint32_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return y == 0 ? 0 : x / ys;
 }
 
 SCALAR_FUN_ATTR uint64_t udiv_safe64(uint64_t x, uint64_t y) {
   uint64_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return y == 0 ? 0 : x / ys;
 }
 
 SCALAR_FUN_ATTR uint8_t udiv_up_safe8(uint8_t x, uint8_t y) {
   uint8_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return y == 0 ? 0 : (x + y - 1) / ys;
 }
 
 SCALAR_FUN_ATTR uint16_t udiv_up_safe16(uint16_t x, uint16_t y) {
   uint16_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return y == 0 ? 0 : (x + y - 1) / ys;
 }
 
 SCALAR_FUN_ATTR uint32_t udiv_up_safe32(uint32_t x, uint32_t y) {
   uint32_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return y == 0 ? 0 : (x + y - 1) / ys;
 }
 
 SCALAR_FUN_ATTR uint64_t udiv_up_safe64(uint64_t x, uint64_t y) {
   uint64_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return y == 0 ? 0 : (x + y - 1) / ys;
 }
 
 SCALAR_FUN_ATTR uint8_t umod_safe8(uint8_t x, uint8_t y) {
   uint8_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return y == 0 ? 0 : x % ys;
 }
 
 SCALAR_FUN_ATTR uint16_t umod_safe16(uint16_t x, uint16_t y) {
   uint16_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return y == 0 ? 0 : x % ys;
 }
 
 SCALAR_FUN_ATTR uint32_t umod_safe32(uint32_t x, uint32_t y) {
   uint32_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return y == 0 ? 0 : x % ys;
 }
 
 SCALAR_FUN_ATTR uint64_t umod_safe64(uint64_t x, uint64_t y) {
   uint64_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return y == 0 ? 0 : x % ys;
 }
 
 SCALAR_FUN_ATTR int8_t sdiv8(int8_t x, int8_t y) {
   int8_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   int8_t q = x / ys;
   int8_t r = x % ys;
-
   return q - ((r != 0 && r < 0 != y < 0) ? 1 : 0);
 }
 
 SCALAR_FUN_ATTR int16_t sdiv16(int16_t x, int16_t y) {
   int16_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   int16_t q = x / ys;
   int16_t r = x % ys;
-
   return q - ((r != 0 && r < 0 != y < 0) ? 1 : 0);
 }
 
 SCALAR_FUN_ATTR int32_t sdiv32(int32_t x, int32_t y) {
   int32_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
+  foreach_active(i) { ys = y; }
   int32_t q = x / ys;
   int32_t r = x % ys;
-
   return q - ((r != 0 && r < 0 != y < 0) ? 1 : 0);
 }
 
 SCALAR_FUN_ATTR int64_t sdiv64(int64_t x, int64_t y) {
   int64_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   int64_t q = x / ys;
   int64_t r = x % ys;
-
   return q - ((r != 0 && r < 0 != y < 0) ? 1 : 0);
 }
 
-SCALAR_FUN_ATTR int8_t sdiv_up8(int8_t x, int8_t y) {
-  return sdiv8(x + y - 1, y);
-}
-
-SCALAR_FUN_ATTR int16_t sdiv_up16(int16_t x, int16_t y) {
-  return sdiv16(x + y - 1, y);
-}
-
-SCALAR_FUN_ATTR int32_t sdiv_up32(int32_t x, int32_t y) {
-  return sdiv32(x + y - 1, y);
-}
-
-SCALAR_FUN_ATTR int64_t sdiv_up64(int64_t x, int64_t y) {
-  return sdiv64(x + y - 1, y);
-}
+SCALAR_FUN_ATTR int8_t sdiv_up8(int8_t x, int8_t y) { return sdiv8(x + y - 1, y); }
+SCALAR_FUN_ATTR int16_t sdiv_up16(int16_t x, int16_t y) { return sdiv16(x + y - 1, y); }
+SCALAR_FUN_ATTR int32_t sdiv_up32(int32_t x, int32_t y) { return sdiv32(x + y - 1, y); }
+SCALAR_FUN_ATTR int64_t sdiv_up64(int64_t x, int64_t y) { return sdiv64(x + y - 1, y); }
 
 SCALAR_FUN_ATTR int8_t smod8(int8_t x, int8_t y) {
   int8_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   int8_t r = x % ys;
-
   return r + (r == 0 || (x > 0 && y > 0) || (x < 0 && y < 0) ? 0 : y);
 }
 
 SCALAR_FUN_ATTR int16_t smod16(int16_t x, int16_t y) {
   int16_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   int16_t r = x % ys;
-
   return r + (r == 0 || (x > 0 && y > 0) || (x < 0 && y < 0) ? 0 : y);
 }
 
 SCALAR_FUN_ATTR int32_t smod32(int32_t x, int32_t y) {
   int32_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   int32_t r = x % ys;
-
   return r + (r == 0 || (x > 0 && y > 0) || (x < 0 && y < 0) ? 0 : y);
 }
 
 SCALAR_FUN_ATTR int64_t smod64(int64_t x, int64_t y) {
   int64_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   int64_t r = x % ys;
-
   return r + (r == 0 || (x > 0 && y > 0) || (x < 0 && y < 0) ? 0 : y);
 }
 
-SCALAR_FUN_ATTR int8_t sdiv_safe8(int8_t x, int8_t y) {
-  return y == 0 ? 0 : sdiv8(x, y);
-}
+SCALAR_FUN_ATTR int8_t   sdiv_safe8(int8_t x, int8_t y)   { return y == 0 ? 0 : sdiv8(x, y); }
+SCALAR_FUN_ATTR int16_t sdiv_safe16(int16_t x, int16_t y) { return y == 0 ? 0 : sdiv16(x, y); }
+SCALAR_FUN_ATTR int32_t sdiv_safe32(int32_t x, int32_t y) { return y == 0 ? 0 : sdiv32(x, y); }
+SCALAR_FUN_ATTR int64_t sdiv_safe64(int64_t x, int64_t y) { return y == 0 ? 0 : sdiv64(x, y); }
 
-SCALAR_FUN_ATTR int16_t sdiv_safe16(int16_t x, int16_t y) {
-  return y == 0 ? 0 : sdiv16(x, y);
-}
+SCALAR_FUN_ATTR int8_t sdiv_up_safe8(int8_t x, int8_t y)     { return sdiv_safe8(x + y - 1, y); }
+SCALAR_FUN_ATTR int16_t sdiv_up_safe16(int16_t x, int16_t y) { return sdiv_safe16(x + y - 1, y); }
+SCALAR_FUN_ATTR int32_t sdiv_up_safe32(int32_t x, int32_t y) { return sdiv_safe32(x + y - 1, y); }
+SCALAR_FUN_ATTR int64_t sdiv_up_safe64(int64_t x, int64_t y) { return sdiv_safe64(x + y - 1, y); }
 
-SCALAR_FUN_ATTR int32_t sdiv_safe32(int32_t x, int32_t y) {
-  return y == 0 ? 0 : sdiv32(x, y);
-}
-
-SCALAR_FUN_ATTR int64_t sdiv_safe64(int64_t x, int64_t y) {
-  return y == 0 ? 0 : sdiv64(x, y);
-}
-
-SCALAR_FUN_ATTR int8_t sdiv_up_safe8(int8_t x, int8_t y) {
-  return sdiv_safe8(x + y - 1, y);
-}
-
-SCALAR_FUN_ATTR int16_t sdiv_up_safe16(int16_t x, int16_t y) {
-  return sdiv_safe16(x + y - 1, y);
-}
-
-SCALAR_FUN_ATTR int32_t sdiv_up_safe32(int32_t x, int32_t y) {
-  return sdiv_safe32(x + y - 1, y);
-}
-
-SCALAR_FUN_ATTR int64_t sdiv_up_safe64(int64_t x, int64_t y) {
-  return sdiv_safe64(x + y - 1, y);
-}
-
-SCALAR_FUN_ATTR int8_t smod_safe8(int8_t x, int8_t y) {
-  return y == 0 ? 0 : smod8(x, y);
-}
-
-SCALAR_FUN_ATTR int16_t smod_safe16(int16_t x, int16_t y) {
-  return y == 0 ? 0 : smod16(x, y);
-}
-
-SCALAR_FUN_ATTR int32_t smod_safe32(int32_t x, int32_t y) {
-  return y == 0 ? 0 : smod32(x, y);
-}
-
-SCALAR_FUN_ATTR int64_t smod_safe64(int64_t x, int64_t y) {
-  return y == 0 ? 0 : smod64(x, y);
-}
+SCALAR_FUN_ATTR int8_t   smod_safe8(int8_t x, int8_t y)   { return y == 0 ? 0 : smod8(x, y); }
+SCALAR_FUN_ATTR int16_t smod_safe16(int16_t x, int16_t y) { return y == 0 ? 0 : smod16(x, y); }
+SCALAR_FUN_ATTR int32_t smod_safe32(int32_t x, int32_t y) { return y == 0 ? 0 : smod32(x, y); }
+SCALAR_FUN_ATTR int64_t smod_safe64(int64_t x, int64_t y) { return y == 0 ? 0 : smod64(x, y); }
 
 SCALAR_FUN_ATTR int8_t squot8(int8_t x, int8_t y) {
   int8_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return x / ys;
 }
 
 SCALAR_FUN_ATTR int16_t squot16(int16_t x, int16_t y) {
   int16_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return x / ys;
 }
 
 SCALAR_FUN_ATTR int32_t squot32(int32_t x, int32_t y) {
   int32_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return x / ys;
 }
 
 SCALAR_FUN_ATTR int64_t squot64(int64_t x, int64_t y) {
   int64_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return x / ys;
 }
 
 SCALAR_FUN_ATTR int8_t srem8(int8_t x, int8_t y) {
   int8_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return x % ys;
 }
 
 SCALAR_FUN_ATTR int16_t srem16(int16_t x, int16_t y) {
   int16_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return x % ys;
 }
 
 SCALAR_FUN_ATTR int32_t srem32(int32_t x, int32_t y) {
   int32_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return x % ys;
 }
 
 SCALAR_FUN_ATTR int64_t srem64(int64_t x, int64_t y) {
   int8_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return x % ys;
 }
 
 SCALAR_FUN_ATTR int8_t squot_safe8(int8_t x, int8_t y) {
   int8_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return y == 0 ? 0 : x / ys;
 }
 
 SCALAR_FUN_ATTR int16_t squot_safe16(int16_t x, int16_t y) {
   int16_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return y == 0 ? 0 : x / ys;
 }
 
 SCALAR_FUN_ATTR int32_t squot_safe32(int32_t x, int32_t y) {
   int32_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return y == 0 ? 0 : x / ys;
 }
 
 SCALAR_FUN_ATTR int64_t squot_safe64(int64_t x, int64_t y) {
   int64_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return y == 0 ? 0 : x / ys;
 }
 
 SCALAR_FUN_ATTR int8_t srem_safe8(int8_t x, int8_t y) {
   int8_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return y == 0 ? 0 : x % ys;
 }
 
 SCALAR_FUN_ATTR int16_t srem_safe16(int16_t x, int16_t y) {
   int16_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return y == 0 ? 0 : x % ys;
 }
 
 SCALAR_FUN_ATTR int32_t srem_safe32(int32_t x, int32_t y) {
   int32_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return y == 0 ? 0 : x % ys;
 }
 
 SCALAR_FUN_ATTR int64_t srem_safe64(int64_t x, int64_t y) {
   int64_t ys = 1;
-  foreach_active(i){
-    ys = y;
-  }
-
+  foreach_active(i) { ys = y; }
   return y == 0 ? 0 : x % ys;
 }
 
 #else
 
-SCALAR_FUN_ATTR uint8_t udiv8(uint8_t x, uint8_t y) {
-  return x / y;
-}
+SCALAR_FUN_ATTR uint8_t   udiv8(uint8_t x, uint8_t y)   { return x / y; }
+SCALAR_FUN_ATTR uint16_t udiv16(uint16_t x, uint16_t y) { return x / y; }
+SCALAR_FUN_ATTR uint32_t udiv32(uint32_t x, uint32_t y) { return x / y; }
+SCALAR_FUN_ATTR uint64_t udiv64(uint64_t x, uint64_t y) { return x / y; }
 
-SCALAR_FUN_ATTR uint16_t udiv16(uint16_t x, uint16_t y) {
-  return x / y;
-}
+SCALAR_FUN_ATTR uint8_t   udiv_up8(uint8_t x, uint8_t y)   { return (x + y - 1) / y; }
+SCALAR_FUN_ATTR uint16_t udiv_up16(uint16_t x, uint16_t y) { return (x + y - 1) / y; }
+SCALAR_FUN_ATTR uint32_t udiv_up32(uint32_t x, uint32_t y) { return (x + y - 1) / y; }
+SCALAR_FUN_ATTR uint64_t udiv_up64(uint64_t x, uint64_t y) { return (x + y - 1) / y; }
 
-SCALAR_FUN_ATTR uint32_t udiv32(uint32_t x, uint32_t y) {
-  return x / y;
-}
+SCALAR_FUN_ATTR uint8_t   umod8(uint8_t x, uint8_t y)   { return x % y; }
+SCALAR_FUN_ATTR uint16_t umod16(uint16_t x, uint16_t y) { return x % y; }
+SCALAR_FUN_ATTR uint32_t umod32(uint32_t x, uint32_t y) { return x % y; }
+SCALAR_FUN_ATTR uint64_t umod64(uint64_t x, uint64_t y) { return x % y; }
 
-SCALAR_FUN_ATTR uint64_t udiv64(uint64_t x, uint64_t y) {
-  return x / y;
-}
+SCALAR_FUN_ATTR uint8_t   udiv_safe8(uint8_t x, uint8_t y)   { return y == 0 ? 0 : x / y; }
+SCALAR_FUN_ATTR uint16_t udiv_safe16(uint16_t x, uint16_t y) { return y == 0 ? 0 : x / y; }
+SCALAR_FUN_ATTR uint32_t udiv_safe32(uint32_t x, uint32_t y) { return y == 0 ? 0 : x / y; }
+SCALAR_FUN_ATTR uint64_t udiv_safe64(uint64_t x, uint64_t y) { return y == 0 ? 0 : x / y; }
 
-SCALAR_FUN_ATTR uint8_t udiv_up8(uint8_t x, uint8_t y) {
-  return (x + y - 1) / y;
-}
+SCALAR_FUN_ATTR uint8_t   udiv_up_safe8(uint8_t x, uint8_t y)   { return y == 0 ? 0 : (x + y - 1) / y; }
+SCALAR_FUN_ATTR uint16_t udiv_up_safe16(uint16_t x, uint16_t y) { return y == 0 ? 0 : (x + y - 1) / y; }
+SCALAR_FUN_ATTR uint32_t udiv_up_safe32(uint32_t x, uint32_t y) { return y == 0 ? 0 : (x + y - 1) / y; }
+SCALAR_FUN_ATTR uint64_t udiv_up_safe64(uint64_t x, uint64_t y) { return y == 0 ? 0 : (x + y - 1) / y; }
 
-SCALAR_FUN_ATTR uint16_t udiv_up16(uint16_t x, uint16_t y) {
-  return (x + y - 1) / y;
-}
-
-SCALAR_FUN_ATTR uint32_t udiv_up32(uint32_t x, uint32_t y) {
-  return (x + y - 1) / y;
-}
-
-SCALAR_FUN_ATTR uint64_t udiv_up64(uint64_t x, uint64_t y) {
-  return (x + y - 1) / y;
-}
-
-SCALAR_FUN_ATTR uint8_t umod8(uint8_t x, uint8_t y) {
-  return x % y;
-}
-
-SCALAR_FUN_ATTR uint16_t umod16(uint16_t x, uint16_t y) {
-  return x % y;
-}
-
-SCALAR_FUN_ATTR uint32_t umod32(uint32_t x, uint32_t y) {
-  return x % y;
-}
-
-SCALAR_FUN_ATTR uint64_t umod64(uint64_t x, uint64_t y) {
-  return x % y;
-}
-
-SCALAR_FUN_ATTR uint8_t udiv_safe8(uint8_t x, uint8_t y) {
-  return y == 0 ? 0 : x / y;
-}
-
-SCALAR_FUN_ATTR uint16_t udiv_safe16(uint16_t x, uint16_t y) {
-  return y == 0 ? 0 : x / y;
-}
-
-SCALAR_FUN_ATTR uint32_t udiv_safe32(uint32_t x, uint32_t y) {
-  return y == 0 ? 0 : x / y;
-}
-
-SCALAR_FUN_ATTR uint64_t udiv_safe64(uint64_t x, uint64_t y) {
-  return y == 0 ? 0 : x / y;
-}
-
-SCALAR_FUN_ATTR uint8_t udiv_up_safe8(uint8_t x, uint8_t y) {
-  return y == 0 ? 0 : (x + y - 1) / y;
-}
-
-SCALAR_FUN_ATTR uint16_t udiv_up_safe16(uint16_t x, uint16_t y) {
-  return y == 0 ? 0 : (x + y - 1) / y;
-}
-
-SCALAR_FUN_ATTR uint32_t udiv_up_safe32(uint32_t x, uint32_t y) {
-  return y == 0 ? 0 : (x + y - 1) / y;
-}
-
-SCALAR_FUN_ATTR uint64_t udiv_up_safe64(uint64_t x, uint64_t y) {
-  return y == 0 ? 0 : (x + y - 1) / y;
-}
-
-SCALAR_FUN_ATTR uint8_t umod_safe8(uint8_t x, uint8_t y) {
-  return y == 0 ? 0 : x % y;
-}
-
-SCALAR_FUN_ATTR uint16_t umod_safe16(uint16_t x, uint16_t y) {
-  return y == 0 ? 0 : x % y;
-}
-
-SCALAR_FUN_ATTR uint32_t umod_safe32(uint32_t x, uint32_t y) {
-  return y == 0 ? 0 : x % y;
-}
-
-SCALAR_FUN_ATTR uint64_t umod_safe64(uint64_t x, uint64_t y) {
-  return y == 0 ? 0 : x % y;
-}
+SCALAR_FUN_ATTR uint8_t   umod_safe8(uint8_t x, uint8_t y)   { return y == 0 ? 0 : x % y; }
+SCALAR_FUN_ATTR uint16_t umod_safe16(uint16_t x, uint16_t y) { return y == 0 ? 0 : x % y; }
+SCALAR_FUN_ATTR uint32_t umod_safe32(uint32_t x, uint32_t y) { return y == 0 ? 0 : x % y; }
+SCALAR_FUN_ATTR uint64_t umod_safe64(uint64_t x, uint64_t y) { return y == 0 ? 0 : x % y; }
 
 SCALAR_FUN_ATTR int8_t sdiv8(int8_t x, int8_t y) {
   int8_t q = x / y;
   int8_t r = x % y;
-
   return q - ((r != 0 && r < 0 != y < 0) ? 1 : 0);
 }
 
 SCALAR_FUN_ATTR int16_t sdiv16(int16_t x, int16_t y) {
   int16_t q = x / y;
   int16_t r = x % y;
-
   return q - ((r != 0 && r < 0 != y < 0) ? 1 : 0);
 }
 
 SCALAR_FUN_ATTR int32_t sdiv32(int32_t x, int32_t y) {
   int32_t q = x / y;
   int32_t r = x % y;
-
   return q - ((r != 0 && r < 0 != y < 0) ? 1 : 0);
 }
 
 SCALAR_FUN_ATTR int64_t sdiv64(int64_t x, int64_t y) {
   int64_t q = x / y;
   int64_t r = x % y;
-
   return q - ((r != 0 && r < 0 != y < 0) ? 1 : 0);
 }
 
-SCALAR_FUN_ATTR int8_t sdiv_up8(int8_t x, int8_t y) {
-  return sdiv8(x + y - 1, y);
-}
-
-SCALAR_FUN_ATTR int16_t sdiv_up16(int16_t x, int16_t y) {
-  return sdiv16(x + y - 1, y);
-}
-
-SCALAR_FUN_ATTR int32_t sdiv_up32(int32_t x, int32_t y) {
-  return sdiv32(x + y - 1, y);
-}
-
-SCALAR_FUN_ATTR int64_t sdiv_up64(int64_t x, int64_t y) {
-  return sdiv64(x + y - 1, y);
-}
+SCALAR_FUN_ATTR int8_t   sdiv_up8(int8_t x, int8_t y)   { return sdiv8(x + y - 1, y); }
+SCALAR_FUN_ATTR int16_t sdiv_up16(int16_t x, int16_t y) { return sdiv16(x + y - 1, y); }
+SCALAR_FUN_ATTR int32_t sdiv_up32(int32_t x, int32_t y) { return sdiv32(x + y - 1, y); }
+SCALAR_FUN_ATTR int64_t sdiv_up64(int64_t x, int64_t y) { return sdiv64(x + y - 1, y); }
 
 SCALAR_FUN_ATTR int8_t smod8(int8_t x, int8_t y) {
   int8_t r = x % y;
-
   return r + (r == 0 || (x > 0 && y > 0) || (x < 0 && y < 0) ? 0 : y);
 }
 
 SCALAR_FUN_ATTR int16_t smod16(int16_t x, int16_t y) {
   int16_t r = x % y;
-
   return r + (r == 0 || (x > 0 && y > 0) || (x < 0 && y < 0) ? 0 : y);
 }
 
 SCALAR_FUN_ATTR int32_t smod32(int32_t x, int32_t y) {
   int32_t r = x % y;
-
   return r + (r == 0 || (x > 0 && y > 0) || (x < 0 && y < 0) ? 0 : y);
 }
 
 SCALAR_FUN_ATTR int64_t smod64(int64_t x, int64_t y) {
   int64_t r = x % y;
-
   return r + (r == 0 || (x > 0 && y > 0) || (x < 0 && y < 0) ? 0 : y);
 }
 
-SCALAR_FUN_ATTR int8_t sdiv_safe8(int8_t x, int8_t y) {
-  return y == 0 ? 0 : sdiv8(x, y);
-}
+SCALAR_FUN_ATTR int8_t   sdiv_safe8(int8_t x, int8_t y)   { return y == 0 ? 0 : sdiv8(x, y); }
+SCALAR_FUN_ATTR int16_t sdiv_safe16(int16_t x, int16_t y) { return y == 0 ? 0 : sdiv16(x, y); }
+SCALAR_FUN_ATTR int32_t sdiv_safe32(int32_t x, int32_t y) { return y == 0 ? 0 : sdiv32(x, y); }
+SCALAR_FUN_ATTR int64_t sdiv_safe64(int64_t x, int64_t y) { return y == 0 ? 0 : sdiv64(x, y); }
 
-SCALAR_FUN_ATTR int16_t sdiv_safe16(int16_t x, int16_t y) {
-  return y == 0 ? 0 : sdiv16(x, y);
-}
+SCALAR_FUN_ATTR int8_t   sdiv_up_safe8(int8_t x, int8_t y)   { return sdiv_safe8(x + y - 1, y);}
+SCALAR_FUN_ATTR int16_t sdiv_up_safe16(int16_t x, int16_t y) { return sdiv_safe16(x + y - 1, y); }
+SCALAR_FUN_ATTR int32_t sdiv_up_safe32(int32_t x, int32_t y) { return sdiv_safe32(x + y - 1, y); }
+SCALAR_FUN_ATTR int64_t sdiv_up_safe64(int64_t x, int64_t y) { return sdiv_safe64(x + y - 1, y); }
 
-SCALAR_FUN_ATTR int32_t sdiv_safe32(int32_t x, int32_t y) {
-  return y == 0 ? 0 : sdiv32(x, y);
-}
+SCALAR_FUN_ATTR int8_t   smod_safe8(int8_t x, int8_t y)   { return y == 0 ? 0 : smod8(x, y); }
+SCALAR_FUN_ATTR int16_t smod_safe16(int16_t x, int16_t y) { return y == 0 ? 0 : smod16(x, y); }
+SCALAR_FUN_ATTR int32_t smod_safe32(int32_t x, int32_t y) { return y == 0 ? 0 : smod32(x, y); }
+SCALAR_FUN_ATTR int64_t smod_safe64(int64_t x, int64_t y) { return y == 0 ? 0 : smod64(x, y); }
 
-SCALAR_FUN_ATTR int64_t sdiv_safe64(int64_t x, int64_t y) {
-  return y == 0 ? 0 : sdiv64(x, y);
-}
+SCALAR_FUN_ATTR int8_t   squot8(int8_t x, int8_t y)   { return x / y; }
+SCALAR_FUN_ATTR int16_t squot16(int16_t x, int16_t y) { return x / y; }
+SCALAR_FUN_ATTR int32_t squot32(int32_t x, int32_t y) { return x / y; }
+SCALAR_FUN_ATTR int64_t squot64(int64_t x, int64_t y) { return x / y; }
 
-SCALAR_FUN_ATTR int8_t sdiv_up_safe8(int8_t x, int8_t y) {
-  return sdiv_safe8(x + y - 1, y);
-}
+SCALAR_FUN_ATTR int8_t   srem8(int8_t x, int8_t y)   { return x % y; }
+SCALAR_FUN_ATTR int16_t srem16(int16_t x, int16_t y) { return x % y; }
+SCALAR_FUN_ATTR int32_t srem32(int32_t x, int32_t y) { return x % y; }
+SCALAR_FUN_ATTR int64_t srem64(int64_t x, int64_t y) { return x % y; }
 
-SCALAR_FUN_ATTR int16_t sdiv_up_safe16(int16_t x, int16_t y) {
-  return sdiv_safe16(x + y - 1, y);
-}
+SCALAR_FUN_ATTR int8_t   squot_safe8(int8_t x, int8_t y)   { return y == 0 ? 0 : x / y; }
+SCALAR_FUN_ATTR int16_t squot_safe16(int16_t x, int16_t y) { return y == 0 ? 0 : x / y; }
+SCALAR_FUN_ATTR int32_t squot_safe32(int32_t x, int32_t y) { return y == 0 ? 0 : x / y; }
+SCALAR_FUN_ATTR int64_t squot_safe64(int64_t x, int64_t y) { return y == 0 ? 0 : x / y; }
 
-SCALAR_FUN_ATTR int32_t sdiv_up_safe32(int32_t x, int32_t y) {
-  return sdiv_safe32(x + y - 1, y);
-}
-
-SCALAR_FUN_ATTR int64_t sdiv_up_safe64(int64_t x, int64_t y) {
-  return sdiv_safe64(x + y - 1, y);
-}
-
-SCALAR_FUN_ATTR int8_t smod_safe8(int8_t x, int8_t y) {
-  return y == 0 ? 0 : smod8(x, y);
-}
-
-SCALAR_FUN_ATTR int16_t smod_safe16(int16_t x, int16_t y) {
-  return y == 0 ? 0 : smod16(x, y);
-}
-
-SCALAR_FUN_ATTR int32_t smod_safe32(int32_t x, int32_t y) {
-  return y == 0 ? 0 : smod32(x, y);
-}
-
-SCALAR_FUN_ATTR int64_t smod_safe64(int64_t x, int64_t y) {
-  return y == 0 ? 0 : smod64(x, y);
-}
-
-SCALAR_FUN_ATTR int8_t squot8(int8_t x, int8_t y) {
-  return x / y;
-}
-
-SCALAR_FUN_ATTR int16_t squot16(int16_t x, int16_t y) {
-  return x / y;
-}
-
-SCALAR_FUN_ATTR int32_t squot32(int32_t x, int32_t y) {
-  return x / y;
-}
-
-SCALAR_FUN_ATTR int64_t squot64(int64_t x, int64_t y) {
-  return x / y;
-}
-
-SCALAR_FUN_ATTR int8_t srem8(int8_t x, int8_t y) {
-  return x % y;
-}
-
-SCALAR_FUN_ATTR int16_t srem16(int16_t x, int16_t y) {
-  return x % y;
-}
-
-SCALAR_FUN_ATTR int32_t srem32(int32_t x, int32_t y) {
-  return x % y;
-}
-
-SCALAR_FUN_ATTR int64_t srem64(int64_t x, int64_t y) {
-  return x % y;
-}
-
-SCALAR_FUN_ATTR int8_t squot_safe8(int8_t x, int8_t y) {
-  return y == 0 ? 0 : x / y;
-}
-
-SCALAR_FUN_ATTR int16_t squot_safe16(int16_t x, int16_t y) {
-  return y == 0 ? 0 : x / y;
-}
-
-SCALAR_FUN_ATTR int32_t squot_safe32(int32_t x, int32_t y) {
-  return y == 0 ? 0 : x / y;
-}
-
-SCALAR_FUN_ATTR int64_t squot_safe64(int64_t x, int64_t y) {
-  return y == 0 ? 0 : x / y;
-}
-
-SCALAR_FUN_ATTR int8_t srem_safe8(int8_t x, int8_t y) {
-  return y == 0 ? 0 : x % y;
-}
-
-SCALAR_FUN_ATTR int16_t srem_safe16(int16_t x, int16_t y) {
-  return y == 0 ? 0 : x % y;
-}
-
-SCALAR_FUN_ATTR int32_t srem_safe32(int32_t x, int32_t y) {
-  return y == 0 ? 0 : x % y;
-}
-
-SCALAR_FUN_ATTR int64_t srem_safe64(int64_t x, int64_t y) {
-  return y == 0 ? 0 : x % y;
-}
+SCALAR_FUN_ATTR int8_t   srem_safe8(int8_t x, int8_t y)   { return y == 0 ? 0 : x % y; }
+SCALAR_FUN_ATTR int16_t srem_safe16(int16_t x, int16_t y) { return y == 0 ? 0 : x % y; }
+SCALAR_FUN_ATTR int32_t srem_safe32(int32_t x, int32_t y) { return y == 0 ? 0 : x % y; }
+SCALAR_FUN_ATTR int64_t srem_safe64(int64_t x, int64_t y) { return y == 0 ? 0 : x % y; }
 
 #endif
 
-SCALAR_FUN_ATTR int8_t smin8(int8_t x, int8_t y) {
-  return x < y ? x : y;
-}
+SCALAR_FUN_ATTR int8_t   smin8(int8_t x, int8_t y)   { return x < y ? x : y; }
+SCALAR_FUN_ATTR int16_t smin16(int16_t x, int16_t y) { return x < y ? x : y; }
+SCALAR_FUN_ATTR int32_t smin32(int32_t x, int32_t y) { return x < y ? x : y; }
+SCALAR_FUN_ATTR int64_t smin64(int64_t x, int64_t y) { return x < y ? x : y; }
 
-SCALAR_FUN_ATTR int16_t smin16(int16_t x, int16_t y) {
-  return x < y ? x : y;
-}
+SCALAR_FUN_ATTR uint8_t   umin8(uint8_t x, uint8_t y)   { return x < y ? x : y; }
+SCALAR_FUN_ATTR uint16_t umin16(uint16_t x, uint16_t y) { return x < y ? x : y; }
+SCALAR_FUN_ATTR uint32_t umin32(uint32_t x, uint32_t y) { return x < y ? x : y; }
+SCALAR_FUN_ATTR uint64_t umin64(uint64_t x, uint64_t y) { return x < y ? x : y; }
 
-SCALAR_FUN_ATTR int32_t smin32(int32_t x, int32_t y) {
-  return x < y ? x : y;
-}
+SCALAR_FUN_ATTR int8_t  smax8(int8_t x, int8_t y)    { return x < y ? y : x; }
+SCALAR_FUN_ATTR int16_t smax16(int16_t x, int16_t y) { return x < y ? y : x; }
+SCALAR_FUN_ATTR int32_t smax32(int32_t x, int32_t y) { return x < y ? y : x; }
+SCALAR_FUN_ATTR int64_t smax64(int64_t x, int64_t y) { return x < y ? y : x; }
 
-SCALAR_FUN_ATTR int64_t smin64(int64_t x, int64_t y) {
-  return x < y ? x : y;
-}
+SCALAR_FUN_ATTR uint8_t   umax8(uint8_t x, uint8_t y)   { return x < y ? y : x; }
+SCALAR_FUN_ATTR uint16_t umax16(uint16_t x, uint16_t y) { return x < y ? y : x; }
+SCALAR_FUN_ATTR uint32_t umax32(uint32_t x, uint32_t y) { return x < y ? y : x; }
+SCALAR_FUN_ATTR uint64_t umax64(uint64_t x, uint64_t y) { return x < y ? y : x; }
 
-SCALAR_FUN_ATTR uint8_t umin8(uint8_t x, uint8_t y) {
-  return x < y ? x : y;
-}
+SCALAR_FUN_ATTR uint8_t   shl8(uint8_t x, uint8_t y)   { return (uint8_t)(x << y); }
+SCALAR_FUN_ATTR uint16_t shl16(uint16_t x, uint16_t y) { return (uint16_t)(x << y); }
+SCALAR_FUN_ATTR uint32_t shl32(uint32_t x, uint32_t y) { return x << y; }
+SCALAR_FUN_ATTR uint64_t shl64(uint64_t x, uint64_t y) { return x << y; }
 
-SCALAR_FUN_ATTR uint16_t umin16(uint16_t x, uint16_t y) {
-  return x < y ? x : y;
-}
+SCALAR_FUN_ATTR uint8_t   lshr8(uint8_t x, uint8_t y)   { return x >> y; }
+SCALAR_FUN_ATTR uint16_t lshr16(uint16_t x, uint16_t y) { return x >> y; }
+SCALAR_FUN_ATTR uint32_t lshr32(uint32_t x, uint32_t y) { return x >> y; }
+SCALAR_FUN_ATTR uint64_t lshr64(uint64_t x, uint64_t y) { return x >> y; }
 
-SCALAR_FUN_ATTR uint32_t umin32(uint32_t x, uint32_t y) {
-  return x < y ? x : y;
-}
+SCALAR_FUN_ATTR int8_t   ashr8(int8_t x, int8_t y)   { return x >> y; }
+SCALAR_FUN_ATTR int16_t ashr16(int16_t x, int16_t y) { return x >> y; }
+SCALAR_FUN_ATTR int32_t ashr32(int32_t x, int32_t y) { return x >> y; }
+SCALAR_FUN_ATTR int64_t ashr64(int64_t x, int64_t y) { return x >> y; }
 
-SCALAR_FUN_ATTR uint64_t umin64(uint64_t x, uint64_t y) {
-  return x < y ? x : y;
-}
+SCALAR_FUN_ATTR uint8_t   and8(uint8_t x, uint8_t y)   { return x & y; }
+SCALAR_FUN_ATTR uint16_t and16(uint16_t x, uint16_t y) { return x & y; }
+SCALAR_FUN_ATTR uint32_t and32(uint32_t x, uint32_t y) { return x & y; }
+SCALAR_FUN_ATTR uint64_t and64(uint64_t x, uint64_t y) { return x & y; }
 
-SCALAR_FUN_ATTR int8_t smax8(int8_t x, int8_t y) {
-  return x < y ? y : x;
-}
+SCALAR_FUN_ATTR uint8_t    or8(uint8_t x, uint8_t y)  { return x | y; }
+SCALAR_FUN_ATTR uint16_t or16(uint16_t x, uint16_t y) { return x | y; }
+SCALAR_FUN_ATTR uint32_t or32(uint32_t x, uint32_t y) { return x | y; }
+SCALAR_FUN_ATTR uint64_t or64(uint64_t x, uint64_t y) { return x | y; }
 
-SCALAR_FUN_ATTR int16_t smax16(int16_t x, int16_t y) {
-  return x < y ? y : x;
-}
+SCALAR_FUN_ATTR uint8_t   xor8(uint8_t x, uint8_t y)   { return x ^ y; }
+SCALAR_FUN_ATTR uint16_t xor16(uint16_t x, uint16_t y) { return x ^ y; }
+SCALAR_FUN_ATTR uint32_t xor32(uint32_t x, uint32_t y) { return x ^ y; }
+SCALAR_FUN_ATTR uint64_t xor64(uint64_t x, uint64_t y) { return x ^ y; }
 
-SCALAR_FUN_ATTR int32_t smax32(int32_t x, int32_t y) {
-  return x < y ? y : x;
-}
+SCALAR_FUN_ATTR bool ult8(uint8_t x, uint8_t y)    { return x < y; }
+SCALAR_FUN_ATTR bool ult16(uint16_t x, uint16_t y) { return x < y; }
+SCALAR_FUN_ATTR bool ult32(uint32_t x, uint32_t y) { return x < y; }
+SCALAR_FUN_ATTR bool ult64(uint64_t x, uint64_t y) { return x < y; }
 
-SCALAR_FUN_ATTR int64_t smax64(int64_t x, int64_t y) {
-  return x < y ? y : x;
-}
+SCALAR_FUN_ATTR bool ule8(uint8_t x, uint8_t y)    { return x <= y; }
+SCALAR_FUN_ATTR bool ule16(uint16_t x, uint16_t y) { return x <= y; }
+SCALAR_FUN_ATTR bool ule32(uint32_t x, uint32_t y) { return x <= y; }
+SCALAR_FUN_ATTR bool ule64(uint64_t x, uint64_t y) { return x <= y; }
 
-SCALAR_FUN_ATTR uint8_t umax8(uint8_t x, uint8_t y) {
-  return x < y ? y : x;
-}
+SCALAR_FUN_ATTR bool  slt8(int8_t x, int8_t y)   { return x < y; }
+SCALAR_FUN_ATTR bool slt16(int16_t x, int16_t y) { return x < y; }
+SCALAR_FUN_ATTR bool slt32(int32_t x, int32_t y) { return x < y; }
+SCALAR_FUN_ATTR bool slt64(int64_t x, int64_t y) { return x < y; }
 
-SCALAR_FUN_ATTR uint16_t umax16(uint16_t x, uint16_t y) {
-  return x < y ? y : x;
-}
-
-SCALAR_FUN_ATTR uint32_t umax32(uint32_t x, uint32_t y) {
-  return x < y ? y : x;
-}
-
-SCALAR_FUN_ATTR uint64_t umax64(uint64_t x, uint64_t y) {
-  return x < y ? y : x;
-}
-
-SCALAR_FUN_ATTR uint8_t shl8(uint8_t x, uint8_t y) {
-  return (uint8_t)(x << y);
-}
-
-SCALAR_FUN_ATTR uint16_t shl16(uint16_t x, uint16_t y) {
-  return (uint16_t)(x << y);
-}
-
-SCALAR_FUN_ATTR uint32_t shl32(uint32_t x, uint32_t y) {
-  return x << y;
-}
-
-SCALAR_FUN_ATTR uint64_t shl64(uint64_t x, uint64_t y) {
-  return x << y;
-}
-
-SCALAR_FUN_ATTR uint8_t lshr8(uint8_t x, uint8_t y) {
-  return x >> y;
-}
-
-SCALAR_FUN_ATTR uint16_t lshr16(uint16_t x, uint16_t y) {
-  return x >> y;
-}
-
-SCALAR_FUN_ATTR uint32_t lshr32(uint32_t x, uint32_t y) {
-  return x >> y;
-}
-
-SCALAR_FUN_ATTR uint64_t lshr64(uint64_t x, uint64_t y) {
-  return x >> y;
-}
-
-SCALAR_FUN_ATTR int8_t ashr8(int8_t x, int8_t y) {
-  return x >> y;
-}
-
-SCALAR_FUN_ATTR int16_t ashr16(int16_t x, int16_t y) {
-  return x >> y;
-}
-
-SCALAR_FUN_ATTR int32_t ashr32(int32_t x, int32_t y) {
-  return x >> y;
-}
-
-SCALAR_FUN_ATTR int64_t ashr64(int64_t x, int64_t y) {
-  return x >> y;
-}
-
-SCALAR_FUN_ATTR uint8_t and8(uint8_t x, uint8_t y) {
-  return x & y;
-}
-
-SCALAR_FUN_ATTR uint16_t and16(uint16_t x, uint16_t y) {
-  return x & y;
-}
-
-SCALAR_FUN_ATTR uint32_t and32(uint32_t x, uint32_t y) {
-  return x & y;
-}
-
-SCALAR_FUN_ATTR uint64_t and64(uint64_t x, uint64_t y) {
-  return x & y;
-}
-
-SCALAR_FUN_ATTR uint8_t or8(uint8_t x, uint8_t y) {
-  return x | y;
-}
-
-SCALAR_FUN_ATTR uint16_t or16(uint16_t x, uint16_t y) {
-  return x | y;
-}
-
-SCALAR_FUN_ATTR uint32_t or32(uint32_t x, uint32_t y) {
-  return x | y;
-}
-
-SCALAR_FUN_ATTR uint64_t or64(uint64_t x, uint64_t y) {
-  return x | y;
-}
-
-SCALAR_FUN_ATTR uint8_t xor8(uint8_t x, uint8_t y) {
-  return x ^ y;
-}
-
-SCALAR_FUN_ATTR uint16_t xor16(uint16_t x, uint16_t y) {
-  return x ^ y;
-}
-
-SCALAR_FUN_ATTR uint32_t xor32(uint32_t x, uint32_t y) {
-  return x ^ y;
-}
-
-SCALAR_FUN_ATTR uint64_t xor64(uint64_t x, uint64_t y) {
-  return x ^ y;
-}
-
-SCALAR_FUN_ATTR bool ult8(uint8_t x, uint8_t y) {
-  return x < y;
-}
-
-SCALAR_FUN_ATTR bool ult16(uint16_t x, uint16_t y) {
-  return x < y;
-}
-
-SCALAR_FUN_ATTR bool ult32(uint32_t x, uint32_t y) {
-  return x < y;
-}
-
-SCALAR_FUN_ATTR bool ult64(uint64_t x, uint64_t y) {
-  return x < y;
-}
-
-SCALAR_FUN_ATTR bool ule8(uint8_t x, uint8_t y) {
-  return x <= y;
-}
-
-SCALAR_FUN_ATTR bool ule16(uint16_t x, uint16_t y) {
-  return x <= y;
-}
-
-SCALAR_FUN_ATTR bool ule32(uint32_t x, uint32_t y) {
-  return x <= y;
-}
-
-SCALAR_FUN_ATTR bool ule64(uint64_t x, uint64_t y) {
-  return x <= y;
-}
-
-SCALAR_FUN_ATTR bool slt8(int8_t x, int8_t y) {
-  return x < y;
-}
-
-SCALAR_FUN_ATTR bool slt16(int16_t x, int16_t y) {
-  return x < y;
-}
-
-SCALAR_FUN_ATTR bool slt32(int32_t x, int32_t y) {
-  return x < y;
-}
-
-SCALAR_FUN_ATTR bool slt64(int64_t x, int64_t y) {
-  return x < y;
-}
-
-SCALAR_FUN_ATTR bool sle8(int8_t x, int8_t y) {
-  return x <= y;
-}
-
-SCALAR_FUN_ATTR bool sle16(int16_t x, int16_t y) {
-  return x <= y;
-}
-
-SCALAR_FUN_ATTR bool sle32(int32_t x, int32_t y) {
-  return x <= y;
-}
-
-SCALAR_FUN_ATTR bool sle64(int64_t x, int64_t y) {
-  return x <= y;
-}
+SCALAR_FUN_ATTR bool  sle8(int8_t x, int8_t y)   { return x <= y; }
+SCALAR_FUN_ATTR bool sle16(int16_t x, int16_t y) { return x <= y; }
+SCALAR_FUN_ATTR bool sle32(int32_t x, int32_t y) { return x <= y; }
+SCALAR_FUN_ATTR bool sle64(int64_t x, int64_t y) { return x <= y; }
 
 SCALAR_FUN_ATTR uint8_t pow8(uint8_t x, uint8_t y) {
   uint8_t res = 1, rem = y;
-
   while (rem != 0) {
     if (rem & 1)
       res *= x;
@@ -1115,7 +566,6 @@ SCALAR_FUN_ATTR uint8_t pow8(uint8_t x, uint8_t y) {
 
 SCALAR_FUN_ATTR uint16_t pow16(uint16_t x, uint16_t y) {
   uint16_t res = 1, rem = y;
-
   while (rem != 0) {
     if (rem & 1)
       res *= x;
@@ -1127,7 +577,6 @@ SCALAR_FUN_ATTR uint16_t pow16(uint16_t x, uint16_t y) {
 
 SCALAR_FUN_ATTR uint32_t pow32(uint32_t x, uint32_t y) {
   uint32_t res = 1, rem = y;
-
   while (rem != 0) {
     if (rem & 1)
       res *= x;
@@ -1139,7 +588,6 @@ SCALAR_FUN_ATTR uint32_t pow32(uint32_t x, uint32_t y) {
 
 SCALAR_FUN_ATTR uint64_t pow64(uint64_t x, uint64_t y) {
   uint64_t res = 1, rem = y;
-
   while (rem != 0) {
     if (rem & 1)
       res *= x;
@@ -1149,37 +597,15 @@ SCALAR_FUN_ATTR uint64_t pow64(uint64_t x, uint64_t y) {
   return res;
 }
 
-SCALAR_FUN_ATTR bool itob_i8_bool(int8_t x) {
-  return x != 0;
-}
+SCALAR_FUN_ATTR bool  itob_i8_bool(int8_t x)  { return x != 0; }
+SCALAR_FUN_ATTR bool itob_i16_bool(int16_t x) { return x != 0; }
+SCALAR_FUN_ATTR bool itob_i32_bool(int32_t x) { return x != 0; }
+SCALAR_FUN_ATTR bool itob_i64_bool(int64_t x) { return x != 0; }
 
-SCALAR_FUN_ATTR bool itob_i16_bool(int16_t x) {
-  return x != 0;
-}
-
-SCALAR_FUN_ATTR bool itob_i32_bool(int32_t x) {
-  return x != 0;
-}
-
-SCALAR_FUN_ATTR bool itob_i64_bool(int64_t x) {
-  return x != 0;
-}
-
-SCALAR_FUN_ATTR int8_t btoi_bool_i8(bool x) {
-  return x;
-}
-
-SCALAR_FUN_ATTR int16_t btoi_bool_i16(bool x) {
-  return x;
-}
-
-SCALAR_FUN_ATTR int32_t btoi_bool_i32(bool x) {
-  return x;
-}
-
-SCALAR_FUN_ATTR int64_t btoi_bool_i64(bool x) {
-  return x;
-}
+SCALAR_FUN_ATTR int8_t btoi_bool_i8(bool x)   { return x; }
+SCALAR_FUN_ATTR int16_t btoi_bool_i16(bool x) { return x; }
+SCALAR_FUN_ATTR int32_t btoi_bool_i32(bool x) { return x; }
+SCALAR_FUN_ATTR int64_t btoi_bool_i64(bool x) { return x; }
 
 #define sext_i8_i8(x) ((int8_t) (int8_t) (x))
 #define sext_i8_i16(x) ((int16_t) (int8_t) (x))
@@ -1214,18 +640,9 @@ SCALAR_FUN_ATTR int64_t btoi_bool_i64(bool x) {
 #define zext_i64_i32(x) ((int32_t) (uint64_t) (x))
 #define zext_i64_i64(x) ((int64_t) (uint64_t) (x))
 
-SCALAR_FUN_ATTR int8_t abs8(int8_t x) {
-  return (int8_t)abs(x);
-}
-
-SCALAR_FUN_ATTR int16_t abs16(int16_t x) {
-  return (int16_t)abs(x);
-}
-
-SCALAR_FUN_ATTR int32_t abs32(int32_t x) {
-  return abs(x);
-}
-
+SCALAR_FUN_ATTR int8_t   abs8(int8_t x)  { return (int8_t)abs(x); }
+SCALAR_FUN_ATTR int16_t abs16(int16_t x) { return (int16_t)abs(x); }
+SCALAR_FUN_ATTR int32_t abs32(int32_t x) { return abs(x); }
 SCALAR_FUN_ATTR int64_t abs64(int64_t x) {
 #if defined(__OPENCL_VERSION__) || defined(ISPC)
   return abs(x);
@@ -1235,38 +652,18 @@ SCALAR_FUN_ATTR int64_t abs64(int64_t x) {
 }
 
 #if defined(__OPENCL_VERSION__)
-SCALAR_FUN_ATTR int32_t futrts_popc8(int8_t x) {
-  return popcount(x);
-}
 
-SCALAR_FUN_ATTR int32_t futrts_popc16(int16_t x) {
-  return popcount(x);
-}
+SCALAR_FUN_ATTR int32_t  futrts_popc8(int8_t x)  { return popcount(x); }
+SCALAR_FUN_ATTR int32_t futrts_popc16(int16_t x) { return popcount(x); }
+SCALAR_FUN_ATTR int32_t futrts_popc32(int32_t x) { return popcount(x); }
+SCALAR_FUN_ATTR int32_t futrts_popc64(int64_t x) { return popcount(x); }
 
-SCALAR_FUN_ATTR int32_t futrts_popc32(int32_t x) {
-  return popcount(x);
-}
-
-SCALAR_FUN_ATTR int32_t futrts_popc64(int64_t x) {
-  return popcount(x);
-}
 #elif defined(__CUDA_ARCH__)
 
-SCALAR_FUN_ATTR int32_t futrts_popc8(int8_t x) {
-  return __popc(zext_i8_i32(x));
-}
-
-SCALAR_FUN_ATTR int32_t futrts_popc16(int16_t x) {
-  return __popc(zext_i16_i32(x));
-}
-
-SCALAR_FUN_ATTR int32_t futrts_popc32(int32_t x) {
-  return __popc(x);
-}
-
-SCALAR_FUN_ATTR int32_t futrts_popc64(int64_t x) {
-  return __popcll(x);
-}
+SCALAR_FUN_ATTR int32_t  futrts_popc8(int8_t x)  { return __popc(zext_i8_i32(x)); }
+SCALAR_FUN_ATTR int32_t futrts_popc16(int16_t x) { return __popc(zext_i16_i32(x)); }
+SCALAR_FUN_ATTR int32_t futrts_popc32(int32_t x) { return __popc(x); }
+SCALAR_FUN_ATTR int32_t futrts_popc64(int64_t x) { return __popcll(x); }
 
 #else // Not OpenCL or CUDA, but plain C.
 
@@ -1400,103 +797,59 @@ SCALAR_FUN_ATTR uint64_t futrts_smad_hi64(int64_t a, int64_t b, int64_t c) { ret
 #endif
 
 #if defined(__OPENCL_VERSION__)
-SCALAR_FUN_ATTR int32_t futrts_clzz8(int8_t x) {
-  return clz(x);
-}
-
-SCALAR_FUN_ATTR int32_t futrts_clzz16(int16_t x) {
-  return clz(x);
-}
-
-SCALAR_FUN_ATTR int32_t futrts_clzz32(int32_t x) {
-  return clz(x);
-}
-
-SCALAR_FUN_ATTR int32_t futrts_clzz64(int64_t x) {
-  return clz(x);
-}
+SCALAR_FUN_ATTR int32_t  futrts_clzz8(int8_t x)  { return clz(x); }
+SCALAR_FUN_ATTR int32_t futrts_clzz16(int16_t x) { return clz(x); }
+SCALAR_FUN_ATTR int32_t futrts_clzz32(int32_t x) { return clz(x); }
+SCALAR_FUN_ATTR int32_t futrts_clzz64(int64_t x) { return clz(x); }
 
 #elif defined(__CUDA_ARCH__)
 
-SCALAR_FUN_ATTR int32_t futrts_clzz8(int8_t x) {
-  return __clz(zext_i8_i32(x)) - 24;
-}
-
-SCALAR_FUN_ATTR int32_t futrts_clzz16(int16_t x) {
-  return __clz(zext_i16_i32(x)) - 16;
-}
-
-SCALAR_FUN_ATTR int32_t futrts_clzz32(int32_t x) {
-  return __clz(x);
-}
-
-SCALAR_FUN_ATTR int32_t futrts_clzz64(int64_t x) {
-  return __clzll(x);
-}
+SCALAR_FUN_ATTR int32_t  futrts_clzz8(int8_t x)  { return __clz(zext_i8_i32(x)) - 24; }
+SCALAR_FUN_ATTR int32_t futrts_clzz16(int16_t x) { return __clz(zext_i16_i32(x)) - 16; }
+SCALAR_FUN_ATTR int32_t futrts_clzz32(int32_t x) { return __clz(x); }
+SCALAR_FUN_ATTR int32_t futrts_clzz64(int64_t x) { return __clzll(x); }
 
 #elif defined(ISPC)
 
-SCALAR_FUN_ATTR int32_t futrts_clzz8(int8_t x) {
-  return count_leading_zeros((int32_t)(uint8_t)x)-24;
-}
-
-SCALAR_FUN_ATTR int32_t futrts_clzz16(int16_t x) {
-  return count_leading_zeros((int32_t)(uint16_t)x)-16;
-}
-
-SCALAR_FUN_ATTR int32_t futrts_clzz32(int32_t x) {
-  return count_leading_zeros(x);
-}
-
-SCALAR_FUN_ATTR int32_t futrts_clzz64(int64_t x) {
-  return count_leading_zeros(x);
-}
+SCALAR_FUN_ATTR int32_t  futrts_clzz8(int8_t x)  { return count_leading_zeros((int32_t)(uint8_t)x)-24; }
+SCALAR_FUN_ATTR int32_t futrts_clzz16(int16_t x) { return count_leading_zeros((int32_t)(uint16_t)x)-16; }
+SCALAR_FUN_ATTR int32_t futrts_clzz32(int32_t x) { return count_leading_zeros(x); }
+SCALAR_FUN_ATTR int32_t futrts_clzz64(int64_t x) { return count_leading_zeros(x); }
 
 #else // Not OpenCL, ISPC or CUDA, but plain C.
 
-SCALAR_FUN_ATTR int32_t futrts_clzz8(int8_t x) {
-  return x == 0 ? 8 : __builtin_clz((uint32_t)zext_i8_i32(x)) - 24;
-}
-
-SCALAR_FUN_ATTR int32_t futrts_clzz16(int16_t x) {
-  return x == 0 ? 16 : __builtin_clz((uint32_t)zext_i16_i32(x)) - 16;
-}
-
-SCALAR_FUN_ATTR int32_t futrts_clzz32(int32_t x) {
-  return x == 0 ? 32 : __builtin_clz((uint32_t)x);
-}
-
-SCALAR_FUN_ATTR int32_t futrts_clzz64(int64_t x) {
-  return x == 0 ? 64 : __builtin_clzll((uint64_t)x);
-}
+SCALAR_FUN_ATTR int32_t futrts_clzz8(int8_t x)
+{ return x == 0 ? 8 : __builtin_clz((uint32_t)zext_i8_i32(x)) - 24; }
+SCALAR_FUN_ATTR int32_t futrts_clzz16(int16_t x)
+{ return x == 0 ? 16 : __builtin_clz((uint32_t)zext_i16_i32(x)) - 16; }
+SCALAR_FUN_ATTR int32_t futrts_clzz32(int32_t x)
+{ return x == 0 ? 32 : __builtin_clz((uint32_t)x); }
+SCALAR_FUN_ATTR int32_t futrts_clzz64(int64_t x)
+{ return x == 0 ? 64 : __builtin_clzll((uint64_t)x); }
 #endif
 
 #if defined(__OPENCL_VERSION__)
 SCALAR_FUN_ATTR int32_t futrts_ctzz8(int8_t x) {
   int i = 0;
-  for (; i < 8 && (x & 1) == 0; i++, x >>= 1)
-    ;
+  for (; i < 8 && (x & 1) == 0; i++, x >>= 1) ;
   return i;
 }
 
 SCALAR_FUN_ATTR int32_t futrts_ctzz16(int16_t x) {
   int i = 0;
-  for (; i < 16 && (x & 1) == 0; i++, x >>= 1)
-    ;
+  for (; i < 16 && (x & 1) == 0; i++, x >>= 1) ;
   return i;
 }
 
 SCALAR_FUN_ATTR int32_t futrts_ctzz32(int32_t x) {
   int i = 0;
-  for (; i < 32 && (x & 1) == 0; i++, x >>= 1)
-    ;
+  for (; i < 32 && (x & 1) == 0; i++, x >>= 1) ;
   return i;
 }
 
 SCALAR_FUN_ATTR int32_t futrts_ctzz64(int64_t x) {
   int i = 0;
-  for (; i < 64 && (x & 1) == 0; i++, x >>= 1)
-    ;
+  for (; i < 64 && (x & 1) == 0; i++, x >>= 1) ;
   return i;
 }
 
@@ -1524,128 +877,46 @@ SCALAR_FUN_ATTR int32_t futrts_ctzz64(int64_t x) {
 
 #elif defined(ISPC)
 
-SCALAR_FUN_ATTR int32_t futrts_ctzz8(int8_t x) {
-  return x == 0 ? 8 : count_trailing_zeros((int32_t)x);
-}
-
-SCALAR_FUN_ATTR int32_t futrts_ctzz16(int16_t x) {
-  return x == 0 ? 16 : count_trailing_zeros((int32_t)x);
-}
-
-SCALAR_FUN_ATTR int32_t futrts_ctzz32(int32_t x) {
-  return count_trailing_zeros(x);
-}
-
-SCALAR_FUN_ATTR int32_t futrts_ctzz64(int64_t x) {
-  return count_trailing_zeros(x);
-}
+SCALAR_FUN_ATTR int32_t futrts_ctzz8(int8_t x) { return x == 0 ? 8 : count_trailing_zeros((int32_t)x); }
+SCALAR_FUN_ATTR int32_t futrts_ctzz16(int16_t x) { return x == 0 ? 16 : count_trailing_zeros((int32_t)x); }
+SCALAR_FUN_ATTR int32_t futrts_ctzz32(int32_t x) { return count_trailing_zeros(x); }
+SCALAR_FUN_ATTR int32_t futrts_ctzz64(int64_t x) { return count_trailing_zeros(x); }
 
 #else // Not OpenCL or CUDA, but plain C.
 
-SCALAR_FUN_ATTR int32_t futrts_ctzz8(int8_t x) {
-  return x == 0 ? 8 : __builtin_ctz((uint32_t)x);
-}
-
-SCALAR_FUN_ATTR int32_t futrts_ctzz16(int16_t x) {
-  return x == 0 ? 16 : __builtin_ctz((uint32_t)x);
-}
-
-SCALAR_FUN_ATTR int32_t futrts_ctzz32(int32_t x) {
-  return x == 0 ? 32 : __builtin_ctz((uint32_t)x);
-}
-
-SCALAR_FUN_ATTR int32_t futrts_ctzz64(int64_t x) {
-  return x == 0 ? 64 : __builtin_ctzll((uint64_t)x);
-}
+SCALAR_FUN_ATTR int32_t  futrts_ctzz8(int8_t x)  { return x == 0 ? 8 : __builtin_ctz((uint32_t)x); }
+SCALAR_FUN_ATTR int32_t futrts_ctzz16(int16_t x) { return x == 0 ? 16 : __builtin_ctz((uint32_t)x); }
+SCALAR_FUN_ATTR int32_t futrts_ctzz32(int32_t x) { return x == 0 ? 32 : __builtin_ctz((uint32_t)x); }
+SCALAR_FUN_ATTR int32_t futrts_ctzz64(int64_t x) { return x == 0 ? 64 : __builtin_ctzll((uint64_t)x); }
 #endif
 
-SCALAR_FUN_ATTR float fdiv32(float x, float y) {
-  return x / y;
-}
+SCALAR_FUN_ATTR float fdiv32(float x, float y) { return x / y; }
+SCALAR_FUN_ATTR float fadd32(float x, float y) { return x + y; }
+SCALAR_FUN_ATTR float fsub32(float x, float y) { return x - y; }
+SCALAR_FUN_ATTR float fmul32(float x, float y) { return x * y; }
+SCALAR_FUN_ATTR bool cmplt32(float x, float y) { return x < y; }
+SCALAR_FUN_ATTR bool cmple32(float x, float y) { return x <= y; }
+SCALAR_FUN_ATTR float sitofp_i8_f32(int8_t x)  { return (float) x; }
 
-SCALAR_FUN_ATTR float fadd32(float x, float y) {
-  return x + y;
-}
-
-SCALAR_FUN_ATTR float fsub32(float x, float y) {
-  return x - y;
-}
-
-SCALAR_FUN_ATTR float fmul32(float x, float y) {
-  return x * y;
-}
-
-SCALAR_FUN_ATTR bool cmplt32(float x, float y) {
-  return x < y;
-}
-
-SCALAR_FUN_ATTR bool cmple32(float x, float y) {
-  return x <= y;
-}
-
-SCALAR_FUN_ATTR float sitofp_i8_f32(int8_t x) {
-  return (float) x;
-}
-
-SCALAR_FUN_ATTR float sitofp_i16_f32(int16_t x) {
-  return (float) x;
-}
-
-SCALAR_FUN_ATTR float sitofp_i32_f32(int32_t x) {
-  return (float) x;
-}
-
-SCALAR_FUN_ATTR float sitofp_i64_f32(int64_t x) {
-  return (float) x;
-}
-
-SCALAR_FUN_ATTR float uitofp_i8_f32(uint8_t x) {
-  return (float) x;
-}
-
-SCALAR_FUN_ATTR float uitofp_i16_f32(uint16_t x) {
-  return (float) x;
-}
-
-SCALAR_FUN_ATTR float uitofp_i32_f32(uint32_t x) {
-  return (float) x;
-}
-
-SCALAR_FUN_ATTR float uitofp_i64_f32(uint64_t x) {
-  return (float) x;
-}
+SCALAR_FUN_ATTR float sitofp_i16_f32(int16_t x) { return (float) x; }
+SCALAR_FUN_ATTR float sitofp_i32_f32(int32_t x) { return (float) x; }
+SCALAR_FUN_ATTR float sitofp_i64_f32(int64_t x) { return (float) x; }
+SCALAR_FUN_ATTR float  uitofp_i8_f32(uint8_t x)  { return (float) x; }
+SCALAR_FUN_ATTR float uitofp_i16_f32(uint16_t x) { return (float) x; }
+SCALAR_FUN_ATTR float uitofp_i32_f32(uint32_t x) { return (float) x; }
+SCALAR_FUN_ATTR float uitofp_i64_f32(uint64_t x) { return (float) x; }
 
 #ifdef __OPENCL_VERSION__
-SCALAR_FUN_ATTR float fabs32(float x) {
-  return fabs(x);
-}
-
-SCALAR_FUN_ATTR float fmax32(float x, float y) {
-  return fmax(x, y);
-}
-
-SCALAR_FUN_ATTR float fmin32(float x, float y) {
-  return fmin(x, y);
-}
-
-SCALAR_FUN_ATTR float fpow32(float x, float y) {
-  return pow(x, y);
-}
+SCALAR_FUN_ATTR float fabs32(float x)          { return fabs(x); }
+SCALAR_FUN_ATTR float fmax32(float x, float y) { return fmax(x, y); }
+SCALAR_FUN_ATTR float fmin32(float x, float y) { return fmin(x, y); }
+SCALAR_FUN_ATTR float fpow32(float x, float y) { return pow(x, y); }
 
 #elif defined(ISPC)
 
-SCALAR_FUN_ATTR float fabs32(float x) {
-  return abs(x);
-}
-
-SCALAR_FUN_ATTR float fmax32(float x, float y) {
-  return isnan(x) ? y : isnan(y) ? x : max(x, y);
-}
-
-SCALAR_FUN_ATTR float fmin32(float x, float y) {
-  return isnan(x) ? y : isnan(y) ? x : min(x, y);
-}
-
+SCALAR_FUN_ATTR float fabs32(float x) { return abs(x); }
+SCALAR_FUN_ATTR float fmax32(float x, float y) { return isnan(x) ? y : isnan(y) ? x : max(x, y); }
+SCALAR_FUN_ATTR float fmin32(float x, float y) { return isnan(x) ? y : isnan(y) ? x : min(x, y); }
 SCALAR_FUN_ATTR float fpow32(float a, float b) {
   float ret;
   foreach_active (i) {
@@ -1657,42 +928,23 @@ SCALAR_FUN_ATTR float fpow32(float a, float b) {
 
 #else // Not OpenCL, but CUDA or plain C.
 
-SCALAR_FUN_ATTR float fabs32(float x) {
-  return fabsf(x);
-}
-
-SCALAR_FUN_ATTR float fmax32(float x, float y) {
-  return fmaxf(x, y);
-}
-
-SCALAR_FUN_ATTR float fmin32(float x, float y) {
-  return fminf(x, y);
-}
-
-SCALAR_FUN_ATTR float fpow32(float x, float y) {
-  return powf(x, y);
-}
+SCALAR_FUN_ATTR float fabs32(float x)          { return fabsf(x); }
+SCALAR_FUN_ATTR float fmax32(float x, float y) { return fmaxf(x, y); }
+SCALAR_FUN_ATTR float fmin32(float x, float y) { return fminf(x, y); }
+SCALAR_FUN_ATTR float fpow32(float x, float y) { return powf(x, y); }
 #endif
 
-SCALAR_FUN_ATTR bool futrts_isnan32(float x) {
-  return isnan(x);
-}
+SCALAR_FUN_ATTR bool futrts_isnan32(float x) { return isnan(x); }
 
 #if defined(ISPC)
 
-SCALAR_FUN_ATTR bool futrts_isinf32(float x) {
-  return !isnan(x) && isnan(x - x);
-}
+SCALAR_FUN_ATTR bool futrts_isinf32(float x) { return !isnan(x) && isnan(x - x); }
 
-SCALAR_FUN_ATTR bool futrts_isfinite32(float x) {
-  return !isnan(x) && !futrts_isinf32(x);
-}
+SCALAR_FUN_ATTR bool futrts_isfinite32(float x) { return !isnan(x) && !futrts_isinf32(x); }
 
 #else
 
-SCALAR_FUN_ATTR bool futrts_isinf32(float x) {
-  return isinf(x);
-}
+SCALAR_FUN_ATTR bool futrts_isinf32(float x) { return isinf(x); }
 
 #endif
 
@@ -1760,200 +1012,59 @@ SCALAR_FUN_ATTR uint64_t fptoui_f32_i64(float x) {
   }
 }
 
-SCALAR_FUN_ATTR bool ftob_f32_bool(float x) {
-  return x != 0;
-}
-
-SCALAR_FUN_ATTR float btof_bool_f32(bool x) {
-  return x ? 1 : 0;
-}
+SCALAR_FUN_ATTR bool ftob_f32_bool(float x) { return x != 0; }
+SCALAR_FUN_ATTR float btof_bool_f32(bool x) { return x ? 1 : 0; }
 
 #ifdef __OPENCL_VERSION__
-SCALAR_FUN_ATTR float futrts_log32(float x) {
-  return log(x);
-}
-
-SCALAR_FUN_ATTR float futrts_log2_32(float x) {
-  return log2(x);
-}
-
-SCALAR_FUN_ATTR float futrts_log10_32(float x) {
-  return log10(x);
-}
-
-SCALAR_FUN_ATTR float futrts_log1p_32(float x) {
-  return log1p(x);
-}
-
-SCALAR_FUN_ATTR float futrts_sqrt32(float x) {
-  return sqrt(x);
-}
-
-SCALAR_FUN_ATTR float futrts_rsqrt32(float x) {
-  return rsqrt(x);
-}
-
-SCALAR_FUN_ATTR float futrts_cbrt32(float x) {
-  return cbrt(x);
-}
-
-SCALAR_FUN_ATTR float futrts_exp32(float x) {
-  return exp(x);
-}
-
-SCALAR_FUN_ATTR float futrts_cos32(float x) {
-  return cos(x);
-}
-
-SCALAR_FUN_ATTR float futrts_cospi32(float x) {
-  return cospi(x);
-}
-
-SCALAR_FUN_ATTR float futrts_sin32(float x) {
-  return sin(x);
-}
-
-SCALAR_FUN_ATTR float futrts_sinpi32(float x) {
-  return sinpi(x);
-}
-
-SCALAR_FUN_ATTR float futrts_tan32(float x) {
-  return tan(x);
-}
-
-SCALAR_FUN_ATTR float futrts_tanpi32(float x) {
-  return tanpi(x);
-}
-
-SCALAR_FUN_ATTR float futrts_acos32(float x) {
-  return acos(x);
-}
-
-SCALAR_FUN_ATTR float futrts_acospi32(float x) {
-  return acospi(x);
-}
-
-SCALAR_FUN_ATTR float futrts_asin32(float x) {
-  return asin(x);
-}
-
-SCALAR_FUN_ATTR float futrts_asinpi32(float x) {
-  return asinpi(x);
-}
-
-SCALAR_FUN_ATTR float futrts_atan32(float x) {
-  return atan(x);
-}
-
-SCALAR_FUN_ATTR float futrts_atanpi32(float x) {
-  return atanpi(x);
-}
-
-SCALAR_FUN_ATTR float futrts_cosh32(float x) {
-  return cosh(x);
-}
-
-SCALAR_FUN_ATTR float futrts_sinh32(float x) {
-  return sinh(x);
-}
-
-SCALAR_FUN_ATTR float futrts_tanh32(float x) {
-  return tanh(x);
-}
-
-SCALAR_FUN_ATTR float futrts_acosh32(float x) {
-  return acosh(x);
-}
-
-SCALAR_FUN_ATTR float futrts_asinh32(float x) {
-  return asinh(x);
-}
-
-SCALAR_FUN_ATTR float futrts_atanh32(float x) {
-  return atanh(x);
-}
-
-SCALAR_FUN_ATTR float futrts_atan2_32(float x, float y) {
-  return atan2(x, y);
-}
-
-SCALAR_FUN_ATTR float futrts_atan2pi_32(float x, float y) {
-  return atan2pi(x, y);
-}
-
-SCALAR_FUN_ATTR float futrts_hypot32(float x, float y) {
-  return hypot(x, y);
-}
-
-SCALAR_FUN_ATTR float futrts_gamma32(float x) {
-  return tgamma(x);
-}
-
-SCALAR_FUN_ATTR float futrts_lgamma32(float x) {
-  return lgamma(x);
-}
-
-SCALAR_FUN_ATTR float futrts_erf32(float x) {
-  return erf(x);
-}
-
-SCALAR_FUN_ATTR float futrts_erfc32(float x) {
-  return erfc(x);
-}
-
-SCALAR_FUN_ATTR float fmod32(float x, float y) {
-  return fmod(x, y);
-}
-
-SCALAR_FUN_ATTR float futrts_round32(float x) {
-  return rint(x);
-}
-
-SCALAR_FUN_ATTR float futrts_floor32(float x) {
-  return floor(x);
-}
-
-SCALAR_FUN_ATTR float futrts_ceil32(float x) {
-  return ceil(x);
-}
-
-SCALAR_FUN_ATTR float futrts_nextafter32(float x, float y) {
-  return nextafter(x, y);
-}
-
-SCALAR_FUN_ATTR float futrts_lerp32(float v0, float v1, float t) {
-  return mix(v0, v1, t);
-}
-
-SCALAR_FUN_ATTR float futrts_ldexp32(float x, int32_t y) {
-  return ldexp(x, y);
-}
-
-SCALAR_FUN_ATTR float futrts_copysign32(float x, float y) {
-  return copysign(x, y);
-}
-
-SCALAR_FUN_ATTR float futrts_mad32(float a, float b, float c) {
-  return mad(a, b, c);
-}
-
-SCALAR_FUN_ATTR float futrts_fma32(float a, float b, float c) {
-  return fma(a, b, c);
-}
+SCALAR_FUN_ATTR float futrts_log32(float x) { return log(x); }
+SCALAR_FUN_ATTR float futrts_log2_32(float x) { return log2(x); }
+SCALAR_FUN_ATTR float futrts_log10_32(float x) { return log10(x); }
+SCALAR_FUN_ATTR float futrts_log1p_32(float x) { return log1p(x); }
+SCALAR_FUN_ATTR float futrts_sqrt32(float x) { return sqrt(x); }
+SCALAR_FUN_ATTR float futrts_rsqrt32(float x) { return rsqrt(x); }
+SCALAR_FUN_ATTR float futrts_cbrt32(float x) { return cbrt(x); }
+SCALAR_FUN_ATTR float futrts_exp32(float x) { return exp(x); }
+SCALAR_FUN_ATTR float futrts_cos32(float x) { return cos(x); }
+SCALAR_FUN_ATTR float futrts_cospi32(float x) { return cospi(x); }
+SCALAR_FUN_ATTR float futrts_sin32(float x) { return sin(x); }
+SCALAR_FUN_ATTR float futrts_sinpi32(float x) { return sinpi(x); }
+SCALAR_FUN_ATTR float futrts_tan32(float x) { return tan(x); }
+SCALAR_FUN_ATTR float futrts_tanpi32(float x) { return tanpi(x); }
+SCALAR_FUN_ATTR float futrts_acos32(float x) { return acos(x); }
+SCALAR_FUN_ATTR float futrts_acospi32(float x) { return acospi(x); }
+SCALAR_FUN_ATTR float futrts_asin32(float x) { return asin(x); }
+SCALAR_FUN_ATTR float futrts_asinpi32(float x) { return asinpi(x); }
+SCALAR_FUN_ATTR float futrts_atan32(float x) { return atan(x); }
+SCALAR_FUN_ATTR float futrts_atanpi32(float x) { return atanpi(x); }
+SCALAR_FUN_ATTR float futrts_cosh32(float x) { return cosh(x); }
+SCALAR_FUN_ATTR float futrts_sinh32(float x) { return sinh(x); }
+SCALAR_FUN_ATTR float futrts_tanh32(float x) { return tanh(x); }
+SCALAR_FUN_ATTR float futrts_acosh32(float x) { return acosh(x); }
+SCALAR_FUN_ATTR float futrts_asinh32(float x) { return asinh(x); }
+SCALAR_FUN_ATTR float futrts_atanh32(float x) { return atanh(x); }
+SCALAR_FUN_ATTR float futrts_atan2_32(float x, float y) { return atan2(x, y); }
+SCALAR_FUN_ATTR float futrts_atan2pi_32(float x, float y) { return atan2pi(x, y); }
+SCALAR_FUN_ATTR float futrts_hypot32(float x, float y) { return hypot(x, y); }
+SCALAR_FUN_ATTR float futrts_gamma32(float x) { return tgamma(x); }
+SCALAR_FUN_ATTR float futrts_lgamma32(float x) { return lgamma(x); }
+SCALAR_FUN_ATTR float futrts_erf32(float x) { return erf(x); }
+SCALAR_FUN_ATTR float futrts_erfc32(float x) { return erfc(x); }
+SCALAR_FUN_ATTR float fmod32(float x, float y) { return fmod(x, y); }
+SCALAR_FUN_ATTR float futrts_round32(float x) { return rint(x); }
+SCALAR_FUN_ATTR float futrts_floor32(float x) { return floor(x); }
+SCALAR_FUN_ATTR float futrts_ceil32(float x) { return ceil(x); }
+SCALAR_FUN_ATTR float futrts_nextafter32(float x, float y) { return nextafter(x, y); }
+SCALAR_FUN_ATTR float futrts_lerp32(float v0, float v1, float t) { return mix(v0, v1, t); }
+SCALAR_FUN_ATTR float futrts_ldexp32(float x, int32_t y) { return ldexp(x, y); }
+SCALAR_FUN_ATTR float futrts_copysign32(float x, float y) { return copysign(x, y); }
+SCALAR_FUN_ATTR float futrts_mad32(float a, float b, float c) { return mad(a, b, c); }
+SCALAR_FUN_ATTR float futrts_fma32(float a, float b, float c) { return fma(a, b, c); }
 
 #elif defined(ISPC)
 
-SCALAR_FUN_ATTR float futrts_log32(float x) {
-  return futrts_isfinite32(x) || (futrts_isinf32(x) && x < 0)? log(x) : x;
-}
-
-SCALAR_FUN_ATTR float futrts_log2_32(float x) {
-  return futrts_log32(x) / log(2.0f);
-}
-
-SCALAR_FUN_ATTR float futrts_log10_32(float x) {
-  return futrts_log32(x) / log(10.0f);
-}
+SCALAR_FUN_ATTR float futrts_log32(float x) { return futrts_isfinite32(x) || (futrts_isinf32(x) && x < 0)? log(x) : x; }
+SCALAR_FUN_ATTR float futrts_log2_32(float x) { return futrts_log32(x) / log(2.0f); }
+SCALAR_FUN_ATTR float futrts_log10_32(float x) { return futrts_log32(x) / log(10.0f); }
 
 SCALAR_FUN_ATTR float futrts_log1p_32(float x) {
   if(x == -1.0f || (futrts_isinf32(x) && x > 0.0f)) return x / 0.0f;
@@ -1962,13 +1073,8 @@ SCALAR_FUN_ATTR float futrts_log1p_32(float x) {
   return log(y) - (z-x)/y;
 }
 
-SCALAR_FUN_ATTR float futrts_sqrt32(float x) {
-  return sqrt(x);
-}
-
-SCALAR_FUN_ATTR float futrts_rsqrt32(float x) {
-  return 1/sqrt(x);
-}
+SCALAR_FUN_ATTR float futrts_sqrt32(float x) { return sqrt(x); }
+SCALAR_FUN_ATTR float futrts_rsqrt32(float x) { return 1/sqrt(x); }
 
 extern "C" unmasked uniform float cbrtf(uniform float);
 SCALAR_FUN_ATTR float futrts_cbrt32(float x) {
@@ -1980,99 +1086,45 @@ SCALAR_FUN_ATTR float futrts_cbrt32(float x) {
   return res;
 }
 
-SCALAR_FUN_ATTR float futrts_exp32(float x) {
-  return exp(x);
-}
-
-SCALAR_FUN_ATTR float futrts_cos32(float x) {
-  return cos(x);
-}
-
-SCALAR_FUN_ATTR float futrts_cospi32(float x) {
-  return cos((float)M_PI*x);
-}
-
-SCALAR_FUN_ATTR float futrts_sin32(float x) {
-  return sin(x);
-}
-
-SCALAR_FUN_ATTR float futrts_sinpi32(float x) {
-  return sin(M_PI*x);
-}
-
-SCALAR_FUN_ATTR float futrts_tan32(float x) {
-  return tan(x);
-}
-
-SCALAR_FUN_ATTR float futrts_tanpi32(float x) {
-  return tan((float)M_PI*x);
-}
-
-SCALAR_FUN_ATTR float futrts_acos32(float x) {
-  return acos(x);
-}
-
-SCALAR_FUN_ATTR float futrts_acospi32(float x) {
-  return acos(x)/(float)M_PI;
-}
-
-SCALAR_FUN_ATTR float futrts_asin32(float x) {
-  return asin(x);
-}
-
-SCALAR_FUN_ATTR float futrts_asinpi32(float x) {
-  return asin(x)/(float)M_PI;
-}
-
-SCALAR_FUN_ATTR float futrts_atan32(float x) {
-  return atan(x);
-}
-
-SCALAR_FUN_ATTR float futrts_atanpi32(float x) {
-  return atan(x)/(float)M_PI;
-}
-
-
-SCALAR_FUN_ATTR float futrts_cosh32(float x) {
-  return (exp(x)+exp(-x)) / 2.0f;
-}
-
-SCALAR_FUN_ATTR float futrts_sinh32(float x) {
-  return (exp(x)-exp(-x)) / 2.0f;
-}
-
-SCALAR_FUN_ATTR float futrts_tanh32(float x) {
-  return futrts_sinh32(x)/futrts_cosh32(x);
-}
+SCALAR_FUN_ATTR float futrts_exp32(float x) { return exp(x); }
+SCALAR_FUN_ATTR float futrts_cos32(float x) { return cos(x); }
+SCALAR_FUN_ATTR float futrts_cospi32(float x) { return cos((float)M_PI*x); }
+SCALAR_FUN_ATTR float futrts_sin32(float x) { return sin(x); }
+SCALAR_FUN_ATTR float futrts_sinpi32(float x) { return sin(M_PI*x); }
+SCALAR_FUN_ATTR float futrts_tan32(float x) { return tan(x); }
+SCALAR_FUN_ATTR float futrts_tanpi32(float x) { return tan((float)M_PI*x); }
+SCALAR_FUN_ATTR float futrts_acos32(float x) { return acos(x); }
+SCALAR_FUN_ATTR float futrts_acospi32(float x) { return acos(x)/(float)M_PI; }
+SCALAR_FUN_ATTR float futrts_asin32(float x) { return asin(x); }
+SCALAR_FUN_ATTR float futrts_asinpi32(float x) { return asin(x)/(float)M_PI; }
+SCALAR_FUN_ATTR float futrts_atan32(float x) { return atan(x); }
+SCALAR_FUN_ATTR float futrts_atanpi32(float x) { return atan(x)/(float)M_PI; }
+SCALAR_FUN_ATTR float futrts_cosh32(float x) { return (exp(x)+exp(-x)) / 2.0f; }
+SCALAR_FUN_ATTR float futrts_sinh32(float x) { return (exp(x)-exp(-x)) / 2.0f; }
+SCALAR_FUN_ATTR float futrts_tanh32(float x) { return futrts_sinh32(x)/futrts_cosh32(x); }
 
 SCALAR_FUN_ATTR float futrts_acosh32(float x) {
   float f = x+sqrt(x*x-1);
-  if(futrts_isfinite32(f)) return log(f);
+  if (futrts_isfinite32(f)) return log(f);
   return f;
 }
 
 SCALAR_FUN_ATTR float futrts_asinh32(float x) {
   float f = x+sqrt(x*x+1);
-  if(futrts_isfinite32(f)) return log(f);
+  if (futrts_isfinite32(f)) return log(f);
   return f;
-
 }
 
 SCALAR_FUN_ATTR float futrts_atanh32(float x) {
   float f = (1+x)/(1-x);
-  if(futrts_isfinite32(f)) return log(f)/2.0f;
+  if (futrts_isfinite32(f)) return log(f)/2.0f;
   return f;
-
 }
 
-SCALAR_FUN_ATTR float futrts_atan2_32(float x, float y) {
-  return (x == 0.0f && y == 0.0f) ? 0.0f : atan2(x, y);
-}
-
-SCALAR_FUN_ATTR float futrts_atan2pi_32(float x, float y) {
-  return (x == 0.0f && y == 0.0f) ? 0.0f : atan2(x, y) / (float)M_PI;
-}
-
+SCALAR_FUN_ATTR float futrts_atan2_32(float x, float y)
+{ return (x == 0.0f && y == 0.0f) ? 0.0f : atan2(x, y); }
+SCALAR_FUN_ATTR float futrts_atan2pi_32(float x, float y)
+{ return (x == 0.0f && y == 0.0f) ? 0.0f : atan2(x, y) / (float)M_PI; }
 
 SCALAR_FUN_ATTR float futrts_hypot32(float x, float y) {
   if (futrts_isfinite32(x) && futrts_isfinite32(y)) {
@@ -2146,21 +1198,10 @@ SCALAR_FUN_ATTR float futrts_erfc32(float x) {
   return res;
 }
 
-SCALAR_FUN_ATTR float fmod32(float x, float y) {
-  return x - y * trunc(x/y);
-}
-
-SCALAR_FUN_ATTR float futrts_round32(float x) {
-  return round(x);
-}
-
-SCALAR_FUN_ATTR float futrts_floor32(float x) {
-  return floor(x);
-}
-
-SCALAR_FUN_ATTR float futrts_ceil32(float x) {
-  return ceil(x);
-}
+SCALAR_FUN_ATTR float fmod32(float x, float y) { return x - y * trunc(x/y); }
+SCALAR_FUN_ATTR float futrts_round32(float x) { return round(x); }
+SCALAR_FUN_ATTR float futrts_floor32(float x) { return floor(x); }
+SCALAR_FUN_ATTR float futrts_ceil32(float x) { return ceil(x); }
 
 extern "C" unmasked uniform float nextafterf(uniform float x, uniform float y);
 SCALAR_FUN_ATTR float futrts_nextafter32(float x, float y) {
@@ -2196,41 +1237,15 @@ SCALAR_FUN_ATTR float futrts_fma32(float a, float b, float c) {
 
 #else // Not OpenCL or ISPC, but CUDA or plain C.
 
-SCALAR_FUN_ATTR float futrts_log32(float x) {
-  return logf(x);
-}
-
-SCALAR_FUN_ATTR float futrts_log2_32(float x) {
-  return log2f(x);
-}
-
-SCALAR_FUN_ATTR float futrts_log10_32(float x) {
-  return log10f(x);
-}
-
-SCALAR_FUN_ATTR float futrts_log1p_32(float x) {
-  return log1pf(x);
-}
-
-SCALAR_FUN_ATTR float futrts_sqrt32(float x) {
-  return sqrtf(x);
-}
-
-SCALAR_FUN_ATTR float futrts_rsqrt32(float x) {
-  return 1/sqrtf(x);
-}
-
-SCALAR_FUN_ATTR float futrts_cbrt32(float x) {
-  return cbrtf(x);
-}
-
-SCALAR_FUN_ATTR float futrts_exp32(float x) {
-  return expf(x);
-}
-
-SCALAR_FUN_ATTR float futrts_cos32(float x) {
-  return cosf(x);
-}
+SCALAR_FUN_ATTR float futrts_log32(float x) { return logf(x); }
+SCALAR_FUN_ATTR float futrts_log2_32(float x) { return log2f(x); }
+SCALAR_FUN_ATTR float futrts_log10_32(float x) { return log10f(x); }
+SCALAR_FUN_ATTR float futrts_log1p_32(float x) { return log1pf(x); }
+SCALAR_FUN_ATTR float futrts_sqrt32(float x) { return sqrtf(x); }
+SCALAR_FUN_ATTR float futrts_rsqrt32(float x) { return 1/sqrtf(x); }
+SCALAR_FUN_ATTR float futrts_cbrt32(float x) { return cbrtf(x); }
+SCALAR_FUN_ATTR float futrts_exp32(float x) { return expf(x); }
+SCALAR_FUN_ATTR float futrts_cos32(float x) { return cosf(x); }
 
 SCALAR_FUN_ATTR float futrts_cospi32(float x) {
 #if defined(__CUDA_ARCH__)
@@ -2239,10 +1254,7 @@ SCALAR_FUN_ATTR float futrts_cospi32(float x) {
   return cosf(((float)M_PI)*x);
 #endif
 }
-
-SCALAR_FUN_ATTR float futrts_sin32(float x) {
-  return sinf(x);
-}
+SCALAR_FUN_ATTR float futrts_sin32(float x) { return sinf(x); }
 
 SCALAR_FUN_ATTR float futrts_sinpi32(float x) {
 #if defined(__CUDA_ARCH__)
@@ -2252,140 +1264,47 @@ SCALAR_FUN_ATTR float futrts_sinpi32(float x) {
 #endif
 }
 
-SCALAR_FUN_ATTR float futrts_tan32(float x) {
-  return tanf(x);
-}
+SCALAR_FUN_ATTR float futrts_tan32(float x) { return tanf(x); }
+SCALAR_FUN_ATTR float futrts_tanpi32(float x) { return tanf((float)M_PI*x); }
+SCALAR_FUN_ATTR float futrts_acos32(float x) { return acosf(x); }
+SCALAR_FUN_ATTR float futrts_acospi32(float x) { return acosf(x)/(float)M_PI; }
+SCALAR_FUN_ATTR float futrts_asin32(float x) { return asinf(x); }
+SCALAR_FUN_ATTR float futrts_asinpi32(float x) { return asinf(x)/(float)M_PI; }
+SCALAR_FUN_ATTR float futrts_atan32(float x) { return atanf(x); }
+SCALAR_FUN_ATTR float futrts_atanpi32(float x) { return atanf(x)/(float)M_PI; }
+SCALAR_FUN_ATTR float futrts_cosh32(float x) { return coshf(x); }
+SCALAR_FUN_ATTR float futrts_sinh32(float x) { return sinhf(x); }
+SCALAR_FUN_ATTR float futrts_tanh32(float x) { return tanhf(x); }
+SCALAR_FUN_ATTR float futrts_acosh32(float x) { return acoshf(x); }
+SCALAR_FUN_ATTR float futrts_asinh32(float x) { return asinhf(x); }
+SCALAR_FUN_ATTR float futrts_atanh32(float x) { return atanhf(x); }
+SCALAR_FUN_ATTR float futrts_atan2_32(float x, float y) { return atan2f(x, y); }
+SCALAR_FUN_ATTR float futrts_atan2pi_32(float x, float y) { return atan2f(x, y) / (float)M_PI; }
+SCALAR_FUN_ATTR float futrts_hypot32(float x, float y) { return hypotf(x, y); }
+SCALAR_FUN_ATTR float futrts_gamma32(float x) { return tgammaf(x); }
+SCALAR_FUN_ATTR float futrts_lgamma32(float x) { return lgammaf(x); }
+SCALAR_FUN_ATTR float futrts_erf32(float x) { return erff(x); }
+SCALAR_FUN_ATTR float futrts_erfc32(float x) { return erfcf(x); }
+SCALAR_FUN_ATTR float fmod32(float x, float y) { return fmodf(x, y); }
+SCALAR_FUN_ATTR float futrts_round32(float x) { return rintf(x); }
+SCALAR_FUN_ATTR float futrts_floor32(float x) { return floorf(x); }
+SCALAR_FUN_ATTR float futrts_ceil32(float x) { return ceilf(x); }
+SCALAR_FUN_ATTR float futrts_nextafter32(float x, float y) { return nextafterf(x, y); }
+SCALAR_FUN_ATTR float futrts_lerp32(float v0, float v1, float t) { return v0 + (v1 - v0) * t; }
+SCALAR_FUN_ATTR float futrts_ldexp32(float x, int32_t y) { return ldexpf(x, y); }
+SCALAR_FUN_ATTR float futrts_copysign32(float x, float y) { return copysignf(x, y); }
+SCALAR_FUN_ATTR float futrts_mad32(float a, float b, float c) { return a * b + c; }
+SCALAR_FUN_ATTR float futrts_fma32(float a, float b, float c) { return fmaf(a, b, c); }
 
-SCALAR_FUN_ATTR float futrts_tanpi32(float x) {
-  return tanf((float)M_PI*x);
-}
-
-SCALAR_FUN_ATTR float futrts_acos32(float x) {
-  return acosf(x);
-}
-
-SCALAR_FUN_ATTR float futrts_acospi32(float x) {
-  return acosf(x)/(float)M_PI;
-}
-
-SCALAR_FUN_ATTR float futrts_asin32(float x) {
-  return asinf(x);
-}
-
-SCALAR_FUN_ATTR float futrts_asinpi32(float x) {
-  return asinf(x)/(float)M_PI;
-}
-
-SCALAR_FUN_ATTR float futrts_atan32(float x) {
-  return atanf(x);
-}
-
-SCALAR_FUN_ATTR float futrts_atanpi32(float x) {
-  return atanf(x)/(float)M_PI;
-}
-
-SCALAR_FUN_ATTR float futrts_cosh32(float x) {
-  return coshf(x);
-}
-
-SCALAR_FUN_ATTR float futrts_sinh32(float x) {
-  return sinhf(x);
-}
-
-SCALAR_FUN_ATTR float futrts_tanh32(float x) {
-  return tanhf(x);
-}
-
-SCALAR_FUN_ATTR float futrts_acosh32(float x) {
-  return acoshf(x);
-}
-
-SCALAR_FUN_ATTR float futrts_asinh32(float x) {
-  return asinhf(x);
-}
-
-SCALAR_FUN_ATTR float futrts_atanh32(float x) {
-  return atanhf(x);
-}
-
-SCALAR_FUN_ATTR float futrts_atan2_32(float x, float y) {
-  return atan2f(x, y);
-}
-
-SCALAR_FUN_ATTR float futrts_atan2pi_32(float x, float y) {
-  return atan2f(x, y) / (float)M_PI;
-}
-
-SCALAR_FUN_ATTR float futrts_hypot32(float x, float y) {
-  return hypotf(x, y);
-}
-
-SCALAR_FUN_ATTR float futrts_gamma32(float x) {
-  return tgammaf(x);
-}
-
-SCALAR_FUN_ATTR float futrts_lgamma32(float x) {
-  return lgammaf(x);
-}
-
-SCALAR_FUN_ATTR float futrts_erf32(float x) {
-  return erff(x);
-}
-
-SCALAR_FUN_ATTR float futrts_erfc32(float x) {
-  return erfcf(x);
-}
-
-SCALAR_FUN_ATTR float fmod32(float x, float y) {
-  return fmodf(x, y);
-}
-
-SCALAR_FUN_ATTR float futrts_round32(float x) {
-  return rintf(x);
-}
-
-SCALAR_FUN_ATTR float futrts_floor32(float x) {
-  return floorf(x);
-}
-
-SCALAR_FUN_ATTR float futrts_ceil32(float x) {
-  return ceilf(x);
-}
-
-SCALAR_FUN_ATTR float futrts_nextafter32(float x, float y) {
-  return nextafterf(x, y);
-}
-
-SCALAR_FUN_ATTR float futrts_lerp32(float v0, float v1, float t) {
-  return v0 + (v1 - v0) * t;
-}
-
-SCALAR_FUN_ATTR float futrts_ldexp32(float x, int32_t y) {
-  return ldexpf(x, y);
-}
-
-SCALAR_FUN_ATTR float futrts_copysign32(float x, float y) {
-  return copysignf(x, y);
-}
-
-SCALAR_FUN_ATTR float futrts_mad32(float a, float b, float c) {
-  return a * b + c;
-}
-
-SCALAR_FUN_ATTR float futrts_fma32(float a, float b, float c) {
-  return fmaf(a, b, c);
-}
 #endif
 
 #if defined(ISPC)
-SCALAR_FUN_ATTR int32_t futrts_to_bits32(float x) {
-  return intbits(x);
-}
 
-SCALAR_FUN_ATTR float futrts_from_bits32(int32_t x) {
-  return floatbits(x);
-}
+SCALAR_FUN_ATTR int32_t futrts_to_bits32(float x) { return intbits(x); }
+SCALAR_FUN_ATTR float futrts_from_bits32(int32_t x) { return floatbits(x); }
+
 #else
+
 SCALAR_FUN_ATTR int32_t futrts_to_bits32(float x) {
   union {
     float f;
@@ -2417,81 +1336,26 @@ SCALAR_FUN_ATTR double futrts_from_bits64(int64_t x);
 SCALAR_FUN_ATTR int64_t futrts_to_bits64(double x);
 
 #if defined(ISPC)
-SCALAR_FUN_ATTR bool futrts_isinf64(float x) {
-  return !isnan(x) && isnan(x - x);
-}
 
-SCALAR_FUN_ATTR bool futrts_isfinite64(float x) {
-  return !isnan(x) && !futrts_isinf64(x);
-}
-
-SCALAR_FUN_ATTR double fdiv64(double x, double y) {
-  return x / y;
-}
-
-SCALAR_FUN_ATTR double fadd64(double x, double y) {
-  return x + y;
-}
-
-SCALAR_FUN_ATTR double fsub64(double x, double y) {
-  return x - y;
-}
-
-SCALAR_FUN_ATTR double fmul64(double x, double y) {
-  return x * y;
-}
-
-SCALAR_FUN_ATTR bool cmplt64(double x, double y) {
-  return x < y;
-}
-
-SCALAR_FUN_ATTR bool cmple64(double x, double y) {
-  return x <= y;
-}
-
-SCALAR_FUN_ATTR double sitofp_i8_f64(int8_t x) {
-  return (double) x;
-}
-
-SCALAR_FUN_ATTR double sitofp_i16_f64(int16_t x) {
-  return (double) x;
-}
-
-SCALAR_FUN_ATTR double sitofp_i32_f64(int32_t x) {
-  return (double) x;
-}
-
-SCALAR_FUN_ATTR double sitofp_i64_f64(int64_t x) {
-  return (double) x;
-}
-
-SCALAR_FUN_ATTR double uitofp_i8_f64(uint8_t x) {
-  return (double) x;
-}
-
-SCALAR_FUN_ATTR double uitofp_i16_f64(uint16_t x) {
-  return (double) x;
-}
-
-SCALAR_FUN_ATTR double uitofp_i32_f64(uint32_t x) {
-  return (double) x;
-}
-
-SCALAR_FUN_ATTR double uitofp_i64_f64(uint64_t x) {
-  return (double) x;
-}
-
-SCALAR_FUN_ATTR double fabs64(double x) {
-  return abs(x);
-}
-
-SCALAR_FUN_ATTR double fmax64(double x, double y) {
-  return isnan(x) ? y : isnan(y) ? x : max(x, y);
-}
-
-SCALAR_FUN_ATTR double fmin64(double x, double y) {
-  return isnan(x) ? y : isnan(y) ? x : min(x, y);
-}
+SCALAR_FUN_ATTR bool futrts_isinf64(float x) { return !isnan(x) && isnan(x - x); }
+SCALAR_FUN_ATTR bool futrts_isfinite64(float x) { return !isnan(x) && !futrts_isinf64(x); }
+SCALAR_FUN_ATTR double fdiv64(double x, double y) { return x / y; }
+SCALAR_FUN_ATTR double fadd64(double x, double y) { return x + y; }
+SCALAR_FUN_ATTR double fsub64(double x, double y) { return x - y; }
+SCALAR_FUN_ATTR double fmul64(double x, double y) { return x * y; }
+SCALAR_FUN_ATTR bool cmplt64(double x, double y) { return x < y; }
+SCALAR_FUN_ATTR bool cmple64(double x, double y) { return x <= y; }
+SCALAR_FUN_ATTR double sitofp_i8_f64(int8_t x) { return (double) x; }
+SCALAR_FUN_ATTR double sitofp_i16_f64(int16_t x) { return (double) x; }
+SCALAR_FUN_ATTR double sitofp_i32_f64(int32_t x) { return (double) x; }
+SCALAR_FUN_ATTR double sitofp_i64_f64(int64_t x) { return (double) x; }
+SCALAR_FUN_ATTR double uitofp_i8_f64(uint8_t x) { return (double) x; }
+SCALAR_FUN_ATTR double uitofp_i16_f64(uint16_t x) { return (double) x; }
+SCALAR_FUN_ATTR double uitofp_i32_f64(uint32_t x) { return (double) x; }
+SCALAR_FUN_ATTR double uitofp_i64_f64(uint64_t x) { return (double) x; }
+SCALAR_FUN_ATTR double fabs64(double x) { return abs(x); }
+SCALAR_FUN_ATTR double fmax64(double x, double y) { return isnan(x) ? y : isnan(y) ? x : max(x, y); }
+SCALAR_FUN_ATTR double fmin64(double x, double y) { return isnan(x) ? y : isnan(y) ? x : min(x, y); }
 
 SCALAR_FUN_ATTR double fpow64(double a, double b) {
   float ret;
@@ -2501,18 +1365,9 @@ SCALAR_FUN_ATTR double fpow64(double a, double b) {
   }
   return ret;
 }
-
-SCALAR_FUN_ATTR double futrts_log64(double x) {
-  return futrts_isfinite64(x) || (futrts_isinf64(x) && x < 0)? log(x) : x;
-}
-
-SCALAR_FUN_ATTR double futrts_log2_64(double x) {
-  return futrts_log64(x)/log(2.0d);
-}
-
-SCALAR_FUN_ATTR double futrts_log10_64(double x) {
-  return futrts_log64(x)/log(10.0d);
-}
+SCALAR_FUN_ATTR double futrts_log64(double x) { return futrts_isfinite64(x) || (futrts_isinf64(x) && x < 0)? log(x) : x; }
+SCALAR_FUN_ATTR double futrts_log2_64(double x) { return futrts_log64(x)/log(2.0d); }
+SCALAR_FUN_ATTR double futrts_log10_64(double x) { return futrts_log64(x)/log(10.0d); }
 
 SCALAR_FUN_ATTR double futrts_log1p_64(double x) {
   if(x == -1.0d || (futrts_isinf64(x) && x > 0.0d)) return x / 0.0d;
@@ -2521,13 +1376,8 @@ SCALAR_FUN_ATTR double futrts_log1p_64(double x) {
   return log(y) - (z-x)/y;
 }
 
-SCALAR_FUN_ATTR double futrts_sqrt64(double x) {
-  return sqrt(x);
-}
-
-SCALAR_FUN_ATTR double futrts_rsqrt64(double x) {
-  return 1/sqrt(x);
-}
+SCALAR_FUN_ATTR double futrts_sqrt64(double x) { return sqrt(x); }
+SCALAR_FUN_ATTR double futrts_rsqrt64(double x) { return 1/sqrt(x); }
 
 extern "C" unmasked uniform double cbrt(uniform double);
 SCALAR_FUN_ATTR double futrts_cbrt64(double x) {
@@ -2538,70 +1388,22 @@ SCALAR_FUN_ATTR double futrts_cbrt64(double x) {
   }
   return res;
 }
-
-SCALAR_FUN_ATTR double futrts_exp64(double x) {
-  return exp(x);
-}
-
-SCALAR_FUN_ATTR double futrts_cos64(double x) {
-  return cos(x);
-}
-
-SCALAR_FUN_ATTR double futrts_cospi64(double x) {
-  return cos(M_PI*x);
-}
-
-SCALAR_FUN_ATTR double futrts_sin64(double x) {
-  return sin(x);
-}
-
-SCALAR_FUN_ATTR double futrts_sinpi64(double x) {
-  return sin(M_PI*x);
-}
-
-SCALAR_FUN_ATTR double futrts_tan64(double x) {
-  return tan(x);
-}
-
-SCALAR_FUN_ATTR double futrts_tanpi64(double x) {
-  return tan(M_PI*x);
-}
-
-SCALAR_FUN_ATTR double futrts_acos64(double x) {
-  return acos(x);
-}
-
-SCALAR_FUN_ATTR double futrts_acospi64(double x) {
-  return acos(x)/M_PI;
-}
-
-SCALAR_FUN_ATTR double futrts_asin64(double x) {
-  return asin(x);
-}
-
-SCALAR_FUN_ATTR double futrts_asinpi64(double x) {
-  return asin(x)/M_PI;
-}
-
-SCALAR_FUN_ATTR double futrts_atan64(double x) {
-  return atan(x);
-}
-
-SCALAR_FUN_ATTR double futrts_atanpi64(double x) {
-  return atan(x)/M_PI;
-}
-
-SCALAR_FUN_ATTR double futrts_cosh64(double x) {
-  return (exp(x)+exp(-x)) / 2.0d;
-}
-
-SCALAR_FUN_ATTR double futrts_sinh64(double x) {
-  return (exp(x)-exp(-x)) / 2.0d;
-}
-
-SCALAR_FUN_ATTR double futrts_tanh64(double x) {
-  return futrts_sinh64(x)/futrts_cosh64(x);
-}
+SCALAR_FUN_ATTR double futrts_exp64(double x) { return exp(x); }
+SCALAR_FUN_ATTR double futrts_cos64(double x) { return cos(x); }
+SCALAR_FUN_ATTR double futrts_cospi64(double x) { return cos(M_PI*x); }
+SCALAR_FUN_ATTR double futrts_sin64(double x) { return sin(x); }
+SCALAR_FUN_ATTR double futrts_sinpi64(double x) { return sin(M_PI*x); }
+SCALAR_FUN_ATTR double futrts_tan64(double x) { return tan(x); }
+SCALAR_FUN_ATTR double futrts_tanpi64(double x) { return tan(M_PI*x); }
+SCALAR_FUN_ATTR double futrts_acos64(double x) { return acos(x); }
+SCALAR_FUN_ATTR double futrts_acospi64(double x) { return acos(x)/M_PI; }
+SCALAR_FUN_ATTR double futrts_asin64(double x) { return asin(x); }
+SCALAR_FUN_ATTR double futrts_asinpi64(double x) { return asin(x)/M_PI; }
+SCALAR_FUN_ATTR double futrts_atan64(double x) { return atan(x); }
+SCALAR_FUN_ATTR double futrts_atanpi64(double x) { return atan(x)/M_PI; }
+SCALAR_FUN_ATTR double futrts_cosh64(double x) { return (exp(x)+exp(-x)) / 2.0d; }
+SCALAR_FUN_ATTR double futrts_sinh64(double x) { return (exp(x)-exp(-x)) / 2.0d; }
+SCALAR_FUN_ATTR double futrts_tanh64(double x) { return futrts_sinh64(x)/futrts_cosh64(x); }
 
 SCALAR_FUN_ATTR double futrts_acosh64(double x) {
   double f = x+sqrt(x*x-1.0d);
@@ -2620,14 +1422,9 @@ SCALAR_FUN_ATTR double futrts_atanh64(double x) {
   if(futrts_isfinite64(f)) return log(f)/2.0d;
   return f;
 }
+SCALAR_FUN_ATTR double futrts_atan2_64(double x, double y) { return atan2(x, y); }
 
-SCALAR_FUN_ATTR double futrts_atan2_64(double x, double y) {
-  return atan2(x, y);
-}
-
-SCALAR_FUN_ATTR double futrts_atan2pi_64(double x, double y) {
-  return atan2(x, y) / M_PI;
-}
+SCALAR_FUN_ATTR double futrts_atan2pi_64(double x, double y) { return atan2(x, y) / M_PI; }
 
 extern "C" unmasked uniform double hypot(uniform double x, uniform double y);
 SCALAR_FUN_ATTR double futrts_hypot64(double x, double y) {
@@ -2679,17 +1476,9 @@ SCALAR_FUN_ATTR double futrts_erfc64(double x) {
   return res;
 }
 
-SCALAR_FUN_ATTR double futrts_fma64(double a, double b, double c) {
-  return a * b + c;
-}
-
-SCALAR_FUN_ATTR double futrts_round64(double x) {
-  return round(x);
-}
-
-SCALAR_FUN_ATTR double futrts_ceil64(double x) {
-  return ceil(x);
-}
+SCALAR_FUN_ATTR double futrts_fma64(double a, double b, double c) { return a * b + c; }
+SCALAR_FUN_ATTR double futrts_round64(double x) { return round(x); }
+SCALAR_FUN_ATTR double futrts_ceil64(double x) { return ceil(x); }
 
 extern "C" unmasked uniform double nextafter(uniform float x, uniform double y);
 SCALAR_FUN_ATTR float futrts_nextafter64(double x, double y) {
@@ -2701,13 +1490,8 @@ SCALAR_FUN_ATTR float futrts_nextafter64(double x, double y) {
   return res;
 }
 
-SCALAR_FUN_ATTR double futrts_floor64(double x) {
-  return floor(x);
-}
-
-SCALAR_FUN_ATTR bool futrts_isnan64(double x) {
-  return isnan(x);
-}
+SCALAR_FUN_ATTR double futrts_floor64(double x) { return floor(x); }
+SCALAR_FUN_ATTR bool futrts_isnan64(double x) { return isnan(x); }
 
 SCALAR_FUN_ATTR int8_t fptosi_f64_i8(double x) {
   if (futrts_isnan64(x) || futrts_isinf64(x)) {
@@ -2773,13 +1557,8 @@ SCALAR_FUN_ATTR uint64_t fptoui_f64_i64(double x) {
   }
 }
 
-SCALAR_FUN_ATTR bool ftob_f64_bool(double x) {
-  return x != 0.0;
-}
-
-SCALAR_FUN_ATTR double btof_bool_f64(bool x) {
-  return x ? 1.0 : 0.0;
-}
+SCALAR_FUN_ATTR bool ftob_f64_bool(double x) { return x != 0.0; }
+SCALAR_FUN_ATTR double btof_bool_f64(bool x) { return x ? 1.0 : 0.0; }
 
 SCALAR_FUN_ATTR int64_t futrts_to_bits64(double x) {
   int64_t res;
@@ -2823,135 +1602,41 @@ SCALAR_FUN_ATTR double futrts_copysign64(double x, double y) {
   return futrts_from_bits64((xb & ~(((int64_t)1)<<63)) | (yb & (((int64_t)1)<<63)));
 }
 
-SCALAR_FUN_ATTR double futrts_mad64(double a, double b, double c) {
-  return a * b + c;
-}
-
-SCALAR_FUN_ATTR float fpconv_f32_f32(float x) {
-  return (float) x;
-}
-
-SCALAR_FUN_ATTR double fpconv_f32_f64(float x) {
-  return (double) x;
-}
-
-SCALAR_FUN_ATTR float fpconv_f64_f32(double x) {
-  return (float) x;
-}
-
-SCALAR_FUN_ATTR double fpconv_f64_f64(double x) {
-  return (double) x;
-}
+SCALAR_FUN_ATTR double futrts_mad64(double a, double b, double c) { return a * b + c; }
+SCALAR_FUN_ATTR float fpconv_f32_f32(float x) { return (float) x; }
+SCALAR_FUN_ATTR double fpconv_f32_f64(float x) { return (double) x; }
+SCALAR_FUN_ATTR float fpconv_f64_f32(double x) { return (float) x; }
+SCALAR_FUN_ATTR double fpconv_f64_f64(double x) { return (double) x; }
 
 #else
 
-SCALAR_FUN_ATTR double fdiv64(double x, double y) {
-  return x / y;
-}
-
-SCALAR_FUN_ATTR double fadd64(double x, double y) {
-  return x + y;
-}
-
-SCALAR_FUN_ATTR double fsub64(double x, double y) {
-  return x - y;
-}
-
-SCALAR_FUN_ATTR double fmul64(double x, double y) {
-  return x * y;
-}
-
-SCALAR_FUN_ATTR bool cmplt64(double x, double y) {
-  return x < y;
-}
-
-SCALAR_FUN_ATTR bool cmple64(double x, double y) {
-  return x <= y;
-}
-
-SCALAR_FUN_ATTR double sitofp_i8_f64(int8_t x) {
-  return (double) x;
-}
-
-SCALAR_FUN_ATTR double sitofp_i16_f64(int16_t x) {
-  return (double) x;
-}
-
-SCALAR_FUN_ATTR double sitofp_i32_f64(int32_t x) {
-  return (double) x;
-}
-
-SCALAR_FUN_ATTR double sitofp_i64_f64(int64_t x) {
-  return (double) x;
-}
-
-SCALAR_FUN_ATTR double uitofp_i8_f64(uint8_t x) {
-  return (double) x;
-}
-
-SCALAR_FUN_ATTR double uitofp_i16_f64(uint16_t x) {
-  return (double) x;
-}
-
-SCALAR_FUN_ATTR double uitofp_i32_f64(uint32_t x) {
-  return (double) x;
-}
-
-SCALAR_FUN_ATTR double uitofp_i64_f64(uint64_t x) {
-  return (double) x;
-}
-
-SCALAR_FUN_ATTR double fabs64(double x) {
-  return fabs(x);
-}
-
-SCALAR_FUN_ATTR double fmax64(double x, double y) {
-  return fmax(x, y);
-}
-
-SCALAR_FUN_ATTR double fmin64(double x, double y) {
-  return fmin(x, y);
-}
-
-SCALAR_FUN_ATTR double fpow64(double x, double y) {
-  return pow(x, y);
-}
-
-SCALAR_FUN_ATTR double futrts_log64(double x) {
-  return log(x);
-}
-
-SCALAR_FUN_ATTR double futrts_log2_64(double x) {
-  return log2(x);
-}
-
-SCALAR_FUN_ATTR double futrts_log10_64(double x) {
-  return log10(x);
-}
-
-SCALAR_FUN_ATTR double futrts_log1p_64(double x) {
-  return log1p(x);
-}
-
-SCALAR_FUN_ATTR double futrts_sqrt64(double x) {
-  return sqrt(x);
-}
-
-SCALAR_FUN_ATTR double futrts_rsqrt64(double x) {
-  return 1/sqrt(x);
-}
-
-SCALAR_FUN_ATTR double futrts_cbrt64(double x) {
-  return cbrt(x);
-}
-
-SCALAR_FUN_ATTR double futrts_exp64(double x) {
-  return exp(x);
-}
-
-SCALAR_FUN_ATTR double futrts_cos64(double x) {
-  return cos(x);
-}
+SCALAR_FUN_ATTR double fdiv64(double x, double y) { return x / y; }
+SCALAR_FUN_ATTR double fadd64(double x, double y) { return x + y; }
+SCALAR_FUN_ATTR double fsub64(double x, double y) { return x - y; }
+SCALAR_FUN_ATTR double fmul64(double x, double y) { return x * y; }
+SCALAR_FUN_ATTR bool cmplt64(double x, double y) { return x < y; }
+SCALAR_FUN_ATTR bool cmple64(double x, double y) { return x <= y; }
+SCALAR_FUN_ATTR double sitofp_i8_f64(int8_t x) { return (double) x; }
+SCALAR_FUN_ATTR double sitofp_i16_f64(int16_t x) { return (double) x; }
+SCALAR_FUN_ATTR double sitofp_i32_f64(int32_t x) { return (double) x; }
+SCALAR_FUN_ATTR double sitofp_i64_f64(int64_t x) { return (double) x; }
+SCALAR_FUN_ATTR double uitofp_i8_f64(uint8_t x) { return (double) x; }
+SCALAR_FUN_ATTR double uitofp_i16_f64(uint16_t x) { return (double) x; }
+SCALAR_FUN_ATTR double uitofp_i32_f64(uint32_t x) { return (double) x; }
+SCALAR_FUN_ATTR double uitofp_i64_f64(uint64_t x) { return (double) x; }
+SCALAR_FUN_ATTR double fabs64(double x) { return fabs(x); }
+SCALAR_FUN_ATTR double fmax64(double x, double y) { return fmax(x, y); }
+SCALAR_FUN_ATTR double fmin64(double x, double y) { return fmin(x, y); }
+SCALAR_FUN_ATTR double fpow64(double x, double y) { return pow(x, y); }
+SCALAR_FUN_ATTR double futrts_log64(double x) { return log(x); }
+SCALAR_FUN_ATTR double futrts_log2_64(double x) { return log2(x); }
+SCALAR_FUN_ATTR double futrts_log10_64(double x) { return log10(x); }
+SCALAR_FUN_ATTR double futrts_log1p_64(double x) { return log1p(x); }
+SCALAR_FUN_ATTR double futrts_sqrt64(double x) { return sqrt(x); }
+SCALAR_FUN_ATTR double futrts_rsqrt64(double x) { return 1/sqrt(x); }
+SCALAR_FUN_ATTR double futrts_cbrt64(double x) { return cbrt(x); }
+SCALAR_FUN_ATTR double futrts_exp64(double x) { return exp(x); }
+SCALAR_FUN_ATTR double futrts_cos64(double x) { return cos(x); }
 
 SCALAR_FUN_ATTR double futrts_cospi64(double x) {
 #ifdef __OPENCL_VERSION__
@@ -3025,33 +1710,13 @@ SCALAR_FUN_ATTR double futrts_atanpi64(double x) {
 #endif
 }
 
-SCALAR_FUN_ATTR double futrts_cosh64(double x) {
-  return cosh(x);
-}
-
-SCALAR_FUN_ATTR double futrts_sinh64(double x) {
-  return sinh(x);
-}
-
-SCALAR_FUN_ATTR double futrts_tanh64(double x) {
-  return tanh(x);
-}
-
-SCALAR_FUN_ATTR double futrts_acosh64(double x) {
-  return acosh(x);
-}
-
-SCALAR_FUN_ATTR double futrts_asinh64(double x) {
-  return asinh(x);
-}
-
-SCALAR_FUN_ATTR double futrts_atanh64(double x) {
-  return atanh(x);
-}
-
-SCALAR_FUN_ATTR double futrts_atan2_64(double x, double y) {
-  return atan2(x, y);
-}
+SCALAR_FUN_ATTR double futrts_cosh64(double x) { return cosh(x); }
+SCALAR_FUN_ATTR double futrts_sinh64(double x) { return sinh(x); }
+SCALAR_FUN_ATTR double futrts_tanh64(double x) { return tanh(x); }
+SCALAR_FUN_ATTR double futrts_acosh64(double x) { return acosh(x); }
+SCALAR_FUN_ATTR double futrts_asinh64(double x) { return asinh(x); }
+SCALAR_FUN_ATTR double futrts_atanh64(double x) { return atanh(x); }
+SCALAR_FUN_ATTR double futrts_atan2_64(double x, double y) { return atan2(x, y); }
 
 SCALAR_FUN_ATTR double futrts_atan2pi_64(double x, double y) {
 #ifdef __OPENCL_VERSION__
@@ -3061,53 +1726,18 @@ SCALAR_FUN_ATTR double futrts_atan2pi_64(double x, double y) {
 #endif
 }
 
-SCALAR_FUN_ATTR double futrts_hypot64(double x, double y) {
-  return hypot(x, y);
-}
-
-SCALAR_FUN_ATTR double futrts_gamma64(double x) {
-  return tgamma(x);
-}
-
-SCALAR_FUN_ATTR double futrts_lgamma64(double x) {
-  return lgamma(x);
-}
-
-SCALAR_FUN_ATTR double futrts_erf64(double x) {
-  return erf(x);
-}
-
-SCALAR_FUN_ATTR double futrts_erfc64(double x) {
-  return erfc(x);
-}
-
-SCALAR_FUN_ATTR double futrts_fma64(double a, double b, double c) {
-  return fma(a, b, c);
-}
-
-SCALAR_FUN_ATTR double futrts_round64(double x) {
-  return rint(x);
-}
-
-SCALAR_FUN_ATTR double futrts_ceil64(double x) {
-  return ceil(x);
-}
-
-SCALAR_FUN_ATTR float futrts_nextafter64(float x, float y) {
-  return nextafter(x, y);
-}
-
-SCALAR_FUN_ATTR double futrts_floor64(double x) {
-  return floor(x);
-}
-
-SCALAR_FUN_ATTR bool futrts_isnan64(double x) {
-  return isnan(x);
-}
-
-SCALAR_FUN_ATTR bool futrts_isinf64(double x) {
-  return isinf(x);
-}
+SCALAR_FUN_ATTR double futrts_hypot64(double x, double y) { return hypot(x, y); }
+SCALAR_FUN_ATTR double futrts_gamma64(double x) { return tgamma(x); }
+SCALAR_FUN_ATTR double futrts_lgamma64(double x) { return lgamma(x); }
+SCALAR_FUN_ATTR double futrts_erf64(double x) { return erf(x); }
+SCALAR_FUN_ATTR double futrts_erfc64(double x) { return erfc(x); }
+SCALAR_FUN_ATTR double futrts_fma64(double a, double b, double c) { return fma(a, b, c); }
+SCALAR_FUN_ATTR double futrts_round64(double x) { return rint(x); }
+SCALAR_FUN_ATTR double futrts_ceil64(double x) { return ceil(x); }
+SCALAR_FUN_ATTR float futrts_nextafter64(float x, float y) { return nextafter(x, y); }
+SCALAR_FUN_ATTR double futrts_floor64(double x) { return floor(x); }
+SCALAR_FUN_ATTR bool futrts_isnan64(double x) { return isnan(x); }
+SCALAR_FUN_ATTR bool futrts_isinf64(double x) { return isinf(x); }
 
 SCALAR_FUN_ATTR int8_t fptosi_f64_i8(double x) {
   if (futrts_isnan64(x) || futrts_isinf64(x)) {
@@ -3173,13 +1803,8 @@ SCALAR_FUN_ATTR uint64_t fptoui_f64_i64(double x) {
   }
 }
 
-SCALAR_FUN_ATTR bool ftob_f64_bool(double x) {
-  return x != 0;
-}
-
-SCALAR_FUN_ATTR double btof_bool_f64(bool x) {
-  return x ? 1 : 0;
-}
+SCALAR_FUN_ATTR bool ftob_f64_bool(double x) { return x != 0; }
+SCALAR_FUN_ATTR double btof_bool_f64(bool x) { return x ? 1 : 0; }
 
 SCALAR_FUN_ATTR int64_t futrts_to_bits64(double x) {
   union {
@@ -3233,21 +1858,10 @@ SCALAR_FUN_ATTR double futrts_mad64(double a, double b, double c) {
 #endif
 }
 
-SCALAR_FUN_ATTR float fpconv_f32_f32(float x) {
-  return (float) x;
-}
-
-SCALAR_FUN_ATTR double fpconv_f32_f64(float x) {
-  return (double) x;
-}
-
-SCALAR_FUN_ATTR float fpconv_f64_f32(double x) {
-  return (float) x;
-}
-
-SCALAR_FUN_ATTR double fpconv_f64_f64(double x) {
-  return (double) x;
-}
+SCALAR_FUN_ATTR float fpconv_f32_f32(float x) { return (float) x; }
+SCALAR_FUN_ATTR double fpconv_f32_f64(float x) { return (double) x; }
+SCALAR_FUN_ATTR float fpconv_f64_f32(double x) { return (float) x; }
+SCALAR_FUN_ATTR double fpconv_f64_f64(double x) { return (double) x; }
 
 #endif
 

--- a/rts/c/scalar_f16.h
+++ b/rts/c/scalar_f16.h
@@ -38,467 +38,156 @@ typedef half f16;
 
 // Some of these functions convert to single precision because half
 // precision versions are not available.
-
-SCALAR_FUN_ATTR f16 fadd16(f16 x, f16 y) {
-  return x + y;
-}
-
-SCALAR_FUN_ATTR f16 fsub16(f16 x, f16 y) {
-  return x - y;
-}
-
-SCALAR_FUN_ATTR f16 fmul16(f16 x, f16 y) {
-  return x * y;
-}
-
-SCALAR_FUN_ATTR bool cmplt16(f16 x, f16 y) {
-  return x < y;
-}
-
-SCALAR_FUN_ATTR bool cmple16(f16 x, f16 y) {
-  return x <= y;
-}
-
-SCALAR_FUN_ATTR f16 sitofp_i8_f16(int8_t x) {
-  return (f16) x;
-}
-
-SCALAR_FUN_ATTR f16 sitofp_i16_f16(int16_t x) {
-  return (f16) x;
-}
-
-SCALAR_FUN_ATTR f16 sitofp_i32_f16(int32_t x) {
-  return (f16) x;
-}
-
-SCALAR_FUN_ATTR f16 sitofp_i64_f16(int64_t x) {
-  return (f16) x;
-}
-
-SCALAR_FUN_ATTR f16 uitofp_i8_f16(uint8_t x) {
-  return (f16) x;
-}
-
-SCALAR_FUN_ATTR f16 uitofp_i16_f16(uint16_t x) {
-  return (f16) x;
-}
-
-SCALAR_FUN_ATTR f16 uitofp_i32_f16(uint32_t x) {
-  return (f16) x;
-}
-
-SCALAR_FUN_ATTR f16 uitofp_i64_f16(uint64_t x) {
-  return (f16) x;
-}
-
-SCALAR_FUN_ATTR int8_t fptosi_f16_i8(f16 x) {
-  return (int8_t) (float) x;
-}
-
-SCALAR_FUN_ATTR int16_t fptosi_f16_i16(f16 x) {
-  return (int16_t) x;
-}
-
-SCALAR_FUN_ATTR int32_t fptosi_f16_i32(f16 x) {
-  return (int32_t) x;
-}
-
-SCALAR_FUN_ATTR int64_t fptosi_f16_i64(f16 x) {
-  return (int64_t) x;
-}
-
-SCALAR_FUN_ATTR uint8_t fptoui_f16_i8(f16 x) {
-  return (uint8_t) (float) x;
-}
-
-SCALAR_FUN_ATTR uint16_t fptoui_f16_i16(f16 x) {
-  return (uint16_t) x;
-}
-
-SCALAR_FUN_ATTR uint32_t fptoui_f16_i32(f16 x) {
-  return (uint32_t) x;
-}
-
-SCALAR_FUN_ATTR uint64_t fptoui_f16_i64(f16 x) {
-  return (uint64_t) x;
-}
-
-SCALAR_FUN_ATTR bool ftob_f16_bool(f16 x) {
-  return x != (f16)0;
-}
-
-SCALAR_FUN_ATTR f16 btof_bool_f16(bool x) {
-  return x ? 1 : 0;
-}
+SCALAR_FUN_ATTR f16 fadd16(f16 x, f16 y) { return x + y; }
+SCALAR_FUN_ATTR f16 fsub16(f16 x, f16 y) { return x - y; }
+SCALAR_FUN_ATTR f16 fmul16(f16 x, f16 y) { return x * y; }
+SCALAR_FUN_ATTR bool cmplt16(f16 x, f16 y) { return x < y; }
+SCALAR_FUN_ATTR bool cmple16(f16 x, f16 y) { return x <= y; }
+SCALAR_FUN_ATTR f16 sitofp_i8_f16(int8_t x) { return (f16) x; }
+SCALAR_FUN_ATTR f16 sitofp_i16_f16(int16_t x) { return (f16) x; }
+SCALAR_FUN_ATTR f16 sitofp_i32_f16(int32_t x) { return (f16) x; }
+SCALAR_FUN_ATTR f16 sitofp_i64_f16(int64_t x) { return (f16) x; }
+SCALAR_FUN_ATTR f16 uitofp_i8_f16(uint8_t x) { return (f16) x; }
+SCALAR_FUN_ATTR f16 uitofp_i16_f16(uint16_t x) { return (f16) x; }
+SCALAR_FUN_ATTR f16 uitofp_i32_f16(uint32_t x) { return (f16) x; }
+SCALAR_FUN_ATTR f16 uitofp_i64_f16(uint64_t x) { return (f16) x; }
+SCALAR_FUN_ATTR int8_t fptosi_f16_i8(f16 x) { return (int8_t) (float) x; }
+SCALAR_FUN_ATTR int16_t fptosi_f16_i16(f16 x) { return (int16_t) x; }
+SCALAR_FUN_ATTR int32_t fptosi_f16_i32(f16 x) { return (int32_t) x; }
+SCALAR_FUN_ATTR int64_t fptosi_f16_i64(f16 x) { return (int64_t) x; }
+SCALAR_FUN_ATTR uint8_t fptoui_f16_i8(f16 x) { return (uint8_t) (float) x; }
+SCALAR_FUN_ATTR uint16_t fptoui_f16_i16(f16 x) { return (uint16_t) x; }
+SCALAR_FUN_ATTR uint32_t fptoui_f16_i32(f16 x) { return (uint32_t) x; }
+SCALAR_FUN_ATTR uint64_t fptoui_f16_i64(f16 x) { return (uint64_t) x; }
+SCALAR_FUN_ATTR bool ftob_f16_bool(f16 x) { return x != (f16)0; }
+SCALAR_FUN_ATTR f16 btof_bool_f16(bool x) { return x ? 1 : 0; }
 
 #ifndef EMULATE_F16
-SCALAR_FUN_ATTR bool futrts_isnan16(f16 x) {
-  return isnan((float)x);
-}
+
+SCALAR_FUN_ATTR bool futrts_isnan16(f16 x) { return isnan((float)x); }
 
 #ifdef __OPENCL_VERSION__
 
-SCALAR_FUN_ATTR f16 fabs16(f16 x) {
-  return fabs(x);
-}
-
-SCALAR_FUN_ATTR f16 fmax16(f16 x, f16 y) {
-  return fmax(x, y);
-}
-
-SCALAR_FUN_ATTR f16 fmin16(f16 x, f16 y) {
-  return fmin(x, y);
-}
-
-SCALAR_FUN_ATTR f16 fpow16(f16 x, f16 y) {
-  return pow(x, y);
-}
+SCALAR_FUN_ATTR f16 fabs16(f16 x) { return fabs(x); }
+SCALAR_FUN_ATTR f16 fmax16(f16 x, f16 y) { return fmax(x, y); }
+SCALAR_FUN_ATTR f16 fmin16(f16 x, f16 y) { return fmin(x, y); }
+SCALAR_FUN_ATTR f16 fpow16(f16 x, f16 y) { return pow(x, y); }
 
 #elif defined(ISPC)
-SCALAR_FUN_ATTR f16 fabs16(f16 x) {
-  return abs(x);
-}
 
-SCALAR_FUN_ATTR f16 fmax16(f16 x, f16 y) {
-  return futrts_isnan16(x) ? y : futrts_isnan16(y) ? x : max(x, y);
-}
-
-SCALAR_FUN_ATTR f16 fmin16(f16 x, f16 y) {
-  return futrts_isnan16(x) ? y : futrts_isnan16(y) ? x : min(x, y);
-}
-
-SCALAR_FUN_ATTR f16 fpow16(f16 x, f16 y) {
-  return pow(x, y);
-}
+SCALAR_FUN_ATTR f16 fabs16(f16 x) { return abs(x); }
+SCALAR_FUN_ATTR f16 fmax16(f16 x, f16 y) { return futrts_isnan16(x) ? y : futrts_isnan16(y) ? x : max(x, y); }
+SCALAR_FUN_ATTR f16 fmin16(f16 x, f16 y) { return futrts_isnan16(x) ? y : futrts_isnan16(y) ? x : min(x, y); }
+SCALAR_FUN_ATTR f16 fpow16(f16 x, f16 y) { return pow(x, y); }
 
 #else // Assuming CUDA.
 
-SCALAR_FUN_ATTR f16 fabs16(f16 x) {
-  return fabsf(x);
-}
+SCALAR_FUN_ATTR f16 fabs16(f16 x) { return fabsf(x); }
+SCALAR_FUN_ATTR f16 fmax16(f16 x, f16 y) { return fmaxf(x, y); }
+SCALAR_FUN_ATTR f16 fmin16(f16 x, f16 y) { return fminf(x, y); }
+SCALAR_FUN_ATTR f16 fpow16(f16 x, f16 y) { return powf(x, y); }
 
-SCALAR_FUN_ATTR f16 fmax16(f16 x, f16 y) {
-  return fmaxf(x, y);
-}
-
-SCALAR_FUN_ATTR f16 fmin16(f16 x, f16 y) {
-  return fminf(x, y);
-}
-
-SCALAR_FUN_ATTR f16 fpow16(f16 x, f16 y) {
-  return powf(x, y);
-}
 #endif
 
 #if defined(ISPC)
-SCALAR_FUN_ATTR bool futrts_isinf16(float x) {
-  return !futrts_isnan16(x) && futrts_isnan16(x - x);
-}
-SCALAR_FUN_ATTR bool futrts_isfinite16(float x) {
-  return !futrts_isnan16(x) && !futrts_isinf16(x);
-}
-
+SCALAR_FUN_ATTR bool futrts_isinf16(float x) { return !futrts_isnan16(x) && futrts_isnan16(x - x); }
+SCALAR_FUN_ATTR bool futrts_isfinite16(float x) { return !futrts_isnan16(x) && !futrts_isinf16(x); }
 #else
-
-SCALAR_FUN_ATTR bool futrts_isinf16(f16 x) {
-  return isinf((float)x);
-}
+SCALAR_FUN_ATTR bool futrts_isinf16(f16 x) { return isinf((float)x); }
 #endif
 
 #ifdef __OPENCL_VERSION__
-SCALAR_FUN_ATTR f16 futrts_log16(f16 x) {
-  return log(x);
-}
+SCALAR_FUN_ATTR f16 futrts_log16(f16 x) { return log(x); }
+SCALAR_FUN_ATTR f16 futrts_log2_16(f16 x) { return log2(x); }
+SCALAR_FUN_ATTR f16 futrts_log10_16(f16 x) { return log10(x); }
+SCALAR_FUN_ATTR f16 futrts_log1p_16(f16 x) { return log1p(x); }
+SCALAR_FUN_ATTR f16 futrts_sqrt16(f16 x) { return sqrt(x); }
+SCALAR_FUN_ATTR f16 futrts_rsqrt16(f16 x) { return rsqrt(x); }
+SCALAR_FUN_ATTR f16 futrts_cbrt16(f16 x) { return cbrt(x); }
+SCALAR_FUN_ATTR f16 futrts_exp16(f16 x) { return exp(x); }
+SCALAR_FUN_ATTR f16 futrts_cos16(f16 x) { return cos(x); }
+SCALAR_FUN_ATTR f16 futrts_cospi16(f16 x) { return cospi(x); }
+SCALAR_FUN_ATTR f16 futrts_sin16(f16 x) { return sin(x); }
+SCALAR_FUN_ATTR f16 futrts_sinpi16(f16 x) { return sinpi(x); }
+SCALAR_FUN_ATTR f16 futrts_tan16(f16 x) { return tan(x); }
+SCALAR_FUN_ATTR f16 futrts_tanpi16(f16 x) { return tanpi(x); }
+SCALAR_FUN_ATTR f16 futrts_acos16(f16 x) { return acos(x); }
+SCALAR_FUN_ATTR f16 futrts_acospi16(f16 x) { return acospi(x); }
+SCALAR_FUN_ATTR f16 futrts_asin16(f16 x) { return asin(x); }
+SCALAR_FUN_ATTR f16 futrts_asinpi16(f16 x) { return asinpi(x); }
+SCALAR_FUN_ATTR f16 futrts_atan16(f16 x) { return atan(x); }
+SCALAR_FUN_ATTR f16 futrts_atanpi16(f16 x) { return atanpi(x); }
+SCALAR_FUN_ATTR f16 futrts_cosh16(f16 x) { return cosh(x); }
+SCALAR_FUN_ATTR f16 futrts_sinh16(f16 x) { return sinh(x); }
+SCALAR_FUN_ATTR f16 futrts_tanh16(f16 x) { return tanh(x); }
+SCALAR_FUN_ATTR f16 futrts_acosh16(f16 x) { return acosh(x); }
+SCALAR_FUN_ATTR f16 futrts_asinh16(f16 x) { return asinh(x); }
+SCALAR_FUN_ATTR f16 futrts_atanh16(f16 x) { return atanh(x); }
+SCALAR_FUN_ATTR f16 futrts_atan2_16(f16 x, f16 y) { return atan2(x, y); }
+SCALAR_FUN_ATTR f16 futrts_atan2pi_16(f16 x, f16 y) { return atan2pi(x, y); }
+SCALAR_FUN_ATTR f16 futrts_hypot16(f16 x, f16 y) { return hypot(x, y); }
+SCALAR_FUN_ATTR f16 futrts_gamma16(f16 x) { return tgamma(x); }
+SCALAR_FUN_ATTR f16 futrts_lgamma16(f16 x) { return lgamma(x); }
+SCALAR_FUN_ATTR f16 futrts_erf16(f16 x) { return erf(x); }
+SCALAR_FUN_ATTR f16 futrts_erfc16(f16 x) { return erfc(x); }
+SCALAR_FUN_ATTR f16 fmod16(f16 x, f16 y) { return fmod(x, y); }
+SCALAR_FUN_ATTR f16 futrts_round16(f16 x) { return rint(x); }
+SCALAR_FUN_ATTR f16 futrts_floor16(f16 x) { return floor(x); }
+SCALAR_FUN_ATTR f16 futrts_ceil16(f16 x) { return ceil(x); }
+SCALAR_FUN_ATTR f16 futrts_nextafter16(f16 x, f16 y) { return nextafter(x, y); }
+SCALAR_FUN_ATTR f16 futrts_lerp16(f16 v0, f16 v1, f16 t) { return mix(v0, v1, t); }
+SCALAR_FUN_ATTR f16 futrts_ldexp16(f16 x, int32_t y) { return ldexp(x, y); }
+SCALAR_FUN_ATTR f16 futrts_copysign16(f16 x, f16 y) { return copysign(x, y); }
+SCALAR_FUN_ATTR f16 futrts_mad16(f16 a, f16 b, f16 c) { return mad(a, b, c); }
+SCALAR_FUN_ATTR f16 futrts_fma16(f16 a, f16 b, f16 c) { return fma(a, b, c); }
 
-SCALAR_FUN_ATTR f16 futrts_log2_16(f16 x) {
-  return log2(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_log10_16(f16 x) {
-  return log10(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_log1p_16(f16 x) {
-  return log1p(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_sqrt16(f16 x) {
-  return sqrt(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_rsqrt16(f16 x) {
-  return rsqrt(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_cbrt16(f16 x) {
-  return cbrt(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_exp16(f16 x) {
-  return exp(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_cos16(f16 x) {
-  return cos(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_cospi16(f16 x) {
-  return cospi(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_sin16(f16 x) {
-  return sin(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_sinpi16(f16 x) {
-  return sinpi(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_tan16(f16 x) {
-  return tan(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_tanpi16(f16 x) {
-  return tanpi(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_acos16(f16 x) {
-  return acos(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_acospi16(f16 x) {
-  return acospi(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_asin16(f16 x) {
-  return asin(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_asinpi16(f16 x) {
-  return asinpi(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_atan16(f16 x) {
-  return atan(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_atanpi16(f16 x) {
-  return atanpi(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_cosh16(f16 x) {
-  return cosh(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_sinh16(f16 x) {
-  return sinh(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_tanh16(f16 x) {
-  return tanh(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_acosh16(f16 x) {
-  return acosh(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_asinh16(f16 x) {
-  return asinh(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_atanh16(f16 x) {
-  return atanh(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_atan2_16(f16 x, f16 y) {
-  return atan2(x, y);
-}
-
-SCALAR_FUN_ATTR f16 futrts_atan2pi_16(f16 x, f16 y) {
-  return atan2pi(x, y);
-}
-
-SCALAR_FUN_ATTR f16 futrts_hypot16(f16 x, f16 y) {
-  return hypot(x, y);
-}
-
-SCALAR_FUN_ATTR f16 futrts_gamma16(f16 x) {
-  return tgamma(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_lgamma16(f16 x) {
-  return lgamma(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_erf16(f16 x) {
-  return erf(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_erfc16(f16 x) {
-  return erfc(x);
-}
-
-SCALAR_FUN_ATTR f16 fmod16(f16 x, f16 y) {
-  return fmod(x, y);
-}
-
-SCALAR_FUN_ATTR f16 futrts_round16(f16 x) {
-  return rint(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_floor16(f16 x) {
-  return floor(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_ceil16(f16 x) {
-  return ceil(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_nextafter16(f16 x, f16 y) {
-  return nextafter(x, y);
-}
-
-SCALAR_FUN_ATTR f16 futrts_lerp16(f16 v0, f16 v1, f16 t) {
-  return mix(v0, v1, t);
-}
-
-SCALAR_FUN_ATTR f16 futrts_ldexp16(f16 x, int32_t y) {
-  return ldexp(x, y);
-}
-
-SCALAR_FUN_ATTR f16 futrts_copysign16(f16 x, f16 y) {
-  return copysign(x, y);
-}
-
-SCALAR_FUN_ATTR f16 futrts_mad16(f16 a, f16 b, f16 c) {
-  return mad(a, b, c);
-}
-
-SCALAR_FUN_ATTR f16 futrts_fma16(f16 a, f16 b, f16 c) {
-  return fma(a, b, c);
-}
 #elif defined(ISPC)
 
-SCALAR_FUN_ATTR f16 futrts_log16(f16 x) {
-  return futrts_isfinite16(x) || (futrts_isinf16(x) && x < 0) ? log(x) : x;
-}
-
-SCALAR_FUN_ATTR f16 futrts_log2_16(f16 x) {
-  return futrts_log16(x) / log(2.0f16);
-}
-
-SCALAR_FUN_ATTR f16 futrts_log10_16(f16 x) {
-  return futrts_log16(x) / log(10.0f16);
-}
-
+SCALAR_FUN_ATTR f16 futrts_log16(f16 x) { return futrts_isfinite16(x) || (futrts_isinf16(x) && x < 0) ? log(x) : x; }
+SCALAR_FUN_ATTR f16 futrts_log2_16(f16 x) { return futrts_log16(x) / log(2.0f16); }
+SCALAR_FUN_ATTR f16 futrts_log10_16(f16 x) { return futrts_log16(x) / log(10.0f16); }
 SCALAR_FUN_ATTR f16 futrts_log1p_16(f16 x) {
   if(x == -1.0f16 || (futrts_isinf16(x) && x > 0.0f16)) return x / 0.0f16;
   f16 y = 1.0f16 + x;
   f16 z = y - 1.0f16;
   return log(y) - (z-x)/y;
 }
-
-SCALAR_FUN_ATTR f16 futrts_sqrt16(f16 x) {
-  return (float16)sqrt((float)x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_rsqrt16(f16 x) {
-  return (float16)1/sqrt((float)x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_exp16(f16 x) {
-  return exp(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_cos16(f16 x) {
-  return (float16)cos((float)x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_cospi16(f16 x) {
-  return (float16)cos((float)M_PI*(float)x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_sin16(f16 x) {
-  return (float16)sin((float)x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_sinpi16(f16 x) {
-  return (float16)sin((float)M_PI*(float)x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_tan16(f16 x) {
-  return (float16)tan((float)x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_tanpi16(f16 x) {
-  return (float16)(tan((float)M_PI*(float)x));
-}
-
-SCALAR_FUN_ATTR f16 futrts_acos16(f16 x) {
-  return (float16)acos((float)x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_acospi16(f16 x) {
-  return (float16)(acos((float)x)/(float)M_PI);
-}
-
-SCALAR_FUN_ATTR f16 futrts_asin16(f16 x) {
-  return (float16)asin((float)x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_asinpi16(f16 x) {
-  return (float16)(asin((float)x)/(float)M_PI);
-}
-
-SCALAR_FUN_ATTR f16 futrts_atan16(f16 x) {
-  return (float16)atan((float)x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_atanpi16(f16 x) {
-  return (float16)(atan((float)x)/(float)M_PI);
-}
-
-SCALAR_FUN_ATTR f16 futrts_cosh16(f16 x) {
-  return (exp(x)+exp(-x)) / 2.0f16;
-}
-
-SCALAR_FUN_ATTR f16 futrts_sinh16(f16 x) {
-  return (exp(x)-exp(-x)) / 2.0f16;
-}
-
-SCALAR_FUN_ATTR f16 futrts_tanh16(f16 x) {
-  return futrts_sinh16(x)/futrts_cosh16(x);
-}
-
+SCALAR_FUN_ATTR f16 futrts_sqrt16(f16 x) { return (float16)sqrt((float)x); }
+SCALAR_FUN_ATTR f16 futrts_rsqrt16(f16 x) { return (float16)1/sqrt((float)x); }
+SCALAR_FUN_ATTR f16 futrts_exp16(f16 x) { return exp(x); }
+SCALAR_FUN_ATTR f16 futrts_cos16(f16 x) { return (float16)cos((float)x); }
+SCALAR_FUN_ATTR f16 futrts_cospi16(f16 x) { return (float16)cos((float)M_PI*(float)x); }
+SCALAR_FUN_ATTR f16 futrts_sin16(f16 x) { return (float16)sin((float)x); }
+SCALAR_FUN_ATTR f16 futrts_sinpi16(f16 x) { return (float16)sin((float)M_PI*(float)x); }
+SCALAR_FUN_ATTR f16 futrts_tan16(f16 x) { return (float16)tan((float)x); }
+SCALAR_FUN_ATTR f16 futrts_tanpi16(f16 x) { return (float16)(tan((float)M_PI*(float)x)); }
+SCALAR_FUN_ATTR f16 futrts_acos16(f16 x) { return (float16)acos((float)x); }
+SCALAR_FUN_ATTR f16 futrts_acospi16(f16 x) { return (float16)(acos((float)x)/(float)M_PI); }
+SCALAR_FUN_ATTR f16 futrts_asin16(f16 x) { return (float16)asin((float)x); }
+SCALAR_FUN_ATTR f16 futrts_asinpi16(f16 x) { return (float16)(asin((float)x)/(float)M_PI); }
+SCALAR_FUN_ATTR f16 futrts_atan16(f16 x) { return (float16)atan((float)x); }
+SCALAR_FUN_ATTR f16 futrts_atanpi16(f16 x) { return (float16)(atan((float)x)/(float)M_PI); }
+SCALAR_FUN_ATTR f16 futrts_cosh16(f16 x) { return (exp(x)+exp(-x)) / 2.0f16; }
+SCALAR_FUN_ATTR f16 futrts_sinh16(f16 x) { return (exp(x)-exp(-x)) / 2.0f16; }
+SCALAR_FUN_ATTR f16 futrts_tanh16(f16 x) { return futrts_sinh16(x)/futrts_cosh16(x); }
 SCALAR_FUN_ATTR f16 futrts_acosh16(f16 x) {
   float16 f = x+(float16)sqrt((float)(x*x-1));
   if(futrts_isfinite16(f)) return log(f);
   return f;
 }
-
 SCALAR_FUN_ATTR f16 futrts_asinh16(f16 x) {
   float16 f = x+(float16)sqrt((float)(x*x+1));
   if(futrts_isfinite16(f)) return log(f);
   return f;
 }
-
 SCALAR_FUN_ATTR f16 futrts_atanh16(f16 x) {
   float16 f = (1+x)/(1-x);
   if(futrts_isfinite16(f)) return log(f)/2.0f16;
   return f;
 }
-
-SCALAR_FUN_ATTR f16 futrts_atan2_16(f16 x, f16 y) {
-  return (float16)atan2((float)x, (float)y);
-}
-
-SCALAR_FUN_ATTR f16 futrts_atan2pi_16(f16 x, f16 y) {
-  return (float16)(atan2((float)x, (float)y)/(float)M_PI);
-}
-
-SCALAR_FUN_ATTR f16 futrts_hypot16(f16 x, f16 y) {
-  return (float16)futrts_hypot32((float)x, (float)y);
-}
+SCALAR_FUN_ATTR f16 futrts_atan2_16(f16 x, f16 y) { return (float16)atan2((float)x, (float)y); }
+SCALAR_FUN_ATTR f16 futrts_atan2pi_16(f16 x, f16 y) { return (float16)(atan2((float)x, (float)y)/(float)M_PI); }
+SCALAR_FUN_ATTR f16 futrts_hypot16(f16 x, f16 y) { return (float16)futrts_hypot32((float)x, (float)y); }
 
 extern "C" unmasked uniform float tgammaf(uniform float x);
 SCALAR_FUN_ATTR f16 futrts_gamma16(f16 x) {
@@ -519,258 +208,77 @@ SCALAR_FUN_ATTR f16 futrts_lgamma16(f16 x) {
   }
   return res;
 }
-
-SCALAR_FUN_ATTR f16 futrts_cbrt16(f16 x) {
-  f16 res = (f16)futrts_cbrt32((float)x);
-  return res;
-}
-
-SCALAR_FUN_ATTR f16 futrts_erf16(f16 x) {
-  f16 res = (f16)futrts_erf32((float)x);
-  return res;
-}
-
-SCALAR_FUN_ATTR f16 futrts_erfc16(f16 x) {
-  f16 res = (f16)futrts_erfc32((float)x);
-  return res;
-}
-
-SCALAR_FUN_ATTR f16 fmod16(f16 x, f16 y) {
-  return x - y * (float16)trunc((float) (x/y));
-}
-
-SCALAR_FUN_ATTR f16 futrts_round16(f16 x) {
-  return (float16)round((float)x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_floor16(f16 x) {
-  return (float16)floor((float)x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_ceil16(f16 x) {
-  return (float16)ceil((float)x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_nextafter16(f16 x, f16 y) {
-  return (float16)futrts_nextafter32((float)x, (float) y);
-}
-
-SCALAR_FUN_ATTR f16 futrts_lerp16(f16 v0, f16 v1, f16 t) {
-  return v0 + (v1 - v0) * t;
-}
-
-SCALAR_FUN_ATTR f16 futrts_ldexp16(f16 x, int32_t y) {
-  return futrts_ldexp32((float)x, y);
-}
-
-SCALAR_FUN_ATTR f16 futrts_copysign16(f16 x, f16 y) {
-  return futrts_copysign32((float)x, y);
-}
-
-SCALAR_FUN_ATTR f16 futrts_mad16(f16 a, f16 b, f16 c) {
-  return a * b + c;
-}
-
-SCALAR_FUN_ATTR f16 futrts_fma16(f16 a, f16 b, f16 c) {
-  return a * b + c;
-}
+SCALAR_FUN_ATTR f16 futrts_cbrt16(f16 x) { return (f16)futrts_cbrt32((float)x); }
+SCALAR_FUN_ATTR f16 futrts_erf16(f16 x) { return (f16)futrts_erf32((float)x); }
+SCALAR_FUN_ATTR f16 futrts_erfc16(f16 x) { return (f16)futrts_erfc32((float)x); }
+SCALAR_FUN_ATTR f16 fmod16(f16 x, f16 y) { return x - y * (float16)trunc((float) (x/y)); }
+SCALAR_FUN_ATTR f16 futrts_round16(f16 x) { return (float16)round((float)x); }
+SCALAR_FUN_ATTR f16 futrts_floor16(f16 x) { return (float16)floor((float)x); }
+SCALAR_FUN_ATTR f16 futrts_ceil16(f16 x) { return (float16)ceil((float)x); }
+SCALAR_FUN_ATTR f16 futrts_nextafter16(f16 x, f16 y) { return (float16)futrts_nextafter32((float)x, (float) y); }
+SCALAR_FUN_ATTR f16 futrts_lerp16(f16 v0, f16 v1, f16 t) { return v0 + (v1 - v0) * t; }
+SCALAR_FUN_ATTR f16 futrts_ldexp16(f16 x, int32_t y) { return futrts_ldexp32((float)x, y); }
+SCALAR_FUN_ATTR f16 futrts_copysign16(f16 x, f16 y) { return futrts_copysign32((float)x, y); }
+SCALAR_FUN_ATTR f16 futrts_mad16(f16 a, f16 b, f16 c) { return a * b + c; }
+SCALAR_FUN_ATTR f16 futrts_fma16(f16 a, f16 b, f16 c) { return a * b + c; }
 
 #else // Assume CUDA.
 
-SCALAR_FUN_ATTR f16 futrts_log16(f16 x) {
-  return hlog(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_log2_16(f16 x) {
-  return hlog2(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_log10_16(f16 x) {
-  return hlog10(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_log1p_16(f16 x) {
-  return (f16)log1pf((float)x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_sqrt16(f16 x) {
-  return hsqrt(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_rsqrt16(f16 x) {
-  return hrsqrt(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_cbrt16(f16 x) {
-  return cbrtf(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_exp16(f16 x) {
-  return hexp(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_cos16(f16 x) {
-  return hcos(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_cospi16(f16 x) {
-  return hcos((f16)M_PI*x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_sin16(f16 x) {
-  return hsin(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_sinpi16(f16 x) {
-  return hsin((f16)M_PI*x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_tan16(f16 x) {
-  return tanf(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_tanpi16(f16 x) {
-  return tanf((f16)M_PI*x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_acos16(f16 x) {
-  return acosf(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_acospi16(f16 x) {
-  return (f16)acosf(x)/(f16)M_PI;
-}
-
-SCALAR_FUN_ATTR f16 futrts_asin16(f16 x) {
-  return asinf(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_asinpi16(f16 x) {
-  return (f16)asinf(x)/(f16)M_PI;
-}
-
-SCALAR_FUN_ATTR f16 futrts_atan16(f16 x) {
-  return (f16)atanf(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_atanpi16(f16 x) {
-  return (f16)atanf(x)/(f16)M_PI;
-}
-
-SCALAR_FUN_ATTR f16 futrts_cosh16(f16 x) {
-  return coshf(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_sinh16(f16 x) {
-  return sinhf(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_tanh16(f16 x) {
-  return tanhf(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_acosh16(f16 x) {
-  return acoshf(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_asinh16(f16 x) {
-  return asinhf(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_atanh16(f16 x) {
-  return atanhf(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_atan2_16(f16 x, f16 y) {
-  return (f16)atan2f(x, y);
-}
-
-SCALAR_FUN_ATTR f16 futrts_atan2pi_16(f16 x, f16 y) {
-  return (f16)atan2f(x, y)/(f16)M_PI;
-}
-
-SCALAR_FUN_ATTR f16 futrts_hypot16(f16 x, f16 y) {
-  return hypotf(x, y);
-}
-
-SCALAR_FUN_ATTR f16 futrts_gamma16(f16 x) {
-  return tgammaf(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_lgamma16(f16 x) {
-  return lgammaf(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_erf16(f16 x) {
-  return erff(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_erfc16(f16 x) {
-  return erfcf(x);
-}
-
-SCALAR_FUN_ATTR f16 fmod16(f16 x, f16 y) {
-  return fmodf(x, y);
-}
-
-SCALAR_FUN_ATTR f16 futrts_round16(f16 x) {
-  return rintf(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_floor16(f16 x) {
-  return hfloor(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_ceil16(f16 x) {
-  return hceil(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_nextafter16(f16 x, f16 y) {
-  return __ushort_as_half(halfbitsnextafter(__half_as_ushort(x), __half_as_ushort(y)));
-}
-
-SCALAR_FUN_ATTR f16 futrts_lerp16(f16 v0, f16 v1, f16 t) {
-  return v0 + (v1 - v0) * t;
-}
-
-SCALAR_FUN_ATTR f16 futrts_ldexp16(f16 x, int32_t y) {
-  return futrts_ldexp32((float)x, y);
-}
-
-SCALAR_FUN_ATTR f16 futrts_copysign16(f16 x, f16 y) {
-  return futrts_copysign32((float)x, y);
-}
-
-SCALAR_FUN_ATTR f16 futrts_mad16(f16 a, f16 b, f16 c) {
-  return a * b + c;
-}
-
-SCALAR_FUN_ATTR f16 futrts_fma16(f16 a, f16 b, f16 c) {
-  return fmaf(a, b, c);
-}
+SCALAR_FUN_ATTR f16 futrts_log16(f16 x) { return hlog(x); }
+SCALAR_FUN_ATTR f16 futrts_log2_16(f16 x) { return hlog2(x); }
+SCALAR_FUN_ATTR f16 futrts_log10_16(f16 x) { return hlog10(x); }
+SCALAR_FUN_ATTR f16 futrts_log1p_16(f16 x) { return (f16)log1pf((float)x); }
+SCALAR_FUN_ATTR f16 futrts_sqrt16(f16 x) { return hsqrt(x); }
+SCALAR_FUN_ATTR f16 futrts_rsqrt16(f16 x) { return hrsqrt(x); }
+SCALAR_FUN_ATTR f16 futrts_cbrt16(f16 x) { return cbrtf(x); }
+SCALAR_FUN_ATTR f16 futrts_exp16(f16 x) { return hexp(x); }
+SCALAR_FUN_ATTR f16 futrts_cos16(f16 x) { return hcos(x); }
+SCALAR_FUN_ATTR f16 futrts_cospi16(f16 x) { return hcos((f16)M_PI*x); }
+SCALAR_FUN_ATTR f16 futrts_sin16(f16 x) { return hsin(x); }
+SCALAR_FUN_ATTR f16 futrts_sinpi16(f16 x) { return hsin((f16)M_PI*x); }
+SCALAR_FUN_ATTR f16 futrts_tan16(f16 x) { return tanf(x); }
+SCALAR_FUN_ATTR f16 futrts_tanpi16(f16 x) { return tanf((f16)M_PI*x); }
+SCALAR_FUN_ATTR f16 futrts_acos16(f16 x) { return acosf(x); }
+SCALAR_FUN_ATTR f16 futrts_acospi16(f16 x) { return (f16)acosf(x)/(f16)M_PI; }
+SCALAR_FUN_ATTR f16 futrts_asin16(f16 x) { return asinf(x); }
+SCALAR_FUN_ATTR f16 futrts_asinpi16(f16 x) { return (f16)asinf(x)/(f16)M_PI; }
+SCALAR_FUN_ATTR f16 futrts_atan16(f16 x) { return (f16)atanf(x); }
+SCALAR_FUN_ATTR f16 futrts_atanpi16(f16 x) { return (f16)atanf(x)/(f16)M_PI; }
+SCALAR_FUN_ATTR f16 futrts_cosh16(f16 x) { return coshf(x); }
+SCALAR_FUN_ATTR f16 futrts_sinh16(f16 x) { return sinhf(x); }
+SCALAR_FUN_ATTR f16 futrts_tanh16(f16 x) { return tanhf(x); }
+SCALAR_FUN_ATTR f16 futrts_acosh16(f16 x) { return acoshf(x); }
+SCALAR_FUN_ATTR f16 futrts_asinh16(f16 x) { return asinhf(x); }
+SCALAR_FUN_ATTR f16 futrts_atanh16(f16 x) { return atanhf(x); }
+SCALAR_FUN_ATTR f16 futrts_atan2_16(f16 x, f16 y) { return (f16)atan2f(x, y); }
+SCALAR_FUN_ATTR f16 futrts_atan2pi_16(f16 x, f16 y) { return (f16)atan2f(x, y)/(f16)M_PI; }
+SCALAR_FUN_ATTR f16 futrts_hypot16(f16 x, f16 y) { return hypotf(x, y); }
+SCALAR_FUN_ATTR f16 futrts_gamma16(f16 x) { return tgammaf(x); }
+SCALAR_FUN_ATTR f16 futrts_lgamma16(f16 x) { return lgammaf(x); }
+SCALAR_FUN_ATTR f16 futrts_erf16(f16 x) { return erff(x); }
+SCALAR_FUN_ATTR f16 futrts_erfc16(f16 x) { return erfcf(x); }
+SCALAR_FUN_ATTR f16 fmod16(f16 x, f16 y) { return fmodf(x, y); }
+SCALAR_FUN_ATTR f16 futrts_round16(f16 x) { return rintf(x); }
+SCALAR_FUN_ATTR f16 futrts_floor16(f16 x) { return hfloor(x); }
+SCALAR_FUN_ATTR f16 futrts_ceil16(f16 x) { return hceil(x); }
+SCALAR_FUN_ATTR f16 futrts_nextafter16(f16 x, f16 y) { return __ushort_as_half(halfbitsnextafter(__half_as_ushort(x), __half_as_ushort(y))); }
+SCALAR_FUN_ATTR f16 futrts_lerp16(f16 v0, f16 v1, f16 t) { return v0 + (v1 - v0) * t; }
+SCALAR_FUN_ATTR f16 futrts_ldexp16(f16 x, int32_t y) { return futrts_ldexp32((float)x, y); }
+SCALAR_FUN_ATTR f16 futrts_copysign16(f16 x, f16 y) { return futrts_copysign32((float)x, y); }
+SCALAR_FUN_ATTR f16 futrts_mad16(f16 a, f16 b, f16 c) { return a * b + c; }
+SCALAR_FUN_ATTR f16 futrts_fma16(f16 a, f16 b, f16 c) { return fmaf(a, b, c); }
 
 #endif
 
 // The CUDA __half type cannot be put in unions for some reason, so we
 // use bespoke conversion functions instead.
 #ifdef __CUDA_ARCH__
-SCALAR_FUN_ATTR int16_t futrts_to_bits16(f16 x) {
-  return __half_as_ushort(x);
-}
-SCALAR_FUN_ATTR f16 futrts_from_bits16(int16_t x) {
-  return __ushort_as_half(x);
-}
+SCALAR_FUN_ATTR int16_t futrts_to_bits16(f16 x) { return __half_as_ushort(x); }
+SCALAR_FUN_ATTR f16 futrts_from_bits16(int16_t x) { return __ushort_as_half(x); }
 #elif defined(ISPC)
-
-SCALAR_FUN_ATTR int16_t futrts_to_bits16(f16 x) {
-  varying int16_t y = *((varying int16_t * uniform)&x);
-  return y;
+SCALAR_FUN_ATTR int16_t futrts_to_bits16(f16 x) { varying int16_t y = *((varying int16_t * uniform)&x); return y;
 }
-
-SCALAR_FUN_ATTR f16 futrts_from_bits16(int16_t x) {
-  varying f16 y = *((varying f16 * uniform)&x);
-  return y;
-}
+SCALAR_FUN_ATTR f16 futrts_from_bits16(int16_t x) { varying f16 y = *((varying f16 * uniform)&x); return y; }
 #else
 SCALAR_FUN_ATTR int16_t futrts_to_bits16(f16 x) {
   union {
@@ -795,201 +303,55 @@ SCALAR_FUN_ATTR f16 futrts_from_bits16(int16_t x) {
 
 #else // No native f16 - emulate.
 
-SCALAR_FUN_ATTR f16 fabs16(f16 x) {
-  return fabs32(x);
-}
-
-SCALAR_FUN_ATTR f16 fmax16(f16 x, f16 y) {
-  return fmax32(x, y);
-}
-
-SCALAR_FUN_ATTR f16 fmin16(f16 x, f16 y) {
-  return fmin32(x, y);
-}
-
-SCALAR_FUN_ATTR f16 fpow16(f16 x, f16 y) {
-  return fpow32(x, y);
-}
-
-SCALAR_FUN_ATTR bool futrts_isnan16(f16 x) {
-  return futrts_isnan32(x);
-}
-
-SCALAR_FUN_ATTR bool futrts_isinf16(f16 x) {
-  return futrts_isinf32(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_log16(f16 x) {
-  return futrts_log32(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_log2_16(f16 x) {
-  return futrts_log2_32(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_log10_16(f16 x) {
-  return futrts_log10_32(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_log1p_16(f16 x) {
-  return futrts_log1p_32(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_sqrt16(f16 x) {
-  return futrts_sqrt32(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_rsqrt16(f16 x) {
-  return futrts_rsqrt32(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_cbrt16(f16 x) {
-  return futrts_cbrt32(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_exp16(f16 x) {
-  return futrts_exp32(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_cos16(f16 x) {
-  return futrts_cos32(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_cospi16(f16 x) {
-  return futrts_cospi32(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_sin16(f16 x) {
-  return futrts_sin32(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_sinpi16(f16 x) {
-  return futrts_sinpi32(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_tan16(f16 x) {
-  return futrts_tan32(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_tanpi16(f16 x) {
-  return futrts_tanpi32(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_acos16(f16 x) {
-  return futrts_acos32(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_acospi16(f16 x) {
-  return futrts_acospi32(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_asin16(f16 x) {
-  return futrts_asin32(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_asinpi16(f16 x) {
-  return futrts_asinpi32(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_atan16(f16 x) {
-  return futrts_atan32(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_atanpi16(f16 x) {
-  return futrts_atanpi32(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_cosh16(f16 x) {
-  return futrts_cosh32(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_sinh16(f16 x) {
-  return futrts_sinh32(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_tanh16(f16 x) {
-  return futrts_tanh32(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_acosh16(f16 x) {
-  return futrts_acosh32(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_asinh16(f16 x) {
-  return futrts_asinh32(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_atanh16(f16 x) {
-  return futrts_atanh32(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_atan2_16(f16 x, f16 y) {
-  return futrts_atan2_32(x, y);
-}
-
-SCALAR_FUN_ATTR f16 futrts_atan2pi_16(f16 x, f16 y) {
-  return futrts_atan2pi_32(x, y);
-}
-
-SCALAR_FUN_ATTR f16 futrts_hypot16(f16 x, f16 y) {
-  return futrts_hypot32(x, y);
-}
-
-SCALAR_FUN_ATTR f16 futrts_gamma16(f16 x) {
-  return futrts_gamma32(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_lgamma16(f16 x) {
-  return futrts_lgamma32(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_erf16(f16 x) {
-  return futrts_erf32(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_erfc16(f16 x) {
-  return futrts_erfc32(x);
-}
-
-SCALAR_FUN_ATTR f16 fmod16(f16 x, f16 y) {
-  return fmod32(x, y);
-}
-
-SCALAR_FUN_ATTR f16 futrts_round16(f16 x) {
-  return futrts_round32(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_floor16(f16 x) {
-  return futrts_floor32(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_ceil16(f16 x) {
-  return futrts_ceil32(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_nextafter16(f16 x, f16 y) {
-  return halfbits2float(halfbitsnextafter(float2halfbits(x), float2halfbits(y)));
-}
-
-SCALAR_FUN_ATTR f16 futrts_lerp16(f16 v0, f16 v1, f16 t) {
-  return futrts_lerp32(v0, v1, t);
-}
-
-SCALAR_FUN_ATTR f16 futrts_ldexp16(f16 x, int32_t y) {
-  return futrts_ldexp32(x, y);
-}
-
-SCALAR_FUN_ATTR f16 futrts_copysign16(f16 x, f16 y) {
-  return futrts_copysign32((float)x, y);
-}
-
-SCALAR_FUN_ATTR f16 futrts_mad16(f16 a, f16 b, f16 c) {
-  return futrts_mad32(a, b, c);
-}
-
-SCALAR_FUN_ATTR f16 futrts_fma16(f16 a, f16 b, f16 c) {
-  return futrts_fma32(a, b, c);
-}
+SCALAR_FUN_ATTR f16 fabs16(f16 x) { return fabs32(x); }
+SCALAR_FUN_ATTR f16 fmax16(f16 x, f16 y) { return fmax32(x, y); }
+SCALAR_FUN_ATTR f16 fmin16(f16 x, f16 y) { return fmin32(x, y); }
+SCALAR_FUN_ATTR f16 fpow16(f16 x, f16 y) { return fpow32(x, y); }
+SCALAR_FUN_ATTR bool futrts_isnan16(f16 x) { return futrts_isnan32(x); }
+SCALAR_FUN_ATTR bool futrts_isinf16(f16 x) { return futrts_isinf32(x); }
+SCALAR_FUN_ATTR f16 futrts_log16(f16 x) { return futrts_log32(x); }
+SCALAR_FUN_ATTR f16 futrts_log2_16(f16 x) { return futrts_log2_32(x); }
+SCALAR_FUN_ATTR f16 futrts_log10_16(f16 x) { return futrts_log10_32(x); }
+SCALAR_FUN_ATTR f16 futrts_log1p_16(f16 x) { return futrts_log1p_32(x); }
+SCALAR_FUN_ATTR f16 futrts_sqrt16(f16 x) { return futrts_sqrt32(x); }
+SCALAR_FUN_ATTR f16 futrts_rsqrt16(f16 x) { return futrts_rsqrt32(x); }
+SCALAR_FUN_ATTR f16 futrts_cbrt16(f16 x) { return futrts_cbrt32(x); }
+SCALAR_FUN_ATTR f16 futrts_exp16(f16 x) { return futrts_exp32(x); }
+SCALAR_FUN_ATTR f16 futrts_cos16(f16 x) { return futrts_cos32(x); }
+SCALAR_FUN_ATTR f16 futrts_cospi16(f16 x) { return futrts_cospi32(x); }
+SCALAR_FUN_ATTR f16 futrts_sin16(f16 x) { return futrts_sin32(x); }
+SCALAR_FUN_ATTR f16 futrts_sinpi16(f16 x) { return futrts_sinpi32(x); }
+SCALAR_FUN_ATTR f16 futrts_tan16(f16 x) { return futrts_tan32(x); }
+SCALAR_FUN_ATTR f16 futrts_tanpi16(f16 x) { return futrts_tanpi32(x); }
+SCALAR_FUN_ATTR f16 futrts_acos16(f16 x) { return futrts_acos32(x); }
+SCALAR_FUN_ATTR f16 futrts_acospi16(f16 x) { return futrts_acospi32(x); }
+SCALAR_FUN_ATTR f16 futrts_asin16(f16 x) { return futrts_asin32(x); }
+SCALAR_FUN_ATTR f16 futrts_asinpi16(f16 x) { return futrts_asinpi32(x); }
+SCALAR_FUN_ATTR f16 futrts_atan16(f16 x) { return futrts_atan32(x); }
+SCALAR_FUN_ATTR f16 futrts_atanpi16(f16 x) { return futrts_atanpi32(x); }
+SCALAR_FUN_ATTR f16 futrts_cosh16(f16 x) { return futrts_cosh32(x); }
+SCALAR_FUN_ATTR f16 futrts_sinh16(f16 x) { return futrts_sinh32(x); }
+SCALAR_FUN_ATTR f16 futrts_tanh16(f16 x) { return futrts_tanh32(x); }
+SCALAR_FUN_ATTR f16 futrts_acosh16(f16 x) { return futrts_acosh32(x); }
+SCALAR_FUN_ATTR f16 futrts_asinh16(f16 x) { return futrts_asinh32(x); }
+SCALAR_FUN_ATTR f16 futrts_atanh16(f16 x) { return futrts_atanh32(x); }
+SCALAR_FUN_ATTR f16 futrts_atan2_16(f16 x, f16 y) { return futrts_atan2_32(x, y); }
+SCALAR_FUN_ATTR f16 futrts_atan2pi_16(f16 x, f16 y) { return futrts_atan2pi_32(x, y); }
+SCALAR_FUN_ATTR f16 futrts_hypot16(f16 x, f16 y) { return futrts_hypot32(x, y); }
+SCALAR_FUN_ATTR f16 futrts_gamma16(f16 x) { return futrts_gamma32(x); }
+SCALAR_FUN_ATTR f16 futrts_lgamma16(f16 x) { return futrts_lgamma32(x); }
+SCALAR_FUN_ATTR f16 futrts_erf16(f16 x) { return futrts_erf32(x); }
+SCALAR_FUN_ATTR f16 futrts_erfc16(f16 x) { return futrts_erfc32(x); }
+SCALAR_FUN_ATTR f16 fmod16(f16 x, f16 y) { return fmod32(x, y); }
+SCALAR_FUN_ATTR f16 futrts_round16(f16 x) { return futrts_round32(x); }
+SCALAR_FUN_ATTR f16 futrts_floor16(f16 x) { return futrts_floor32(x); }
+SCALAR_FUN_ATTR f16 futrts_ceil16(f16 x) { return futrts_ceil32(x); }
+SCALAR_FUN_ATTR f16 futrts_nextafter16(f16 x, f16 y) { return halfbits2float(halfbitsnextafter(float2halfbits(x), float2halfbits(y))); }
+SCALAR_FUN_ATTR f16 futrts_lerp16(f16 v0, f16 v1, f16 t) { return futrts_lerp32(v0, v1, t); }
+SCALAR_FUN_ATTR f16 futrts_ldexp16(f16 x, int32_t y) { return futrts_ldexp32(x, y); }
+SCALAR_FUN_ATTR f16 futrts_copysign16(f16 x, f16 y) { return futrts_copysign32((float)x, y); }
+SCALAR_FUN_ATTR f16 futrts_mad16(f16 a, f16 b, f16 c) { return futrts_mad32(a, b, c); }
+SCALAR_FUN_ATTR f16 futrts_fma16(f16 a, f16 b, f16 c) { return futrts_fma32(a, b, c); }
 
 // Even when we are using an OpenCL that does not support cl_khr_fp16,
 // it must still support vload_half for actually creating a
@@ -1009,51 +371,25 @@ SCALAR_FUN_ATTR f16 futrts_from_bits16(int16_t x) {
 }
 
 #else
-
-SCALAR_FUN_ATTR int16_t futrts_to_bits16(f16 x) {
-  return (int16_t)float2halfbits(x);
-}
-
-SCALAR_FUN_ATTR f16 futrts_from_bits16(int16_t x) {
-  return halfbits2float((uint16_t)x);
-}
-
-SCALAR_FUN_ATTR f16 fsignum16(f16 x) {
-  return futrts_isnan16(x) ? x : (x > 0 ? 1 : 0) - (x < 0 ? 1 : 0);
-}
+SCALAR_FUN_ATTR int16_t futrts_to_bits16(f16 x) { return (int16_t)float2halfbits(x); }
+SCALAR_FUN_ATTR f16 futrts_from_bits16(int16_t x) { return halfbits2float((uint16_t)x); }
+SCALAR_FUN_ATTR f16 fsignum16(f16 x) { return futrts_isnan16(x) ? x : (x > 0 ? 1 : 0) - (x < 0 ? 1 : 0); }
 
 #endif
 
 #endif
 
-SCALAR_FUN_ATTR float fpconv_f16_f16(f16 x) {
-  return x;
-}
-
-SCALAR_FUN_ATTR float fpconv_f16_f32(f16 x) {
-  return x;
-}
-
-SCALAR_FUN_ATTR f16 fpconv_f32_f16(float x) {
-  return (f16) x;
-}
+SCALAR_FUN_ATTR float fpconv_f16_f16(f16 x) { return x; }
+SCALAR_FUN_ATTR float fpconv_f16_f32(f16 x) { return x; }
+SCALAR_FUN_ATTR f16 fpconv_f32_f16(float x) { return (f16) x; }
 
 #ifdef FUTHARK_F64_ENABLED
-
-SCALAR_FUN_ATTR double fpconv_f16_f64(f16 x) {
-  return (double) x;
-}
-
+SCALAR_FUN_ATTR double fpconv_f16_f64(f16 x) { return (double) x; }
 #if defined(ISPC)
-SCALAR_FUN_ATTR f16 fpconv_f64_f16(double x) {
-  return (f16) ((float)x);
-}
+SCALAR_FUN_ATTR f16 fpconv_f64_f16(double x) { return (f16) ((float)x); }
 #else
-SCALAR_FUN_ATTR f16 fpconv_f64_f16(double x) {
-  return (f16) x;
-}
+SCALAR_FUN_ATTR f16 fpconv_f64_f16(double x) { return (f16) x; }
 #endif
 #endif
-
 
 // End of scalar_f16.h.


### PR DESCRIPTION
The conventional style is too verbose when it comes to navigating a huge amount of trivial functions.