### PR TITLE
Fix variable name in C API futhark_context_free

### DIFF
--- a/src/Futhark/CodeGen/Backends/GenericC.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC.hs
@@ -516,7 +516,7 @@ $entry_point_decls
 
       headerDecl InitDecl [C.cedecl|struct futhark_context;|]
       headerDecl InitDecl [C.cedecl|struct futhark_context* futhark_context_new(struct futhark_context_config* cfg);|]
-      headerDecl InitDecl [C.cedecl|void futhark_context_free(struct futhark_context* cfg);|]
+      headerDecl InitDecl [C.cedecl|void futhark_context_free(struct futhark_context* ctx);|]
       headerDecl MiscDecl [C.cedecl|int futhark_context_sync(struct futhark_context* ctx);|]
 
       generateTuningParams params


### PR DESCRIPTION
The variable name of the argument of `futhark_context_free` in the header file declaration is `cfg`, not `ctx`. This is inconsistent, and this PR fixes it to read `ctx`.