### PR TITLE
Fix #2273

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Incorrect handling of projections used in size expressions.
 
+* Subtle interactions of modules and sizes in the interpreter and compiler
+  (#2273).
+
 ## [0.25.30]
 
 ### Added

--- a/src/Language/Futhark/Interpreter.hs
+++ b/src/Language/Futhark/Interpreter.hs
@@ -332,8 +332,9 @@ lookupInEnv ::
 lookupInEnv onEnv qv env = f env $ qualQuals qv
   where
     f m (q : qs) =
-      case M.lookup q $ envTerm m of
-        Just (TermModule (Module mod)) -> f mod qs
+      case (M.lookup (qualLeaf qv) $ onEnv m, M.lookup q $ envTerm m) of
+        (Just x, _) -> Just x
+        (Nothing, Just (TermModule (Module mod))) -> f mod qs
         _ -> Nothing
     f m [] = M.lookup (qualLeaf qv) $ onEnv m
 
@@ -1202,7 +1203,14 @@ evalModExp env (ModApply f e (Info psubst) (Info rsubst) _) = do
       let res_env = case res_mod of
             Module x -> x
             _ -> mempty
-      pure (f_env <> e_env <> res_env, res_mod)
+      -- The following environment handles the case where rsubst refers to names
+      -- that are not actually defined in the module itself, but merely
+      -- inherited from an outer environment (see #2273).
+      let env_substs = (`Env` mempty) $ M.fromList $ do
+            (to, from) <- M.toList rsubst
+            x <- maybeToList $ M.lookup from $ envTerm env
+            pure (to, x)
+      pure (f_env <> e_env <> res_env <> env_substs, res_mod)
     _ -> error "Expected ModuleFun."
 
 evalDec :: Env -> Dec -> EvalM Env

--- a/src/Language/Futhark/Semantic.hs
+++ b/src/Language/Futhark/Semantic.hs
@@ -28,7 +28,7 @@ import Futhark.Util.Pretty
 import Language.Futhark
 import System.FilePath qualified as Native
 import System.FilePath.Posix qualified as Posix
-import Prelude hiding (mod)
+import Prelude hiding (abs, mod)
 
 -- | Create an import name immediately from a file path specified by
 -- the user.
@@ -158,7 +158,10 @@ instance Monoid Env where
   mempty = Env mempty mempty mempty mempty mempty
 
 instance Pretty MTy where
-  pretty = pretty . mtyMod
+  pretty (MTy abs mod) =
+    "abstract" <> parens (hsep $ map p $ M.toList abs) </> pretty mod
+    where
+      p (v, l) = pretty l <> pretty v
 
 instance Pretty Mod where
   pretty (ModEnv e) = pretty e

--- a/tests/issue2273.fut
+++ b/tests/issue2273.fut
@@ -1,0 +1,246 @@
+module fraction = {
+  type t = (i64, i64)
+
+  local
+  def gcd a b =
+    let a = i64.abs a
+    let b = i64.abs b
+    in (loop (a, b) = (i64.abs a, i64.abs b)
+        while a != b && a != 0 do
+          let (a, b) = if a < b then (a, b) else (b, a)
+          in (a, b - a)).1
+
+  def reduce (a: i64, b: i64) =
+    let s = i64.sgn b
+    let a = s * a
+    let b = s * b
+    let d = gcd a b
+    in (a / d, b / d)
+
+  def add (a, b) (c, d) = reduce (a * d + b * c, b * d)
+  def sub (a, b) (c, d) = reduce (a * d - b * c, b * d)
+  def mul (a, b) (c, d) = reduce (a * c, b * d)
+  def div (a, b) (c, d) = reduce (a * d, b * c)
+  def zero : t = (0, 1)
+  def one : t = (1, 1)
+}
+
+module SI (v: real) = {
+  module f = fraction
+
+  type unit [s]
+            [s_d]
+            [m]
+            [m_d]
+            [kg]
+            [kg_d]
+            [A]
+            [A_d]
+            [K]
+            [K_d]
+            [mol]
+            [mol_d]
+            [cd]
+            [cd_d] =
+    [0][s][s_d][m][m_d][kg][kg_d][A][A_d][K][K_d][mol][mol_d][cd][cd_d]()
+
+  type value [s]
+             [s_d]
+             [m]
+             [m_d]
+             [kg]
+             [kg_d]
+             [A]
+             [A_d]
+             [K]
+             [K_d]
+             [mol]
+             [mol_d]
+             [cd]
+             [cd_d] =
+    (v.t, unit [s] [s_d] [m] [m_d] [kg] [kg_d] [A] [A_d] [K] [K_d] [mol] [mol_d] [cd] [cd_d])
+
+  def unit (s: f.t) (m: f.t) (kg: f.t) (A: f.t) (K: f.t) (mol: f.t) (cd: f.t) : unit [s.0] [s.1] [m.0] [m.1] [kg.0] [kg.1] [A.0] [A.1] [K.0] [K.1] [mol.0] [mol.1] [cd.0] [cd.1] =
+    []
+
+  def add [s0]
+          [s_d0]
+          [m0]
+          [m_d0]
+          [kg0]
+          [kg_d0]
+          [A0]
+          [A_d0]
+          [K0]
+          [K_d0]
+          [mol0]
+          [mol_d0]
+          [cd0]
+          [cd_d0]
+          [s1]
+          [s_d1]
+          [m1]
+          [m_d1]
+          [kg1]
+          [kg_d1]
+          [A1]
+          [A_d1]
+          [K1]
+          [K_d1]
+          [mol1]
+          [mol_d1]
+          [cd1]
+          [cd_d1]
+          (a: value [s0] [s_d0] [m0] [m_d0] [kg0] [kg_d0] [A0] [A_d0] [K0] [K_d0] [mol0] [mol_d0] [cd0] [cd_d0])
+          (b: value [s1] [s_d1] [m1] [m_d1] [kg1] [kg_d1] [A1] [A_d1] [K1] [K_d1] [mol1] [mol_d1] [cd1] [cd_d1]) =
+    (a.0 v.+ b.0, a.1 :> unit [s1] [s_d1] [m1] [m_d1] [kg1] [kg_d1] [A1] [A_d1] [K1] [K_d1] [mol1] [mol_d1] [cd1] [cd_d1])
+
+  def sub [s0]
+          [s_d0]
+          [m0]
+          [m_d0]
+          [kg0]
+          [kg_d0]
+          [A0]
+          [A_d0]
+          [K0]
+          [K_d0]
+          [mol0]
+          [mol_d0]
+          [cd0]
+          [cd_d0]
+          [s1]
+          [s_d1]
+          [m1]
+          [m_d1]
+          [kg1]
+          [kg_d1]
+          [A1]
+          [A_d1]
+          [K1]
+          [K_d1]
+          [mol1]
+          [mol_d1]
+          [cd1]
+          [cd_d1]
+          (a: value [s0] [s_d0] [m0] [m_d0] [kg0] [kg_d0] [A0] [A_d0] [K0] [K_d0] [mol0] [mol_d0] [cd0] [cd_d0])
+          (b: value [s1] [s_d1] [m1] [m_d1] [kg1] [kg_d1] [A1] [A_d1] [K1] [K_d1] [mol1] [mol_d1] [cd1] [cd_d1]) =
+    (a.0 v.- b.0, a.1 :> unit [s1] [s_d1] [m1] [m_d1] [kg1] [kg_d1] [A1] [A_d1] [K1] [K_d1] [mol1] [mol_d1] [cd1] [cd_d1])
+
+  def mul [s0]
+          [s_d0]
+          [m0]
+          [m_d0]
+          [kg0]
+          [kg_d0]
+          [A0]
+          [A_d0]
+          [K0]
+          [K_d0]
+          [mol0]
+          [mol_d0]
+          [cd0]
+          [cd_d0]
+          [s1]
+          [s_d1]
+          [m1]
+          [m_d1]
+          [kg1]
+          [kg_d1]
+          [A1]
+          [A_d1]
+          [K1]
+          [K_d1]
+          [mol1]
+          [mol_d1]
+          [cd1]
+          [cd_d1]
+          (a: value [s0] [s_d0] [m0] [m_d0] [kg0] [kg_d0] [A0] [A_d0] [K0] [K_d0] [mol0] [mol_d0] [cd0] [cd_d0])
+          (b: value [s1] [s_d1] [m1] [m_d1] [kg1] [kg_d1] [A1] [A_d1] [K1] [K_d1] [mol1] [mol_d1] [cd1] [cd_d1]) =
+    ( a.0 v.* b.0
+    , unit (f.add (s0, s_d0) (s1, s_d1))
+           (f.add (m0, m_d0) (m1, m_d1))
+           (f.add (kg0, kg_d0) (kg1, kg_d1))
+           (f.add (A0, A_d0) (A1, A_d1))
+           (f.add (K0, K_d0) (K1, K_d1))
+           (f.add (mol0, mol_d0) (mol1, mol_d1))
+           (f.add (cd0, cd_d0) (cd1, cd_d1))
+    )
+
+  def div [s0]
+          [s_d0]
+          [m0]
+          [m_d0]
+          [kg0]
+          [kg_d0]
+          [A0]
+          [A_d0]
+          [K0]
+          [K_d0]
+          [mol0]
+          [mol_d0]
+          [cd0]
+          [cd_d0]
+          [s1]
+          [s_d1]
+          [m1]
+          [m_d1]
+          [kg1]
+          [kg_d1]
+          [A1]
+          [A_d1]
+          [K1]
+          [K_d1]
+          [mol1]
+          [mol_d1]
+          [cd1]
+          [cd_d1]
+          (a: value [s0] [s_d0] [m0] [m_d0] [kg0] [kg_d0] [A0] [A_d0] [K0] [K_d0] [mol0] [mol_d0] [cd0] [cd_d0])
+          (b: value [s1] [s_d1] [m1] [m_d1] [kg1] [kg_d1] [A1] [A_d1] [K1] [K_d1] [mol1] [mol_d1] [cd1] [cd_d1]) =
+    ( a.0 v./ b.0
+    , unit (f.sub (s0, s_d0) (s1, s_d1))
+           (f.sub (m0, m_d0) (m1, m_d1))
+           (f.sub (kg0, kg_d0) (kg1, kg_d1))
+           (f.sub (A0, A_d0) (A1, A_d1))
+           (f.sub (K0, K_d0) (K1, K_d1))
+           (f.sub (mol0, mol_d0) (mol1, mol_d1))
+           (f.sub (cd0, cd_d0) (cd1, cd_d1))
+    )
+
+  def pow [s] [s_d] [m] [m_d] [kg] [kg_d] [A] [A_d] [K] [K_d] [mol] [mol_d] [cd] [cd_d]
+          (base: value [s] [s_d] [m] [m_d] [kg] [kg_d] [A] [A_d] [K] [K_d] [mol] [mol_d] [cd] [cd_d])
+          (exponent: f.t) =
+    ( base.0 v.** v.from_fraction exponent.0 exponent.1
+    , unit (f.mul exponent (s, s_d))
+           (f.mul exponent (m, m_d))
+           (f.mul exponent (kg, kg_d))
+           (f.mul exponent (A, A_d))
+           (f.mul exponent (K, K_d))
+           (f.mul exponent (mol, mol_d))
+           (f.mul exponent (cd, cd_d))
+    )
+
+  def (+) = add
+  def (-) = sub
+  def (*) = mul
+  def (/) = div
+  def lift (a: v.t) = (a, unit f.zero f.zero f.zero f.zero f.zero f.zero f.zero)
+
+  module units = {
+    -- base units
+    def s = (v.i32 1, unit f.one f.zero f.zero f.zero f.zero f.zero f.zero)
+    def m = (v.i32 1, unit f.zero f.one f.zero f.zero f.zero f.zero f.zero)
+    def kg = (v.i32 1, unit f.zero f.zero f.one f.zero f.zero f.zero f.zero)
+    def A = (v.i32 1, unit f.zero f.zero f.zero f.one f.zero f.zero f.zero)
+    def K = (v.i32 1, unit f.zero f.zero f.zero f.zero f.one f.zero f.zero)
+    def mol = (v.i32 1, unit f.zero f.zero f.zero f.zero f.zero f.one f.zero)
+    def cd = (v.i32 1, unit f.zero f.zero f.zero f.zero f.zero f.zero f.one)
+  }
+}
+
+local open SI f32
+local open units
+
+entry velocity = lift 10 * m / s
+entry time = lift 100 * s
+entry distance = velocity * time

--- a/tests/modules/functor31.fut
+++ b/tests/modules/functor31.fut
@@ -1,7 +1,7 @@
 -- Distilled from #2273. The problem was that we destroyed type annotations when
 -- generating new names for the result of applying a parameterised module.
 -- ==
--- input {}
+-- input {} output { 0i64 1i64 }
 
 module fraction = {
   type t = (i64, i64)
@@ -28,4 +28,4 @@ module SI (_v: {}) = {
 
 module M = SI {}
 
-entry main = M.div M.m M.m
+entry main = let [x][y] (_: [0][x][y]()) = M.div M.m M.m in (x, y)

--- a/tests/modules/functor31.fut
+++ b/tests/modules/functor31.fut
@@ -1,0 +1,31 @@
+-- Distilled from #2273. The problem was that we destroyed type annotations when
+-- generating new names for the result of applying a parameterised module.
+-- ==
+-- input {}
+
+module fraction = {
+  type t = (i64, i64)
+  def sub (a, b) (c, d) : t = (a * d - b * c, b * d)
+  def zero : t = (0, 1)
+}
+
+module SI (_v: {}) = {
+  module localfraction = fraction
+
+  type unit [s] [s_d] =
+    [0][s][s_d]()
+
+  def unit (s: fraction.t) : unit [s.0] [s.1] =
+    []
+
+  def div [s0] [s_d0] [s1] [s_d1]
+          (_: unit [s0] [s_d0])
+          (_: unit [s1] [s_d1]) =
+    unit (fraction.sub (s0, s_d0) (s1, s_d1))
+
+  def m = unit fraction.zero
+}
+
+module M = SI {}
+
+entry main = M.div M.m M.m

--- a/tests/paths/has_abs.fut
+++ b/tests/paths/has_abs.fut
@@ -1,13 +1,13 @@
 -- File containing an abstract type.
 
-module m = {
-  type t = i32
-  def x = 0i32
-  def eq = (i32.==)
-}
-
-open (m : {
-  type t
-  val x: t
-  val eq: t -> t -> bool
-})
+open (
+  {
+    type t = i32
+    def x = 0i32
+    def eq = (i32.==)
+  }:
+  {
+    type t
+    val x : t
+    val eq : t -> t -> bool
+  })


### PR DESCRIPTION
These were some very subtle defects in how we implement modules. Two keys bugs:

1. Substitutions in `newNamesForMTy` destroyed type annotations.
2. We did not handle inherited names correctly in the interpreter.