### PR TITLE
Fix f64 atomics on pre-CC 6 CUDA GPUs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+* `f64` atomics on NVIDIA GPUs with less than CC 6.0 (Maxwell and older).
+
 ## [0.25.31]
 
 ### Added

--- a/rts/c/atomics64.h
+++ b/rts/c/atomics64.h
@@ -34,7 +34,7 @@ SCALAR_FUN_ATTR int64_t atomic_xchg_i64_global(volatile __global int64_t *p, int
 #if defined(FUTHARK_CUDA) || defined(FUTHARK_HIP)
   return atomicExch((unsigned long long*)p, x);
 #else
-  return atom_xor(p, x);
+  return atom_xchg(p, x);
 #endif
 }
 
@@ -42,7 +42,7 @@ SCALAR_FUN_ATTR int64_t atomic_xchg_i64_shared(volatile __local int64_t *p, int6
 #if defined(FUTHARK_CUDA) || defined(FUTHARK_HIP)
   return atomicExch((unsigned long long*)p, x);
 #else
-  return atom_xor(p, x);
+  return atom_xchg(p, x);
 #endif
 }
 
@@ -103,9 +103,9 @@ SCALAR_FUN_ATTR double atomic_fadd_f64_global(volatile __global double *p, doubl
   union {int64_t i; double f;} ret;
   old.f = x;
   while (1) {
-    ret.i = atom_xchg((volatile __global int64_t*)p, (int64_t)0);
+    ret.i = atomic_xchg_i64_global((volatile __global int64_t*)p, (int64_t)0);
     ret.f += old.f;
-    old.i = atom_xchg((volatile __global int64_t*)p, ret.i);
+    old.i = atomic_xchg_i64_global((volatile __global int64_t*)p, ret.i);
     if (old.i == 0) {
       break;
     }


### PR DESCRIPTION
The fallback case used OpenCL atomics by accident. Now it uses our portable wrappers.