### PR TITLE
Begin tracking provenance of IR statements.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -627,7 +627,7 @@ jobs:
     - name: Install OS dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y ffmpeg oclgrind
+        sudo apt-get install -y ffmpeg oclgrind opencl-headers
 
     - uses: actions/checkout@v4
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -627,7 +627,7 @@ jobs:
     - name: Install OS dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y ffmpeg oclgrind opencl-headers
+        sudo apt-get install -y opencl-headers oclgrind nvidia-opencl-dev
 
     - uses: actions/checkout@v4
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -627,7 +627,7 @@ jobs:
     - name: Install OS dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y opencl-headers oclgrind nvidia-opencl-dev
+        sudo apt-get install -y ffmpeg opencl-headers oclgrind nvidia-opencl-dev
 
     - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * `cuda` backend: explicitly support CC 8.9, 9.0, 10.0, 10.1, and 12.0.
 
+* Profiling now provides source locations for the profiled events. Some things
+  are not yet accurately tracked, and only the static location is reported
+  (i.e., no full call stack).
+
 ### Removed
 
 ### Changed

--- a/cabal.project
+++ b/cabal.project
@@ -5,3 +5,5 @@ package futhark
   ghc-options: -j -fwrite-ide-info -hiedir=.hie
 
 allow-newer: base, template-haskell, ghc-prim
+
+multi-repl: True

--- a/docs/c-api.rst
+++ b/docs/c-api.rst
@@ -206,12 +206,14 @@ Context
 .. c:function:: char *futhark_context_report(struct futhark_context *ctx)
 
    Produce a C string encoding a JSON object with debug and profiling
-   information collected during program runtime.  It is the caller's
-   responsibility to free the returned string.  It is likely to only
-   contain interesting information if
+   information collected during program runtime. It is the caller's
+   responsibility to free the returned string. The format of the string is
+   intentionally undocumented and is not a stable format, but can be passed to
+   ``futhark profile`` to produce human-readable information. The report is
+   likely to only contain interesting information if
    :c:func:`futhark_context_config_set_debugging` or
-   :c:func:`futhark_context_config_set_profiling` has been called
-   previously.  Returns ``NULL`` on failure.
+   :c:func:`futhark_context_config_set_profiling` has been called previously.
+   Returns ``NULL`` on failure.
 
 .. c:function:: int futhark_context_clear_caches(struct futhark_context *ctx)
 

--- a/docs/man/futhark-profile.rst
+++ b/docs/man/futhark-profile.rst
@@ -14,13 +14,13 @@ futhark profile JSONFILES
 DESCRIPTION
 ===========
 
-This tool produces human-readable profiling information based on
-information collected with :ref:`futhark bench<futhark-bench(1)>`.
-Futhark has only rudimentary support for profiling.  While the system
-can collect information about the run-time behaviour of the program,
-there is currently no automatic way to connect the information to the
-program source code.  However, the collected information can still be
-useful for estimating the source of inefficiencies.
+This tool produces human-readable profiling information based on information
+collected with :ref:`futhark bench<futhark-bench(1)>`. Futhark has basic support
+for profiling. The system can collect information about the run-time behaviour
+of the program, and connects it as best it is able to the program source code.
+This works best for the GPU backends, and not at all for the sequential
+backends. The collected information can then be used to estimate the source of
+inefficiencies.
 
 USAGE
 =====
@@ -49,16 +49,18 @@ Files produced
 Supposing a dataset ``foo``, ``futhark profile`` will produce the
 following files in the top level directory.
 
-* ``foo.log``: the running log produced during execution.  Contains
-  many details on dynamic behaviour, depending on the exact backend.
+* ``foo.log``: the running log produced during execution. Contains many details
+  on dynamic behaviour, depending on the exact backend.
 
-* ``foo.summary``: a summary of memory usage and cost centres.  For
-  the GPU backends, the cost centres are kernel executions and memory
-  copies.
+* ``foo.summary``: a summary of memory usage and cost centres. For the GPU
+  backends, the cost centres are kernel executions and memory copies.
 
-* ``foo.timeline``: a list of all recorded profiling events, in the
-  order in which they occurred, along with their runtime and other
-  available information
+* ``foo.timeline``: a list of all recorded profiling events, in the order in
+  which they occurred, along with their runtime and other available information,
+  most importantly the source locations.
+
+The log file is often too verbose to be useful, but the summary and timeline
+should be inspected, even if the latter is sometimes fairly large.
 
 Technicalities
 --------------
@@ -73,10 +75,10 @@ behaviour of the run time system.
 Raw reports
 -----------
 
-Alternatively, the JSON can also contain a raw profiling report as
-produced by the C API function ``futhark_context_report()``. A
-directory is still created, but it will only contain a single set of
-files, and it will not contain a log.
+Alternatively, the JSON file passed to ``futhark profile`` may also be a raw
+profiling report as produced by the C API function ``futhark_context_report()``.
+A directory is still created, but it will only contain a single set of files,
+and it will not contain a log.
 
 EXAMPLES
 ========

--- a/futhark.cabal
+++ b/futhark.cabal
@@ -549,6 +549,7 @@ library futhark-testing
     , free
     , futhark
     , megaparsec
+    , srcloc
     , tasty
     , tasty-hunit
     , tasty-quickcheck

--- a/rts/c/backends/cuda.h
+++ b/rts/c/backends/cuda.h
@@ -888,7 +888,7 @@ static int gpu_scalar_to_device(struct futhark_context* ctx,
   if (event != NULL) {
     add_event(ctx,
               "copy_scalar_to_dev",
-              strdup(""),
+              NULL,
               event,
               (event_report_fn)cuda_event_report);
     CUDA_SUCCEED_FATAL(cuEventRecord(event->start, ctx->stream));
@@ -907,7 +907,7 @@ static int gpu_scalar_from_device(struct futhark_context* ctx,
   if (event != NULL) {
     add_event(ctx,
               "copy_scalar_from_dev",
-              strdup(""),
+              NULL,
               event,
               (event_report_fn)cuda_event_report);
     CUDA_SUCCEED_FATAL(cuEventRecord(event->start, ctx->stream));
@@ -927,7 +927,7 @@ static int gpu_memcpy(struct futhark_context* ctx,
   if (event != NULL) {
     add_event(ctx,
               "copy_dev_to_dev",
-              strdup(""),
+              NULL,
               event,
               (event_report_fn)cuda_event_report);
     CUDA_SUCCEED_FATAL(cuEventRecord(event->start, ctx->stream));
@@ -948,7 +948,7 @@ static int memcpy_host2gpu(struct futhark_context* ctx, bool sync,
     if (event != NULL) {
       add_event(ctx,
                 "copy_host_to_dev",
-                strdup(""),
+                NULL,
                 event,
                 (event_report_fn)cuda_event_report);
       CUDA_SUCCEED_FATAL(cuEventRecord(event->start, ctx->stream));
@@ -976,7 +976,7 @@ static int memcpy_gpu2host(struct futhark_context* ctx, bool sync,
     if (event != NULL) {
       add_event(ctx,
                 "copy_dev_to_host",
-                strdup(""),
+                NULL,
                 event,
                 (event_report_fn)cuda_event_report);
       CUDA_SUCCEED_FATAL(cuEventRecord(event->start, ctx->stream));
@@ -1028,16 +1028,7 @@ static int gpu_launch_kernel(struct futhark_context* ctx,
     CUDA_SUCCEED_FATAL(cuEventRecord(event->start, ctx->stream));
     add_event(ctx,
               name,
-              msgprintf("At: %s\n"
-                        "Kernel %s with\n"
-                        "  grid=(%d,%d,%d)\n"
-                        "  block=(%d,%d,%d)\n"
-                        "  shared memory=%d",
-                        provenance ? provenance : "unknown",
-                        name,
-                        grid[0], grid[1], grid[2],
-                        block[0], block[1], block[2],
-                        shared_mem_bytes),
+              provenance,
               event,
               (event_report_fn)cuda_event_report);
   }

--- a/rts/c/backends/cuda.h
+++ b/rts/c/backends/cuda.h
@@ -1040,7 +1040,7 @@ static int gpu_launch_kernel(struct futhark_context* ctx,
     CUDA_SUCCEED_FATAL(cuEventRecord(event->start, ctx->stream));
 
     struct kvs *kvs = kvs_new();
-    kvs_printf(kvs, "kernel", "%s", name);
+    kvs_printf(kvs, "kernel", "\"%s\"", name);
     kvs_printf(kvs, "grid", "[%d,%d,%d]", grid[0], grid[1], grid[2]);
     kvs_printf(kvs, "block", "[%d,%d,%d]", block[0], block[1], block[2]);
     kvs_printf(kvs, "shared memory", "%d", shared_mem_bytes);

--- a/rts/c/backends/cuda.h
+++ b/rts/c/backends/cuda.h
@@ -882,13 +882,14 @@ static void gpu_free_kernel(struct futhark_context *ctx,
 }
 
 static int gpu_scalar_to_device(struct futhark_context* ctx,
+                                const char *provenance,
                                 gpu_mem dst, size_t offset, size_t size,
                                 void *src) {
   struct cuda_event *event = cuda_event_new(ctx);
   if (event != NULL) {
     add_event(ctx,
               "copy_scalar_to_dev",
-              NULL,
+              provenance,
               NULL,
               event,
               (event_report_fn)cuda_event_report);
@@ -902,13 +903,14 @@ static int gpu_scalar_to_device(struct futhark_context* ctx,
 }
 
 static int gpu_scalar_from_device(struct futhark_context* ctx,
+                                  const char *provenance,
                                   void *dst,
                                   gpu_mem src, size_t offset, size_t size) {
   struct cuda_event *event = cuda_event_new(ctx);
   if (event != NULL) {
     add_event(ctx,
               "copy_scalar_from_dev",
-              NULL,
+              provenance,
               NULL,
               event,
               (event_report_fn)cuda_event_report);
@@ -922,6 +924,7 @@ static int gpu_scalar_from_device(struct futhark_context* ctx,
 }
 
 static int gpu_memcpy(struct futhark_context* ctx,
+                      const char *provenance,
                       gpu_mem dst, int64_t dst_offset,
                       gpu_mem src, int64_t src_offset,
                       int64_t nbytes) {
@@ -929,7 +932,7 @@ static int gpu_memcpy(struct futhark_context* ctx,
   if (event != NULL) {
     add_event(ctx,
               "copy_dev_to_dev",
-              NULL,
+              provenance,
               NULL,
               event,
               (event_report_fn)cuda_event_report);
@@ -942,7 +945,9 @@ static int gpu_memcpy(struct futhark_context* ctx,
   return FUTHARK_SUCCESS;
 }
 
-static int memcpy_host2gpu(struct futhark_context* ctx, bool sync,
+static int memcpy_host2gpu(struct futhark_context* ctx,
+                           const char *provenance,
+                           bool sync,
                            gpu_mem dst, int64_t dst_offset,
                            const unsigned char* src, int64_t src_offset,
                            int64_t nbytes) {
@@ -951,7 +956,7 @@ static int memcpy_host2gpu(struct futhark_context* ctx, bool sync,
     if (event != NULL) {
       add_event(ctx,
                 "copy_host_to_dev",
-                NULL,
+                provenance,
                 NULL,
                 event,
                 (event_report_fn)cuda_event_report);
@@ -971,7 +976,9 @@ static int memcpy_host2gpu(struct futhark_context* ctx, bool sync,
   return FUTHARK_SUCCESS;
 }
 
-static int memcpy_gpu2host(struct futhark_context* ctx, bool sync,
+static int memcpy_gpu2host(struct futhark_context* ctx,
+                           const char *provenance,
+                           bool sync,
                            unsigned char* dst, int64_t dst_offset,
                            gpu_mem src, int64_t src_offset,
                            int64_t nbytes) {
@@ -980,7 +987,7 @@ static int memcpy_gpu2host(struct futhark_context* ctx, bool sync,
     if (event != NULL) {
       add_event(ctx,
                 "copy_dev_to_host",
-                NULL,
+                provenance,
                 NULL,
                 event,
                 (event_report_fn)cuda_event_report);

--- a/rts/c/backends/cuda.h
+++ b/rts/c/backends/cuda.h
@@ -889,6 +889,7 @@ static int gpu_scalar_to_device(struct futhark_context* ctx,
     add_event(ctx,
               "copy_scalar_to_dev",
               NULL,
+              NULL,
               event,
               (event_report_fn)cuda_event_report);
     CUDA_SUCCEED_FATAL(cuEventRecord(event->start, ctx->stream));
@@ -907,6 +908,7 @@ static int gpu_scalar_from_device(struct futhark_context* ctx,
   if (event != NULL) {
     add_event(ctx,
               "copy_scalar_from_dev",
+              NULL,
               NULL,
               event,
               (event_report_fn)cuda_event_report);
@@ -928,6 +930,7 @@ static int gpu_memcpy(struct futhark_context* ctx,
     add_event(ctx,
               "copy_dev_to_dev",
               NULL,
+              NULL,
               event,
               (event_report_fn)cuda_event_report);
     CUDA_SUCCEED_FATAL(cuEventRecord(event->start, ctx->stream));
@@ -948,6 +951,7 @@ static int memcpy_host2gpu(struct futhark_context* ctx, bool sync,
     if (event != NULL) {
       add_event(ctx,
                 "copy_host_to_dev",
+                NULL,
                 NULL,
                 event,
                 (event_report_fn)cuda_event_report);
@@ -976,6 +980,7 @@ static int memcpy_gpu2host(struct futhark_context* ctx, bool sync,
     if (event != NULL) {
       add_event(ctx,
                 "copy_dev_to_host",
+                NULL,
                 NULL,
                 event,
                 (event_report_fn)cuda_event_report);
@@ -1026,9 +1031,17 @@ static int gpu_launch_kernel(struct futhark_context* ctx,
 
   if (event != NULL) {
     CUDA_SUCCEED_FATAL(cuEventRecord(event->start, ctx->stream));
+
+    struct kvs *kvs = kvs_new();
+    kvs_printf(kvs, "kernel", "%s", name);
+    kvs_printf(kvs, "grid", "[%d,%d,%d]", grid[0], grid[1], grid[2]);
+    kvs_printf(kvs, "block", "[%d,%d,%d]", block[0], block[1], block[2]);
+    kvs_printf(kvs, "shared memory", "%d", shared_mem_bytes);
+
     add_event(ctx,
               name,
               provenance,
+              kvs,
               event,
               (event_report_fn)cuda_event_report);
   }

--- a/rts/c/backends/cuda.h
+++ b/rts/c/backends/cuda.h
@@ -996,7 +996,8 @@ static int memcpy_gpu2host(struct futhark_context* ctx, bool sync,
 }
 
 static int gpu_launch_kernel(struct futhark_context* ctx,
-                             gpu_kernel kernel, const char *name,
+                             gpu_kernel kernel,
+                             const char *name, const char *provenance,
                              const int32_t grid[3],
                              const int32_t block[3],
                              unsigned int shared_mem_bytes,
@@ -1022,10 +1023,12 @@ static int gpu_launch_kernel(struct futhark_context* ctx,
     CUDA_SUCCEED_FATAL(cuEventRecord(event->start, ctx->stream));
     add_event(ctx,
               name,
-              msgprintf("Kernel %s with\n"
+              msgprintf("At: %s\n"
+                        "Kernel %s with\n"
                         "  grid=(%d,%d,%d)\n"
                         "  block=(%d,%d,%d)\n"
                         "  shared memory=%d",
+                        provenance ? provenance : "unknown",
                         name,
                         grid[0], grid[1], grid[2],
                         block[0], block[1], block[2],

--- a/rts/c/backends/hip.h
+++ b/rts/c/backends/hip.h
@@ -847,7 +847,8 @@ static int memcpy_gpu2host(struct futhark_context* ctx, bool sync,
 }
 
 static int gpu_launch_kernel(struct futhark_context* ctx,
-                             gpu_kernel kernel, const char *name,
+                             gpu_kernel kernel,
+                             const char *name, const char *provenance,
                              const int32_t grid[3],
                              const int32_t block[3],
                              unsigned int shared_mem_bytes,
@@ -873,10 +874,12 @@ static int gpu_launch_kernel(struct futhark_context* ctx,
     HIP_SUCCEED_FATAL(hipEventRecord(event->start, ctx->stream));
     add_event(ctx,
               name,
-              msgprintf("Kernel %s with\n"
+              msgprintf("At: %s\n"
+                        "Kernel %s with\n"
                         "  grid=(%d,%d,%d)\n"
                         "  block=(%d,%d,%d)\n"
                         "  shared memory=%d",
+                        provenance ? provenance : "unknown",
                         name,
                         grid[0], grid[1], grid[2],
                         block[0], block[1], block[2],

--- a/rts/c/backends/hip.h
+++ b/rts/c/backends/hip.h
@@ -886,7 +886,7 @@ static int gpu_launch_kernel(struct futhark_context* ctx,
     HIP_SUCCEED_FATAL(hipEventRecord(event->start, ctx->stream));
 
     struct kvs *kvs = kvs_new();
-    kvs_printf(kvs, "kernel", "%s", name);
+    kvs_printf(kvs, "kernel", "\"%s\"", name);
     kvs_printf(kvs, "grid", "[%d,%d,%d]", grid[0], grid[1], grid[2]);
     kvs_printf(kvs, "block", "[%d,%d,%d]", block[0], block[1], block[2]);
     kvs_printf(kvs, "shared memory", "%d", shared_mem_bytes);

--- a/rts/c/backends/hip.h
+++ b/rts/c/backends/hip.h
@@ -727,6 +727,7 @@ static int gpu_scalar_to_device(struct futhark_context* ctx,
     add_event(ctx,
               "copy_scalar_to_dev",
               NULL,
+              NULL,
               event,
               (event_report_fn)hip_event_report);
     HIP_SUCCEED_FATAL(hipEventRecord(event->start, ctx->stream));
@@ -745,6 +746,7 @@ static int gpu_scalar_from_device(struct futhark_context* ctx,
   if (event != NULL) {
     add_event(ctx,
               "copy_scalar_from_dev",
+              NULL,
               NULL,
               event,
               (event_report_fn)hip_event_report);
@@ -765,6 +767,7 @@ static int gpu_memcpy(struct futhark_context* ctx,
   if (event != NULL) {
     add_event(ctx,
               "copy_dev_to_dev",
+              NULL,
               NULL,
               event,
               (event_report_fn)hip_event_report);
@@ -787,6 +790,7 @@ static int memcpy_host2gpu(struct futhark_context* ctx, bool sync,
     if (event != NULL) {
       add_event(ctx,
                 "copy_host_to_dev",
+                NULL,
                 NULL,
                 event,
                 (event_report_fn)hip_event_report);
@@ -818,6 +822,7 @@ static int memcpy_gpu2host(struct futhark_context* ctx, bool sync,
     if (event != NULL) {
       add_event(ctx,
                 "copy_dev_to_host",
+                NULL,
                 NULL,
                 event,
                 (event_report_fn)hip_event_report);
@@ -872,9 +877,17 @@ static int gpu_launch_kernel(struct futhark_context* ctx,
 
   if (event != NULL) {
     HIP_SUCCEED_FATAL(hipEventRecord(event->start, ctx->stream));
+
+    struct kvs *kvs = kvs_new();
+    kvs_printf(kvs, "kernel", "%s", name);
+    kvs_printf(kvs, "grid", "[%d,%d,%d]", grid[0], grid[1], grid[2]);
+    kvs_printf(kvs, "block", "[%d,%d,%d]", block[0], block[1], block[2]);
+    kvs_printf(kvs, "shared memory", "%d", shared_mem_bytes);
+
     add_event(ctx,
               name,
-              NULL,
+              provenance,
+              kvs,
               event,
               (event_report_fn)hip_event_report);
   }

--- a/rts/c/backends/hip.h
+++ b/rts/c/backends/hip.h
@@ -726,7 +726,7 @@ static int gpu_scalar_to_device(struct futhark_context* ctx,
   if (event != NULL) {
     add_event(ctx,
               "copy_scalar_to_dev",
-              strdup(""),
+              NULL,
               event,
               (event_report_fn)hip_event_report);
     HIP_SUCCEED_FATAL(hipEventRecord(event->start, ctx->stream));
@@ -745,7 +745,7 @@ static int gpu_scalar_from_device(struct futhark_context* ctx,
   if (event != NULL) {
     add_event(ctx,
               "copy_scalar_from_dev",
-              strdup(""),
+              NULL,
               event,
               (event_report_fn)hip_event_report);
     HIP_SUCCEED_FATAL(hipEventRecord(event->start, ctx->stream));
@@ -765,7 +765,7 @@ static int gpu_memcpy(struct futhark_context* ctx,
   if (event != NULL) {
     add_event(ctx,
               "copy_dev_to_dev",
-              strdup(""),
+              NULL,
               event,
               (event_report_fn)hip_event_report);
     HIP_SUCCEED_FATAL(hipEventRecord(event->start, ctx->stream));
@@ -787,7 +787,7 @@ static int memcpy_host2gpu(struct futhark_context* ctx, bool sync,
     if (event != NULL) {
       add_event(ctx,
                 "copy_host_to_dev",
-                strdup(""),
+                NULL,
                 event,
                 (event_report_fn)hip_event_report);
       HIP_SUCCEED_FATAL(hipEventRecord(event->start, ctx->stream));
@@ -818,7 +818,7 @@ static int memcpy_gpu2host(struct futhark_context* ctx, bool sync,
     if (event != NULL) {
       add_event(ctx,
                 "copy_dev_to_host",
-                strdup(""),
+                NULL,
                 event,
                 (event_report_fn)hip_event_report);
       HIP_SUCCEED_FATAL(hipEventRecord(event->start, ctx->stream));
@@ -874,16 +874,7 @@ static int gpu_launch_kernel(struct futhark_context* ctx,
     HIP_SUCCEED_FATAL(hipEventRecord(event->start, ctx->stream));
     add_event(ctx,
               name,
-              msgprintf("At: %s\n"
-                        "Kernel %s with\n"
-                        "  grid=(%d,%d,%d)\n"
-                        "  block=(%d,%d,%d)\n"
-                        "  shared memory=%d",
-                        provenance ? provenance : "unknown",
-                        name,
-                        grid[0], grid[1], grid[2],
-                        block[0], block[1], block[2],
-                        shared_mem_bytes),
+              NULL,
               event,
               (event_report_fn)hip_event_report);
   }

--- a/rts/c/backends/hip.h
+++ b/rts/c/backends/hip.h
@@ -720,13 +720,14 @@ static void gpu_free_kernel(struct futhark_context *ctx,
 }
 
 static int gpu_scalar_to_device(struct futhark_context* ctx,
+                                const char *provenance,
                                 gpu_mem dst, size_t offset, size_t size,
                                 void *src) {
   struct hip_event *event = hip_event_new(ctx);
   if (event != NULL) {
     add_event(ctx,
               "copy_scalar_to_dev",
-              NULL,
+              provenance,
               NULL,
               event,
               (event_report_fn)hip_event_report);
@@ -740,13 +741,14 @@ static int gpu_scalar_to_device(struct futhark_context* ctx,
 }
 
 static int gpu_scalar_from_device(struct futhark_context* ctx,
+                                  const char *provenance,
                                   void *dst,
                                   gpu_mem src, size_t offset, size_t size) {
   struct hip_event *event = hip_event_new(ctx);
   if (event != NULL) {
     add_event(ctx,
               "copy_scalar_from_dev",
-              NULL,
+              provenance,
               NULL,
               event,
               (event_report_fn)hip_event_report);
@@ -760,6 +762,7 @@ static int gpu_scalar_from_device(struct futhark_context* ctx,
 }
 
 static int gpu_memcpy(struct futhark_context* ctx,
+                      const char *provenance,
                       gpu_mem dst, int64_t dst_offset,
                       gpu_mem src, int64_t src_offset,
                       int64_t nbytes) {
@@ -767,7 +770,7 @@ static int gpu_memcpy(struct futhark_context* ctx,
   if (event != NULL) {
     add_event(ctx,
               "copy_dev_to_dev",
-              NULL,
+              provenance,
               NULL,
               event,
               (event_report_fn)hip_event_report);
@@ -781,7 +784,9 @@ static int gpu_memcpy(struct futhark_context* ctx,
   return FUTHARK_SUCCESS;
 }
 
-static int memcpy_host2gpu(struct futhark_context* ctx, bool sync,
+static int memcpy_host2gpu(struct futhark_context* ctx,
+                           const char *provenance,
+                           bool sync,
                            gpu_mem dst, int64_t dst_offset,
                            const unsigned char* src, int64_t src_offset,
                            int64_t nbytes) {
@@ -790,7 +795,7 @@ static int memcpy_host2gpu(struct futhark_context* ctx, bool sync,
     if (event != NULL) {
       add_event(ctx,
                 "copy_host_to_dev",
-                NULL,
+                provenance,
                 NULL,
                 event,
                 (event_report_fn)hip_event_report);
@@ -813,7 +818,9 @@ static int memcpy_host2gpu(struct futhark_context* ctx, bool sync,
   return FUTHARK_SUCCESS;
 }
 
-static int memcpy_gpu2host(struct futhark_context* ctx, bool sync,
+static int memcpy_gpu2host(struct futhark_context* ctx,
+                           const char *provenance,
+                           bool sync,
                            unsigned char* dst, int64_t dst_offset,
                            gpu_mem src, int64_t src_offset,
                            int64_t nbytes) {
@@ -822,7 +829,7 @@ static int memcpy_gpu2host(struct futhark_context* ctx, bool sync,
     if (event != NULL) {
       add_event(ctx,
                 "copy_dev_to_host",
-                NULL,
+                provenance,
                 NULL,
                 event,
                 (event_report_fn)hip_event_report);

--- a/rts/c/backends/opencl.h
+++ b/rts/c/backends/opencl.h
@@ -1157,13 +1157,14 @@ static void gpu_free_kernel(struct futhark_context *ctx,
 }
 
 static int gpu_scalar_to_device(struct futhark_context* ctx,
+                                const char *provenance,
                                 gpu_mem dst, size_t offset, size_t size,
                                 void *src) {
   cl_event* event = opencl_event_new(ctx);
   if (event != NULL) {
     add_event(ctx,
               "copy_scalar_to_dev",
-              NULL,
+              provenance,
               NULL,
               event,
               (event_report_fn)opencl_event_report);
@@ -1176,13 +1177,14 @@ static int gpu_scalar_to_device(struct futhark_context* ctx,
 }
 
 static int gpu_scalar_from_device(struct futhark_context* ctx,
+                                  const char *provenance,
                                   void *dst,
                                   gpu_mem src, size_t offset, size_t size) {
   cl_event* event = opencl_event_new(ctx);
   if (event != NULL) {
     add_event(ctx,
               "copy_scalar_from_dev",
-              NULL,
+              provenance,
               NULL,
               event,
               (event_report_fn)opencl_event_report);
@@ -1194,7 +1196,7 @@ static int gpu_scalar_from_device(struct futhark_context* ctx,
   return 0;
 }
 
-static int gpu_memcpy(struct futhark_context* ctx,
+static int gpu_memcpy(struct futhark_context* ctx, const char *provenance,
                       gpu_mem dst, int64_t dst_offset,
                       gpu_mem src, int64_t src_offset,
                       int64_t nbytes) {
@@ -1203,7 +1205,7 @@ static int gpu_memcpy(struct futhark_context* ctx,
     if (event != NULL) {
       add_event(ctx,
                 "copy_dev_to_dev",
-                NULL,
+                provenance,
                 NULL,
                 event,
                 (event_report_fn)opencl_event_report);
@@ -1221,7 +1223,8 @@ static int gpu_memcpy(struct futhark_context* ctx,
   return FUTHARK_SUCCESS;
 }
 
-static int memcpy_host2gpu(struct futhark_context* ctx, bool sync,
+static int memcpy_host2gpu(struct futhark_context* ctx, const char *provenance,
+                           bool sync,
                            gpu_mem dst, int64_t dst_offset,
                            const unsigned char* src, int64_t src_offset,
                            int64_t nbytes) {
@@ -1230,7 +1233,7 @@ static int memcpy_host2gpu(struct futhark_context* ctx, bool sync,
     if (event != NULL) {
       add_event(ctx,
                 "copy_host_to_dev",
-                NULL,
+                provenance,
                 NULL,
                 event,
                 (event_report_fn)opencl_event_report);
@@ -1249,7 +1252,8 @@ static int memcpy_host2gpu(struct futhark_context* ctx, bool sync,
   return FUTHARK_SUCCESS;
 }
 
-static int memcpy_gpu2host(struct futhark_context* ctx, bool sync,
+static int memcpy_gpu2host(struct futhark_context* ctx, const char *provenance,
+                           bool sync,
                            unsigned char* dst, int64_t dst_offset,
                            gpu_mem src, int64_t src_offset,
                            int64_t nbytes) {
@@ -1258,7 +1262,7 @@ static int memcpy_gpu2host(struct futhark_context* ctx, bool sync,
     if (event != NULL) {
       add_event(ctx,
                 "copy_dev_to_host",
-                NULL,
+                provenance,
                 NULL,
                 event,
                 (event_report_fn)opencl_event_report);

--- a/rts/c/backends/opencl.h
+++ b/rts/c/backends/opencl.h
@@ -1164,6 +1164,7 @@ static int gpu_scalar_to_device(struct futhark_context* ctx,
     add_event(ctx,
               "copy_scalar_to_dev",
               NULL,
+              NULL,
               event,
               (event_report_fn)opencl_event_report);
   }
@@ -1181,6 +1182,7 @@ static int gpu_scalar_from_device(struct futhark_context* ctx,
   if (event != NULL) {
     add_event(ctx,
               "copy_scalar_from_dev",
+              NULL,
               NULL,
               event,
               (event_report_fn)opencl_event_report);
@@ -1201,6 +1203,7 @@ static int gpu_memcpy(struct futhark_context* ctx,
     if (event != NULL) {
       add_event(ctx,
                 "copy_dev_to_dev",
+                NULL,
                 NULL,
                 event,
                 (event_report_fn)opencl_event_report);
@@ -1228,6 +1231,7 @@ static int memcpy_host2gpu(struct futhark_context* ctx, bool sync,
       add_event(ctx,
                 "copy_host_to_dev",
                 NULL,
+                NULL,
                 event,
                 (event_report_fn)opencl_event_report);
     }
@@ -1254,6 +1258,7 @@ static int memcpy_gpu2host(struct futhark_context* ctx, bool sync,
     if (event != NULL) {
       add_event(ctx,
                 "copy_dev_to_host",
+                NULL,
                 NULL,
                 event,
                 (event_report_fn)opencl_event_report);
@@ -1294,9 +1299,17 @@ static int gpu_launch_kernel(struct futhark_context* ctx,
 
   cl_event* event = opencl_event_new(ctx);
   if (event != NULL) {
+
+    struct kvs *kvs = kvs_new();
+    kvs_printf(kvs, "kernel", "%s", name);
+    kvs_printf(kvs, "grid", "[%d,%d,%d]", grid[0], grid[1], grid[2]);
+    kvs_printf(kvs, "block", "[%d,%d,%d]", block[0], block[1], block[2]);
+    kvs_printf(kvs, "shared memory", "%d", shared_mem_bytes);
+
     add_event(ctx,
               name,
               provenance,
+              kvs,
               event,
               (event_report_fn)opencl_event_report);
   }

--- a/rts/c/backends/opencl.h
+++ b/rts/c/backends/opencl.h
@@ -1163,7 +1163,7 @@ static int gpu_scalar_to_device(struct futhark_context* ctx,
   if (event != NULL) {
     add_event(ctx,
               "copy_scalar_to_dev",
-              strdup(""),
+              NULL,
               event,
               (event_report_fn)opencl_event_report);
   }
@@ -1181,7 +1181,7 @@ static int gpu_scalar_from_device(struct futhark_context* ctx,
   if (event != NULL) {
     add_event(ctx,
               "copy_scalar_from_dev",
-              strdup(""),
+              NULL,
               event,
               (event_report_fn)opencl_event_report);
   }
@@ -1201,7 +1201,7 @@ static int gpu_memcpy(struct futhark_context* ctx,
     if (event != NULL) {
       add_event(ctx,
                 "copy_dev_to_dev",
-                strdup(""),
+                NULL,
                 event,
                 (event_report_fn)opencl_event_report);
     }
@@ -1227,7 +1227,7 @@ static int memcpy_host2gpu(struct futhark_context* ctx, bool sync,
     if (event != NULL) {
       add_event(ctx,
                 "copy_host_to_dev",
-                strdup(""),
+                NULL,
                 event,
                 (event_report_fn)opencl_event_report);
     }
@@ -1254,7 +1254,7 @@ static int memcpy_gpu2host(struct futhark_context* ctx, bool sync,
     if (event != NULL) {
       add_event(ctx,
                 "copy_dev_to_host",
-                strdup(""),
+                NULL,
                 event,
                 (event_report_fn)opencl_event_report);
     }
@@ -1296,16 +1296,7 @@ static int gpu_launch_kernel(struct futhark_context* ctx,
   if (event != NULL) {
     add_event(ctx,
               name,
-              msgprintf("At: %s\n"
-                        "Kernel %s with\n"
-                        "  grid=(%d,%d,%d)\n"
-                        "  block=(%d,%d,%d)\n"
-                        "  shared memory=%d",
-                        provenance ? provenance : "unknown",
-                        name,
-                        grid[0], grid[1], grid[2],
-                        block[0], block[1], block[2],
-                        shared_mem_bytes),
+              provenance,
               event,
               (event_report_fn)opencl_event_report);
   }

--- a/rts/c/backends/opencl.h
+++ b/rts/c/backends/opencl.h
@@ -1305,7 +1305,7 @@ static int gpu_launch_kernel(struct futhark_context* ctx,
   if (event != NULL) {
 
     struct kvs *kvs = kvs_new();
-    kvs_printf(kvs, "kernel", "%s", name);
+    kvs_printf(kvs, "kernel", "\"%s\"", name);
     kvs_printf(kvs, "grid", "[%d,%d,%d]", grid[0], grid[1], grid[2]);
     kvs_printf(kvs, "block", "[%d,%d,%d]", block[0], block[1], block[2]);
     kvs_printf(kvs, "shared memory", "%d", shared_mem_bytes);

--- a/rts/c/backends/opencl.h
+++ b/rts/c/backends/opencl.h
@@ -1275,7 +1275,9 @@ static int memcpy_gpu2host(struct futhark_context* ctx, bool sync,
 }
 
 static int gpu_launch_kernel(struct futhark_context* ctx,
-                             gpu_kernel kernel, const char *name,
+                             gpu_kernel kernel,
+                             const char *name,
+                             const char *provenance,
                              const int32_t grid[3],
                              const int32_t block[3],
                              unsigned int shared_mem_bytes,
@@ -1294,10 +1296,12 @@ static int gpu_launch_kernel(struct futhark_context* ctx,
   if (event != NULL) {
     add_event(ctx,
               name,
-              msgprintf("Kernel %s with\n"
+              msgprintf("At: %s\n"
+                        "Kernel %s with\n"
                         "  grid=(%d,%d,%d)\n"
                         "  block=(%d,%d,%d)\n"
                         "  shared memory=%d",
+                        provenance ? provenance : "unknown",
                         name,
                         grid[0], grid[1], grid[2],
                         block[0], block[1], block[2],

--- a/rts/c/context.h
+++ b/rts/c/context.h
@@ -71,12 +71,16 @@ static void host_free(struct futhark_context* ctx,
 static void add_event(struct futhark_context* ctx,
                       const char* name,
                       const char* provenance,
+                      struct kvs *kvs,
                       void* data,
                       event_report_fn f) {
   if (ctx->logging) {
-    fprintf(ctx->log, "Event: %s\n  %s\n", name, provenance);
+    fprintf(ctx->log, "Event: %s\n  at: %s\n", name, provenance);
+    if (kvs) {
+      kvs_log(kvs, "  ", ctx->log);
+    }
   }
-  add_event_to_list(&ctx->event_list, name, provenance, data, f);
+  add_event_to_list(&ctx->event_list, name, provenance, kvs, data, f);
 }
 
 char *futhark_context_get_error(struct futhark_context *ctx) {

--- a/rts/c/context.h
+++ b/rts/c/context.h
@@ -74,6 +74,9 @@ static void add_event(struct futhark_context* ctx,
                       struct kvs *kvs,
                       void* data,
                       event_report_fn f) {
+  if (provenance == NULL) {
+    provenance = "unknown";
+  }
   if (ctx->logging) {
     fprintf(ctx->log, "Event: %s\n  at: %s\n", name, provenance);
     if (kvs) {

--- a/rts/c/context.h
+++ b/rts/c/context.h
@@ -70,13 +70,13 @@ static void host_free(struct futhark_context* ctx,
 
 static void add_event(struct futhark_context* ctx,
                       const char* name,
-                      char* description,
+                      const char* provenance,
                       void* data,
                       event_report_fn f) {
   if (ctx->logging) {
-    fprintf(ctx->log, "Event: %s\n%s\n", name, description);
+    fprintf(ctx->log, "Event: %s\n  %s\n", name, provenance);
   }
-  add_event_to_list(&ctx->event_list, name, description, data, f);
+  add_event_to_list(&ctx->event_list, name, provenance, data, f);
 }
 
 char *futhark_context_get_error(struct futhark_context *ctx) {

--- a/rts/c/context_prototypes.h
+++ b/rts/c/context_prototypes.h
@@ -20,9 +20,11 @@ static void host_alloc(struct futhark_context* ctx, size_t size, const char* tag
 // Allocate memory allocated with host_alloc().
 static void host_free(struct futhark_context* ctx, size_t size, const char* tag, void* mem);
 
-// Log that a copy has occurred.
+// Log that a copy has occurred. The provenance may be NULL, if we do not know
+// where this came from.
 static void log_copy(struct futhark_context* ctx,
-                     const char *kind, int r,
+                     const char *kind, const char *provenance,
+                     int r,
                      int64_t dst_offset, int64_t dst_strides[r],
                      int64_t src_offset, int64_t src_strides[r],
                      int64_t shape[r]);

--- a/rts/c/context_prototypes.h
+++ b/rts/c/context_prototypes.h
@@ -46,6 +46,7 @@ static bool lmad_memcpyable(int r,
 static void add_event(struct futhark_context* ctx,
                       const char* name,
                       const char* provenance,
+                      struct kvs *kvs,
                       void* data,
                       event_report_fn f);
 

--- a/rts/c/context_prototypes.h
+++ b/rts/c/context_prototypes.h
@@ -45,7 +45,7 @@ static bool lmad_memcpyable(int r,
 
 static void add_event(struct futhark_context* ctx,
                       const char* name,
-                      char* description,
+                      const char* provenance,
                       void* data,
                       event_report_fn f);
 

--- a/rts/c/copy.h
+++ b/rts/c/copy.h
@@ -188,12 +188,14 @@ static bool lmad_memcpyable(int r,
 
 
 static void log_copy(struct futhark_context* ctx,
-                     const char *kind, int r,
+                     const char *kind, const char *provenance,
+                     int r,
                      int64_t dst_offset, int64_t dst_strides[r],
                      int64_t src_offset, int64_t src_strides[r],
                      int64_t shape[r]) {
   if (ctx->logging) {
     fprintf(ctx->log, "\n# Copy %s\n", kind);
+    if (provenance) { fprintf(ctx->log, "At: %s\n", provenance); }
     fprintf(ctx->log, "Shape: ");
     for (int i = 0; i < r; i++) { fprintf(ctx->log, "[%ld]", (long int)shape[i]); }
     fprintf(ctx->log, "\n");
@@ -225,7 +227,7 @@ static void log_transpose(struct futhark_context* ctx,
    ELEM_TYPE* dst, int64_t dst_offset, int64_t dst_strides[r],          \
    ELEM_TYPE *src, int64_t src_offset, int64_t src_strides[r],          \
    int64_t shape[r]) {                                                  \
-    log_copy(ctx, "CPU to CPU", r, dst_offset, dst_strides,             \
+    log_copy(ctx, "CPU to CPU", NULL, r, dst_offset, dst_strides,       \
              src_offset, src_strides, shape);                           \
     int64_t size = 1;                                                   \
     for (int i = 0; i < r; i++) { size *= shape[i]; }                   \

--- a/rts/c/event_list.h
+++ b/rts/c/event_list.h
@@ -35,7 +35,8 @@ static void add_event_to_list(struct event_list *l,
     l->events = realloc(l->events, l->capacity * sizeof(struct event));
   }
   l->events[l->num_events].name = name;
-  l->events[l->num_events].provenance = provenance ? provenance : "unknown";
+  l->events[l->num_events].provenance =
+    provenance ? provenance : "\"unknown\"";
   l->events[l->num_events].data = data;
   l->events[l->num_events].f = f;
   l->num_events++;

--- a/rts/c/event_list.h
+++ b/rts/c/event_list.h
@@ -2,11 +2,114 @@
 
 typedef int (*event_report_fn)(struct str_builder*, void*);
 
+// A collection of key-value associations. Used to associate extra data with
+// events.
+struct kvs {
+  // A buffer that contains all value data. Must be freed when the struct kvs is
+  // no longer used.
+  char *buf;
+
+  // Size of buf in bytes.
+  size_t buf_size;
+
+  // Number of bytes used in buf.
+  size_t buf_used;
+
+  // Number of associations stored.
+  size_t n;
+
+  // Capacity of vals.
+  size_t vals_capacity;
+
+  // An array of keys.
+  const char* *keys;
+
+  // Indexes into 'buf' that contains the values as zero-terminated strings.
+  size_t *vals;
+};
+
+static const size_t KVS_INIT_BUF_SIZE = 128;
+static const size_t KVS_INIT_NUMKEYS = 8;
+
+void kvs_init(struct kvs* kvs) {
+  kvs->buf = malloc(KVS_INIT_BUF_SIZE);
+  kvs->buf_size = KVS_INIT_BUF_SIZE;
+  kvs->buf_used = 0;
+  kvs->vals_capacity = KVS_INIT_NUMKEYS;
+  kvs->keys = calloc(kvs->vals_capacity, sizeof(const char*));
+  kvs->vals = calloc(kvs->vals_capacity, sizeof(size_t));
+  kvs->n = 0;
+}
+
+struct kvs* kvs_new(void) {
+  struct kvs *kvs = malloc(sizeof(struct kvs));
+  kvs_init(kvs);
+  return kvs;
+}
+
+void kvs_printf(struct kvs* kvs, const char* key, const char* fmt, ...) {
+  va_list vl;
+  va_start(vl, fmt);
+
+  size_t needed = 1 + (size_t)vsnprintf(NULL, 0, fmt, vl);
+
+  while (kvs->buf_used+needed > kvs->buf_size) {
+    kvs->buf_size *= 2;
+    kvs->buf = realloc(kvs->buf, kvs->buf_size * sizeof(const char*));
+  }
+
+  if (kvs->n == kvs->vals_capacity) {
+    kvs->vals_capacity *= 2;
+    kvs->vals = realloc(kvs->vals, kvs->vals_capacity * sizeof(size_t));
+    kvs->keys = realloc(kvs->keys, kvs->vals_capacity * sizeof(char*));
+  }
+
+  kvs->keys[kvs->n] = key;
+  kvs->vals[kvs->n] = kvs->buf_used;
+  kvs->buf_used += needed;
+
+  va_start(vl, fmt); // Must re-init.
+  vsnprintf(&kvs->buf[kvs->vals[kvs->n]], needed, fmt, vl);
+
+  kvs->n++;
+}
+
+void kvs_free(struct kvs* kvs) {
+  free(kvs->vals);
+  free(kvs->keys);
+  free(kvs->buf);
+}
+
+// Assumes all of the values are valid JSON objects.
+void kvs_json(const struct kvs* kvs, struct str_builder *sb) {
+  str_builder_char(sb, '{');
+  for (size_t i = 0; i < kvs->n; i++) {
+    if (i != 0) {
+      str_builder_str(sb, ",");
+    }
+    str_builder_json_str(sb, kvs->keys[i]);
+    str_builder_str(sb, ":");
+    str_builder_str(sb, &kvs->buf[kvs->vals[i]]);
+  }
+  str_builder_char(sb, '}');
+}
+
+void kvs_log(const struct kvs* kvs, const char* prefix, FILE* f) {
+  for (size_t i = 0; i < kvs->n; i++) {
+    fprintf(f, "%s%s: %s\n",
+            prefix,
+            kvs->keys[i],
+            &kvs->buf[kvs->vals[i]]);
+  }
+}
+
 struct event {
   void* data;
   event_report_fn f;
   const char* name;
   const char *provenance;
+  // Key-value information that is also to be printed.
+  struct kvs *kvs;
 };
 
 struct event_list {
@@ -28,6 +131,7 @@ static void event_list_free(struct event_list *l) {
 static void add_event_to_list(struct event_list *l,
                               const char* name,
                               const char* provenance,
+                              struct kvs *kvs,
                               void* data,
                               event_report_fn f) {
   if (l->num_events == l->capacity) {
@@ -36,7 +140,8 @@ static void add_event_to_list(struct event_list *l,
   }
   l->events[l->num_events].name = name;
   l->events[l->num_events].provenance =
-    provenance ? provenance : "\"unknown\"";
+    provenance ? provenance : "unknown";
+  l->events[l->num_events].kvs = kvs;
   l->events[l->num_events].data = data;
   l->events[l->num_events].f = f;
   l->num_events++;
@@ -52,10 +157,18 @@ static int report_events_in_list(struct event_list *l,
     str_builder_str(sb, "{\"name\":");
     str_builder_json_str(sb, l->events[i].name);
     str_builder_str(sb, ",\"provenance\":");
-    str_builder_str(sb, l->events[i].provenance);
+    str_builder_json_str(sb, l->events[i].provenance);
     if (l->events[i].f(sb, l->events[i].data) != 0) {
       ret = 1;
       break;
+    }
+
+    str_builder_str(sb, ",\"details\":");
+    if (l->events[i].kvs) {
+      kvs_json(l->events[i].kvs, sb);
+      kvs_free(l->events[i].kvs);
+    } else {
+      str_builder_str(sb, "{}");
     }
 
     str_builder(sb, "}");

--- a/rts/c/event_list.h
+++ b/rts/c/event_list.h
@@ -6,7 +6,7 @@ struct event {
   void* data;
   event_report_fn f;
   const char* name;
-  char *description;
+  const char *provenance;
 };
 
 struct event_list {
@@ -27,7 +27,7 @@ static void event_list_free(struct event_list *l) {
 
 static void add_event_to_list(struct event_list *l,
                               const char* name,
-                              char* description,
+                              const char* provenance,
                               void* data,
                               event_report_fn f) {
   if (l->num_events == l->capacity) {
@@ -35,7 +35,7 @@ static void add_event_to_list(struct event_list *l,
     l->events = realloc(l->events, l->capacity * sizeof(struct event));
   }
   l->events[l->num_events].name = name;
-  l->events[l->num_events].description = description;
+  l->events[l->num_events].provenance = provenance ? provenance : "unknown";
   l->events[l->num_events].data = data;
   l->events[l->num_events].f = f;
   l->num_events++;
@@ -50,13 +50,13 @@ static int report_events_in_list(struct event_list *l,
     }
     str_builder_str(sb, "{\"name\":");
     str_builder_json_str(sb, l->events[i].name);
-    str_builder_str(sb, ",\"description\":");
-    str_builder_json_str(sb, l->events[i].description);
-    free(l->events[i].description);
+    str_builder_str(sb, ",\"provenance\":");
+    str_builder_str(sb, l->events[i].provenance);
     if (l->events[i].f(sb, l->events[i].data) != 0) {
       ret = 1;
       break;
     }
+
     str_builder(sb, "}");
   }
   event_list_free(l);

--- a/src-testing/Futhark/IR/Syntax/CoreTests.hs
+++ b/src-testing/Futhark/IR/Syntax/CoreTests.hs
@@ -69,15 +69,25 @@ subShapeTests =
 
 provenanceTests :: [TestTree]
 provenanceTests =
-  [ testCase "simple" $
-      (Provenance [] line1 <> Provenance [] line0) @?= Provenance [] lines01,
-    testCase "mempty left" $
-      (Provenance [] mempty <> Provenance [] line0) @?= Provenance [] line0,
-    testCase "mempty right" $
-      (Provenance [] line1 <> Provenance [] mempty) @?= Provenance [] line1
+  [ testGroup
+      "<>"
+      [ testCase "simple" $
+          (Provenance [] line1 <> Provenance [] line0) @?= Provenance [] lines01,
+        testCase "mempty left" $
+          (Provenance [] mempty <> Provenance [] line0) @?= Provenance [] line0,
+        testCase "mempty right" $
+          (Provenance [] line1 <> Provenance [] mempty) @?= Provenance [] line1
+      ],
+    testGroup
+      "stackProvenance"
+      [ testCase "encloses" $
+          (Provenance [] line0 `stackProvenance` Provenance [] line0_sub)
+            @?= Provenance [] line0_sub
+      ]
   ]
   where
     line0 = Loc (Pos "" 0 1 0) (Pos "" 0 10 10)
+    line0_sub = Loc (Pos "" 0 2 1) (Pos "" 0 9 9)
     line1 = Loc (Pos "" 1 1 0) (Pos "" 1 10 20)
     lines01 = Loc (Pos "" 0 1 0) (Pos "" 1 10 20)
 

--- a/src-testing/Futhark/ProfileTests.hs
+++ b/src-testing/Futhark/ProfileTests.hs
@@ -21,4 +21,3 @@ instance Arbitrary ProfilingReport where
     ProfilingReport
       <$> arbitrary
       <*> (M.fromList <$> listOf ((,) <$> arbText <*> arbitrary))
-      <*> (M.fromList <$> listOf ((,) <$> arbText <*> arbText))

--- a/src-testing/Futhark/ProfileTests.hs
+++ b/src-testing/Futhark/ProfileTests.hs
@@ -21,3 +21,4 @@ instance Arbitrary ProfilingReport where
     ProfilingReport
       <$> arbitrary
       <*> (M.fromList <$> listOf ((,) <$> arbText <*> arbitrary))
+      <*> (M.fromList <$> listOf ((,) <$> arbText <*> arbText))

--- a/src-testing/Futhark/ProfileTests.hs
+++ b/src-testing/Futhark/ProfileTests.hs
@@ -14,7 +14,7 @@ arbText :: Gen T.Text
 arbText = T.pack <$> printable
 
 instance Arbitrary ProfilingEvent where
-  arbitrary = ProfilingEvent <$> arbText <*> arbitrary <*> arbText
+  arbitrary = ProfilingEvent <$> arbText <*> arbitrary <*> listOf arbText <*> arbitrary
 
 instance Arbitrary ProfilingReport where
   arbitrary =

--- a/src-testing/Futhark/ProfileTests.hs
+++ b/src-testing/Futhark/ProfileTests.hs
@@ -14,7 +14,7 @@ arbText :: Gen T.Text
 arbText = T.pack <$> printable
 
 instance Arbitrary ProfilingEvent where
-  arbitrary = ProfilingEvent <$> arbText <*> arbitrary <*> listOf arbText <*> arbitrary
+  arbitrary = ProfilingEvent <$> arbText <*> arbitrary <*> arbText <*> arbitrary
 
 instance Arbitrary ProfilingReport where
   arbitrary =

--- a/src/Futhark/Analysis/AccessPattern.hs
+++ b/src/Futhark/Analysis/AccessPattern.hs
@@ -471,7 +471,7 @@ analyseBasicOp ctx expression pats =
         BinOp _ lsubexp rsubexp -> concatVariableInfos mempty [lsubexp, rsubexp]
         CmpOp _ lsubexp rsubexp -> concatVariableInfos mempty [lsubexp, rsubexp]
         ConvOp _ se -> varInfoFromSubExp se
-        Assert se _ _ -> varInfoFromSubExp se
+        Assert se _ -> varInfoFromSubExp se
         Index name _ ->
           error $ "unhandled: Index (This should NEVER happen) into " ++ prettyString name
         Update _ name _slice _subexp ->

--- a/src/Futhark/Analysis/Alias.hs
+++ b/src/Futhark/Analysis/Alias.hs
@@ -82,11 +82,11 @@ analyseStm ::
   AliasTable ->
   Stm rep ->
   Stm (Aliases rep)
-analyseStm aliases (Let pat (StmAux cs attrs dec) e) =
+analyseStm aliases (Let pat aux e) =
   let e' = analyseExp aliases e
       pat' = mkAliasedPat pat e'
-      rep' = (AliasDec $ consumedInExp e', dec)
-   in Let pat' (StmAux cs attrs rep') e'
+      aux' = (AliasDec (consumedInExp e'),) <$> aux
+   in Let pat' aux' e'
 
 -- | Perform alias analysis on expression.
 analyseExp ::

--- a/src/Futhark/Analysis/PrimExp/Convert.hs
+++ b/src/Futhark/Analysis/PrimExp/Convert.hs
@@ -48,7 +48,7 @@ instance (ToExp v) => ToExp (PrimExp v) where
     Apply (nameFromText h)
       <$> args'
       <*> pure [(primRetType t, mempty)]
-      <*> pure (Safe, mempty, [])
+      <*> pure Safe
     where
       args' = zip <$> mapM (toSubExp "apply_arg") args <*> pure (repeat Observe)
   toExp (LeafExp v _) =

--- a/src/Futhark/Builder/Class.hs
+++ b/src/Futhark/Builder/Class.hs
@@ -113,7 +113,10 @@ attributing attrs = censorStms $ fmap onStm
 -- this action.
 auxing :: (MonadBuilder m) => StmAux anyrep -> m a -> m a
 auxing outer
-  | stmAuxCerts outer == mempty && stmAuxAttrs outer == mempty = id
+  | stmAuxCerts outer == mempty,
+    stmAuxAttrs outer == mempty,
+    stmAuxLoc outer == mempty =
+      id
   | otherwise = censorStms $ fmap onStm
   where
     onStm (Let pat aux e) =

--- a/src/Futhark/CLI/Misc.hs
+++ b/src/Futhark/CLI/Misc.hs
@@ -22,8 +22,8 @@ import Futhark.Test
 import Futhark.Util (hashText, interactWithFileSafely)
 import Futhark.Util.Options
 import Futhark.Util.Pretty (prettyTextOneLine)
+import Language.Futhark.Core (isBuiltin)
 import Language.Futhark.Parser.Lexer (scanTokensText)
-import Language.Futhark.Prop (isBuiltin)
 import Language.Futhark.Semantic (includeToString)
 import System.Environment (getExecutablePath)
 import System.Exit

--- a/src/Futhark/CLI/Profile.hs
+++ b/src/Futhark/CLI/Profile.hs
@@ -48,7 +48,7 @@ data EvSummary = EvSummary
 tabulateEvents :: [ProfilingEvent] -> T.Text
 tabulateEvents = mkRows . M.toList . M.fromListWith comb . map pair
   where
-    pair (ProfilingEvent name dur _) = (name, EvSummary 1 dur dur dur)
+    pair (ProfilingEvent name dur _ _details) = (name, EvSummary 1 dur dur dur)
     comb (EvSummary xn xdur xmin xmax) (EvSummary yn ydur ymin ymax) =
       EvSummary (xn + yn) (xdur + ydur) (min xmin ymin) (max xmax ymax)
     numpad = 15
@@ -92,8 +92,11 @@ tabulateEvents = mkRows . M.toList . M.fromListWith comb . map pair
 timeline :: [ProfilingEvent] -> T.Text
 timeline = T.unlines . L.intercalate [""] . map onEvent
   where
-    onEvent (ProfilingEvent name duration description) =
-      [name, "Duration: " <> showText duration <> " μs"] <> T.lines description
+    onEvent (ProfilingEvent name duration provenance _details) =
+      [ name,
+        "Duration: " <> showText duration <> " μs",
+        "At: " <> T.intercalate "->" provenance
+      ]
 
 data TargetFiles = TargetFiles
   { summaryFile :: FilePath,

--- a/src/Futhark/CLI/Profile.hs
+++ b/src/Futhark/CLI/Profile.hs
@@ -95,7 +95,7 @@ timeline = T.unlines . L.intercalate [""] . map onEvent
     onEvent (ProfilingEvent name duration provenance _details) =
       [ name,
         "Duration: " <> showText duration <> " μs",
-        "At: " <> T.intercalate "->" provenance
+        "At: " <> provenance
       ]
 
 data TargetFiles = TargetFiles

--- a/src/Futhark/CodeGen/Backends/GPU.hs
+++ b/src/Futhark/CodeGen/Backends/GPU.hs
@@ -171,9 +171,7 @@ copygpu2gpu _ t shape dst (dstoffset, dststride) src (srcoffset, srcstride) = do
       dststride_inits = [[C.cinit|$exp:e|] | Count e <- dststride]
       srcstride_inits = [[C.cinit|$exp:e|] | Count e <- srcstride]
       shape_inits = [[C.cinit|$exp:e|] | Count e <- shape]
-
   provenance <- provenanceExp
-
   GC.stm
     [C.cstm|
          if ((err =
@@ -193,11 +191,13 @@ copyhost2gpu sync t shape dst (dstoffset, dststride) src (srcoffset, srcstride) 
       dststride_inits = [[C.cinit|$exp:e|] | Count e <- dststride]
       srcstride_inits = [[C.cinit|$exp:e|] | Count e <- srcstride]
       shape_inits = [[C.cinit|$exp:e|] | Count e <- shape]
+  provenance <- provenanceExp
   GC.stm
     [C.cstm|
          if ((err =
                 lmad_copy_host2gpu
-                         (ctx, $int:(primByteSize t::Int), $exp:sync', $int:r,
+                         (ctx, $exp:provenance,
+                         $int:(primByteSize t::Int), $exp:sync', $int:r,
                           $exp:dst, $exp:(unCount dstoffset),
                           (typename int64_t[]){ $inits:dststride_inits },
                           $exp:src, $exp:(unCount srcoffset),

--- a/src/Futhark/CodeGen/Backends/GenericC/Code.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC/Code.hs
@@ -223,8 +223,8 @@ compileCode (Op op) =
 compileCode Skip = pure ()
 compileCode (Meta (MetaComment s)) = do
   comment s
-compileCode (Meta (MetaProvenance l)) =
-  comment $ prettyText l
+compileCode (Meta (MetaProvenance (Provenance _ l))) =
+  unless (l == mempty) $ comment $ locText l
 compileCode (TracePrint msg) = do
   (formatstr, formatargs) <- errorMsgString msg
   stm [C.cstm|fprintf(ctx->log, $string:formatstr, $args:formatargs);|]

--- a/src/Futhark/CodeGen/Backends/GenericC/Code.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC/Code.hs
@@ -224,10 +224,11 @@ compileCode Skip = pure ()
 compileCode (Meta (MetaComment s) code) = do
   xs <- collect $ compileCode code
   let comment = "// " ++ T.unpack s
-  stm
-    [C.cstm|$comment:comment
-              { $items:xs }
-             |]
+  stm [C.cstm|$comment:comment { $items:xs } |]
+compileCode (Meta (MetaProvenance l) code) = do
+  xs <- collect $ compileCode code
+  let comment = T.unpack $ "// " <> prettyText l
+  stm [C.cstm|$comment:comment { $items:xs } |]
 compileCode (TracePrint msg) = do
   (formatstr, formatargs) <- errorMsgString msg
   stm [C.cstm|fprintf(ctx->log, $string:formatstr, $args:formatargs);|]

--- a/src/Futhark/CodeGen/Backends/GenericC/Code.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC/Code.hs
@@ -223,12 +223,11 @@ compileCode (Op op) =
 compileCode Skip = pure ()
 compileCode (Meta (MetaComment s) code) = do
   xs <- collect $ compileCode code
-  let comment = "// " ++ T.unpack s
-  stm [C.cstm|$comment:comment { $items:xs } |]
+  let s' = "// " ++ T.unpack s
+  stm [C.cstm|$comment:s' { $items:xs } |]
 compileCode (Meta (MetaProvenance l) code) = do
-  xs <- collect $ compileCode code
-  let comment = T.unpack $ "// " <> prettyText l
-  stm [C.cstm|$comment:comment { $items:xs } |]
+  comment $ prettyText l
+  compileCode code
 compileCode (TracePrint msg) = do
   (formatstr, formatargs) <- errorMsgString msg
   stm [C.cstm|fprintf(ctx->log, $string:formatstr, $args:formatargs);|]

--- a/src/Futhark/CodeGen/Backends/GenericC/Code.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC/Code.hs
@@ -268,6 +268,9 @@ compileCode (c1 :>>: c2) = go (linearCode (c1 :>>: c2))
           args' <- mapM compileArg args
           item [C.citem|$tyquals:(volQuals vol) $ty:ct $id:name = $id:(funName fname)($args:args');|]
           go code
+    go (x@(Meta (MetaProvenance p)) : xs) = do
+      compileCode x
+      localProvenance p $ go xs
     go (x : xs) = compileCode x >> go xs
     go [] = pure ()
 compileCode (Assert e msg (loc, locs)) = do

--- a/src/Futhark/CodeGen/Backends/GenericC/Code.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC/Code.hs
@@ -221,7 +221,7 @@ compileCode :: Code op -> CompilerM op s ()
 compileCode (Op op) =
   join $ asks (opsCompiler . envOperations) <*> pure op
 compileCode Skip = pure ()
-compileCode (Comment s code) = do
+compileCode (Meta (MetaComment s) code) = do
   xs <- collect $ compileCode code
   let comment = "// " ++ T.unpack s
   stm

--- a/src/Futhark/CodeGen/Backends/GenericC/Code.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC/Code.hs
@@ -227,7 +227,7 @@ compileCode (Meta (MetaComment s) code) = do
   stm [C.cstm|$comment:s' { $items:xs } |]
 compileCode (Meta (MetaProvenance l) code) = do
   comment $ prettyText l
-  compileCode code
+  localProvenance l $ compileCode code
 compileCode (TracePrint msg) = do
   (formatstr, formatargs) <- errorMsgString msg
   stm [C.cstm|fprintf(ctx->log, $string:formatstr, $args:formatargs);|]

--- a/src/Futhark/CodeGen/Backends/GenericC/Code.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC/Code.hs
@@ -221,13 +221,10 @@ compileCode :: Code op -> CompilerM op s ()
 compileCode (Op op) =
   join $ asks (opsCompiler . envOperations) <*> pure op
 compileCode Skip = pure ()
-compileCode (Meta (MetaComment s) code) = do
-  xs <- collect $ compileCode code
-  let s' = "// " ++ T.unpack s
-  stm [C.cstm|$comment:s' { $items:xs } |]
-compileCode (Meta (MetaProvenance l) code) = do
+compileCode (Meta (MetaComment s)) = do
+  comment s
+compileCode (Meta (MetaProvenance l)) =
   comment $ prettyText l
-  localProvenance l $ compileCode code
 compileCode (TracePrint msg) = do
   (formatstr, formatargs) <- errorMsgString msg
   stm [C.cstm|fprintf(ctx->log, $string:formatstr, $args:formatargs);|]

--- a/src/Futhark/CodeGen/Backends/GenericC/Monad.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC/Monad.hs
@@ -63,6 +63,7 @@ module Futhark.CodeGen.Backends.GenericC.Monad
     configType,
     localProvenance,
     askProvenance,
+    provenanceExp,
 
     -- * Building Blocks
     copyMemoryDefaultSpace,
@@ -356,6 +357,15 @@ localProvenance p = local $ \env -> env {envProvenance = p}
 -- | The provenance of the closest enclosing 'Imp.MetaProvenance'.
 askProvenance :: CompilerM op s Provenance
 askProvenance = asks envProvenance
+
+-- | A C expression corresponding to the current provenance.
+provenanceExp :: CompilerM op s C.Exp
+provenanceExp = do
+  p <- askProvenance
+  pure $
+    if p == mempty
+      then [C.cexp|NULL|]
+      else [C.cexp|$string:(prettyString p)|]
 
 -- | Used when we, inside an existing 'CompilerM' action, want to
 -- generate code for a new function.  Use this so that the compiler

--- a/src/Futhark/CodeGen/Backends/GenericPython.hs
+++ b/src/Futhark/CodeGen/Backends/GenericPython.hs
@@ -1306,11 +1306,10 @@ compileCode (Imp.DeclareArray name t vs) = do
         ]
   name' <- compileVar name
   stm $ Assign name' $ simpleCall "unwrapArray" [Var arr_name]
-compileCode (Imp.Meta (Imp.MetaComment s) code) = do
-  code' <- collect $ compileCode code
-  stm $ Comment (T.unpack s) code'
-compileCode (Imp.Meta _ code) =
-  compileCode code
+compileCode (Imp.Meta (Imp.MetaComment s)) =
+  stm $ Comment (T.unpack s) []
+compileCode (Imp.Meta {}) =
+  pure ()
 compileCode (Imp.Assert e msg (loc, locs)) = do
   e' <- compileExp e
   (formatstr, formatargs) <- errorMsgString msg

--- a/src/Futhark/CodeGen/Backends/GenericPython.hs
+++ b/src/Futhark/CodeGen/Backends/GenericPython.hs
@@ -1306,7 +1306,7 @@ compileCode (Imp.DeclareArray name t vs) = do
         ]
   name' <- compileVar name
   stm $ Assign name' $ simpleCall "unwrapArray" [Var arr_name]
-compileCode (Imp.Comment s code) = do
+compileCode (Imp.Meta (Imp.MetaComment s) code) = do
   code' <- collect $ compileCode code
   stm $ Comment (T.unpack s) code'
 compileCode (Imp.Assert e msg (loc, locs)) = do

--- a/src/Futhark/CodeGen/Backends/GenericPython.hs
+++ b/src/Futhark/CodeGen/Backends/GenericPython.hs
@@ -1309,6 +1309,8 @@ compileCode (Imp.DeclareArray name t vs) = do
 compileCode (Imp.Meta (Imp.MetaComment s) code) = do
   code' <- collect $ compileCode code
   stm $ Comment (T.unpack s) code'
+compileCode (Imp.Meta _ code) =
+  compileCode code
 compileCode (Imp.Assert e msg (loc, locs)) = do
   e' <- compileExp e
   (formatstr, formatargs) <- errorMsgString msg

--- a/src/Futhark/CodeGen/Backends/MulticoreC.hs
+++ b/src/Futhark/CodeGen/Backends/MulticoreC.hs
@@ -203,6 +203,7 @@ mcMemToCType v space = do
 benchmarkCode :: Name -> [C.BlockItem] -> GC.CompilerM op s [C.BlockItem]
 benchmarkCode name code = do
   event <- newVName "event"
+  provenance <- GC.provenanceExp
   pure
     [C.citems|
      struct mc_event* $id:event = mc_event_new(ctx);
@@ -215,7 +216,7 @@ benchmarkCode name code = do
        lock_lock(&ctx->event_list_lock);
        add_event(ctx,
                  $string:(nameToString name),
-                 strdup("nothing further"),
+                 $exp:provenance,
                  $id:event,
                  (typename event_report_fn)mc_event_report);
        lock_unlock(&ctx->event_list_lock);

--- a/src/Futhark/CodeGen/Backends/MulticoreC.hs
+++ b/src/Futhark/CodeGen/Backends/MulticoreC.hs
@@ -217,6 +217,7 @@ benchmarkCode name code = do
        add_event(ctx,
                  $string:(nameToString name),
                  $exp:provenance,
+                 NULL,
                  $id:event,
                  (typename event_report_fn)mc_event_report);
        lock_unlock(&ctx->event_list_lock);

--- a/src/Futhark/CodeGen/Backends/MulticoreISPC.hs
+++ b/src/Futhark/CodeGen/Backends/MulticoreISPC.hs
@@ -474,7 +474,7 @@ compileExp (FunExp h args _) = do
 -- All recursive constructors are duplicated here, since not doing so
 -- would cause use to enter regular generic C codegen with no escape.
 compileCode :: MCCode -> ISPCCompilerM ()
-compileCode (Comment s code) = do
+compileCode (Meta (MetaComment s) code) = do
   xs <- GC.collect $ compileCode code
   let comment = "// " ++ T.unpack s
   GC.stm
@@ -729,7 +729,7 @@ mayProduceError (x :>>: y) = mayProduceError x || mayProduceError y
 mayProduceError (If _ x y) = mayProduceError x || mayProduceError y
 mayProduceError (For _ _ x) = mayProduceError x
 mayProduceError (While _ x) = mayProduceError x
-mayProduceError (Comment _ x) = mayProduceError x
+mayProduceError (Meta _ x) = mayProduceError x
 mayProduceError (Op (ForEachActive _ body)) = mayProduceError body
 mayProduceError (Op (ForEach _ _ _ body)) = mayProduceError body
 mayProduceError (Op SegOp {}) = True
@@ -1015,7 +1015,7 @@ findDeps (For idx bound x) = do
     free = freeIn bound
 findDeps (While cond x) = do
   local (<> freeIn cond) $ findDeps x
-findDeps (Comment _ x) =
+findDeps (Meta _ x) =
   findDeps x
 findDeps (Op (SegOp _ free _ _ retvals _)) =
   mapM_
@@ -1064,7 +1064,7 @@ findVarying (x :>>: y) = findVarying x ++ findVarying y
 findVarying (If _ x y) = findVarying x ++ findVarying y
 findVarying (For _ _ x) = findVarying x
 findVarying (While _ x) = findVarying x
-findVarying (Comment _ x) = findVarying x
+findVarying (Meta _ x) = findVarying x
 findVarying (Op (ForEachActive _ body)) = findVarying body
 findVarying (Op (ForEach idx _ _ body)) = idx : findVarying body
 findVarying (DeclareMem mem _) = [mem]

--- a/src/Futhark/CodeGen/ImpCode.hs
+++ b/src/Futhark/CodeGen/ImpCode.hs
@@ -328,7 +328,7 @@ data Code a
   | -- | Assert that something must be true.  Should it turn
     -- out not to be true, then report a failure along with
     -- the given error message.
-    Assert Exp (ErrorMsg Exp) (SrcLoc, [SrcLoc])
+    Assert Exp (ErrorMsg Exp) (Loc, [Loc])
   | -- | Print the given value to the screen, somehow
     -- annotated with the given string as a description.  If
     -- no type/value pair, just print the string.  This has

--- a/src/Futhark/CodeGen/ImpCode.hs
+++ b/src/Futhark/CodeGen/ImpCode.hs
@@ -117,6 +117,7 @@ import Futhark.IR.Syntax.Core
     ErrorMsgPart (..),
     OpaqueType (..),
     OpaqueTypes (..),
+    Provenance (..),
     Rank (..),
     Signedness (..),
     Space (..),
@@ -244,9 +245,11 @@ data ArrayContents
 
 -- | A piece of additional information attached to a piece of code, which should
 -- not have any effect on how it is executed.
-newtype Metadata
+data Metadata
   = -- | An informative comment that can be inserted into generated code.
     MetaComment T.Text
+  | -- | Where this bit of code came from.
+    MetaProvenance Provenance
   deriving (Eq, Ord, Show)
 
 -- | A block of imperative code.  Parameterised by an 'Op', which
@@ -652,6 +655,8 @@ instance (Pretty op) => Pretty (Code op) where
       <> parens (commasep $ map pretty args)
   pretty (Meta (MetaComment s) code) =
     "--" <+> pretty s </> pretty code
+  pretty (Meta (MetaProvenance l) code) =
+    "@" <+> align (pretty l) </> pretty code
   pretty (DebugPrint desc (Just e)) =
     "debug" <+> parens (commasep [pretty (show desc), pretty e])
   pretty (DebugPrint desc Nothing) =

--- a/src/Futhark/CodeGen/ImpCode/Multicore.hs
+++ b/src/Futhark/CodeGen/ImpCode/Multicore.hs
@@ -194,7 +194,6 @@ lexicalMemoryUsageMC gokernel func =
     go f (If _ x y) = f x <> f y
     go f (For _ _ x) = f x
     go f (While _ x) = f x
-    go f (Meta _ x) = f x
     go f (Op op) = goOp f op
     go _ _ = mempty
 

--- a/src/Futhark/CodeGen/ImpCode/Multicore.hs
+++ b/src/Futhark/CodeGen/ImpCode/Multicore.hs
@@ -194,7 +194,7 @@ lexicalMemoryUsageMC gokernel func =
     go f (If _ x y) = f x <> f y
     go f (For _ _ x) = f x
     go f (While _ x) = f x
-    go f (Comment _ x) = f x
+    go f (Meta _ x) = f x
     go f (Op op) = goOp f op
     go _ _ = mempty
 

--- a/src/Futhark/CodeGen/ImpGen.hs
+++ b/src/Futhark/CodeGen/ImpGen.hs
@@ -731,6 +731,9 @@ compileStms alive_after_stms all_stms m = do
   cb <- asks envStmsCompiler
   cb alive_after_stms all_stms m
 
+attachProvenance :: Provenance -> Imp.Code op -> Imp.Code op
+attachProvenance p = if p == mempty then id else Imp.Meta (Imp.MetaProvenance p)
+
 defCompileStms ::
   (Mem rep inner, FreeIn op) =>
   Names ->
@@ -748,7 +751,7 @@ defCompileStms alive_after_stms all_stms m =
       dVars (Just e) (patElems pat)
 
       e_code <-
-        localAttrs (stmAuxAttrs aux) $
+        localAttrs (stmAuxAttrs aux) . fmap (attachProvenance (stmAuxLoc aux)) $
           collect $
             compileExp pat e
       (live_after, bs_code) <- collect' $ compileStms' (patternAllocs pat <> allocs) bs

--- a/src/Futhark/CodeGen/ImpGen.hs
+++ b/src/Futhark/CodeGen/ImpGen.hs
@@ -748,12 +748,12 @@ defCompileStms alive_after_stms all_stms m =
   void $ compileStms' mempty $ stmsToList all_stms
   where
     compileStms' allocs (Let pat aux e : bs) = do
-      dVars (Just e) (patElems pat)
-
-      e_code <-
-        localAttrs (stmAuxAttrs aux) . fmap (attachProvenance (stmAuxLoc aux)) $
-          collect $
-            compileExp pat e
+      e_code <- fmap (attachProvenance (stmAuxLoc aux))
+        . localAttrs (stmAuxAttrs aux)
+        . collect
+        $ do
+          dVars (Just e) (patElems pat)
+          compileExp pat e
       (live_after, bs_code) <- collect' $ compileStms' (patternAllocs pat <> allocs) bs
       let dies_here v =
             (v `notNameIn` live_after) && (v `nameIn` freeIn e_code)

--- a/src/Futhark/CodeGen/ImpGen.hs
+++ b/src/Futhark/CodeGen/ImpGen.hs
@@ -738,7 +738,10 @@ compileStms alive_after_stms all_stms m = do
   cb alive_after_stms all_stms m
 
 attachProvenance :: Provenance -> Imp.Code op -> Imp.Code op
-attachProvenance p = if p == mempty then id else (Imp.Meta (Imp.MetaProvenance p) <>)
+attachProvenance _ Imp.Skip = Imp.Skip
+attachProvenance p c
+  | p == mempty = c
+  | otherwise = Imp.Meta (Imp.MetaProvenance p) <> c
 
 defCompileStms ::
   (Mem rep inner, FreeIn op) =>

--- a/src/Futhark/CodeGen/ImpGen.hs
+++ b/src/Futhark/CodeGen/ImpGen.hs
@@ -908,11 +908,11 @@ defCompileBasicOp _ (Assert e msg) = do
   e' <- toExp e
   msg' <- traverse toExp msg
   Imp.Provenance locs loc <- askProvenance
-  emit $ Imp.Assert e' msg' (loc, locs)
+  emit $ Imp.Assert e' msg' (loc, reverse locs)
 
   attrs <- askAttrs
   when (AttrComp "warn" ["safety_checks"] `inAttrs` attrs) $
-    warn loc locs "Safety check required at run-time."
+    warn loc (reverse locs) "Safety check required at run-time."
 defCompileBasicOp (Pat [pe]) (Index src slice)
   | Just idxs <- sliceIndices slice =
       copyDWIM (patElemName pe) [] (Var src) $ map (DimFix . pe64) idxs

--- a/src/Futhark/CodeGen/ImpGen.hs
+++ b/src/Futhark/CodeGen/ImpGen.hs
@@ -904,14 +904,15 @@ defCompileBasicOp (Pat [pe]) (CmpOp bop x y) = do
   x' <- toExp x
   y' <- toExp y
   patElemName pe <~~ Imp.CmpOpExp bop x' y'
-defCompileBasicOp _ (Assert e msg loc) = do
+defCompileBasicOp _ (Assert e msg) = do
   e' <- toExp e
   msg' <- traverse toExp msg
-  emit $ Imp.Assert e' msg' loc
+  Imp.Provenance locs loc <- askProvenance
+  emit $ Imp.Assert e' msg' (loc, locs)
 
   attrs <- askAttrs
   when (AttrComp "warn" ["safety_checks"] `inAttrs` attrs) $
-    uncurry warn loc "Safety check required at run-time."
+    warn loc locs "Safety check required at run-time."
 defCompileBasicOp (Pat [pe]) (Index src slice)
   | Just idxs <- sliceIndices slice =
       copyDWIM (patElemName pe) [] (Var src) $ map (DimFix . pe64) idxs

--- a/src/Futhark/CodeGen/ImpGen.hs
+++ b/src/Futhark/CodeGen/ImpGen.hs
@@ -1733,11 +1733,11 @@ sWhile cond body = do
   emit $ Imp.While cond body'
 
 -- | Execute a code generation action, wrapping the generated code
--- within a 'Imp.Comment' with the given description.
+-- within a 'Imp.MetaComment' with the given description.
 sComment :: T.Text -> ImpM rep r op () -> ImpM rep r op ()
 sComment s code = do
   code' <- collect code
-  emit $ Imp.Comment s code'
+  emit $ Imp.Meta (Imp.MetaComment s) code'
 
 sIf :: Imp.TExp Bool -> ImpM rep r op () -> ImpM rep r op () -> ImpM rep r op ()
 sIf cond tbranch fbranch = do

--- a/src/Futhark/CodeGen/ImpGen.hs
+++ b/src/Futhark/CodeGen/ImpGen.hs
@@ -124,7 +124,7 @@ import Control.Monad
 import Control.Monad.Reader
 import Control.Monad.State
 import Control.Parallel.Strategies
-import Data.Bifunctor (first)
+import Data.Bifunctor (first, second)
 import Data.DList qualified as DL
 import Data.Either
 import Data.List (find)
@@ -1889,6 +1889,8 @@ function fname outputs inputs m = local newFunction $ do
 constParams :: Names -> Imp.Code a -> (DL.DList Imp.Param, Imp.Code a)
 constParams used (x Imp.:>>: y) =
   constParams used x <> constParams used y
+constParams used (Imp.Meta s x) =
+  second (Imp.Meta s) $ constParams used x
 constParams used (Imp.DeclareMem name space)
   | name `nameIn` used =
       ( DL.singleton $ Imp.MemParam name space,

--- a/src/Futhark/CodeGen/ImpGen/GPU/Base.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/Base.hs
@@ -1243,7 +1243,7 @@ sKernelOp attrs constants ops name m = do
   -- to somewhere in /prelude), so try to synthesize it from the body instead.
   -- It may be that we should do this earlier in the compiler.
   let p = Imp.foldProvenances (const mempty) body
-  emit $ Imp.Meta $ Imp.MetaProvenance p
+  when (p /= mempty) $ emit $ Imp.Meta $ Imp.MetaProvenance p
   emit . Imp.Op . Imp.CallKernel $
     Imp.Kernel
       { Imp.kernelBody = body,

--- a/src/Futhark/CodeGen/ImpGen/GPU/Base.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/Base.hs
@@ -1239,7 +1239,11 @@ sKernelOp attrs constants ops name m = do
   body <- makeAllMemoryGlobal $ subImpM_ (KernelEnv atomics constants locks) ops m
   uses <- computeKernelUses body $ M.keys $ kAttrConstExps attrs
   tblock_size <- onBlockSize $ kernelBlockSize constants
-  emit . Imp.Op . Imp.CallKernel $
+  -- XXX: the provenance of the kernel itself is usually boring (it just points
+  -- to somewhere in /prelude), so try to synthesize it from the body instead.
+  -- It may be that we should do this earlier in the compiler.
+  let p = Imp.foldProvenances (const mempty) body
+  emit . Imp.Meta (Imp.MetaProvenance p) . Imp.Op . Imp.CallKernel $
     Imp.Kernel
       { Imp.kernelBody = body,
         Imp.kernelUses = uses <> map constToUse (M.toList (kAttrConstExps attrs)),

--- a/src/Futhark/CodeGen/ImpGen/GPU/Base.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/Base.hs
@@ -1243,7 +1243,8 @@ sKernelOp attrs constants ops name m = do
   -- to somewhere in /prelude), so try to synthesize it from the body instead.
   -- It may be that we should do this earlier in the compiler.
   let p = Imp.foldProvenances (const mempty) body
-  emit . mappend (Imp.Meta (Imp.MetaProvenance p)) . Imp.Op . Imp.CallKernel $
+  emit $ Imp.Meta $ Imp.MetaProvenance p
+  emit . Imp.Op . Imp.CallKernel $
     Imp.Kernel
       { Imp.kernelBody = body,
         Imp.kernelUses = uses <> map constToUse (M.toList (kAttrConstExps attrs)),

--- a/src/Futhark/CodeGen/ImpGen/GPU/Base.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/Base.hs
@@ -1243,7 +1243,7 @@ sKernelOp attrs constants ops name m = do
   -- to somewhere in /prelude), so try to synthesize it from the body instead.
   -- It may be that we should do this earlier in the compiler.
   let p = Imp.foldProvenances (const mempty) body
-  emit . Imp.Meta (Imp.MetaProvenance p) . Imp.Op . Imp.CallKernel $
+  emit . mappend (Imp.Meta (Imp.MetaProvenance p)) . Imp.Op . Imp.CallKernel $
     Imp.Kernel
       { Imp.kernelBody = body,
         Imp.kernelUses = uses <> map constToUse (M.toList (kAttrConstExps attrs)),

--- a/src/Futhark/CodeGen/ImpGen/GPU/ToOpenCL.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/ToOpenCL.hs
@@ -194,7 +194,7 @@ codeMayFail f (x :>>: y) = codeMayFail f x || codeMayFail f y
 codeMayFail f (For _ _ x) = codeMayFail f x
 codeMayFail f (While _ x) = codeMayFail f x
 codeMayFail f (If _ x y) = codeMayFail f x || codeMayFail f y
-codeMayFail f (Comment _ x) = codeMayFail f x
+codeMayFail f (Meta _ x) = codeMayFail f x
 codeMayFail _ _ = False
 
 hostOpMayFail :: ImpGPU.HostOp -> Bool
@@ -896,7 +896,7 @@ typesInCode (Call _ _ es) = mconcat $ map typesInArg es
 typesInCode (If (TPrimExp e) c1 c2) =
   typesInExp e <> typesInCode c1 <> typesInCode c2
 typesInCode (Assert e _ _) = typesInExp e
-typesInCode (Comment _ c) = typesInCode c
+typesInCode (Meta _ c) = typesInCode c
 typesInCode (DebugPrint _ v) = maybe mempty typesInExp v
 typesInCode (TracePrint msg) = foldMap typesInExp msg
 typesInCode Op {} = mempty

--- a/src/Futhark/CodeGen/ImpGen/GPU/ToOpenCL.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/ToOpenCL.hs
@@ -194,7 +194,6 @@ codeMayFail f (x :>>: y) = codeMayFail f x || codeMayFail f y
 codeMayFail f (For _ _ x) = codeMayFail f x
 codeMayFail f (While _ x) = codeMayFail f x
 codeMayFail f (If _ x y) = codeMayFail f x || codeMayFail f y
-codeMayFail f (Meta _ x) = codeMayFail f x
 codeMayFail _ _ = False
 
 hostOpMayFail :: ImpGPU.HostOp -> Bool
@@ -896,7 +895,7 @@ typesInCode (Call _ _ es) = mconcat $ map typesInArg es
 typesInCode (If (TPrimExp e) c1 c2) =
   typesInExp e <> typesInCode c1 <> typesInCode c2
 typesInCode (Assert e _ _) = typesInExp e
-typesInCode (Meta _ c) = typesInCode c
+typesInCode (Meta _) = mempty
 typesInCode (DebugPrint _ v) = maybe mempty typesInExp v
 typesInCode (TracePrint msg) = foldMap typesInExp msg
 typesInCode Op {} = mempty

--- a/src/Futhark/CodeGen/ImpGen/Multicore.hs
+++ b/src/Futhark/CodeGen/ImpGen/Multicore.hs
@@ -155,9 +155,12 @@ compileMCOp pat (ParOp par_op op) = do
   s <- segOpString op
   let seq_task = Imp.ParallelTask seq_code
   free_params <- filter (`notElem` retvals) <$> freeParams (par_task, seq_task)
-  emit . Imp.Op $
-    Imp.SegOp s free_params seq_task par_task retvals $
-      scheduling_info (decideScheduling' op seq_code)
+  let code =
+        Imp.Op $
+          Imp.SegOp s free_params seq_task par_task retvals $
+            scheduling_info (decideScheduling' op seq_code)
+  emit $ Imp.Meta $ Imp.MetaProvenance $ taskProvenance code
+  emit code
 
 compileSegOp ::
   Pat LetDecMem ->

--- a/src/Futhark/CodeGen/ImpGen/Multicore/Base.hs
+++ b/src/Futhark/CodeGen/ImpGen/Multicore/Base.hs
@@ -151,7 +151,7 @@ isLoadBalanced :: Imp.MCCode -> Bool
 isLoadBalanced (a Imp.:>>: b) = isLoadBalanced a && isLoadBalanced b
 isLoadBalanced (Imp.For _ _ a) = isLoadBalanced a
 isLoadBalanced (Imp.If _ a b) = isLoadBalanced a && isLoadBalanced b
-isLoadBalanced (Imp.Comment _ a) = isLoadBalanced a
+isLoadBalanced (Imp.Meta _ a) = isLoadBalanced a
 isLoadBalanced Imp.While {} = False
 isLoadBalanced (Imp.Op (Imp.ParLoop _ code _)) = isLoadBalanced code
 isLoadBalanced (Imp.Op (Imp.ForEachActive _ a)) = isLoadBalanced a
@@ -189,8 +189,8 @@ extractAllocations segop_code = f segop_code
       (mempty, Imp.While cond body)
     f (Imp.For i bound body) =
       (mempty, Imp.For i bound body)
-    f (Imp.Comment s code) =
-      second (Imp.Comment s) (f code)
+    f (Imp.Meta s code) =
+      second (Imp.Meta s) (f code)
     f Imp.Free {} =
       mempty
     f (Imp.If cond tcode fcode) =

--- a/src/Futhark/CodeGen/ImpGen/Multicore/Base.hs
+++ b/src/Futhark/CodeGen/ImpGen/Multicore/Base.hs
@@ -30,7 +30,6 @@ module Futhark.CodeGen.ImpGen.Multicore.Base
 where
 
 import Control.Monad
-import Data.Bifunctor
 import Data.Map qualified as M
 import Data.Maybe
 import Futhark.CodeGen.ImpCode.Multicore qualified as Imp
@@ -151,7 +150,6 @@ isLoadBalanced :: Imp.MCCode -> Bool
 isLoadBalanced (a Imp.:>>: b) = isLoadBalanced a && isLoadBalanced b
 isLoadBalanced (Imp.For _ _ a) = isLoadBalanced a
 isLoadBalanced (Imp.If _ a b) = isLoadBalanced a && isLoadBalanced b
-isLoadBalanced (Imp.Meta _ a) = isLoadBalanced a
 isLoadBalanced Imp.While {} = False
 isLoadBalanced (Imp.Op (Imp.ParLoop _ code _)) = isLoadBalanced code
 isLoadBalanced (Imp.Op (Imp.ForEachActive _ a)) = isLoadBalanced a
@@ -189,8 +187,6 @@ extractAllocations segop_code = f segop_code
       (mempty, Imp.While cond body)
     f (Imp.For i bound body) =
       (mempty, Imp.For i bound body)
-    f (Imp.Meta s code) =
-      second (Imp.Meta s) (f code)
     f Imp.Free {} =
       mempty
     f (Imp.If cond tcode fcode) =

--- a/src/Futhark/Compiler/Program.hs
+++ b/src/Futhark/Compiler/Program.hs
@@ -46,9 +46,9 @@ import Futhark.FreshNames
 import Futhark.Util (interactWithFileSafely, nubOrd, startupTime)
 import Futhark.Util.Pretty (Doc, align, pretty)
 import Language.Futhark qualified as E
+import Language.Futhark.Core (isBuiltin)
 import Language.Futhark.Parser (SyntaxError (..), parseFuthark)
 import Language.Futhark.Prelude
-import Language.Futhark.Prop (isBuiltin)
 import Language.Futhark.Semantic
 import Language.Futhark.TypeChecker qualified as E
 import Language.Futhark.Warnings

--- a/src/Futhark/IR/Aliases.hs
+++ b/src/Futhark/IR/Aliases.hs
@@ -380,10 +380,10 @@ mkAliasedStm ::
   StmAux (ExpDec rep) ->
   Exp (Aliases rep) ->
   Stm (Aliases rep)
-mkAliasedStm pat (StmAux cs attrs dec) e =
+mkAliasedStm pat aux e =
   Let
     (mkAliasedPat pat e)
-    (StmAux cs attrs (AliasDec $ consumedInExp e, dec))
+    (fmap (AliasDec (consumedInExp e),) aux)
     e
 
 instance

--- a/src/Futhark/IR/Mem/Simplify.hs
+++ b/src/Futhark/IR/Mem/Simplify.hs
@@ -105,7 +105,7 @@ blockers =
 -- the certificates on it.  This can help hoist things that would
 -- otherwise be stuck inside loops or branches.
 decertifySafeAlloc :: (SimplifyMemory rep inner) => TopDownRuleOp (Wise rep)
-decertifySafeAlloc _ pat (StmAux cs attrs _) op
+decertifySafeAlloc _ pat (StmAux cs attrs _ _) op
   | cs /= mempty,
     [Mem _] <- patTypes pat,
     safeOp op =

--- a/src/Futhark/IR/Parse.hs
+++ b/src/Futhark/IR/Parse.hs
@@ -239,7 +239,11 @@ pErrorMsg :: Parser (ErrorMsg SubExp)
 pErrorMsg = ErrorMsg <$> braces (pErrorMsgPart `sepBy` pComma)
 
 pLoc :: Parser Loc
-pLoc = pStringLiteral $> mempty -- FIXME
+pLoc =
+  choice
+    [ pStringLiteral $> mempty, -- FIXME
+      pure mempty
+    ]
 
 pSrcLoc :: Parser SrcLoc
 pSrcLoc = srclocOf <$> pLoc

--- a/src/Futhark/IR/Parse.hs
+++ b/src/Futhark/IR/Parse.hs
@@ -245,12 +245,6 @@ pLoc =
       pure mempty
     ]
 
-pSrcLoc :: Parser SrcLoc
-pSrcLoc = srclocOf <$> pLoc
-
-pErrorLoc :: Parser (SrcLoc, [SrcLoc])
-pErrorLoc = (,mempty) <$> pSrcLoc
-
 pIota :: Parser BasicOp
 pIota =
   choice $ map p allIntTypes
@@ -281,15 +275,7 @@ pBasicOp =
         $> uncurry (Opaque . OpaqueTrace)
         <*> parens ((,) <$> pStringLiteral <* pComma <*> pSubExp),
       keyword "copy" $> Replicate mempty . Var <*> parens pVName,
-      keyword "assert"
-        *> parens
-          ( Assert
-              <$> pSubExp
-              <* pComma
-              <*> pErrorMsg
-              <* pComma
-              <*> pErrorLoc
-          ),
+      keyword "assert" *> parens (Assert <$> pSubExp <* pComma <*> pErrorMsg),
       keyword "replicate"
         *> parens (Replicate <$> pShape <* pComma <*> pSubExp),
       keyword "reshape"
@@ -492,7 +478,7 @@ pApply pr =
         <*> parens (pArg `sepBy` pComma)
         <* pColon
         <*> pRetTypes pr
-        <*> pure (safety, mempty, mempty)
+        <*> pure safety
 
     pArg =
       choice
@@ -595,7 +581,7 @@ pSubExpRes :: Parser SubExpRes
 pSubExpRes = SubExpRes <$> pCerts <*> pSubExp
 
 pProvenance :: Parser Provenance
-pProvenance = Provenance <$> pLoc
+pProvenance = Provenance mempty <$> pLoc
 
 pStm :: PR rep -> Parser (Stm rep)
 pStm pr = do

--- a/src/Futhark/IR/Pretty.hs
+++ b/src/Futhark/IR/Pretty.hs
@@ -152,7 +152,7 @@ prettyLoc :: Loc -> Doc a
 prettyLoc = pretty . locText
 
 instance Pretty Provenance where
-  pretty (Provenance loc) = prettyLoc loc
+  pretty (Provenance locs loc) = mconcat $ punctuate "->" $ map prettyLoc $ locs ++ [loc]
 
 instance (Pretty dec) => Pretty (StmAux dec) where
   pretty (StmAux cs attrs p dec) =
@@ -254,8 +254,8 @@ instance Pretty BasicOp where
     "concat" <> "@" <> pretty i <> apply (pretty w : pretty x : map pretty xs)
   pretty (Manifest v perm) =
     "manifest" <> apply [pretty v, apply (map pretty perm)]
-  pretty (Assert e msg (loc, _)) =
-    "assert" <> apply [pretty e, pretty msg, pretty $ show $ locStr loc]
+  pretty (Assert e msg) =
+    "assert" <> apply [pretty e, pretty msg]
   pretty (UpdateAcc safety acc is v) =
     update_acc_str
       <> apply
@@ -323,7 +323,7 @@ instance (PrettyRep rep) => Pretty (Exp rep) where
         MatchFallback -> " <fallback>"
         MatchEquiv -> " <equiv>"
   pretty (BasicOp op) = pretty op
-  pretty (Apply fname args ret (safety, _, _)) =
+  pretty (Apply fname args ret safety) =
     applykw
       <+> pretty (nameToString fname)
       <> apply (map (align . prettyArg) args)

--- a/src/Futhark/IR/Prop.hs
+++ b/src/Futhark/IR/Prop.hs
@@ -167,7 +167,7 @@ commutativeLambda lam =
 
 -- | A 'StmAux' with empty 'Certs'.
 defAux :: dec -> StmAux dec
-defAux = StmAux mempty mempty
+defAux = StmAux mempty mempty mempty
 
 -- | The certificates associated with a statement.
 stmCerts :: Stm rep -> Certs
@@ -175,8 +175,8 @@ stmCerts = stmAuxCerts . stmAux
 
 -- | Add certificates to a statement.
 certify :: Certs -> Stm rep -> Stm rep
-certify cs1 (Let pat (StmAux cs2 attrs dec) e) =
-  Let pat (StmAux (cs2 <> cs1) attrs dec) e
+certify cs1 (Let pat aux e) =
+  Let pat (aux {stmAuxCerts = stmAuxCerts aux <> cs1}) e
 
 -- | A handy shorthand for properties that we usually want for things
 -- we stuff into ASTs.

--- a/src/Futhark/IR/Prop/Names.hs
+++ b/src/Futhark/IR/Prop/Names.hs
@@ -307,7 +307,7 @@ instance
   ) =>
   FreeIn (Stm rep)
   where
-  freeIn' (Let pat (StmAux cs attrs dec) e) =
+  freeIn' (Let pat (StmAux cs attrs _ dec) e) =
     freeIn' cs
       <> freeIn' attrs
       <> precomputed dec (freeIn' dec <> freeIn' e <> freeIn' pat)
@@ -399,7 +399,7 @@ instance FreeIn Attrs where
   freeIn' (Attrs _) = mempty
 
 instance (FreeIn dec) => FreeIn (StmAux dec) where
-  freeIn' (StmAux cs attrs dec) = freeIn' cs <> freeIn' attrs <> freeIn' dec
+  freeIn' (StmAux cs attrs _ dec) = freeIn' cs <> freeIn' attrs <> freeIn' dec
 
 instance (FreeIn a) => FreeIn (MatchDec a) where
   freeIn' (MatchDec r _) = freeIn' r

--- a/src/Futhark/IR/Rephrase.hs
+++ b/src/Futhark/IR/Rephrase.hs
@@ -56,10 +56,10 @@ rephraseExp = mapExpM . mapper
 
 -- | Rephrase a statement.
 rephraseStm :: (Monad m) => Rephraser m from to -> Stm from -> m (Stm to)
-rephraseStm rephraser (Let pat (StmAux cs attrs dec) e) =
+rephraseStm rephraser (Let pat aux e) =
   Let
     <$> rephrasePat (rephraseLetBoundDec rephraser) pat
-    <*> (StmAux cs attrs <$> rephraseExpDec rephraser dec)
+    <*> traverse (rephraseExpDec rephraser) aux
     <*> rephraseExp rephraser e
 
 -- | Rephrase a pattern.

--- a/src/Futhark/IR/Syntax.hs
+++ b/src/Futhark/IR/Syntax.hs
@@ -121,7 +121,6 @@ module Futhark.IR.Syntax
     PatElem (..),
     Pat (..),
     StmAux (..),
-    Provenance (..),
     Stm (..),
     Stms,
     SubExpRes (..),
@@ -200,17 +199,6 @@ instance Foldable Pat where
 instance Traversable Pat where
   traverse f (Pat xs) =
     Pat <$> traverse (traverse f) xs
-
--- | Information about what in the original program a given IR statement
--- corresponds to. See Note [Tracking Source Locations].
-newtype Provenance = Provenance Loc
-  deriving (Eq, Ord, Show)
-
-instance Semigroup Provenance where
-  Provenance x <> Provenance y = Provenance $ x <> y
-
-instance Monoid Provenance where
-  mempty = Provenance mempty
 
 -- | Auxilliary Information associated with a statement.
 data StmAux dec = StmAux

--- a/src/Futhark/IR/Syntax.hs
+++ b/src/Futhark/IR/Syntax.hs
@@ -387,9 +387,10 @@ data BasicOp
     CmpOp CmpOp SubExp SubExp
   | -- | Conversion "casting".
     ConvOp ConvOp SubExp
-  | -- | Turn a boolean into a certificate, halting the program with the
-    -- given error message if the boolean is false.
-    Assert SubExp (ErrorMsg SubExp) (SrcLoc, [SrcLoc])
+  | -- | Turn a boolean into a certificate, halting the program with the given
+    -- error message if the boolean is false. The error location comes from the
+    -- provenance of the statement.
+    Assert SubExp (ErrorMsg SubExp)
   | -- | The certificates for bounds-checking are part of the 'Stm'.
     Index VName (Slice SubExp)
   | -- | An in-place update of the given array at the given position.
@@ -483,7 +484,7 @@ instance Semigroup RetAls where
 data Exp rep
   = -- | A simple (non-recursive) operation.
     BasicOp BasicOp
-  | Apply Name [(SubExp, Diet)] [(RetType rep, RetAls)] (Safety, SrcLoc, [SrcLoc])
+  | Apply Name [(SubExp, Diet)] [(RetType rep, RetAls)] Safety
   | -- | A match statement picks a branch by comparing the given
     -- subexpressions (called the /scrutinee/) with the pattern in
     -- each of the cases.  If none of the cases match, the /default

--- a/src/Futhark/IR/Syntax.hs
+++ b/src/Futhark/IR/Syntax.hs
@@ -121,6 +121,7 @@ module Futhark.IR.Syntax
     PatElem (..),
     Pat (..),
     StmAux (..),
+    Provenance (..),
     Stm (..),
     Stms,
     SubExpRes (..),
@@ -200,20 +201,42 @@ instance Traversable Pat where
   traverse f (Pat xs) =
     Pat <$> traverse (traverse f) xs
 
+-- | Information about what in the original program a given IR statement
+-- corresponds to. See Note [Tracking Source Locations].
+newtype Provenance = Provenance Loc
+  deriving (Eq, Ord, Show)
+
+instance Semigroup Provenance where
+  Provenance x <> Provenance y = Provenance $ x <> y
+
+instance Monoid Provenance where
+  mempty = Provenance mempty
+
 -- | Auxilliary Information associated with a statement.
 data StmAux dec = StmAux
   { stmAuxCerts :: !Certs,
     stmAuxAttrs :: Attrs,
+    stmAuxLoc :: Provenance,
     stmAuxDec :: dec
   }
   deriving (Ord, Show, Eq)
 
+instance Functor StmAux where
+  fmap = fmapDefault
+
+instance Foldable StmAux where
+  foldMap = foldMapDefault
+
+instance Traversable StmAux where
+  traverse f (StmAux cs attrs loc dec) =
+    StmAux cs attrs loc <$> f dec
+
 instance (Monoid dec) => Monoid (StmAux dec) where
-  mempty = StmAux mempty mempty mempty
+  mempty = StmAux mempty mempty mempty mempty
 
 instance (Semigroup dec) => Semigroup (StmAux dec) where
-  StmAux cs1 attrs1 dec1 <> StmAux cs2 attrs2 dec2 =
-    StmAux (cs1 <> cs2) (attrs1 <> attrs2) (dec1 <> dec2)
+  StmAux cs1 attrs1 loc1 dec1 <> StmAux cs2 attrs2 loc2 dec2 =
+    StmAux (cs1 <> cs2) (attrs1 <> attrs2) (loc1 <> loc2) (dec1 <> dec2)
 
 -- | A local variable binding.
 data Stm rep = Let
@@ -608,3 +631,25 @@ data Prog rep = Prog
     progFuns :: [FunDef rep]
   }
   deriving (Eq, Ord, Show)
+
+-- Note [Tracking Source Locations]
+--
+-- It is useful for such things as profiling to be able to relate the generated
+-- code to the original source code. The Futhark compiler is not great at this,
+-- but we have begun to try a bit.
+--
+-- Each 'Stm' is associated with a 'Provenance', which keeps information about
+-- the (single) source expression that gave rise to the statement. This is by
+-- itself not challenging (although a single source expression can give rise to
+-- multiple core expressions). The real challenge is how to propagate this
+-- information when the compiler starts rewriting the program, without every
+-- rewrite having to be laboriously aware of provenances. In practice, we stick
+-- it in the StmAux and hope that consistent use of such constructs as 'auxing'
+-- will mostly do the right thing.
+--
+-- Another downside of our representation is that it is not flow-sensitive: an
+-- expression can be reached in multiple ways and generally the innermost one is
+-- picked. This is particularly problematic for the prelude functions (e.g.
+-- f32.exp), as it is not exceptionally useful when the provenance simply points
+-- at a file in /prelude. We could address this by just special casing /prelude,
+-- but that won't help when users write their own libraries.

--- a/src/Futhark/IR/Syntax/Core.hs
+++ b/src/Futhark/IR/Syntax/Core.hs
@@ -73,6 +73,9 @@ module Futhark.IR.Syntax.Core
     FlatDimIndex (..),
     flatSliceDims,
     flatSliceStrides,
+
+    -- * Provenance
+    Provenance (..),
   )
 where
 
@@ -642,3 +645,14 @@ instance Monoid OpaqueTypes where
 instance Semigroup OpaqueTypes where
   OpaqueTypes x <> OpaqueTypes y =
     OpaqueTypes $ x <> filter ((`notElem` map fst x) . fst) y
+
+-- | Information about what in the original program a given IR statement
+-- corresponds to. See Note [Tracking Source Locations].
+newtype Provenance = Provenance Loc
+  deriving (Eq, Ord, Show)
+
+instance Semigroup Provenance where
+  Provenance x <> Provenance y = Provenance $ x <> y
+
+instance Monoid Provenance where
+  mempty = Provenance mempty

--- a/src/Futhark/IR/TypeCheck.hs
+++ b/src/Futhark/IR/TypeCheck.hs
@@ -1257,7 +1257,9 @@ checkStm ::
   Stm (Aliases rep) ->
   TypeM rep a ->
   TypeM rep a
-checkStm stm@(Let pat (StmAux (Certs cs) _ (_, dec)) e) m = do
+checkStm stm@(Let pat aux e) m = do
+  let Certs cs = stmAuxCerts aux
+      (_, dec) = stmAuxDec aux
   context "When checking certificates" $ mapM_ (requireI [Prim Unit]) cs
   context "When checking expression annotation" $ checkExpDec dec
   context ("When matching\n" <> message "  " pat <> "\nwith\n" <> message "  " e) $

--- a/src/Futhark/IR/TypeCheck.hs
+++ b/src/Futhark/IR/TypeCheck.hs
@@ -940,7 +940,7 @@ checkBasicOp (Concat i (arr1exp :| arr2exps) ressize) = do
   require [Prim int64] ressize
 checkBasicOp (Manifest arr perm) =
   checkBasicOp $ Rearrange arr perm -- Basically same thing!
-checkBasicOp (Assert e (ErrorMsg parts) _) = do
+checkBasicOp (Assert e (ErrorMsg parts)) = do
   require [Prim Bool] e
   mapM_ checkPart parts
   where

--- a/src/Futhark/Internalise/Defunctionalise.hs
+++ b/src/Futhark/Internalise/Defunctionalise.hs
@@ -910,11 +910,11 @@ liftedName i (AppExp (Apply f _ _) _) =
 liftedName _ _ = "defunc"
 
 defuncApplyArg ::
-  String ->
+  (String, SrcLoc) ->
   (Exp, StaticVal) ->
   ((Maybe VName, Exp), [ParamType]) ->
   DefM (Exp, StaticVal)
-defuncApplyArg fname_s (f', LambdaSV pat lam_e_t lam_e closure_env) ((argext, arg), _) = do
+defuncApplyArg (fname_s, floc) (f', LambdaSV pat lam_e_t lam_e closure_env) ((argext, arg), _) = do
   (arg', arg_sv) <- defuncExp arg
   let env' = alwaysMatchPatSV pat arg_sv
       dims = mempty
@@ -961,7 +961,7 @@ defuncApplyArg fname_s (f', LambdaSV pat lam_e_t lam_e closure_env) ((argext, ar
   let f_t = toStruct $ typeOf f'
       arg_t = toStruct $ typeOf arg'
       fname_t = foldFunType [toParam Observe f_t, toParam (diet (patternType pat)) arg_t] lifted_rettype
-      fname' = Var (qualName fname) (Info fname_t) (srclocOf arg)
+      fname' = Var (qualName fname) (Info fname_t) floc
   callret <- unRetType lifted_rettype
 
   pure
@@ -979,7 +979,7 @@ defuncApplyArg _ (f', DynamicFun _ sv) ((argext, arg), argtypes) = do
       apply_e = mkApply f' [(argext, arg')] callret
   pure (apply_e, sv)
 --
-defuncApplyArg fname_s (_, sv) ((_, arg), _) =
+defuncApplyArg (fname_s, _) (_, sv) ((_, arg), _) =
   error $
     "defuncApplyArg: cannot apply StaticVal\n"
       <> show sv
@@ -1009,7 +1009,7 @@ defuncApply f args appres loc = do
       let fname = liftedName 0 f
           (argtypes, _) = unfoldFunType $ typeOf f
       fmap (first $ updateReturn appres) $
-        foldM (defuncApplyArg fname) (f', f_sv) $
+        foldM (defuncApplyArg (fname, loc)) (f', f_sv) $
           NE.zip args $
             NE.tails argtypes
   where

--- a/src/Futhark/Internalise/Defunctionalise.hs
+++ b/src/Futhark/Internalise/Defunctionalise.hs
@@ -738,7 +738,7 @@ defuncSoacExp e
       (pats, body, tp) <- etaExpand (RetType [] $ toRes Nonunique $ typeOf e) e
       let env = foldMap envFromPat pats
       body' <- localEnv env $ defuncExp' body
-      pure $ Lambda pats body' Nothing (Info tp) mempty
+      pure $ Lambda pats body' Nothing (Info tp) (srclocOf e)
   | otherwise = defuncExp' e
 
 etaExpand :: ResRetType -> Exp -> DefM ([Pat ParamType], Exp, ResRetType)

--- a/src/Futhark/Internalise/Exps.hs
+++ b/src/Futhark/Internalise/Exps.hs
@@ -46,7 +46,7 @@ shiftRetAls :: Int -> RetAls -> RetAls
 shiftRetAls d (RetAls pals rals) = RetAls pals $ map (+ d) rals
 
 internaliseValBind :: VisibleTypes -> E.ValBind -> InternaliseM ()
-internaliseValBind types fb@(E.ValBind entry fname _ (Info rettype) tparams params body _ attrs loc) = do
+internaliseValBind types fb@(E.ValBind entry fname _ (Info rettype) tparams params body _ attrs _) = do
   bindingFParams tparams params $ \shapeparams params' -> do
     let shapenames = map I.paramName shapeparams
         all_params = map pure shapeparams ++ concat params'
@@ -70,7 +70,7 @@ internaliseValBind types fb@(E.ValBind entry fname _ (Info rettype) tparams para
         bindExtSizes (E.AppRes (E.toStruct $ E.retType rettype) (E.retDims rettype)) body_res
 
       body_res' <-
-        ensureResultExtShape msg loc (map I.fromDecl rettype') $ subExpsRes body_res
+        ensureResultExtShape msg (map I.fromDecl rettype') $ subExpsRes body_res
       let num_ctx = length (shapeContext rettype')
       pure
         ( body_res',
@@ -110,7 +110,7 @@ internaliseValBind types fb@(E.ValBind entry fname _ (Info rettype) tparams para
 
 generateEntryPoint :: VisibleTypes -> E.EntryPoint -> E.ValBind -> InternaliseM ()
 generateEntryPoint types (E.EntryPoint e_params e_rettype) vb = do
-  let (E.ValBind _ ofname _ (Info rettype) tparams params _ _ attrs loc) = vb
+  let (E.ValBind _ ofname _ (Info rettype) tparams params _ _ attrs _) = vb
   bindingFParams tparams params $ \shapeparams params' -> do
     let all_params = map pure shapeparams ++ concat params'
         (entry_rettype, retals) =
@@ -133,7 +133,7 @@ generateEntryPoint types (E.EntryPoint e_params e_rettype) vb = do
         Just ses ->
           pure ses
         Nothing ->
-          funcall "entry_result" (E.qualName ofname) args loc
+          funcall "entry_result" (E.qualName ofname) args
       ctx <-
         extractShapeContext (zeroExts $ concat entry_rettype)
           <$> mapM (fmap I.arrayDims . subExpType) vals
@@ -182,17 +182,17 @@ letValExp' _ (BasicOp (SubExp se)) = pure [se]
 letValExp' name ses = map I.Var <$> letValExp name ses
 
 internaliseAppExp :: String -> E.AppRes -> E.AppExp -> InternaliseM [I.SubExp]
-internaliseAppExp desc _ (E.Index e idxs loc) = do
+internaliseAppExp desc _ (E.Index e idxs _) = do
   vs <- internaliseExpToVars "indexed" e
   dims <- case vs of
     [] -> pure [] -- Will this happen?
     v : _ -> I.arrayDims <$> lookupType v
-  (idxs', cs) <- internaliseSlice loc dims idxs
+  (idxs', cs) <- internaliseSlice dims idxs
   let index v = do
         v_t <- lookupType v
         pure $ I.BasicOp $ I.Index v $ fullSlice v_t idxs'
   certifying cs $ mapM (letSubExp desc <=< index) vs
-internaliseAppExp desc _ (E.Range start maybe_second end loc) = do
+internaliseAppExp desc _ (E.Range start maybe_second end _) = do
   start' <- internaliseExp1 "range_start" start
   end' <- internaliseExp1 "range_end" $ case end of
     DownToExclusive e -> e
@@ -325,7 +325,7 @@ internaliseAppExp desc _ (E.Range start maybe_second end loc) = do
       I.BasicOp $
         I.BinOp I.LogOr step_invalid bounds_invalid
   valid <- letSubExp "valid" $ I.BasicOp $ I.UnOp (I.Neg I.Bool) invalid
-  cs <- assert "range_valid_c" valid errmsg loc
+  cs <- assert "range_valid_c" valid errmsg
 
   step_i64 <- asIntS Int64 step
   pos_step <-
@@ -358,7 +358,6 @@ internaliseAppExp desc (E.AppRes et ext) e@E.Apply {} =
       -- Argument evaluation is outermost-in so that any existential sizes
       -- created by function applications can be brought into scope.
       let fname = nameFromString $ prettyString $ baseName $ qualLeaf qfname
-          loc = srclocOf e
           arg_desc = nameToString fname ++ "_arg"
 
       -- Some functions are magical (overloaded) and we handle that here.
@@ -383,26 +382,26 @@ internaliseAppExp desc (E.AppRes et ext) e@E.Apply {} =
           -- arguments (except equality, but those cannot be
           -- existential), so we can safely ignore the existential
           -- dimensions.
-          | Just internalise <- isOverloadedFunction qfname desc loc -> do
+          | Just internalise <- isOverloadedFunction qfname desc -> do
               let prepareArg (arg, _) =
                     (E.toStruct (E.typeOf arg),) <$> internaliseExp "arg" arg
               internalise =<< mapM prepareArg args
-          | Just internalise <- isIntrinsicFunction qfname (map fst args) loc ->
+          | Just internalise <- isIntrinsicFunction qfname (map fst args) ->
               internalise desc
           | baseTag (qualLeaf qfname) <= maxIntrinsicTag,
             Just (rettype, _) <- M.lookup fname I.builtInFunctions -> do
               let tag ses = [(se, I.Observe) | se <- ses]
               args' <- reverse <$> mapM (internaliseArg arg_desc) (reverse args)
               let args'' = concatMap tag args'
-              letValExp' desc $ I.Apply fname args'' [(I.Prim rettype, mempty)] (Safe, loc, [])
+              letValExp' desc $ I.Apply fname args'' [(I.Prim rettype, mempty)] Safe
           | otherwise -> do
               args' <- concat . reverse <$> mapM (internaliseArg arg_desc) (reverse args)
-              funcall desc qfname args' loc
+              funcall desc qfname args'
 internaliseAppExp desc _ (E.LetPat sizes pat e body _) =
   internalisePat desc sizes pat e $ internaliseExp desc body
 internaliseAppExp _ _ (E.LetFun ofname _ _ _) =
   error $ "Unexpected LetFun " ++ prettyString ofname
-internaliseAppExp desc _ (E.Loop sparams mergepat loopinit form loopbody loc) = do
+internaliseAppExp desc _ (E.Loop sparams mergepat loopinit form loopbody _) = do
   ses <- internaliseExp "loop_init" $ loopInitExp loopinit
   ((loopbody', (form', shapepat, mergepat', mergeinit')), initstms) <-
     collectStms $ handleForm ses form
@@ -422,7 +421,6 @@ internaliseAppExp desc _ (E.Loop sparams mergepat loopinit form loopbody loc) = 
   args' <-
     ensureArgShapes
       "initial loop values have right shape"
-      loc
       (map I.paramName shapepat)
       (map paramType $ shapepat ++ mergepat')
       args
@@ -439,7 +437,6 @@ internaliseAppExp desc _ (E.Loop sparams mergepat loopinit form loopbody loc) = 
       fmap subExpsRes
         . ensureArgShapes
           "shape of loop result does not match shapes in loop parameter"
-          loc
           (map (I.paramName . fst) merge)
           merge_ts
         . map resSubExp
@@ -603,7 +600,7 @@ internaliseExp desc (E.Parens e _) =
 internaliseExp desc (E.Hole (Info t) loc) = do
   let msg = docText $ "Reached hole of type: " <> align (pretty t)
       ts = foldMap toList $ internaliseType (E.toStruct t)
-  c <- assert "hole_c" (constant False) (errorMsg [ErrorString msg]) loc
+  c <- assert "hole_c" (constant False) $ errorMsg [ErrorString msg]
   case mapM hasStaticShape ts of
     Nothing ->
       error $ "Hole at " <> locStr loc <> " has existential type:\n" <> show ts
@@ -689,7 +686,6 @@ internaliseExp desc (E.ArrayLit es (Info arr_t) loc)
               mapM
                 ( ensureShape
                     "shape of element differs from shape of first element"
-                    loc
                     rt
                     "elem_reshaped"
                 )
@@ -710,7 +706,7 @@ internaliseExp desc (E.ArrayLit es (Info arr_t) loc)
       Just ([], [e])
 internaliseExp desc (E.Ascript e _ _) =
   internaliseExp desc e
-internaliseExp desc (E.Coerce e _ (Info et) loc) = do
+internaliseExp desc (E.Coerce e _ (Info et) _) = do
   ses <- internaliseExp desc e
   ts <- internaliseCoerceType (E.toStruct et) <$> mapM subExpType ses
   dt' <- typeExpForError $ toStruct et
@@ -722,7 +718,7 @@ internaliseExp desc (E.Coerce e _ (Info et) loc) = do
             ++ ["] cannot match shape of type \""]
             ++ dt'
             ++ ["\"."]
-    ensureExtShape (errorMsg parts) loc (I.fromDecl t') desc e'
+    ensureExtShape (errorMsg parts) (I.fromDecl t') desc e'
 internaliseExp desc (E.Negate e loc) = locating loc $ do
   e' <- internaliseExp1 "negate_arg" e
   et <- subExpType e'
@@ -749,7 +745,7 @@ internaliseExp desc (E.Update src slice ve loc) = locating loc $ do
         <$> (I.arrayDims <$> lookupType src_v)
         <*> (I.arrayDims <$> subExpType ve_v)
     _ -> pure ([], []) -- Will this happen?
-  (idxs', cs) <- internaliseSlice loc src_dims slice
+  (idxs', cs) <- internaliseSlice src_dims slice
   let src_dims' = sliceDims (Slice idxs')
       rank = length src_dims'
       errormsg =
@@ -764,7 +760,7 @@ internaliseExp desc (E.Update src slice ve loc) = locating loc $ do
         let full_slice = fullSlice sname_t idxs'
             rowtype = sname_t `setArrayDims` sliceDims full_slice
         ve'' <-
-          ensureShape errormsg loc rowtype "lw_val_correct_shape" ve'
+          ensureShape errormsg rowtype "lw_val_correct_shape" ve'
         letInPlace desc sname full_slice $ BasicOp $ SubExp ve''
   certifying cs $ map I.Var <$> zipWithM comb srcs ves
 internaliseExp desc (E.RecordUpdate src fields ve _ loc) = locating loc $ do
@@ -823,9 +819,9 @@ internaliseExp desc (E.Attr attr e loc) = do
           env {envDoBoundsChecks = False}
       | otherwise =
           env {envAttrs = envAttrs env <> oneAttr attr'}
-internaliseExp desc (E.Assert e1 e2 (Info check) loc) = do
+internaliseExp desc (E.Assert e1 e2 (Info check) loc) = locating loc $ do
   e1' <- internaliseExp1 "assert_cond" e1
-  c <- assert "assert_c" e1' (errorMsg [ErrorString $ "Assertion is false: " <> check]) loc
+  c <- assert "assert_c" e1' $ errorMsg [ErrorString $ "Assertion is false: " <> check]
   -- Make sure there are some bindings to certify.
   certifying c $ mapM rebind =<< internaliseExp desc e2
   where
@@ -1024,11 +1020,10 @@ internalisePat' sizes p ses m = do
     m
 
 internaliseSlice ::
-  SrcLoc ->
   [SubExp] ->
   [E.DimIndex] ->
   InternaliseM ([I.DimIndex SubExp], Certs)
-internaliseSlice loc dims idxs = do
+internaliseSlice dims idxs = do
   (idxs', oks, parts) <- unzip3 <$> zipWithM internaliseDimIndex dims idxs
   ok <- letSubExp "index_ok" =<< eAll oks
   let msg =
@@ -1038,7 +1033,7 @@ internaliseSlice loc dims idxs = do
             ++ ["] out of bounds for array of shape ["]
             ++ intersperse "][" (map (ErrorVal int64) $ take (length idxs) dims)
             ++ ["]."]
-  c <- assert "index_certs" ok msg loc
+  c <- assert "index_certs" ok msg
   pure (idxs', c)
 
 internaliseDimIndex ::
@@ -1187,16 +1182,15 @@ internaliseScanOrReduce ::
   String ->
   String ->
   (SubExp -> I.Lambda SOACS -> [SubExp] -> [VName] -> InternaliseM (SOAC SOACS)) ->
-  (E.Exp, E.Exp, E.Exp, SrcLoc) ->
+  (E.Exp, E.Exp, E.Exp) ->
   InternaliseM [SubExp]
-internaliseScanOrReduce desc what f (lam, ne, arr, loc) = do
+internaliseScanOrReduce desc what f (lam, ne, arr) = do
   arrs <- internaliseExpToVars (what ++ "_arr") arr
   nes <- internaliseExp (what ++ "_ne") ne
   nes' <- forM (zip nes arrs) $ \(ne', arr') -> do
     rowtype <- I.stripArray 1 <$> lookupType arr'
     ensureShape
       "Row shape of input array does not match shape of neutral element"
-      loc
       rowtype
       (what ++ "_ne_right_shape")
       ne'
@@ -1215,9 +1209,8 @@ internaliseHist ::
   E.Exp ->
   E.Exp ->
   E.Exp ->
-  SrcLoc ->
   InternaliseM [SubExp]
-internaliseHist dim desc rf hist op ne buckets img loc = do
+internaliseHist dim desc rf hist op ne buckets img = do
   rf' <- internaliseExp1 "hist_rf" rf
   ne' <- internaliseExp "hist_ne" ne
   hist' <- internaliseExpToVars "hist_hist" hist
@@ -1229,7 +1222,6 @@ internaliseHist dim desc rf hist op ne buckets img loc = do
     rowtype <- I.stripArray 1 <$> lookupType h
     ensureShape
       "Row shape of destination array does not match shape of neutral element"
-      loc
       rowtype
       "hist_ne_right_shape"
       n
@@ -1248,7 +1240,6 @@ internaliseHist dim desc rf hist op ne buckets img loc = do
     mkLambda params $
       ensureResultShape
         "Row shape of value array does not match row shape of hist target"
-        (srclocOf img)
         rettype
         =<< bodyBind body
 
@@ -1334,35 +1325,32 @@ internaliseOperation s e op = do
   mapM (letSubExp s . I.BasicOp <=< op) vs
 
 certifyingNonzero ::
-  SrcLoc ->
   IntType ->
   SubExp ->
   InternaliseM a ->
   InternaliseM a
-certifyingNonzero loc t x m = do
+certifyingNonzero t x m = do
   zero <-
     letSubExp "zero" $
       I.BasicOp $
         CmpOp (CmpEq (IntType t)) x (intConst t 0)
   nonzero <- letSubExp "nonzero" $ I.BasicOp $ UnOp (I.Neg I.Bool) zero
-  c <- assert "nonzero_cert" nonzero "division by zero" loc
+  c <- assert "nonzero_cert" nonzero "division by zero"
   certifying c m
 
 certifyingNonnegative ::
-  SrcLoc ->
   IntType ->
   SubExp ->
   InternaliseM a ->
   InternaliseM a
-certifyingNonnegative loc t x m = do
+certifyingNonnegative t x m = do
   nonnegative <-
     letSubExp "nonnegative" . I.BasicOp $
       CmpOp (CmpSle t) (intConst t 0) x
-  c <- assert "nonzero_cert" nonnegative "negative exponent" loc
+  c <- assert "nonzero_cert" nonnegative "negative exponent"
   certifying c m
 
 internaliseBinOp ::
-  SrcLoc ->
   String ->
   E.BinOp ->
   I.SubExp ->
@@ -1370,123 +1358,123 @@ internaliseBinOp ::
   E.PrimType ->
   E.PrimType ->
   InternaliseM [I.SubExp]
-internaliseBinOp _ desc E.LogAnd x y E.Bool _ =
+internaliseBinOp desc E.LogAnd x y E.Bool _ =
   simpleBinOp desc I.LogAnd x y
-internaliseBinOp _ desc E.LogOr x y E.Bool _ =
+internaliseBinOp desc E.LogOr x y E.Bool _ =
   simpleBinOp desc I.LogOr x y
-internaliseBinOp _ desc E.Plus x y (E.Signed t) _ =
+internaliseBinOp desc E.Plus x y (E.Signed t) _ =
   simpleBinOp desc (I.Add t I.OverflowWrap) x y
-internaliseBinOp _ desc E.Plus x y (E.Unsigned t) _ =
+internaliseBinOp desc E.Plus x y (E.Unsigned t) _ =
   simpleBinOp desc (I.Add t I.OverflowWrap) x y
-internaliseBinOp _ desc E.Plus x y (E.FloatType t) _ =
+internaliseBinOp desc E.Plus x y (E.FloatType t) _ =
   simpleBinOp desc (I.FAdd t) x y
-internaliseBinOp _ desc E.Minus x y (E.Signed t) _ =
+internaliseBinOp desc E.Minus x y (E.Signed t) _ =
   simpleBinOp desc (I.Sub t I.OverflowWrap) x y
-internaliseBinOp _ desc E.Minus x y (E.Unsigned t) _ =
+internaliseBinOp desc E.Minus x y (E.Unsigned t) _ =
   simpleBinOp desc (I.Sub t I.OverflowWrap) x y
-internaliseBinOp _ desc E.Minus x y (E.FloatType t) _ =
+internaliseBinOp desc E.Minus x y (E.FloatType t) _ =
   simpleBinOp desc (I.FSub t) x y
-internaliseBinOp _ desc E.Times x y (E.Signed t) _ =
+internaliseBinOp desc E.Times x y (E.Signed t) _ =
   simpleBinOp desc (I.Mul t I.OverflowWrap) x y
-internaliseBinOp _ desc E.Times x y (E.Unsigned t) _ =
+internaliseBinOp desc E.Times x y (E.Unsigned t) _ =
   simpleBinOp desc (I.Mul t I.OverflowWrap) x y
-internaliseBinOp _ desc E.Times x y (E.FloatType t) _ =
+internaliseBinOp desc E.Times x y (E.FloatType t) _ =
   simpleBinOp desc (I.FMul t) x y
-internaliseBinOp loc desc E.Divide x y (E.Signed t) _ =
-  certifyingNonzero loc t y $
+internaliseBinOp desc E.Divide x y (E.Signed t) _ =
+  certifyingNonzero t y $
     simpleBinOp desc (I.SDiv t I.Unsafe) x y
-internaliseBinOp loc desc E.Divide x y (E.Unsigned t) _ =
-  certifyingNonzero loc t y $
+internaliseBinOp desc E.Divide x y (E.Unsigned t) _ =
+  certifyingNonzero t y $
     simpleBinOp desc (I.UDiv t I.Unsafe) x y
-internaliseBinOp _ desc E.Divide x y (E.FloatType t) _ =
+internaliseBinOp desc E.Divide x y (E.FloatType t) _ =
   simpleBinOp desc (I.FDiv t) x y
-internaliseBinOp _ desc E.Pow x y (E.FloatType t) _ =
+internaliseBinOp desc E.Pow x y (E.FloatType t) _ =
   simpleBinOp desc (I.FPow t) x y
-internaliseBinOp loc desc E.Pow x y (E.Signed t) _ =
-  certifyingNonnegative loc t y $
+internaliseBinOp desc E.Pow x y (E.Signed t) _ =
+  certifyingNonnegative t y $
     simpleBinOp desc (I.Pow t) x y
-internaliseBinOp _ desc E.Pow x y (E.Unsigned t) _ =
+internaliseBinOp desc E.Pow x y (E.Unsigned t) _ =
   simpleBinOp desc (I.Pow t) x y
-internaliseBinOp loc desc E.Mod x y (E.Signed t) _ =
-  certifyingNonzero loc t y $
+internaliseBinOp desc E.Mod x y (E.Signed t) _ =
+  certifyingNonzero t y $
     simpleBinOp desc (I.SMod t I.Unsafe) x y
-internaliseBinOp loc desc E.Mod x y (E.Unsigned t) _ =
-  certifyingNonzero loc t y $
+internaliseBinOp desc E.Mod x y (E.Unsigned t) _ =
+  certifyingNonzero t y $
     simpleBinOp desc (I.UMod t I.Unsafe) x y
-internaliseBinOp _ desc E.Mod x y (E.FloatType t) _ =
+internaliseBinOp desc E.Mod x y (E.FloatType t) _ =
   simpleBinOp desc (I.FMod t) x y
-internaliseBinOp loc desc E.Quot x y (E.Signed t) _ =
-  certifyingNonzero loc t y $
+internaliseBinOp desc E.Quot x y (E.Signed t) _ =
+  certifyingNonzero t y $
     simpleBinOp desc (I.SQuot t I.Unsafe) x y
-internaliseBinOp loc desc E.Quot x y (E.Unsigned t) _ =
-  certifyingNonzero loc t y $
+internaliseBinOp desc E.Quot x y (E.Unsigned t) _ =
+  certifyingNonzero t y $
     simpleBinOp desc (I.UDiv t I.Unsafe) x y
-internaliseBinOp loc desc E.Rem x y (E.Signed t) _ =
-  certifyingNonzero loc t y $
+internaliseBinOp desc E.Rem x y (E.Signed t) _ =
+  certifyingNonzero t y $
     simpleBinOp desc (I.SRem t I.Unsafe) x y
-internaliseBinOp loc desc E.Rem x y (E.Unsigned t) _ =
-  certifyingNonzero loc t y $
+internaliseBinOp desc E.Rem x y (E.Unsigned t) _ =
+  certifyingNonzero t y $
     simpleBinOp desc (I.UMod t I.Unsafe) x y
-internaliseBinOp _ desc E.ShiftR x y (E.Signed t) _ =
+internaliseBinOp desc E.ShiftR x y (E.Signed t) _ =
   simpleBinOp desc (I.AShr t) x y
-internaliseBinOp _ desc E.ShiftR x y (E.Unsigned t) _ =
+internaliseBinOp desc E.ShiftR x y (E.Unsigned t) _ =
   simpleBinOp desc (I.LShr t) x y
-internaliseBinOp _ desc E.ShiftL x y (E.Signed t) _ =
+internaliseBinOp desc E.ShiftL x y (E.Signed t) _ =
   simpleBinOp desc (I.Shl t) x y
-internaliseBinOp _ desc E.ShiftL x y (E.Unsigned t) _ =
+internaliseBinOp desc E.ShiftL x y (E.Unsigned t) _ =
   simpleBinOp desc (I.Shl t) x y
-internaliseBinOp _ desc E.Band x y (E.Signed t) _ =
+internaliseBinOp desc E.Band x y (E.Signed t) _ =
   simpleBinOp desc (I.And t) x y
-internaliseBinOp _ desc E.Band x y (E.Unsigned t) _ =
+internaliseBinOp desc E.Band x y (E.Unsigned t) _ =
   simpleBinOp desc (I.And t) x y
-internaliseBinOp _ desc E.Xor x y (E.Signed t) _ =
+internaliseBinOp desc E.Xor x y (E.Signed t) _ =
   simpleBinOp desc (I.Xor t) x y
-internaliseBinOp _ desc E.Xor x y (E.Unsigned t) _ =
+internaliseBinOp desc E.Xor x y (E.Unsigned t) _ =
   simpleBinOp desc (I.Xor t) x y
-internaliseBinOp _ desc E.Bor x y (E.Signed t) _ =
+internaliseBinOp desc E.Bor x y (E.Signed t) _ =
   simpleBinOp desc (I.Or t) x y
-internaliseBinOp _ desc E.Bor x y (E.Unsigned t) _ =
+internaliseBinOp desc E.Bor x y (E.Unsigned t) _ =
   simpleBinOp desc (I.Or t) x y
-internaliseBinOp _ desc E.Equal x y t _ =
+internaliseBinOp desc E.Equal x y t _ =
   simpleCmpOp desc (I.CmpEq $ internalisePrimType t) x y
-internaliseBinOp _ desc E.NotEqual x y t _ = do
+internaliseBinOp desc E.NotEqual x y t _ = do
   eq <- letSubExp (desc ++ "true") $ I.BasicOp $ I.CmpOp (I.CmpEq $ internalisePrimType t) x y
   fmap pure $ letSubExp desc $ I.BasicOp $ I.UnOp (I.Neg I.Bool) eq
-internaliseBinOp _ desc E.Less x y (E.Signed t) _ =
+internaliseBinOp desc E.Less x y (E.Signed t) _ =
   simpleCmpOp desc (I.CmpSlt t) x y
-internaliseBinOp _ desc E.Less x y (E.Unsigned t) _ =
+internaliseBinOp desc E.Less x y (E.Unsigned t) _ =
   simpleCmpOp desc (I.CmpUlt t) x y
-internaliseBinOp _ desc E.Leq x y (E.Signed t) _ =
+internaliseBinOp desc E.Leq x y (E.Signed t) _ =
   simpleCmpOp desc (I.CmpSle t) x y
-internaliseBinOp _ desc E.Leq x y (E.Unsigned t) _ =
+internaliseBinOp desc E.Leq x y (E.Unsigned t) _ =
   simpleCmpOp desc (I.CmpUle t) x y
-internaliseBinOp _ desc E.Greater x y (E.Signed t) _ =
+internaliseBinOp desc E.Greater x y (E.Signed t) _ =
   simpleCmpOp desc (I.CmpSlt t) y x -- Note the swapped x and y
-internaliseBinOp _ desc E.Greater x y (E.Unsigned t) _ =
+internaliseBinOp desc E.Greater x y (E.Unsigned t) _ =
   simpleCmpOp desc (I.CmpUlt t) y x -- Note the swapped x and y
-internaliseBinOp _ desc E.Geq x y (E.Signed t) _ =
+internaliseBinOp desc E.Geq x y (E.Signed t) _ =
   simpleCmpOp desc (I.CmpSle t) y x -- Note the swapped x and y
-internaliseBinOp _ desc E.Geq x y (E.Unsigned t) _ =
+internaliseBinOp desc E.Geq x y (E.Unsigned t) _ =
   simpleCmpOp desc (I.CmpUle t) y x -- Note the swapped x and y
-internaliseBinOp _ desc E.Less x y (E.FloatType t) _ =
+internaliseBinOp desc E.Less x y (E.FloatType t) _ =
   simpleCmpOp desc (I.FCmpLt t) x y
-internaliseBinOp _ desc E.Leq x y (E.FloatType t) _ =
+internaliseBinOp desc E.Leq x y (E.FloatType t) _ =
   simpleCmpOp desc (I.FCmpLe t) x y
-internaliseBinOp _ desc E.Greater x y (E.FloatType t) _ =
+internaliseBinOp desc E.Greater x y (E.FloatType t) _ =
   simpleCmpOp desc (I.FCmpLt t) y x -- Note the swapped x and y
-internaliseBinOp _ desc E.Geq x y (E.FloatType t) _ =
+internaliseBinOp desc E.Geq x y (E.FloatType t) _ =
   simpleCmpOp desc (I.FCmpLe t) y x -- Note the swapped x and y
 
 -- Relational operators for booleans.
-internaliseBinOp _ desc E.Less x y E.Bool _ =
+internaliseBinOp desc E.Less x y E.Bool _ =
   simpleCmpOp desc I.CmpLlt x y
-internaliseBinOp _ desc E.Leq x y E.Bool _ =
+internaliseBinOp desc E.Leq x y E.Bool _ =
   simpleCmpOp desc I.CmpLle x y
-internaliseBinOp _ desc E.Greater x y E.Bool _ =
+internaliseBinOp desc E.Greater x y E.Bool _ =
   simpleCmpOp desc I.CmpLlt y x -- Note the swapped x and y
-internaliseBinOp _ desc E.Geq x y E.Bool _ =
+internaliseBinOp desc E.Geq x y E.Bool _ =
   simpleCmpOp desc I.CmpLle y x -- Note the swapped x and y
-internaliseBinOp _ _ op _ _ t1 t2 =
+internaliseBinOp _ op _ _ t1 t2 =
   error $
     "Invalid binary operator "
       ++ prettyString op
@@ -1554,7 +1542,6 @@ internaliseLambdaCoerce lam argtypes = do
   mkLambda params $
     ensureResultShape
       (ErrorMsg [ErrorString "unexpected lambda result size"])
-      (srclocOf lam)
       rettype
       =<< bodyBind body
 
@@ -1562,9 +1549,8 @@ internaliseLambdaCoerce lam argtypes = do
 isOverloadedFunction ::
   E.QualName VName ->
   String ->
-  SrcLoc ->
   Maybe ([(E.StructType, [SubExp])] -> InternaliseM [SubExp])
-isOverloadedFunction qname desc loc = do
+isOverloadedFunction qname desc = do
   guard $ baseTag (qualLeaf qname) <= maxIntrinsicTag
   handle $ baseString $ qualLeaf qname
   where
@@ -1626,7 +1612,7 @@ isOverloadedFunction qname desc loc = do
           Just $ \[(x_t, [x']), (y_t, [y'])] ->
             case (x_t, y_t) of
               (E.Scalar (E.Prim t1), E.Scalar (E.Prim t2)) ->
-                internaliseBinOp loc desc bop x' y' t1 t2
+                internaliseBinOp desc bop x' y' t1 t2
               _ -> error "Futhark.Internalise.internaliseExp: non-primitive type in BinOp."
     handle _ = Nothing
 
@@ -1636,9 +1622,8 @@ isOverloadedFunction qname desc loc = do
 isIntrinsicFunction ::
   E.QualName VName ->
   [E.Exp] ->
-  SrcLoc ->
   Maybe (String -> InternaliseM [SubExp])
-isIntrinsicFunction qname args loc = do
+isIntrinsicFunction qname args = do
   guard $ baseTag (qualLeaf qname) <= maxIntrinsicTag
   let handlers =
         [ handleSign,
@@ -1696,28 +1681,28 @@ isIntrinsicFunction qname args loc = do
         fromInt32 (IntLit k' (Info (E.Scalar (E.Prim (E.Signed Int32)))) _) = Just $ fromInteger k'
         fromInt32 _ = Nothing
     handleSOACs [lam, ne, arr] "reduce" = Just $ \desc ->
-      internaliseScanOrReduce desc "reduce" reduce (lam, ne, arr, loc)
+      internaliseScanOrReduce desc "reduce" reduce (lam, ne, arr)
       where
         reduce w red_lam nes arrs =
           I.Screma w arrs
             <$> I.reduceSOAC [Reduce Noncommutative red_lam nes]
     handleSOACs [lam, ne, arr] "reduce_comm" = Just $ \desc ->
-      internaliseScanOrReduce desc "reduce" reduce (lam, ne, arr, loc)
+      internaliseScanOrReduce desc "reduce" reduce (lam, ne, arr)
       where
         reduce w red_lam nes arrs =
           I.Screma w arrs
             <$> I.reduceSOAC [Reduce Commutative red_lam nes]
     handleSOACs [lam, ne, arr] "scan" = Just $ \desc ->
-      internaliseScanOrReduce desc "scan" reduce (lam, ne, arr, loc)
+      internaliseScanOrReduce desc "scan" reduce (lam, ne, arr)
       where
         reduce w scan_lam nes arrs =
           I.Screma w arrs <$> I.scanSOAC [Scan scan_lam nes]
     handleSOACs [rf, dest, op, ne, buckets, img] "hist_1d" = Just $ \desc ->
-      internaliseHist 1 desc rf dest op ne buckets img loc
+      internaliseHist 1 desc rf dest op ne buckets img
     handleSOACs [rf, dest, op, ne, buckets, img] "hist_2d" = Just $ \desc ->
-      internaliseHist 2 desc rf dest op ne buckets img loc
+      internaliseHist 2 desc rf dest op ne buckets img
     handleSOACs [rf, dest, op, ne, buckets, img] "hist_3d" = Just $ \desc ->
-      internaliseHist 3 desc rf dest op ne buckets img loc
+      internaliseHist 3 desc rf dest op ne buckets img
     handleSOACs _ _ = Nothing
 
     handleAccs [dest, f, bs] "scatter_stream" = Just $ \desc ->
@@ -1762,20 +1747,16 @@ isIntrinsicFunction qname args loc = do
               .&&. pe64 m'
               .>=. 0
       dim_ok_cert <-
-        assert
-          "dim_ok_cert"
-          dim_ok
-          ( ErrorMsg
-              [ "Cannot unflatten array of shape [",
-                ErrorVal int64 old_dim,
-                "] to array of shape [",
-                ErrorVal int64 n',
-                "][",
-                ErrorVal int64 m',
-                "]"
-              ]
-          )
-          loc
+        assert "dim_ok_cert" dim_ok $
+          ErrorMsg
+            [ "Cannot unflatten array of shape [",
+              ErrorVal int64 old_dim,
+              "] to array of shape [",
+              ErrorVal int64 n',
+              "][",
+              ErrorVal int64 m',
+              "]"
+            ]
       certifying dim_ok_cert $
         forM arrs $ \arr' -> do
           arr_t <- lookupType arr'
@@ -1832,17 +1813,17 @@ isIntrinsicFunction qname args loc = do
       mapM (letSubExp desc . BasicOp . Replicate mempty . I.Var)
         =<< internaliseExpToVars desc x
     handleRest [arr, offset, n1, s1, n2, s2] "flat_index_2d" = Just $ \desc -> do
-      flatIndexHelper desc loc arr offset [(n1, s1), (n2, s2)]
+      flatIndexHelper desc arr offset [(n1, s1), (n2, s2)]
     handleRest [arr1, offset, s1, s2, arr2] "flat_update_2d" = Just $ \desc -> do
-      flatUpdateHelper desc loc arr1 offset [s1, s2] arr2
+      flatUpdateHelper desc arr1 offset [s1, s2] arr2
     handleRest [arr, offset, n1, s1, n2, s2, n3, s3] "flat_index_3d" = Just $ \desc -> do
-      flatIndexHelper desc loc arr offset [(n1, s1), (n2, s2), (n3, s3)]
+      flatIndexHelper desc arr offset [(n1, s1), (n2, s2), (n3, s3)]
     handleRest [arr1, offset, s1, s2, s3, arr2] "flat_update_3d" = Just $ \desc -> do
-      flatUpdateHelper desc loc arr1 offset [s1, s2, s3] arr2
+      flatUpdateHelper desc arr1 offset [s1, s2, s3] arr2
     handleRest [arr, offset, n1, s1, n2, s2, n3, s3, n4, s4] "flat_index_4d" = Just $ \desc -> do
-      flatIndexHelper desc loc arr offset [(n1, s1), (n2, s2), (n3, s3), (n4, s4)]
+      flatIndexHelper desc arr offset [(n1, s1), (n2, s2), (n3, s3), (n4, s4)]
     handleRest [arr1, offset, s1, s2, s3, s4, arr2] "flat_update_4d" = Just $ \desc -> do
-      flatUpdateHelper desc loc arr1 offset [s1, s2, s3, s4] arr2
+      flatUpdateHelper desc arr1 offset [s1, s2, s3, s4] arr2
     handleRest _ _ = Nothing
 
     toSigned int_to e desc = do
@@ -1902,7 +1883,6 @@ isIntrinsicFunction qname args loc = do
             "write_cert"
             cmp
             "length of index and value array does not match"
-            loc
         certifying c $
           letExp (baseString sv ++ "_write_sv") $
             shapeCoerce (I.shapeDims (reshapeOuter (I.Shape [si_w]) 1 sv_shape)) sv
@@ -1925,7 +1905,6 @@ isIntrinsicFunction qname args loc = do
           letSubExp "write_res" $ I.BasicOp $ I.SubExp $ I.Var name
         ensureResultShape
           "scatter value has wrong size"
-          loc
           bodyTypes
           (subExpsRes results)
 
@@ -1941,8 +1920,8 @@ isIntrinsicFunction qname args loc = do
           spec = zip3 sa_ws (repeat 1) sas
       letTupExp' desc $ I.Op $ I.Scatter si_w sivs spec lam
 
-flatIndexHelper :: String -> SrcLoc -> E.Exp -> E.Exp -> [(E.Exp, E.Exp)] -> InternaliseM [SubExp]
-flatIndexHelper desc loc arr offset slices = do
+flatIndexHelper :: String -> E.Exp -> E.Exp -> [(E.Exp, E.Exp)] -> InternaliseM [SubExp]
+flatIndexHelper desc arr offset slices = do
   arrs <- internaliseExpToVars "arr" arr
   offset' <- internaliseExp1 "offset" offset
   old_dim <- I.arraysSize 0 <$> mapM lookupType arrs
@@ -1981,14 +1960,16 @@ flatIndexHelper desc loc arr offset slices = do
       offset_inbounds_down
       [offset_inbounds_up, min_in_bounds, max_in_bounds]
 
-  c <- assert "bounds_cert" all_bounds (ErrorMsg [ErrorString $ "Flat slice out of bounds: " <> prettyText old_dim <> " and " <> prettyText slices']) loc
+  c <-
+    assert "bounds_cert" all_bounds $
+      ErrorMsg [ErrorString $ "Flat slice out of bounds: " <> prettyText old_dim <> " and " <> prettyText slices']
   let slice = I.FlatSlice offset' $ map (uncurry FlatDimIndex) slices'
   certifying c $
     forM arrs $ \arr' ->
       letSubExp desc $ I.BasicOp $ I.FlatIndex arr' slice
 
-flatUpdateHelper :: String -> SrcLoc -> E.Exp -> E.Exp -> [E.Exp] -> E.Exp -> InternaliseM [SubExp]
-flatUpdateHelper desc loc arr1 offset slices arr2 = do
+flatUpdateHelper :: String -> E.Exp -> E.Exp -> [E.Exp] -> E.Exp -> InternaliseM [SubExp]
+flatUpdateHelper desc arr1 offset slices arr2 = do
   arrs1 <- internaliseExpToVars "arr" arr1
   offset' <- internaliseExp1 "offset" offset
   old_dim <- I.arraysSize 0 <$> mapM lookupType arrs1
@@ -2029,7 +2010,9 @@ flatUpdateHelper desc loc arr1 offset slices arr2 = do
       offset_inbounds_down
       [offset_inbounds_up, min_in_bounds, max_in_bounds]
 
-  c <- assert "bounds_cert" all_bounds (ErrorMsg [ErrorString $ "Flat slice out of bounds: " <> prettyText old_dim <> " and " <> prettyText slices']) loc
+  c <-
+    assert "bounds_cert" all_bounds $
+      ErrorMsg [ErrorString $ "Flat slice out of bounds: " <> prettyText old_dim <> " and " <> prettyText slices']
   let slice = I.FlatSlice offset' $ map (uncurry FlatDimIndex) slices'
   certifying c $
     forM (zip arrs1 arrs2) $ \(arr1', arr2') ->
@@ -2039,9 +2022,8 @@ funcall ::
   String ->
   QualName VName ->
   [SubExp] ->
-  SrcLoc ->
   InternaliseM [SubExp]
-funcall desc (QualName _ fname) args loc = do
+funcall desc (QualName _ fname) args = do
   (shapes, value_paramts, fun_params, rettype_fun) <- lookupFunction fname
   argts <- mapM subExpType args
 
@@ -2052,7 +2034,6 @@ funcall desc (QualName _ fname) args loc = do
   args' <-
     ensureArgShapes
       "function arguments of wrong shape"
-      loc
       (map I.paramName fun_params)
       (map I.paramType fun_params)
       (shapeargs ++ args)
@@ -2075,7 +2056,7 @@ funcall desc (QualName _ fname) args loc = do
       safety <- askSafety
       attrs <- asks envAttrs
       attributing attrs . letValExp' desc $
-        I.Apply (internaliseFunName fname) (zip args' diets) ts (safety, loc, mempty)
+        I.Apply (internaliseFunName fname) (zip args' diets) ts safety
 
 -- Bind existential names defined by an expression, based on the
 -- concrete values that expression evaluated to.  This most

--- a/src/Futhark/Internalise/FullNormalise.hs
+++ b/src/Futhark/Internalise/FullNormalise.hs
@@ -218,7 +218,7 @@ getOrdering final (OpSectionLeft op ty e (Info (xp, _, xext), Info (yp, yty)) (I
   let y = Var (qualName yn) (Info $ toStruct yty) mempty
       ret' = applySubst (pSubst x y) ret
       body =
-        mkApply (Var op ty mempty) [(xext, x), (Nothing, y)] $
+        mkApply (Var op ty loc) [(xext, x), (Nothing, y)] $
           AppRes (toStruct ret') exts
   nameExp final $ Lambda [Id yn (Info yty) mempty] body Nothing (Info (RetType dims ret')) loc
   where
@@ -231,7 +231,7 @@ getOrdering final (OpSectionRight op ty e (Info (xp, xty), Info (yp, _, yext)) (
   y <- getOrdering False e
   let x = Var (qualName xn) (Info $ toStruct xty) mempty
       ret' = applySubst (pSubst x y) ret
-      body = mkApply (Var op ty mempty) [(Nothing, x), (yext, y)] $ AppRes (toStruct ret') []
+      body = mkApply (Var op ty loc) [(Nothing, x), (yext, y)] $ AppRes (toStruct ret') []
   nameExp final $ Lambda [Id xn (Info xty) mempty] body Nothing (Info (RetType dims ret')) loc
   where
     pSubst x y vn

--- a/src/Futhark/Internalise/Lambdas.hs
+++ b/src/Futhark/Internalise/Lambdas.hs
@@ -33,7 +33,6 @@ internaliseFoldLambda internaliseLambda lam acctypes arrtypes = do
   mkLambda params $
     ensureResultShape
       (ErrorMsg [ErrorString "shape of result does not match shape of initial value"])
-      (srclocOf lam)
       rettype'
       =<< bodyBind body
 

--- a/src/Futhark/Internalise/Monad.hs
+++ b/src/Futhark/Internalise/Monad.hs
@@ -16,6 +16,7 @@ module Futhark.Internalise.Monad
     bindFunction,
     bindConstant,
     assert,
+    locating,
 
     -- * Convenient reexports
     module Futhark.Tools,
@@ -49,7 +50,8 @@ data InternaliseEnv = InternaliseEnv
   { envSubsts :: VarSubsts,
     envDoBoundsChecks :: Bool,
     envSafe :: Bool,
-    envAttrs :: Attrs
+    envAttrs :: Attrs,
+    envLoc :: Loc
   }
 
 data InternaliseState = InternaliseState
@@ -115,7 +117,8 @@ runInternaliseM safe (InternaliseM m) =
         { envSubsts = mempty,
           envDoBoundsChecks = True,
           envSafe = safe,
-          envAttrs = mempty
+          envAttrs = mempty,
+          envLoc = mempty
         }
     newState src =
       InternaliseState
@@ -215,3 +218,13 @@ assertingOne ::
   InternaliseM VName ->
   InternaliseM Certs
 assertingOne m = asserting $ Certs . pure <$> m
+
+-- | Attach the provided location to all statements produced during execution of
+-- this action.
+locating :: (Located a) => a -> InternaliseM b -> InternaliseM b
+locating a
+  | loc == mempty = id
+  | otherwise = censorStms $ fmap onStm
+  where
+    loc = locOf a
+    onStm (Let pat aux e) = Let pat (aux {stmAuxLoc = Provenance loc}) e

--- a/src/Futhark/LSP/Tool.hs
+++ b/src/Futhark/LSP/Tool.hs
@@ -20,7 +20,7 @@ import Futhark.LSP.PositionMapping
 import Futhark.LSP.State (State (..), getStaleContent, getStaleMapping)
 import Futhark.Util.Loc (Loc (Loc, NoLoc), Pos (Pos))
 import Futhark.Util.Pretty (prettyText)
-import Language.Futhark.Prop (isBuiltinLoc)
+import Language.Futhark.Core (isBuiltinLoc)
 import Language.Futhark.Query
   ( AtPos (AtName),
     BoundTo (..),

--- a/src/Futhark/Optimise/ArrayShortCircuiting.hs
+++ b/src/Futhark/Optimise/ArrayShortCircuiting.hs
@@ -118,14 +118,14 @@ replaceInStm ::
   (Mem rep inner, LetDec rep ~ LetDecMem) =>
   Stm rep ->
   UpdateM (inner rep) (Stm rep)
-replaceInStm (Let (Pat elems) (StmAux c a d) e) = do
+replaceInStm (Let (Pat elems) (StmAux c a loc d) e) = do
   elems' <- mapM replaceInPatElem elems
   e' <- replaceInExp elems' e
   entries <- asks (M.elems . envCoalesceTab)
   let c' = case filter (\entry -> (map patElemName elems `L.intersect` M.keys (vartab entry)) /= []) entries of
         [] -> c
         entries' -> c <> foldMap certs entries'
-  pure $ Let (Pat elems') (StmAux c' a d) e'
+  pure $ Let (Pat elems') (StmAux c' a loc d) e'
   where
     replaceInPatElem :: PatElem LetDecMem -> UpdateM inner (PatElem LetDecMem)
     replaceInPatElem p@(PatElem vname (MemArray _ _ u _)) =

--- a/src/Futhark/Optimise/ArrayShortCircuiting/TopdownAnalysis.hs
+++ b/src/Futhark/Optimise/ArrayShortCircuiting/TopdownAnalysis.hs
@@ -180,7 +180,7 @@ updateTopdownEnv env stm@(Let pat _ (Op (Inner inner))) =
       nonNegatives = nonNegatives env <> innerNonNegatives (patNames pat) inner,
       knownLessThan = knownLessThan env <> innerKnownLessThan inner
     }
-updateTopdownEnv env stm@(Let (Pat _) _ (BasicOp (Assert se _ _))) =
+updateTopdownEnv env stm@(Let (Pat _) _ (BasicOp (Assert se _))) =
   env
     { scope = scope env <> scopeOf stm,
       td_asserts = se : td_asserts env

--- a/src/Futhark/Optimise/CSE.hs
+++ b/src/Futhark/Optimise/CSE.hs
@@ -209,28 +209,28 @@ cseInStm ::
   Stm rep ->
   ([Stm rep] -> CSEM rep a) ->
   CSEM rep a
-cseInStm consumed (Let pat (StmAux cs attrs edec) e) m = do
+cseInStm consumed (Let pat aux e) m = do
   CSEState (esubsts, nsubsts) cse_arrays <- ask
   let e' = normExp $ substituteNames nsubsts e
       pat' = substituteNames nsubsts pat
   if not (alreadyAliases e) && any (bad cse_arrays) (patElems pat)
-    then m [Let pat' (StmAux cs attrs edec) e']
-    else case M.lookup (edec, e') esubsts of
+    then m [Let pat' aux e']
+    else case M.lookup (stmAuxDec aux, e') esubsts of
       Just (subcs, subpat) -> do
-        let subsumes = all (`elem` unCerts subcs) (unCerts cs)
+        let subsumes = all (`elem` unCerts subcs) (unCerts (stmAuxCerts aux))
         -- We can only do a plain name substitution if it doesn't
         -- violate any certificate dependencies.
         local (if subsumes then addNameSubst pat' subpat else id) $ do
           let lets =
-                [ Let (Pat [patElem']) (StmAux cs attrs edec) $
+                [ Let (Pat [patElem']) aux $
                     BasicOp (SubExp $ Var $ patElemName patElem)
                   | (name, patElem) <- zip (patNames pat') $ patElems subpat,
                     let patElem' = patElem {patElemName = name}
                 ]
           m lets
       _ ->
-        local (addExpSubst pat' edec cs e') $
-          m [Let pat' (StmAux cs attrs edec) e']
+        local (addExpSubst pat' (stmAuxDec aux) (stmAuxCerts aux) e') $
+          m [Let pat' aux e']
   where
     alreadyAliases (BasicOp Index {}) = True
     alreadyAliases (BasicOp Reshape {}) = True

--- a/src/Futhark/Optimise/CSE.hs
+++ b/src/Futhark/Optimise/CSE.hs
@@ -196,13 +196,6 @@ cseInStms consumed (stm : stms) m =
       | patElemName pe `nameIn` consumed = Consume
       | otherwise = Observe
 
--- A small amount of normalisation of expressions that otherwise would
--- be different for pointless reasons.
-normExp :: Exp lore -> Exp lore
-normExp (Apply fname args ret (safety, _, _)) =
-  Apply fname args ret (safety, mempty, mempty)
-normExp e = e
-
 cseInStm ::
   (ASTRep rep) =>
   Names ->
@@ -211,7 +204,7 @@ cseInStm ::
   CSEM rep a
 cseInStm consumed (Let pat aux e) m = do
   CSEState (esubsts, nsubsts) cse_arrays <- ask
-  let e' = normExp $ substituteNames nsubsts e
+  let e' = substituteNames nsubsts e
       pat' = substituteNames nsubsts pat
   if not (alreadyAliases e) && any (bad cse_arrays) (patElems pat)
     then m [Let pat' aux e']

--- a/src/Futhark/Optimise/Fusion.hs
+++ b/src/Futhark/Optimise/Fusion.hs
@@ -350,7 +350,6 @@ vFuseNodeT
       pat1_acc_nms <- namesFromList $ take n $ map patElemName $ patElems pat1,
       -- not $ namesIntersect (freeIn soac) pat1_acc_nms
       all ((`notNameIn` pat1_acc_nms) . getName) edges = do
-        let empty_aux = StmAux mempty mempty mempty
         wlam <- fst <$> doFusionInLambda wlam0
         bdy' <-
           runBodyBuilder $ inScopeOf wlam $ do
@@ -360,7 +359,7 @@ vFuseNodeT
             let other_pr1 = drop n $ zip (patElems pat1) wlam_res
             forM_ other_pr1 $ \(pat_elm, bdy_res) -> do
               let (nm, se, tp) = (patElemName pat_elm, resSubExp bdy_res, patElemType pat_elm)
-                  aux = empty_aux {stmAuxCerts = resCerts bdy_res}
+                  aux = (defAux ()) {stmAuxCerts = resCerts bdy_res}
               addStm $ Let (Pat [PatElem nm tp]) aux $ BasicOp $ SubExp se
             -- add the soac stmt
             soac' <- H.toExp soac

--- a/src/Futhark/Optimise/ReduceDeviceSyncs.hs
+++ b/src/Futhark/Optimise/ReduceDeviceSyncs.hs
@@ -136,11 +136,10 @@ optimizeStm out stm = do
                 let e' = BasicOp $ Replicate (Shape dims) (Var v')
                 let repl = Let pat' (stmAux stm) e'
 
-                let aux = StmAux mempty mempty ()
                 let slice = map sliceDim (arrayDims arr_t)
                 let slice' = slice ++ [DimFix $ intConst Int64 0]
                 let idx = BasicOp $ Index n' (Slice slice')
-                let index = Let (stmPat stm) aux idx
+                let index = Let (stmPat stm) (defAux ()) idx
 
                 pure (out |> repl |> index)
       BasicOp {} ->
@@ -479,7 +478,7 @@ eIndex arr = BasicOp $ Index arr (Slice [DimFix $ intConst Int64 0])
 
 -- | A shorthand for binding a single variable to an expression.
 bind :: PatElem Type -> Exp GPU -> Stm GPU
-bind pe = Let (Pat [pe]) (StmAux mempty mempty ())
+bind pe = Let (Pat [pe]) (defAux ())
 
 -- | Returns the array alias of @se@ if it is a variable that has been migrated
 -- to device. Otherwise returns @Nothing@.
@@ -606,7 +605,7 @@ inGPUBody m = do
 
   let pes = patElems (stmPat stm)
   pat <- Pat <$> mapM arrayizePatElem pes
-  let aux = StmAux mempty mempty ()
+  let aux = defAux ()
   let types = map patElemType pes
   let res = map (SubExpRes mempty . Var . patElemName) pes
   let body = Body () (prologue |> stm) res
@@ -711,9 +710,9 @@ rewriteStms = foldM rewriteTo mempty
     bnd :: Stms GPU -> (PatElem Type, SubExpRes) -> Stms GPU
     bnd out (pe, SubExpRes cs se)
       | Just t' <- peelArray 1 (typeOf pe) =
-          out |> Let (Pat [pe]) (StmAux cs mempty ()) (BasicOp $ ArrayLit [se] t')
+          out |> Let (Pat [pe]) (StmAux cs mempty mempty ()) (BasicOp $ ArrayLit [se] t')
       | otherwise =
-          out |> Let (Pat [pe]) (StmAux cs mempty ()) (BasicOp $ SubExp se)
+          out |> Let (Pat [pe]) (StmAux cs mempty mempty ()) (BasicOp $ SubExp se)
 
 -- | Rewrite all bindings introduced by a single statement (to ensure they are
 -- unique) and fix any dependencies that are broken as a result of migration or
@@ -745,9 +744,9 @@ rewritePatElem (PatElem n t) = do
 -- | Fix any 'StmAux' certificate references that are broken as a result of
 -- migration or rewriting.
 rewriteStmAux :: StmAux () -> RewriteM (StmAux ())
-rewriteStmAux (StmAux certs attrs _) = do
-  certs' <- renameCerts certs
-  pure (StmAux certs' attrs ())
+rewriteStmAux aux = do
+  certs' <- renameCerts $ stmAuxCerts aux
+  pure $ aux {stmAuxCerts = certs'}
 
 -- | Rewrite the bindings introduced by an expression (to ensure they are
 -- unique) and fix any dependencies that are broken as a result of migration or

--- a/src/Futhark/Optimise/Simplify/Engine.hs
+++ b/src/Futhark/Optimise/Simplify/Engine.hs
@@ -296,10 +296,10 @@ protectIf _ _ taken (Let pat aux (Match [cond] [Case [Just (BoolValue True)] tak
   auxing aux . letBind pat $
     Match [cond'] [Case [Just (BoolValue True)] taken_body] untaken_body $
       MatchDec if_ts MatchFallback
-protectIf _ _ taken (Let pat aux (BasicOp (Assert cond msg loc))) = do
+protectIf _ _ taken (Let pat aux (BasicOp (Assert cond msg))) = do
   not_taken <- letSubExp "loop_not_taken" $ BasicOp $ UnOp (Neg Bool) taken
   cond' <- letSubExp "protect_assert_disj" $ BasicOp $ BinOp LogOr not_taken cond
-  auxing aux $ letBind pat $ BasicOp $ Assert cond' msg loc
+  auxing aux $ letBind pat $ BasicOp $ Assert cond' msg
 protectIf protect _ taken (Let pat aux (Op op))
   | Just m <- protect taken pat op =
       auxing aux m

--- a/src/Futhark/Optimise/Simplify/Engine.hs
+++ b/src/Futhark/Optimise/Simplify/Engine.hs
@@ -423,11 +423,11 @@ nonrecSimplifyStm ::
   (SimplifiableRep rep) =>
   Stm (Wise rep) ->
   SimpleM rep (Stm (Wise rep))
-nonrecSimplifyStm (Let pat (StmAux cs attrs (_, dec)) e) = do
+nonrecSimplifyStm (Let pat (StmAux cs attrs loc (_, dec)) e) = do
   cs' <- simplify cs
   e' <- simplifyExpBase e
   (pat', pat_cs) <- collectCerts $ traverse simplify $ removePatWisdom pat
-  let aux' = StmAux (cs' <> pat_cs) attrs dec
+  let aux' = StmAux (cs' <> pat_cs) attrs loc dec
   pure $ mkWiseStm pat' aux' e'
 
 -- Bottom-up simplify a statement.  Recurses into sub-Bodies and Ops.
@@ -439,9 +439,9 @@ recSimplifyStm ::
   Stm (Wise rep) ->
   UT.UsageTable ->
   SimpleM rep (Stms (Wise rep), Stm (Wise rep))
-recSimplifyStm (Let pat (StmAux cs attrs (_, dec)) e) usage = do
+recSimplifyStm (Let pat (StmAux cs attrs loc (_, dec)) e) usage = do
   ((e', e_hoisted), e_cs) <- collectCerts $ simplifyExp (usage <> UT.usageInPat pat) pat e
-  let aux' = StmAux (cs <> e_cs) attrs dec
+  let aux' = StmAux (cs <> e_cs) attrs loc dec
   pure (e_hoisted, mkWiseStm (removePatWisdom pat) aux' e')
 
 hoistStms ::

--- a/src/Futhark/Optimise/Simplify/Rep.hs
+++ b/src/Futhark/Optimise/Simplify/Rep.hs
@@ -252,9 +252,9 @@ mkWiseStm ::
   StmAux (ExpDec rep) ->
   Exp (Wise rep) ->
   Stm (Wise rep)
-mkWiseStm pat (StmAux cs attrs dec) e =
+mkWiseStm pat aux e =
   let pat' = addWisdomToPat pat e
-   in Let pat' (StmAux cs attrs $ mkWiseExpDec pat' dec e) e
+   in Let pat' (flip (mkWiseExpDec pat') e <$> aux) e
 
 -- | Produce simplifier information for an expression.
 mkWiseExpDec ::

--- a/src/Futhark/Optimise/Simplify/Rules/Match.hs
+++ b/src/Futhark/Optimise/Simplify/Rules/Match.hs
@@ -40,9 +40,9 @@ ruleMatch _ pat _ (cond, cases, _, ifdec)
     new_default : _ <- reverse always_matches =
       Simplify $ letBind pat $ Match cond cases' (caseBody new_default) ifdec
 -- Remove caseless match.
-ruleMatch _ pat (StmAux cs _ _) (_, [], defbody, _) = Simplify $ do
+ruleMatch _ pat aux (_, [], defbody, _) = Simplify $ do
   defbody_res <- bodyBind defbody
-  certifying cs $ forM_ (zip (patElems pat) defbody_res) $ \(pe, res) ->
+  certifying (stmAuxCerts aux) $ forM_ (zip (patElems pat) defbody_res) $ \(pe, res) ->
     certifying (resCerts res) . letBind (Pat [pe]) $
       BasicOp (SubExp $ resSubExp res)
 -- IMPROVE: the following two rules can be generalised to work in more

--- a/src/Futhark/Optimise/Simplify/Rules/Simple.hs
+++ b/src/Futhark/Optimise/Simplify/Rules/Simple.hs
@@ -263,7 +263,7 @@ simplifyConvOp _ _ _ =
 
 -- If expression is true then just replace assertion.
 simplifyAssert :: SimpleRule rep
-simplifyAssert _ _ (Assert (Constant (BoolValue True)) _ _) =
+simplifyAssert _ _ (Assert (Constant (BoolValue True)) _) =
   constRes UnitValue
 simplifyAssert _ _ _ =
   Nothing

--- a/src/Futhark/Pass/ExtractKernels.hs
+++ b/src/Futhark/Pass/ExtractKernels.hs
@@ -392,7 +392,7 @@ transformStm path (Let pat aux (Loop merge form body)) =
 transformStm path (Let pat aux (Op (Screma w arrs form)))
   | Just lam <- isMapSOAC form =
       onMap path $ MapLoop pat aux w lam arrs
-transformStm path (Let pat aux@(StmAux cs _ _) (Op (Screma w arrs form)))
+transformStm path (Let pat aux (Op (Screma w arrs form)))
   | Just scans <- isScanSOAC form,
     Scan scan_lam nes <- singleScan scans,
     Just do_iswim <- iswim pat w scan_lam $ zip nes arrs = do
@@ -425,6 +425,8 @@ transformStm path (Let pat aux@(StmAux cs _ _) (Op (Screma w arrs form)))
               =<< (mkBody <$> paralleliseInner path' <*> pure (varsRes (patNames pat)))
 
       versionScanRed path pat aux w map_lam paralleliseOuter outerParallelBody innerParallelBody
+  where
+    cs = stmAuxCerts aux
 transformStm path (Let res_pat aux (Op (Screma w arrs form)))
   | Just [Reduce comm red_fun nes] <- isReduceSOAC form,
     let comm'
@@ -434,7 +436,7 @@ transformStm path (Let res_pat aux (Op (Screma w arrs form)))
       types <- asksScope scopeForSOACs
       stms <- fst <$> runBuilderT (simplifyStms =<< collectStms_ (auxing aux do_irwim)) types
       transformStms path $ stmsToList stms
-transformStm path (Let pat aux@(StmAux cs _ _) (Op (Screma w arrs form)))
+transformStm path (Let pat aux (Op (Screma w arrs form)))
   | Just (reds, map_lam) <- isRedomapSOAC form = do
       let paralleliseOuter = runBuilder_ $ do
             red_ops <- forM reds $ \(Reduce comm red_lam nes) -> do
@@ -465,11 +467,13 @@ transformStm path (Let pat aux@(StmAux cs _ _) (Op (Screma w arrs form)))
               =<< (mkBody <$> paralleliseInner path' <*> pure (varsRes (patNames pat)))
 
       versionScanRed path pat aux w map_lam paralleliseOuter outerParallelBody innerParallelBody
-transformStm path (Let pat (StmAux cs _ _) (Op (Screma w arrs form))) = do
+  where
+    cs = stmAuxCerts aux
+transformStm path (Let pat aux (Op (Screma w arrs form))) = do
   -- This screma is too complicated for us to immediately do
   -- anything, so split it up and try again.
   scope <- asksScope scopeForSOACs
-  transformStms path . map (certify cs) . stmsToList . snd
+  transformStms path . map (certify (stmAuxCerts aux)) . stmsToList . snd
     =<< runBuilderT (dissectScrema pat w form arrs) scope
 transformStm path (Let pat _ (Op (Stream w arrs nes fold_fun))) = do
   -- Remove the stream and leave the body parallel.  It will be
@@ -526,7 +530,7 @@ transformStm path (Let pat aux (Op (Scatter w arrs as lam)))
       addStms stms
       letBind (Pat [res_pe]) $ Op $ SegOp kernel
 --
-transformStm _ (Let pat (StmAux cs _ _) (Op (Scatter w ivs as lam))) = runBuilder_ $ do
+transformStm _ (Let pat aux (Op (Scatter w ivs as lam))) = runBuilder_ $ do
   let lam' = soacsLambdaToGPU lam
   write_i <- newVName "write_i"
   let krets = do
@@ -547,10 +551,10 @@ transformStm _ (Let pat (StmAux cs _ _) (Op (Scatter w ivs as lam))) = runBuilde
       inputs
       (patTypes pat)
       body
-  certifying cs $ do
+  certifying (stmAuxCerts aux) $ do
     addStms stms
     letBind pat $ Op $ SegOp kernel
-transformStm _ (Let orig_pat (StmAux cs _ _) (Op (Hist w imgs ops bucket_fun))) = do
+transformStm _ (Let orig_pat aux (Op (Hist w imgs ops bucket_fun))) = do
   let bfun' = soacsLambdaToGPU bucket_fun
 
   -- It is important not to launch unnecessarily many threads for
@@ -558,7 +562,7 @@ transformStm _ (Let orig_pat (StmAux cs _ _) (Op (Hist w imgs ops bucket_fun))) 
   -- subhistograms as well.
   runBuilder_ $ do
     lvl <- segThreadCapped [w] "seghist" $ NoRecommendation SegNoVirt
-    addStms =<< histKernel onLambda lvl orig_pat [] [] cs w ops bfun' imgs
+    addStms =<< histKernel onLambda lvl orig_pat [] [] (stmAuxCerts aux) w ops bfun' imgs
   where
     onLambda = pure . soacsLambdaToGPU
 transformStm _ stm =

--- a/src/Futhark/Pass/ExtractKernels/DistributeNests.hs
+++ b/src/Futhark/Pass/ExtractKernels/DistributeNests.hs
@@ -334,13 +334,13 @@ distributeMapBodyStms ::
 distributeMapBodyStms orig_acc = distribute <=< onStms orig_acc . stmsToList
   where
     onStms acc [] = pure acc
-    onStms acc (Let pat (StmAux cs _ _) (Op (Stream w arrs accs lam)) : stms) = do
+    onStms acc (Let pat aux (Op (Stream w arrs accs lam)) : stms) = do
       types <- asksScope scopeForSOACs
       stream_stms <-
         snd <$> runBuilderT (sequentialStreamWholeArray pat w accs lam arrs) types
       stream_stms' <-
         runReaderT (copyPropagateInStms simpleSOACS types stream_stms) types
-      onStms acc $ stmsToList (fmap (certify cs) stream_stms') ++ stms
+      onStms acc $ stmsToList (fmap (certify (stmAuxCerts aux)) stream_stms') ++ stms
     onStms acc (stm : stms) =
       -- It is important that stm is in scope if 'maybeDistributeStm'
       -- wants to distribute, even if this causes the slightly silly
@@ -463,7 +463,7 @@ maybeDistributeStm (Let pat aux (Op (Screma w arrs form))) acc
       distributeMapBodyStms acc stms
 
 -- Parallelise segmented scatters.
-maybeDistributeStm stm@(Let pat (StmAux cs _ _) (Op (Scatter w ivs as lam))) acc =
+maybeDistributeStm stm@(Let pat aux (Op (Scatter w ivs as lam))) acc =
   distributeSingleStm acc stm >>= \case
     Just (kernels, res, nest, acc')
       | Just (perm, pat_unused) <- permutationAndMissing pat res ->
@@ -471,12 +471,12 @@ maybeDistributeStm stm@(Let pat (StmAux cs _ _) (Op (Scatter w ivs as lam))) acc
             nest' <- expandKernelNest pat_unused nest
             lam' <- soacsLambda lam
             addPostStms kernels
-            postStm =<< segmentedScatterKernel nest' perm pat cs w lam' ivs as
+            postStm =<< segmentedScatterKernel nest' perm pat (stmAuxCerts aux) w lam' ivs as
             pure acc'
     _ ->
       addStmToAcc stm acc
 -- Parallelise segmented Hist.
-maybeDistributeStm stm@(Let pat (StmAux cs _ _) (Op (Hist w as ops lam))) acc =
+maybeDistributeStm stm@(Let pat aux (Op (Hist w as ops lam))) acc =
   distributeSingleStm acc stm >>= \case
     Just (kernels, res, nest, acc')
       | Just (perm, pat_unused) <- permutationAndMissing pat res ->
@@ -484,7 +484,7 @@ maybeDistributeStm stm@(Let pat (StmAux cs _ _) (Op (Hist w as ops lam))) acc =
             lam' <- soacsLambda lam
             nest' <- expandKernelNest pat_unused nest
             addPostStms kernels
-            postStm =<< segmentedHistKernel nest' perm cs w ops lam' as
+            postStm =<< segmentedHistKernel nest' perm (stmAuxCerts aux) w ops lam' as
             pure acc'
     _ ->
       addStmToAcc stm acc
@@ -507,7 +507,7 @@ maybeDistributeStm stm@(Let (Pat [pe]) aux (BasicOp (Index arr slice))) acc
 --
 -- If the scan cannot be distributed by itself, it will be
 -- sequentialised in the default case for this function.
-maybeDistributeStm stm@(Let pat (StmAux cs _ _) (Op (Screma w arrs form))) acc
+maybeDistributeStm stm@(Let pat aux (Op (Screma w arrs form))) acc
   | Just (scans, map_lam) <- isScanomapSOAC form,
     Scan lam nes <- singleScan scans =
       distributeSingleStm acc stm >>= \case
@@ -519,7 +519,7 @@ maybeDistributeStm stm@(Let pat (StmAux cs _ _) (Op (Screma w arrs form))) acc
                 nest' <- expandKernelNest pat_unused nest
                 map_lam' <- soacsLambda map_lam
                 localScope (typeEnvFromDistAcc acc') $
-                  segmentedScanomapKernel nest' perm cs w lam map_lam' nes arrs
+                  segmentedScanomapKernel nest' perm (stmAuxCerts aux) w lam map_lam' nes arrs
                     >>= kernelOrNot mempty stm acc kernels acc'
         _ ->
           addStmToAcc stm acc
@@ -536,7 +536,7 @@ maybeDistributeStm (Let pat aux (Op (Screma w arrs form))) acc
 --
 -- If the reduction cannot be distributed by itself, it will be
 -- sequentialised in the default case for this function.
-maybeDistributeStm stm@(Let pat (StmAux cs _ _) (Op (Screma w arrs form))) acc
+maybeDistributeStm stm@(Let pat aux (Op (Screma w arrs form))) acc
   | Just (reds, map_lam) <- isRedomapSOAC form,
     Reduce comm lam nes <- singleReduce reds =
       distributeSingleStm acc stm >>= \case
@@ -554,15 +554,15 @@ maybeDistributeStm stm@(Let pat (StmAux cs _ _) (Op (Screma w arrs form))) acc
                       | commutativeLambda lam = Commutative
                       | otherwise = comm
 
-                regularSegmentedRedomapKernel nest' perm cs w comm' lam' map_lam' nes arrs
+                regularSegmentedRedomapKernel nest' perm (stmAuxCerts aux) w comm' lam' map_lam' nes arrs
                   >>= kernelOrNot mempty stm acc kernels acc'
         _ ->
           addStmToAcc stm acc
-maybeDistributeStm (Let pat (StmAux cs _ _) (Op (Screma w arrs form))) acc = do
+maybeDistributeStm (Let pat aux (Op (Screma w arrs form))) acc = do
   -- This Screma is too complicated for us to immediately do
   -- anything, so split it up and try again.
   scope <- asksScope scopeForSOACs
-  distributeMapBodyStms acc . fmap (certify cs) . snd
+  distributeMapBodyStms acc . fmap (certify (stmAuxCerts aux)) . snd
     =<< runBuilderT (dissectScrema pat w form arrs) scope
 maybeDistributeStm stm@(Let _ aux (BasicOp (Replicate shape (Var stm_arr)))) acc = do
   distributeSingleUnaryStm acc stm stm_arr $ \nest outerpat arr ->
@@ -771,7 +771,7 @@ segmentedScatterKernel nest perm scatter_pat cs scatter_w lam ivs dests = do
   -- KernelNest we produce here is technically not sensible, but it's
   -- good enough for flatKernel to work.
   let nesting =
-        MapNesting scatter_pat (StmAux cs mempty ()) scatter_w $ zip (lambdaParams lam) ivs
+        MapNesting scatter_pat (StmAux cs mempty mempty ()) scatter_w $ zip (lambdaParams lam) ivs
       nest' =
         pushInnerKernelNesting (scatter_pat, bodyResult $ lambdaBody lam) nesting nest
   (ispace, kernel_inps) <- flatKernel nest'

--- a/src/Futhark/Profile.hs
+++ b/src/Futhark/Profile.hs
@@ -23,18 +23,22 @@ data ProfilingEvent = ProfilingEvent
     eventName :: T.Text,
     -- | In microseconds.
     eventDuration :: Double,
-    -- | Long, may be multiple lines, contains information about the specific
-    -- arguments and parameters.
-    eventDescription :: T.Text
+    -- | The provenance of the event - that is, from where in the original
+    -- program it originates.
+    eventProvenance :: [T.Text],
+    -- | Arbitrary additional information, probably in the form of a dictionary,
+    -- but that depends on the backend.
+    eventDetails :: JSON.Value
   }
   deriving (Eq, Ord, Show)
 
 instance JSON.ToJSON ProfilingEvent where
-  toJSON (ProfilingEvent name duration description) =
+  toJSON (ProfilingEvent name duration provenance details) =
     JSON.object
       [ ("name", JSON.toJSON name),
         ("duration", JSON.toJSON duration),
-        ("description", JSON.toJSON description)
+        ("provenance", JSON.toJSON provenance),
+        ("details", details)
       ]
 
 instance JSON.FromJSON ProfilingEvent where
@@ -42,7 +46,8 @@ instance JSON.FromJSON ProfilingEvent where
     ProfilingEvent
       <$> o JSON..: "name"
       <*> o JSON..: "duration"
-      <*> o JSON..: "description"
+      <*> o JSON..: "provenance"
+      <*> o JSON..: "details"
 
 -- | A profiling report contains all profiling information for a
 -- single benchmark (meaning a single invocation on an entry point on

--- a/src/Futhark/Profile.hs
+++ b/src/Futhark/Profile.hs
@@ -25,7 +25,7 @@ data ProfilingEvent = ProfilingEvent
     eventDuration :: Double,
     -- | The provenance of the event - that is, from where in the original
     -- program it originates.
-    eventProvenance :: [T.Text],
+    eventProvenance :: T.Text,
     -- | Arbitrary additional information, probably in the form of a dictionary,
     -- but that depends on the backend.
     eventDetails :: JSON.Value

--- a/src/Futhark/Profile.hs
+++ b/src/Futhark/Profile.hs
@@ -50,10 +50,7 @@ instance JSON.FromJSON ProfilingEvent where
 data ProfilingReport = ProfilingReport
   { profilingEvents :: [ProfilingEvent],
     -- | Mapping memory spaces to bytes.
-    profilingMemory :: M.Map T.Text Integer,
-    -- | Information about the names that can occur in 'eventName', which may
-    -- relate them to the source program.
-    profilingProvenance :: M.Map T.Text T.Text
+    profilingMemory :: M.Map T.Text Integer
   }
   deriving (Eq, Ord, Show)
 
@@ -61,11 +58,10 @@ mapToJSON :: (JSON.ToJSON v) => M.Map T.Text v -> JSON.Value
 mapToJSON = JSON.object . map (bimap JSON.fromText JSON.toJSON) . M.toList
 
 instance JSON.ToJSON ProfilingReport where
-  toJSON (ProfilingReport events memory provenance) =
+  toJSON (ProfilingReport events memory) =
     JSON.object
       [ ("events", JSON.toJSON events),
-        ("memory", mapToJSON memory),
-        ("provenance", mapToJSON provenance)
+        ("memory", mapToJSON memory)
       ]
 
 instance JSON.FromJSON ProfilingReport where
@@ -73,7 +69,6 @@ instance JSON.FromJSON ProfilingReport where
     ProfilingReport
       <$> o JSON..: "events"
       <*> (JSON.toMapText <$> o JSON..: "memory")
-      <*> (JSON.toMapText <$> o JSON..: "provenance")
 
 -- | Read a profiling report from a bytestring containing JSON.
 decodeProfilingReport :: LBS.ByteString -> Maybe ProfilingReport

--- a/src/Futhark/Transform/Rename.hs
+++ b/src/Futhark/Transform/Rename.hs
@@ -245,8 +245,8 @@ instance Rename Attrs where
   rename = pure
 
 instance (Rename dec) => Rename (StmAux dec) where
-  rename (StmAux cs attrs dec) =
-    StmAux <$> rename cs <*> rename attrs <*> rename dec
+  rename (StmAux cs attrs loc dec) =
+    StmAux <$> rename cs <*> rename attrs <*> pure loc <*> rename dec
 
 instance Rename SubExpRes where
   rename (SubExpRes cs se) = SubExpRes <$> rename cs <*> rename se

--- a/src/Futhark/Transform/Substitute.hs
+++ b/src/Futhark/Transform/Substitute.hs
@@ -80,10 +80,11 @@ instance Substitute Attrs where
   substituteNames _ attrs = attrs
 
 instance (Substitute dec) => Substitute (StmAux dec) where
-  substituteNames substs (StmAux cs attrs dec) =
+  substituteNames substs (StmAux cs attrs loc dec) =
     StmAux
       (substituteNames substs cs)
       (substituteNames substs attrs)
+      loc
       (substituteNames substs dec)
 
 instance (Substitute dec) => Substitute (Param dec) where

--- a/src/Language/Futhark/Core.hs
+++ b/src/Language/Futhark/Core.hs
@@ -18,6 +18,8 @@ module Language.Futhark.Core
     locText,
     locTextRel,
     prettyStacktrace,
+    isBuiltin,
+    isBuiltinLoc,
 
     -- * Name handling
     Name,
@@ -54,6 +56,7 @@ import Futhark.Util (showText)
 import Futhark.Util.Loc
 import Futhark.Util.Pretty
 import Numeric.Half
+import System.FilePath (takeDirectory)
 import Prelude hiding (id, (.))
 
 -- | The uniqueness attribute of a type.  This essentially indicates
@@ -160,6 +163,18 @@ locText = T.pack . locStr
 -- | 'locStrRel', but for text.
 locTextRel :: (Located a, Located b) => a -> b -> T.Text
 locTextRel a b = T.pack $ locStrRel a b
+
+-- | Is this include part of the built-in prelude?
+isBuiltin :: FilePath -> Bool
+isBuiltin = (== "/prelude") . takeDirectory
+
+-- | Is the position of this thing builtin as per 'isBuiltin'?  Things
+-- without location are considered not built-in.
+isBuiltinLoc :: (Located a) => a -> Bool
+isBuiltinLoc x =
+  case locOf x of
+    NoLoc -> False
+    Loc pos _ -> isBuiltin $ posFile pos
 
 -- | Given a list of strings representing entries in the stack trace
 -- and the index of the frame to highlight, produce a final

--- a/src/Language/Futhark/Prop.hs
+++ b/src/Language/Futhark/Prop.hs
@@ -7,8 +7,6 @@ module Language.Futhark.Prop
     Intrinsic (..),
     intrinsics,
     intrinsicVar,
-    isBuiltin,
-    isBuiltinLoc,
     maxIntrinsicTag,
     namesToPrimTypes,
     qualName,
@@ -135,7 +133,6 @@ import Data.Char
 import Data.Foldable
 import Data.List (genericLength, isPrefixOf, sortOn)
 import Data.List.NonEmpty qualified as NE
-import Data.Loc (Loc (..), posFile)
 import Data.Map.Strict qualified as M
 import Data.Maybe
 import Data.Ord
@@ -147,7 +144,6 @@ import Language.Futhark.Primitive qualified as Primitive
 import Language.Futhark.Syntax
 import Language.Futhark.Traversals
 import Language.Futhark.Tuple
-import System.FilePath (takeDirectory)
 
 -- | The name of the default program entry point (@main@).
 defaultEntryPoint :: Name
@@ -1197,18 +1193,6 @@ intrinsics =
       Prim $ Signed Int64
     tupInt64 x =
       tupleRecord $ replicate x $ Scalar $ Prim $ Signed Int64
-
--- | Is this include part of the built-in prelude?
-isBuiltin :: FilePath -> Bool
-isBuiltin = (== "/prelude") . takeDirectory
-
--- | Is the position of this thing builtin as per 'isBuiltin'?  Things
--- without location are considered not built-in.
-isBuiltinLoc :: (Located a) => a -> Bool
-isBuiltinLoc x =
-  case locOf x of
-    NoLoc -> False
-    Loc pos _ -> isBuiltin $ posFile pos
 
 -- | The largest tag used by an intrinsic - this can be used to
 -- determine whether a 'VName' refers to an intrinsic or a user-defined name.

--- a/tests_adhoc/kvs/.gitignore
+++ b/tests_adhoc/kvs/.gitignore
@@ -1,0 +1,1 @@
+testkvs

--- a/tests_adhoc/kvs/test.sh
+++ b/tests_adhoc/kvs/test.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+#
+# Test part of the RTS in an ad-hoc way.
+
+set -ex
+
+gcc testkvs.c -I../../ -o testkvs -g -fsanitize=address -fsanitize=undefined -Wall -Wextra -Werror -pedantic -Wno-unused-function
+
+./testkvs

--- a/tests_adhoc/kvs/testkvs.c
+++ b/tests_adhoc/kvs/testkvs.c
@@ -1,0 +1,28 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include "rts/c/util.h"
+#include "rts/c/event_list.h"
+
+int main() {
+  struct kvs kvs;
+  kvs_init(&kvs);
+
+  kvs_printf(&kvs, "x", "%d", 123);
+  kvs_printf(&kvs, "x", "%s", "\"foo\"");
+
+  for (size_t i = 0; i < 128; i++) {
+    kvs_printf(&kvs, "dup", "%f", rand()/1.0);
+  }
+
+  struct str_builder sb;
+  str_builder_init(&sb);
+
+  kvs_json(&kvs, &sb);
+  puts(sb.str);
+
+  kvs_log(&kvs, "", stdout);
+
+  free(sb.str);
+  kvs_free(&kvs);
+}

--- a/tests_adhoc/profile/test.sh
+++ b/tests_adhoc/profile/test.sh
@@ -5,7 +5,7 @@ set -e
 with_backend() {
     echo
     echo "Trying backend $1"
-    futhark bench --backend=$1 --profile --json prog.json prog.fut
+    $2 futhark bench --backend=$1 --profile --json prog.json prog.fut
     rm -rf prog.prof
     futhark profile prog.json
 }
@@ -13,3 +13,5 @@ with_backend() {
 with_backend c
 
 with_backend multicore
+
+with_backend opencl oclgrind


### PR DESCRIPTION
The goal is to eventually provide more useful profiling information, with references to the original source code. However, it is crucial that this does not overly burden the various compiler passes.

The key trick here is to stuff the provenance into the StmAux, which we always propagate (hopefully) because it is where we stuff attributes and certificates as well.