### PR TITLE
allow `~` character in package path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * FutharkScript now permits chained `let` without `in`, just as in Futhark.
 
+* `futhark pkg` now allows the `~` character in package paths.
+
 ### Removed
 
 ### Changed

--- a/src/Futhark/Pkg/Types.hs
+++ b/src/Futhark/Pkg/Types.hs
@@ -282,7 +282,7 @@ pPkgManifest = do
 
     pPkgPath =
       T.pack
-        <$> some (alphaNumChar <|> oneOf ("@-/.:_" :: String))
+        <$> some (alphaNumChar <|> oneOf ("@-/.:_~" :: String))
         <?> "package path"
 
     pRequired =


### PR DESCRIPTION
Allow the `~` character to be used in package paths so that sourcehut repositories (e.g., git.sr.ht/~user/project) can be used.