### PR TITLE
cuda backend: explicitly support CC 8.9, 9.0, 10.0, 10.1, and 12.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * `futhark pkg` now allows the `~` character in package paths.
 
+* `cuda` backend: explicitly support CC 8.9, 9.0, 10.0, 10.1, and 12.0.
+
 ### Removed
 
 ### Changed

--- a/rts/c/backends/cuda.h
+++ b/rts/c/backends/cuda.h
@@ -339,7 +339,12 @@ static const char *cuda_nvrtc_get_arch(CUdevice dev) {
     { 7, 5, "compute_75" },
     { 8, 0, "compute_80" },
     { 8, 6, "compute_80" },
-    { 8, 7, "compute_80" }
+    { 8, 7, "compute_80" },
+    { 8, 9, "compute_80" },
+    { 9, 0, "compute_90" },
+    { 10, 0, "compute_100" },
+    { 10, 1, "compute_101" },
+    { 12, 0, "compute_120" }
   };
 
   int major = device_query(dev, COMPUTE_CAPABILITY_MAJOR);


### PR DESCRIPTION
This is only partially tested, as the newest GPU I have access to is an H100.

Fixes #2286.