### PR TITLE
Fix #2288.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Missing fusion inside reduction and scan operators (#2283).
 
+* Incorrect aliasing for memory blocks could cause some optimisations to be
+  misapplied. (#2288)
+
 ## [0.25.31]
 
 ### Added

--- a/src/Futhark/IR/Pretty.hs
+++ b/src/Futhark/IR/Pretty.hs
@@ -317,7 +317,7 @@ instance (PrettyRep rep) => Pretty (Exp rep) where
       <+> pretty (nameToString fname)
       <> apply (map (align . prettyArg) args)
         </> colon
-        <+> braces (commasep $ map prettyRet ret)
+        <+> braces (align $ commasep $ map prettyRet ret)
     where
       prettyArg (arg, Consume) = "*" <> pretty arg
       prettyArg (arg, _) = pretty arg

--- a/src/Futhark/IR/Prop/Types.hs
+++ b/src/Futhark/IR/Prop/Types.hs
@@ -12,6 +12,7 @@ module Futhark.IR.Prop.Types
     staticShapes1,
     primType,
     isAcc,
+    isMem,
     arrayOf,
     arrayOfRow,
     arrayOfShape,
@@ -297,6 +298,11 @@ primType _ = False
 isAcc :: TypeBase shape u -> Bool
 isAcc Acc {} = True
 isAcc _ = False
+
+-- | Is this a memory block?
+isMem :: TypeBase shape u -> Bool
+isMem Mem {} = True
+isMem _ = False
 
 -- | Returns the bottommost type of an array.  For @[][]i32@, this
 -- would be @i32@.  If the given type is not an array, it is returned.

--- a/src/Futhark/Pass/ExplicitAllocations.hs
+++ b/src/Futhark/Pass/ExplicitAllocations.hs
@@ -615,8 +615,11 @@ explicitAllocationsGeneric space handleOp hints =
             allocInFunBody (map (const $ Just space) rettype) fbody
           let num_extra_params = length params' - length params
               num_extra_rets = length mem_rets
+              -- The mem_pals is an over-approximation, like in the case for Apply.
+              mem_pals = map fst $ filter (isMem . paramType . snd) $ zip [0 ..] params'
+              mem_als = RetAls mem_pals mempty
               rettype' =
-                map (,RetAls mempty mempty) mem_rets
+                map (,mem_als) mem_rets
                   ++ zip
                     (memoryInDeclExtType space (length mem_rets) (map fst rettype))
                     (map (shiftRetAls num_extra_params num_extra_rets . snd) rettype)
@@ -915,16 +918,20 @@ allocInExp (Loop merge form (Body () bodystms bodyres)) =
 allocInExp (Apply fname args rettype loc) = do
   args' <- funcallArgs args
   space <- askDefaultSpace
-  -- We assume that every array is going to be in its own memory.
-  let num_extra_args = length args' - length args
+  args_ts <- mapM (subExpType . fst) args'
+  -- We assume that every array is going to be in its own memory. Further, we
+  -- assume that every result memory block can alias any argument memory block.
+  -- This is an overapproximation that can be loosened in the future.
+  let mem_als = RetAls (map fst $ filter (isMem . snd) $ zip [0 ..] args_ts) mempty
+      mems = replicate num_arrays (MemMem space, mem_als)
+      num_extra_args = length args' - length args
       rettype' =
-        mems space
+        mems
           ++ zip
             (memoryInDeclExtType space num_arrays (map fst rettype))
             (map (shiftRetAls num_extra_args num_arrays . snd) rettype)
   pure $ Apply fname args' rettype' loc
   where
-    mems space = replicate num_arrays (MemMem space, RetAls mempty mempty)
     num_arrays = length $ filter ((> 0) . arrayRank . declExtTypeOf . fst) rettype
 allocInExp (Match ses cases defbody (MatchDec rets ifsort)) = do
   (defbody', def_reqs) <- allocInMatchBody rets defbody

--- a/tests/issue2288.fut
+++ b/tests/issue2288.fut
@@ -1,0 +1,15 @@
+-- ==
+-- entry: main
+-- compiled input {[0f32, 0f32, 0f32]} auto output
+-- compiled random input {[10]f32} auto output
+
+def map_func [n] (c: *[n]f32) : *[n]f32 =
+  map (+ 1) c
+
+entry main [n] (c: [n]f32) : [n]f32 =
+  let acc_init = replicate n 0.0f32
+  in loop acc = acc_init
+     for _i < n do
+       let c_copy = copy c
+       let res = #[noinline] map_func c_copy
+       in res with [0] = acc[0] + 1


### PR DESCRIPTION
There are still some quality-of-life issues regarding memory aliasing (perhaps even a few obscure bugs).

1. We do not add information that the memory blocks returned can alias each other.

2. On the other hand, we let every returned memory block alias every argument memory block.