### PR TITLE
Fix #2292.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Incorrect aliasing for memory blocks could cause some optimisations to be
   misapplied. (#2288)
 
+* `to_bits`/`from_bits` not handled by AD (#2292).
+
 ## [0.25.31]
 
 ### Added

--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,6 @@
 packages: futhark.cabal
 index-state: 2025-05-28T09:14:26Z
+multi-repl: True
 
 package futhark
   ghc-options: -j -fwrite-ide-info -hiedir=.hie

--- a/prelude/math.fut
+++ b/prelude/math.fut
@@ -1036,8 +1036,8 @@ module f64 : (float with t = f64 with int_t = u64) = {
   def ldexp x y = intrinsics.ldexp64 (x, y)
   def copysign x y = intrinsics.copysign64 (x, y)
 
-  def to_bits (x: f64) : u64 = u64m.i64 (intrinsics.to_bits64 x)
-  def from_bits (x: u64) : f64 = intrinsics.from_bits64 (intrinsics.sign_i64 x)
+  def to_bits (x: f64) : u64 = u64m.i64 (intrinsics.fptobits_f64_i64 x)
+  def from_bits (x: u64) : f64 = intrinsics.bitstofp_i64_f64 (intrinsics.sign_i64 x)
 
   def num_bits = 64i32
   def get_bit (bit: i32) (x: t) = u64m.get_bit bit (to_bits x)
@@ -1161,8 +1161,8 @@ module f32 : (float with t = f32 with int_t = u32) = {
   def ldexp x y = intrinsics.ldexp32 (x, y)
   def copysign x y = intrinsics.copysign32 (x, y)
 
-  def to_bits (x: f32) : u32 = u32m.i32 (intrinsics.to_bits32 x)
-  def from_bits (x: u32) : f32 = intrinsics.from_bits32 (intrinsics.sign_i32 x)
+  def to_bits (x: f32) : u32 = u32m.i32 (intrinsics.fptobits_f32_i32 x)
+  def from_bits (x: u32) : f32 = intrinsics.bitstofp_i32_f32 (intrinsics.sign_i32 x)
 
   def num_bits = 32i32
   def get_bit (bit: i32) (x: t) = u32m.get_bit bit (to_bits x)
@@ -1290,8 +1290,8 @@ module f16 : (float with t = f16 with int_t = u16) = {
   def ldexp x y = intrinsics.ldexp16 (x, y)
   def copysign x y = intrinsics.copysign16 (x, y)
 
-  def to_bits (x: f16) : u16 = u16m.i16 (intrinsics.to_bits16 x)
-  def from_bits (x: u16) : f16 = intrinsics.from_bits16 (intrinsics.sign_i16 x)
+  def to_bits (x: f16) : u16 = u16m.i16 (intrinsics.fptobits_f16_i16 x)
+  def from_bits (x: u16) : f16 = intrinsics.bitstofp_i16_f16 (intrinsics.sign_i16 x)
 
   def num_bits = 16i32
   def get_bit (bit: i32) (x: t) = u16m.get_bit bit (to_bits x)

--- a/rts/c/atomics16.h
+++ b/rts/c/atomics16.h
@@ -150,13 +150,13 @@ SCALAR_FUN_ATTR f16 atomic_fadd_f16_global(volatile __global uint16_t *p, f16 va
   int shift = offset * 16;
   int32_t mask = 0xffff << shift;
   int32_t old = 0;
-  int32_t upd = mask & ((int32_t)futrts_to_bits16(val) << shift);
+  int32_t upd = mask & ((int32_t)fptobits_f16_i16(val) << shift);
   int32_t saw;
   while ((saw=atomic_cmpxchg_i32_global(p32, old, upd)) != old) {
     old = saw;
-    upd = (old & ~mask) | (int32_t)futrts_to_bits16(futrts_from_bits16((uint32_t)old >> shift) + val) << shift;
+    upd = (old & ~mask) | (int32_t)fptobits_f16_i16(bitstofp_i16_f16((uint32_t)old >> shift) + val) << shift;
   }
-  return futrts_from_bits16((uint32_t)old >> shift);
+  return bitstofp_i16_f16((uint32_t)old >> shift);
 }
 
 SCALAR_FUN_ATTR f16 atomic_fadd_f16_shared(volatile __local uint16_t *p, f16 val) {
@@ -165,13 +165,13 @@ SCALAR_FUN_ATTR f16 atomic_fadd_f16_shared(volatile __local uint16_t *p, f16 val
   int shift = offset * 16;
   int32_t mask = 0xffff << shift;
   int32_t old = 0;
-  int32_t upd = mask & ((int32_t)futrts_to_bits16(val) << shift);
+  int32_t upd = mask & ((int32_t)fptobits_f16_i16(val) << shift);
   int32_t saw;
   while ((saw=atomic_cmpxchg_i32_shared(p32, old, upd)) != old) {
     old = saw;
-    upd = (old & ~mask) | (int32_t)futrts_to_bits16(futrts_from_bits16((uint32_t)old >> shift) + val) << shift;
+    upd = (old & ~mask) | (int32_t)fptobits_f16_i16(bitstofp_i16_f16((uint32_t)old >> shift) + val) << shift;
   }
-  return futrts_from_bits16((uint32_t)old >> shift);
+  return bitstofp_i16_f16((uint32_t)old >> shift);
 }
 
 // End of atomics16.h

--- a/rts/c/scalar.h
+++ b/rts/c/scalar.h
@@ -21,8 +21,8 @@
 #define M_PI 3.141592653589793
 #endif
 
-SCALAR_FUN_ATTR int32_t futrts_to_bits32(float x);
-SCALAR_FUN_ATTR float futrts_from_bits32(int32_t x);
+SCALAR_FUN_ATTR int32_t fptobits_f32_i32(float x);
+SCALAR_FUN_ATTR float bitstofp_i32_f32(int32_t x);
 
 SCALAR_FUN_ATTR uint8_t   add8(uint8_t x, uint8_t y)   { return x + y; }
 SCALAR_FUN_ATTR uint16_t add16(uint16_t x, uint16_t y) { return x + y; }
@@ -1222,9 +1222,9 @@ SCALAR_FUN_ATTR float futrts_ldexp32(float x, int32_t y) {
 }
 
 SCALAR_FUN_ATTR float futrts_copysign32(float x, float y) {
-  int32_t xb = futrts_to_bits32(x);
-  int32_t yb = futrts_to_bits32(y);
-  return futrts_from_bits32((xb & ~(1<<31)) | (yb & (1<<31)));
+  int32_t xb = fptobits_f32_i32(x);
+  int32_t yb = fptobits_f32_i32(y);
+  return bitstofp_i32_f32((xb & ~(1<<31)) | (yb & (1<<31)));
 }
 
 SCALAR_FUN_ATTR float futrts_mad32(float a, float b, float c) {
@@ -1300,12 +1300,12 @@ SCALAR_FUN_ATTR float futrts_fma32(float a, float b, float c) { return fmaf(a, b
 
 #if defined(ISPC)
 
-SCALAR_FUN_ATTR int32_t futrts_to_bits32(float x) { return intbits(x); }
-SCALAR_FUN_ATTR float futrts_from_bits32(int32_t x) { return floatbits(x); }
+SCALAR_FUN_ATTR int32_t fptobits_f32_i32(float x) { return intbits(x); }
+SCALAR_FUN_ATTR float bitstofp_i32_f32(int32_t x) { return floatbits(x); }
 
 #else
 
-SCALAR_FUN_ATTR int32_t futrts_to_bits32(float x) {
+SCALAR_FUN_ATTR int32_t fptobits_f32_i32(float x) {
   union {
     float f;
     int32_t t;
@@ -1315,7 +1315,7 @@ SCALAR_FUN_ATTR int32_t futrts_to_bits32(float x) {
   return p.t;
 }
 
-SCALAR_FUN_ATTR float futrts_from_bits32(int32_t x) {
+SCALAR_FUN_ATTR float bitstofp_i32_f32(int32_t x) {
   union {
     int32_t f;
     float t;
@@ -1332,8 +1332,8 @@ SCALAR_FUN_ATTR float fsignum32(float x) {
 
 #ifdef FUTHARK_F64_ENABLED
 
-SCALAR_FUN_ATTR double futrts_from_bits64(int64_t x);
-SCALAR_FUN_ATTR int64_t futrts_to_bits64(double x);
+SCALAR_FUN_ATTR double bitstofp_i64_f64(int64_t x);
+SCALAR_FUN_ATTR int64_t fptobits_f64_i64(double x);
 
 #if defined(ISPC)
 
@@ -1560,7 +1560,7 @@ SCALAR_FUN_ATTR uint64_t fptoui_f64_i64(double x) {
 SCALAR_FUN_ATTR bool ftob_f64_bool(double x) { return x != 0.0; }
 SCALAR_FUN_ATTR double btof_bool_f64(bool x) { return x ? 1.0 : 0.0; }
 
-SCALAR_FUN_ATTR int64_t futrts_to_bits64(double x) {
+SCALAR_FUN_ATTR int64_t fptobits_f64_i64(double x) {
   int64_t res;
   foreach_active (i) {
     uniform double tmp = extract(x, i);
@@ -1570,7 +1570,7 @@ SCALAR_FUN_ATTR int64_t futrts_to_bits64(double x) {
   return res;
 }
 
-SCALAR_FUN_ATTR double futrts_from_bits64(int64_t x) {
+SCALAR_FUN_ATTR double bitstofp_i64_f64(int64_t x) {
   double res;
   foreach_active (i) {
     uniform int64_t tmp = extract(x, i);
@@ -1597,9 +1597,9 @@ SCALAR_FUN_ATTR double futrts_ldexp64(double x, int32_t y) {
 }
 
 SCALAR_FUN_ATTR double futrts_copysign64(double x, double y) {
-  int64_t xb = futrts_to_bits64(x);
-  int64_t yb = futrts_to_bits64(y);
-  return futrts_from_bits64((xb & ~(((int64_t)1)<<63)) | (yb & (((int64_t)1)<<63)));
+  int64_t xb = fptobits_f64_i64(x);
+  int64_t yb = fptobits_f64_i64(y);
+  return bitstofp_i64_f64((xb & ~(((int64_t)1)<<63)) | (yb & (((int64_t)1)<<63)));
 }
 
 SCALAR_FUN_ATTR double futrts_mad64(double a, double b, double c) { return a * b + c; }
@@ -1806,7 +1806,7 @@ SCALAR_FUN_ATTR uint64_t fptoui_f64_i64(double x) {
 SCALAR_FUN_ATTR bool ftob_f64_bool(double x) { return x != 0; }
 SCALAR_FUN_ATTR double btof_bool_f64(bool x) { return x ? 1 : 0; }
 
-SCALAR_FUN_ATTR int64_t futrts_to_bits64(double x) {
+SCALAR_FUN_ATTR int64_t fptobits_f64_i64(double x) {
   union {
     double f;
     int64_t t;
@@ -1816,7 +1816,7 @@ SCALAR_FUN_ATTR int64_t futrts_to_bits64(double x) {
   return p.t;
 }
 
-SCALAR_FUN_ATTR double futrts_from_bits64(int64_t x) {
+SCALAR_FUN_ATTR double bitstofp_i64_f64(int64_t x) {
   union {
     int64_t f;
     double t;

--- a/rts/c/scalar_f16.h
+++ b/rts/c/scalar_f16.h
@@ -273,14 +273,14 @@ SCALAR_FUN_ATTR f16 futrts_fma16(f16 a, f16 b, f16 c) { return fmaf(a, b, c); }
 // The CUDA __half type cannot be put in unions for some reason, so we
 // use bespoke conversion functions instead.
 #ifdef __CUDA_ARCH__
-SCALAR_FUN_ATTR int16_t futrts_to_bits16(f16 x) { return __half_as_ushort(x); }
-SCALAR_FUN_ATTR f16 futrts_from_bits16(int16_t x) { return __ushort_as_half(x); }
+SCALAR_FUN_ATTR int16_t fptobits_f16_i16(f16 x) { return __half_as_ushort(x); }
+SCALAR_FUN_ATTR f16 bitstofp_i16_f16(int16_t x) { return __ushort_as_half(x); }
 #elif defined(ISPC)
-SCALAR_FUN_ATTR int16_t futrts_to_bits16(f16 x) { varying int16_t y = *((varying int16_t * uniform)&x); return y;
+SCALAR_FUN_ATTR int16_t fptobits_f16_i16(f16 x) { varying int16_t y = *((varying int16_t * uniform)&x); return y;
 }
-SCALAR_FUN_ATTR f16 futrts_from_bits16(int16_t x) { varying f16 y = *((varying f16 * uniform)&x); return y; }
+SCALAR_FUN_ATTR f16 bitstofp_i16_f16(int16_t x) { varying f16 y = *((varying f16 * uniform)&x); return y; }
 #else
-SCALAR_FUN_ATTR int16_t futrts_to_bits16(f16 x) {
+SCALAR_FUN_ATTR int16_t fptobits_f16_i16(f16 x) {
   union {
     f16 f;
     int16_t t;
@@ -290,7 +290,7 @@ SCALAR_FUN_ATTR int16_t futrts_to_bits16(f16 x) {
   return p.t;
 }
 
-SCALAR_FUN_ATTR f16 futrts_from_bits16(int16_t x) {
+SCALAR_FUN_ATTR f16 bitstofp_i16_f16(int16_t x) {
   union {
     int16_t f;
     f16 t;
@@ -359,20 +359,20 @@ SCALAR_FUN_ATTR f16 futrts_fma16(f16 a, f16 b, f16 c) { return futrts_fma32(a, b
 // float.  Similarly for vstore_half.
 #ifdef __OPENCL_VERSION__
 
-SCALAR_FUN_ATTR int16_t futrts_to_bits16(f16 x) {
+SCALAR_FUN_ATTR int16_t fptobits_f16_i16(f16 x) {
   int16_t y;
   // Violating strict aliasing here.
   vstore_half((float)x, 0, (half*)&y);
   return y;
 }
 
-SCALAR_FUN_ATTR f16 futrts_from_bits16(int16_t x) {
+SCALAR_FUN_ATTR f16 bitstofp_i16_f16(int16_t x) {
   return (f16)vload_half(0, (half*)&x);
 }
 
 #else
-SCALAR_FUN_ATTR int16_t futrts_to_bits16(f16 x) { return (int16_t)float2halfbits(x); }
-SCALAR_FUN_ATTR f16 futrts_from_bits16(int16_t x) { return halfbits2float((uint16_t)x); }
+SCALAR_FUN_ATTR int16_t fptobits_f16_i16(f16 x) { return (int16_t)float2halfbits(x); }
+SCALAR_FUN_ATTR f16 bitstofp_i16_f16(int16_t x) { return halfbits2float((uint16_t)x); }
 SCALAR_FUN_ATTR f16 fsignum16(f16 x) { return futrts_isnan16(x) ? x : (x > 0 ? 1 : 0) - (x < 0 ? 1 : 0); }
 
 #endif

--- a/rts/c/uniform.h
+++ b/rts/c/uniform.h
@@ -1704,11 +1704,11 @@ static inline uniform f16 futrts_fma16(uniform f16 a, uniform f16 b, uniform f16
   return a * b + c;
 }
 
-static inline uniform int16_t futrts_to_bits16(uniform f16 x) {
+static inline uniform int16_t fptobits_f16_i16(uniform f16 x) {
   return *((uniform int16_t *)&x);
 }
 
-static inline uniform f16 futrts_from_bits16(uniform int16_t x) {
+static inline uniform f16 bitstofp_i16_f16(uniform int16_t x) {
   return *((uniform f16 *)&x);
 }
 

--- a/rts/python/scalar.py
+++ b/rts/python/scalar.py
@@ -736,14 +736,12 @@ def futhark_isinf64(x):
     return np.isinf(x)
 
 
-def futhark_to_bits64(x):
-    s = struct.pack(">d", x)
-    return np.int64(struct.unpack(">q", s)[0])
+def fptobits_f64_i64(x):
+    return x.view(np.int64)
 
 
-def futhark_from_bits64(x):
-    s = struct.pack(">q", x)
-    return np.float64(struct.unpack(">d", s)[0])
+def bitstofp_i64_f64(x):
+    return x.view(np.float64)
 
 
 def futhark_log32(x):
@@ -902,14 +900,12 @@ def futhark_isinf32(x):
     return np.isinf(x)
 
 
-def futhark_to_bits32(x):
-    s = struct.pack(">f", x)
-    return np.int32(struct.unpack(">l", s)[0])
+def fptobits_f32_i32(x):
+    return x.view(np.int32)
 
 
-def futhark_from_bits32(x):
-    s = struct.pack(">l", x)
-    return np.float32(struct.unpack(">f", s)[0])
+def bitstofp_i32_f32(x):
+    return x.view(np.float32)
 
 
 def futhark_log16(x):
@@ -1068,14 +1064,12 @@ def futhark_isinf16(x):
     return np.isinf(x)
 
 
-def futhark_to_bits16(x):
-    s = struct.pack(">e", x)
-    return np.int16(struct.unpack(">H", s)[0])
+def fptobits_f16_i16(x):
+    return x.view(np.int16)
 
 
-def futhark_from_bits16(x):
-    s = struct.pack(">H", np.uint16(x))
-    return np.float16(struct.unpack(">e", s)[0])
+def bitstofp_i16_f16(x):
+    return x.view(np.float16)
 
 
 def futhark_lerp16(v0, v1, t):

--- a/src/Futhark/AD/Derivatives.hs
+++ b/src/Futhark/AD/Derivatives.hs
@@ -357,18 +357,6 @@ pdBuiltin "mad32" [a, b, _c] =
   Just [b, a, fConst Float32 1]
 pdBuiltin "mad64" [a, b, _c] =
   Just [b, a, fConst Float64 1]
-pdBuiltin "from_bits16" [_] =
-  Just [fConst Float16 1]
-pdBuiltin "from_bits32" [_] =
-  Just [fConst Float32 1]
-pdBuiltin "from_bits64" [_] =
-  Just [fConst Float64 1]
-pdBuiltin "to_bits16" [_] =
-  Just [iConst Int16 1]
-pdBuiltin "to_bits32" [_] =
-  Just [iConst Int32 1]
-pdBuiltin "to_bits64" [_] =
-  Just [iConst Int64 1]
 pdBuiltin "hypot16" [x, y] =
   Just
     [ untyped $ isF16 x / isF16 (FunExp "hypot16" [x, y] $ FloatType Float16),

--- a/src/Futhark/CodeGen/Backends/GenericPython.hs
+++ b/src/Futhark/CodeGen/Backends/GenericPython.hs
@@ -1062,13 +1062,13 @@ compilePrimToExtNp bt ept =
 -- | Convert from scalar to storage representation for the given type.
 toStorage :: PrimType -> PyExp -> PyExp
 toStorage (FloatType Float16) e =
-  simpleCall "ct.c_int16" [simpleCall "futhark_to_bits16" [e]]
+  simpleCall "ct.c_int16" [simpleCall "fptobits_f16_i16" [e]]
 toStorage t e = simpleCall (compilePrimType t) [e]
 
 -- | Convert from storage to scalar representation for the given type.
 fromStorage :: PrimType -> PyExp -> PyExp
 fromStorage (FloatType Float16) e =
-  simpleCall "futhark_from_bits16" [simpleCall "np.int16" [e]]
+  simpleCall "bitstofp_i16_f16" [simpleCall "np.int16" [e]]
 fromStorage t e = simpleCall (compilePrimToNp t) [e]
 
 compilePrimValue :: Imp.PrimValue -> PyExp

--- a/src/Futhark/CodeGen/Backends/SimpleRep.hs
+++ b/src/Futhark/CodeGen/Backends/SimpleRep.hs
@@ -88,12 +88,12 @@ primAPIType _ t = primStorageType t
 
 -- | Convert from scalar to storage representation for the given type.
 toStorage :: PrimType -> C.Exp -> C.Exp
-toStorage (FloatType Float16) e = [C.cexp|futrts_to_bits16($exp:e)|]
+toStorage (FloatType Float16) e = [C.cexp|fptobits_f16_i16($exp:e)|]
 toStorage _ e = e
 
 -- | Convert from storage to scalar representation for the given type.
 fromStorage :: PrimType -> C.Exp -> C.Exp
-fromStorage (FloatType Float16) e = [C.cexp|futrts_from_bits16($exp:e)|]
+fromStorage (FloatType Float16) e = [C.cexp|bitstofp_i16_f16($exp:e)|]
 fromStorage _ e = e
 
 -- | @tupleField i@ is the name of field number @i@ in a tuple.

--- a/src/Futhark/CodeGen/ImpGen/GPU/Base.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/Base.hs
@@ -893,17 +893,9 @@ atomicUpdateCAS space t arr old bucket x do_op = do
   -- While-loop: Try to insert your value
   let (toBits, fromBits) =
         case t of
-          FloatType Float16 ->
-            ( \v -> Imp.FunExp "to_bits16" [v] int16,
-              \v -> Imp.FunExp "from_bits16" [v] t
-            )
-          FloatType Float32 ->
-            ( \v -> Imp.FunExp "to_bits32" [v] int32,
-              \v -> Imp.FunExp "from_bits32" [v] t
-            )
-          FloatType Float64 ->
-            ( \v -> Imp.FunExp "to_bits64" [v] int64,
-              \v -> Imp.FunExp "from_bits64" [v] t
+          FloatType ft ->
+            ( Imp.ConvOpExp (FPToBits ft),
+              Imp.ConvOpExp (BitsToFP ft)
             )
           _ -> (id, id)
 

--- a/src/Futhark/CodeGen/ImpGen/Multicore/Base.hs
+++ b/src/Futhark/CodeGen/ImpGen/Multicore/Base.hs
@@ -491,17 +491,9 @@ atomicUpdateCAS t arr old bucket x do_op = do
   bytes <- toIntegral $ primBitSize t
   let (toBits, fromBits) =
         case t of
-          FloatType Float16 ->
-            ( \v -> Imp.FunExp "to_bits16" [v] int16,
-              \v -> Imp.FunExp "from_bits16" [v] t
-            )
-          FloatType Float32 ->
-            ( \v -> Imp.FunExp "to_bits32" [v] int32,
-              \v -> Imp.FunExp "from_bits32" [v] t
-            )
-          FloatType Float64 ->
-            ( \v -> Imp.FunExp "to_bits64" [v] int64,
-              \v -> Imp.FunExp "from_bits64" [v] t
+          FloatType ft ->
+            ( Imp.ConvOpExp (FPToBits ft),
+              Imp.ConvOpExp (BitsToFP ft)
             )
           _ -> (id, id)
 

--- a/src/Futhark/IR/Parse.hs
+++ b/src/Futhark/IR/Parse.hs
@@ -341,6 +341,8 @@ pBasicOp =
       pConvOp "btoi" (const BToI) (keyword "bool") pIntType,
       pConvOp "ftob" (const . FToB) pFloatType (keyword "bool"),
       pConvOp "btof" (const BToF) (keyword "bool") pFloatType,
+      pConvOp "fptobits" (const . FPToBits) pFloatType pIntType,
+      pConvOp "bitstofp" (const BitsToFP) pIntType pFloatType,
       --
       pIndex,
       pFlatIndex,

--- a/tests/ad/issue2292.fut
+++ b/tests/ad/issue2292.fut
@@ -1,0 +1,13 @@
+-- ==
+-- entry: fwd
+-- input { 2f32 1f32 }
+-- output { 1065353216i32 }
+
+-- ==
+-- entry: rev
+-- input { 2f32 0i32 }
+-- output { 1.0e-45f32 }
+
+entry fwd = jvp (\x -> i32.u32 (f32.to_bits x))
+
+entry rev = vjp (\x -> i32.u32 (f32.to_bits x))


### PR DESCRIPTION
This turned out to be a little bit more involved than I thought, as it was related to improper handling of built-in functions that have different return and argument types.

The ultimate solution was to change the to_bits/from_bits functions from being built-in functions to instead being conversion operators - this significantly simplifies the logic.