### PR TITLE
KernelBody simplification.

### DIFF
--- a/src/Futhark/AD/Rev/Map.hs
+++ b/src/Futhark/AD/Rev/Map.hs
@@ -10,7 +10,7 @@ import Futhark.AD.Rev.Monad
 import Futhark.Analysis.PrimExp.Convert
 import Futhark.Builder
 import Futhark.IR.SOACS
-import Futhark.Tools
+import Futhark.Tools hiding (withAcc)
 import Futhark.Transform.Rename
 import Futhark.Util (splitAt3)
 

--- a/src/Futhark/Analysis/AccessPattern.hs
+++ b/src/Futhark/Analysis/AccessPattern.hs
@@ -554,7 +554,7 @@ analyseSegOp op ctx pats =
           . unSegSpace
           $ segSpace op
    in -- Analyse statements in the SegOp body
-      analyseStms segspace_context (SegOpName . segOpType op) pats . stmsToList . kernelBodyStms $ segBody op
+      analyseStms segspace_context (SegOpName . segOpType op) pats . stmsToList . bodyStms $ segBody op
 
 analyseSizeOp :: SizeOp -> Context rep -> [VName] -> (Context rep, IndexTable rep)
 analyseSizeOp op ctx pats =

--- a/src/Futhark/Analysis/Alias.hs
+++ b/src/Futhark/Analysis/Alias.hs
@@ -49,10 +49,10 @@ analyseFun (FunDef entry attrs fname restype params body) =
 
 -- | Perform alias analysis on Body.
 analyseBody ::
-  (AliasableRep rep) =>
+  (AliasableRep rep, FreeIn res) =>
   AliasTable ->
-  Body rep ->
-  Body (Aliases rep)
+  GBody rep res ->
+  GBody (Aliases rep) res
 analyseBody atable (Body rep stms result) =
   let (stms', _atable') = analyseStms atable stms
    in mkAliasedBody rep stms' result

--- a/src/Futhark/Analysis/Interference.hs
+++ b/src/Futhark/Analysis/Interference.hs
@@ -128,7 +128,7 @@ analyseKernelBody ::
   InUse ->
   KernelBody GPUMem ->
   m (InUse, LastUsed, Graph VName)
-analyseKernelBody lumap inuse body = analyseStms lumap inuse $ kernelBodyStms body
+analyseKernelBody lumap inuse body = analyseStms lumap inuse $ bodyStms body
 
 analyseBody ::
   (LocalScope GPUMem m) =>
@@ -274,11 +274,11 @@ memSizes stms =
     memSizesExp :: (LocalScope GPUMem m) => Exp GPUMem -> m (Map VName Int)
     memSizesExp (Op (Inner (SegOp segop))) =
       let body = segBody segop
-       in inScopeOf (kernelBodyStms body)
+       in inScopeOf (bodyStms body)
             $ fmap mconcat
               <$> mapM memSizesStm
             $ stmsToList
-            $ kernelBodyStms body
+            $ bodyStms body
     memSizesExp (Match _ cases defbody _) = do
       mconcat <$> mapM (memSizes . bodyStms) (defbody : map caseBody cases)
     memSizesExp (Loop _ _ body) =
@@ -295,7 +295,7 @@ memSpaces stms =
       M.singleton name sp
     getSpacesStm (Let _ _ (Op (Alloc _ _))) = error "impossible"
     getSpacesStm (Let _ _ (Op (Inner (SegOp segop)))) =
-      foldMap getSpacesStm $ kernelBodyStms $ segBody segop
+      foldMap getSpacesStm $ bodyStms $ segBody segop
     getSpacesStm (Let _ _ (Match _ cases defbody _)) =
       foldMap (foldMap getSpacesStm . bodyStms) $ defbody : map caseBody cases
     getSpacesStm (Let _ _ (Loop _ _ body)) =

--- a/src/Futhark/Analysis/LastUse.hs
+++ b/src/Futhark/Analysis/LastUse.hs
@@ -165,7 +165,7 @@ lastUseKernelBody ::
   --      (i) an updated last-use table,
   --     (ii) an updated set of used names (including the binding).
   LastUseM rep (LUTabFun, Names)
-lastUseKernelBody bdy@(KernelBody _ stms result) (lutab, used_nms) =
+lastUseKernelBody bdy@(Body _ stms result) (lutab, used_nms) =
   inScopeOf stms $ do
     -- perform analysis bottom-up in bindings: results are known to be used,
     -- hence they are added to the used_nms set.

--- a/src/Futhark/Analysis/MemAlias.hs
+++ b/src/Futhark/Analysis/MemAlias.hs
@@ -67,13 +67,13 @@ type MemAliasesM inner a = Reader (Env inner) a
 
 analyzeHostOp :: MemAliases -> HostOp NoOp GPUMem -> MemAliasesM (HostOp NoOp GPUMem) MemAliases
 analyzeHostOp m (SegOp (SegMap _ _ _ kbody)) =
-  analyzeStms (kernelBodyStms kbody) m
+  analyzeStms (bodyStms kbody) m
 analyzeHostOp m (SegOp (SegRed _ _ _ kbody _)) =
-  analyzeStms (kernelBodyStms kbody) m
+  analyzeStms (bodyStms kbody) m
 analyzeHostOp m (SegOp (SegScan _ _ _ kbody _)) =
-  analyzeStms (kernelBodyStms kbody) m
+  analyzeStms (bodyStms kbody) m
 analyzeHostOp m (SegOp (SegHist _ _ _ kbody _)) =
-  analyzeStms (kernelBodyStms kbody) m
+  analyzeStms (bodyStms kbody) m
 analyzeHostOp m SizeOp {} = pure m
 analyzeHostOp m GPUBody {} = pure m
 analyzeHostOp m (OtherOp NoOp) = pure m

--- a/src/Futhark/Analysis/Metrics.hs
+++ b/src/Futhark/Analysis/Metrics.hs
@@ -90,7 +90,7 @@ funDefMetrics :: (OpMetrics (Op rep)) => FunDef rep -> MetricsM ()
 funDefMetrics = bodyMetrics . funDefBody
 
 -- | Compute metrics for this body.
-bodyMetrics :: (OpMetrics (Op rep)) => Body rep -> MetricsM ()
+bodyMetrics :: (OpMetrics (Op rep)) => GBody rep res -> MetricsM ()
 bodyMetrics = mapM_ stmMetrics . bodyStms
 
 -- | Compute metrics for this statement.

--- a/src/Futhark/Analysis/PrimExp/Table.hs
+++ b/src/Futhark/Analysis/PrimExp/Table.hs
@@ -70,9 +70,9 @@ kernelToBodyPrimExps ::
   Scope rep ->
   KernelBody rep ->
   State PrimExpTable ()
-kernelToBodyPrimExps scope kbody = mapM_ (stmToPrimExps scope') (kernelBodyStms kbody)
+kernelToBodyPrimExps scope kbody = mapM_ (stmToPrimExps scope') (bodyStms kbody)
   where
-    scope' = scope <> scopeOf (kernelBodyStms kbody)
+    scope' = scope <> scopeOf (bodyStms kbody)
 
 -- | Adds a statement to the PrimExpTable. If it can't be resolved as a `PrimExp`,
 -- it will be added as `Nothing`.

--- a/src/Futhark/Builder.hs
+++ b/src/Futhark/Builder.hs
@@ -45,10 +45,10 @@ class (ASTRep rep) => BuilderOps rep where
     Exp rep ->
     m (ExpDec rep)
   mkBodyB ::
-    (MonadBuilder m, Rep m ~ rep) =>
+    (MonadBuilder m, Rep m ~ rep, FreeIn res) =>
     Stms rep ->
-    Result ->
-    m (Body rep)
+    [res] ->
+    m (GBody rep res)
   mkLetNamesB ::
     (MonadBuilder m, Rep m ~ rep) =>
     [VName] ->
@@ -63,10 +63,10 @@ class (ASTRep rep) => BuilderOps rep where
   mkExpDecB pat e = pure $ mkExpDec pat e
 
   default mkBodyB ::
-    (MonadBuilder m, Buildable rep) =>
+    (MonadBuilder m, Buildable rep, FreeIn res) =>
     Stms rep ->
-    Result ->
-    m (Body rep)
+    [res] ->
+    m (GBody rep res)
   mkBodyB stms res = pure $ mkBody stms res
 
   default mkLetNamesB ::
@@ -201,10 +201,11 @@ runBodyBuilder ::
   ( Buildable rep,
     MonadFreshNames m,
     HasScope somerep m,
-    SameScope somerep rep
+    SameScope somerep rep,
+    FreeIn res
   ) =>
-  Builder rep Result ->
-  m (Body rep)
+  Builder rep [res] ->
+  m (GBody rep res)
 runBodyBuilder =
   fmap (uncurry $ flip insertStms) . runBuilder . fmap (mkBody mempty)
 

--- a/src/Futhark/Builder/Class.hs
+++ b/src/Futhark/Builder/Class.hs
@@ -43,7 +43,7 @@ class
   where
   mkExpPat :: [Ident] -> Exp rep -> Pat (LetDec rep)
   mkExpDec :: Pat (LetDec rep) -> Exp rep -> ExpDec rep
-  mkBody :: Stms rep -> Result -> Body rep
+  mkBody :: (FreeIn res) => Stms rep -> [res] -> GBody rep res
   mkLetNames ::
     (MonadFreshNames m, HasScope rep m) =>
     [VName] ->
@@ -72,7 +72,7 @@ class
   where
   type Rep m :: Data.Kind.Type
   mkExpDecM :: Pat (LetDec (Rep m)) -> Exp (Rep m) -> m (ExpDec (Rep m))
-  mkBodyM :: Stms (Rep m) -> Result -> m (Body (Rep m))
+  mkBodyM :: (FreeIn res) => Stms (Rep m) -> [res] -> m (GBody (Rep m) res)
   mkLetNamesM :: [VName] -> Exp (Rep m) -> m (Stm (Rep m))
 
   -- | Add a statement to the 'Stms' under construction.
@@ -170,9 +170,9 @@ bodyBind (Body _ stms res) = do
   pure res
 
 -- | Add several bindings at the outermost level of a t'Body'.
-insertStms :: (Buildable rep) => Stms rep -> Body rep -> Body rep
+insertStms :: (Buildable rep, FreeIn res) => Stms rep -> GBody rep res -> GBody rep res
 insertStms stms1 (Body _ stms2 res) = mkBody (stms1 <> stms2) res
 
 -- | Add a single binding at the outermost level of a t'Body'.
-insertStm :: (Buildable rep) => Stm rep -> Body rep -> Body rep
+insertStm :: (Buildable rep, FreeIn res) => Stm rep -> GBody rep res -> GBody rep res
 insertStm = insertStms . oneStm

--- a/src/Futhark/CodeGen/ImpGen/GPU/Base.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/Base.hs
@@ -1470,12 +1470,5 @@ compileThreadResult _ _ RegTileReturns {} =
 compileThreadResult space pe (Returns _ _ what) = do
   let is = map (Imp.le64 . fst) $ unSegSpace space
   copyDWIMFix (patElemName pe) is what []
-compileThreadResult _ pe (WriteReturns _ arr dests) = do
-  arr_t <- lookupType arr
-  let rws' = map pe64 $ arrayDims arr_t
-  forM_ dests $ \(slice, e) -> do
-    let slice' = fmap pe64 slice
-        write = inBounds slice' rws'
-    sWhen write $ copyDWIM (patElemName pe) (unSlice slice') e []
 compileThreadResult _ _ TileReturns {} =
   compilerBugS "compileThreadResult: TileReturns unhandled."

--- a/src/Futhark/CodeGen/ImpGen/GPU/Block.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/Block.hs
@@ -361,9 +361,9 @@ compileBlockOp pat (Inner (SegOp (SegMap lvl space _ body))) = do
   compileFlatId space
 
   blockCoverSegSpace (segVirt lvl) space $
-    compileStms mempty (kernelBodyStms body) $
+    compileStms mempty (bodyStms body) $
       zipWithM_ (compileThreadResult space) (patElems pat) $
-        kernelBodyResult body
+        bodyResult body
   sOp $ Imp.ErrorSync Imp.FenceLocal
 compileBlockOp pat (Inner (SegOp (SegScan lvl space _ body scans))) = do
   compileFlatId space
@@ -372,8 +372,8 @@ compileBlockOp pat (Inner (SegOp (SegScan lvl space _ body scans))) = do
       dims' = map pe64 dims
 
   blockCoverSegSpace (segVirt lvl) space $
-    compileStms mempty (kernelBodyStms body) $
-      forM_ (zip (patNames pat) $ kernelBodyResult body) $ \(dest, res) ->
+    compileStms mempty (bodyStms body) $
+      forM_ (zip (patNames pat) $ bodyResult body) $ \(dest, res) ->
         copyDWIMFix
           dest
           (map Imp.le64 ltids)
@@ -421,9 +421,9 @@ compileBlockOp pat (Inner (SegOp (SegRed lvl space _ body ops))) = do
 
   tmp_arrs <- mapM mkTempArr $ concatMap (lambdaReturnType . segBinOpLambda) ops
   blockCoverSegSpace (segVirt lvl) space $
-    compileStms mempty (kernelBodyStms body) $ do
+    compileStms mempty (bodyStms body) $ do
       let (red_res, map_res) =
-            splitAt (segBinOpResults ops) $ kernelBodyResult body
+            splitAt (segBinOpResults ops) $ bodyResult body
       forM_ (zip tmp_arrs red_res) $ \(dest, res) ->
         copyDWIMFix dest (map Imp.le64 ltids) (kernelResultSubExp res) []
       zipWithM_ (compileThreadResult space) map_pes map_res
@@ -551,8 +551,8 @@ compileBlockOp pat (Inner (SegOp (SegHist lvl space _ kbody ops))) = do
   sOp $ Imp.Barrier Imp.FenceLocal
 
   blockCoverSegSpace (segVirt lvl) space $
-    compileStms mempty (kernelBodyStms kbody) $ do
-      let (red_res, map_res) = splitAt num_red_res $ kernelBodyResult kbody
+    compileStms mempty (bodyStms kbody) $ do
+      let (red_res, map_res) = splitAt num_red_res $ bodyResult kbody
           (red_is, red_vs) = splitAt (length ops) $ map kernelResultSubExp red_res
       zipWithM_ (compileThreadResult space) map_pes map_res
 

--- a/src/Futhark/CodeGen/ImpGen/GPU/Block.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/Block.hs
@@ -698,8 +698,6 @@ compileBlockResult space pe (Returns _ _ what) = do
     -- block.  TODO: also do this if the array is in global memory
     -- (but this is a bit more tricky, synchronisation-wise).
       copyDWIMFix (patElemName pe) gids what []
-compileBlockResult _ _ WriteReturns {} =
-  compilerLimitationS "compileBlockResult: WriteReturns not handled yet."
 
 -- | The sizes of nested iteration spaces in the kernel.
 type SegOpSizes = S.Set [SubExp]

--- a/src/Futhark/CodeGen/ImpGen/GPU/SegHist.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/SegHist.hs
@@ -47,6 +47,7 @@ import Futhark.CodeGen.ImpGen
 import Futhark.CodeGen.ImpGen.GPU.Base
 import Futhark.CodeGen.ImpGen.GPU.SegRed (compileSegRed')
 import Futhark.Construct (fullSliceNum)
+import Futhark.IR.Aliases (consumedInBody)
 import Futhark.IR.GPUMem
 import Futhark.IR.Mem.LMAD qualified as LMAD
 import Futhark.Pass.ExplicitAllocations ()
@@ -198,7 +199,7 @@ data Passage = MustBeSinglePass | MayBeMultiPass deriving (Eq, Ord)
 
 bodyPassage :: KernelBody GPUMem -> Passage
 bodyPassage kbody
-  | mempty == consumedInKernelBody (Alias.analyseBody mempty kbody) =
+  | mempty == consumedInBody (Alias.analyseBody mempty kbody) =
       MayBeMultiPass
   | otherwise =
       MustBeSinglePass

--- a/src/Futhark/CodeGen/ImpGen/GPU/SegMap.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/SegMap.hs
@@ -45,20 +45,20 @@ compileSegMap pat lvl space kbody = do
           dIndexSpace (zip is dims') global_tid
 
           sWhen (isActive $ unSegSpace space) $
-            compileStms mempty (kernelBodyStms kbody) $
+            compileStms mempty (bodyStms kbody) $
               zipWithM_ (compileThreadResult space) (patElems pat) $
-                kernelBodyResult kbody
+                bodyResult kbody
     SegBlock {} -> do
-      pc <- precomputeConstants tblock_size' $ kernelBodyStms kbody
+      pc <- precomputeConstants tblock_size' $ bodyStms kbody
       virt_num_tblocks <- dPrimVE "virt_num_tblocks" $ sExt32 $ product dims'
       sKernelBlock "segmap_intrablock" (segFlat space) attrs $ do
         precomputedConstants pc $
           virtualiseBlocks (segVirt lvl) virt_num_tblocks $ \tblock_id -> do
             dIndexSpace (zip is dims') $ sExt64 tblock_id
 
-            compileStms mempty (kernelBodyStms kbody) $
+            compileStms mempty (bodyStms kbody) $
               zipWithM_ (compileBlockResult space) (patElems pat) $
-                kernelBodyResult kbody
+                bodyResult kbody
     SegThreadInBlock {} ->
       error "compileSegMap: SegThreadInBlock"
   emit $ Imp.DebugPrint "" Nothing

--- a/src/Futhark/CodeGen/ImpGen/GPU/SegRed.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/SegRed.hs
@@ -113,8 +113,8 @@ compileSegRed pat lvl space segbinops map_kbody = do
 
   compileSegRed' pat grid space segbinops $ \red_cont ->
     sComment "apply map function" $
-      compileStms mempty (kernelBodyStms map_kbody) $ do
-        let (red_res, map_res) = splitAt (segBinOpResults segbinops) $ kernelBodyResult map_kbody
+      compileStms mempty (bodyStms map_kbody) $ do
+        let (red_res, map_res) = splitAt (segBinOpResults segbinops) $ bodyResult map_kbody
 
         let mapout_arrs = drop (segBinOpResults segbinops) $ patElems pat
         unless (null mapout_arrs) $

--- a/src/Futhark/CodeGen/ImpGen/GPU/SegScan/SinglePass.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/SegScan/SinglePass.hs
@@ -352,9 +352,9 @@ compileSegScan pat lvl space scan_op map_kbody = do
           dIndexSpace (zip gtids dims') virt_tid
           -- Perform the map
           let in_bounds =
-                compileStms mempty (kernelBodyStms map_kbody) $ do
+                compileStms mempty (bodyStms map_kbody) $ do
                   let (all_scan_res, map_res) =
-                        splitAt (segBinOpResults [scan_op]) $ kernelBodyResult map_kbody
+                        splitAt (segBinOpResults [scan_op]) $ bodyResult map_kbody
 
                   -- Write map results to their global memory destinations
                   forM_ (zip (takeLast (length map_res) all_pes) map_res) $ \(dest, src) ->

--- a/src/Futhark/CodeGen/ImpGen/GPU/SegScan/TwoPass.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/SegScan/TwoPass.hs
@@ -196,9 +196,9 @@ scanStage1 (Pat all_pes) num_tblocks tblock_size space scans kbody = do
           in_bounds =
             foldl1 (.&&.) $ zipWith (.<.) (map Imp.le64 gtids) dims'
 
-          when_in_bounds = compileStms mempty (kernelBodyStms kbody) $ do
+          when_in_bounds = compileStms mempty (bodyStms kbody) $ do
             let (all_scan_res, map_res) =
-                  splitAt (segBinOpResults scans) $ kernelBodyResult kbody
+                  splitAt (segBinOpResults scans) $ bodyResult kbody
                 per_scan_res =
                   segBinOpChunks scans all_scan_res
 

--- a/src/Futhark/CodeGen/ImpGen/Multicore/Base.hs
+++ b/src/Futhark/CodeGen/ImpGen/Multicore/Base.hs
@@ -134,8 +134,6 @@ compileThreadResult ::
 compileThreadResult space pe (Returns _ _ what) = do
   let is = map (Imp.le64 . fst) $ unSegSpace space
   copyDWIMFix (patElemName pe) is what []
-compileThreadResult _ _ WriteReturns {} =
-  compilerBugS "compileThreadResult: WriteReturns unhandled."
 compileThreadResult _ _ TileReturns {} =
   compilerBugS "compileThreadResult: TileReturns unhandled."
 compileThreadResult _ _ RegTileReturns {} =

--- a/src/Futhark/CodeGen/ImpGen/Multicore/SegMap.hs
+++ b/src/Futhark/CodeGen/ImpGen/Multicore/SegMap.hs
@@ -18,14 +18,6 @@ writeResult ::
   MulticoreGen ()
 writeResult is pe (Returns _ _ se) =
   copyDWIMFix (patElemName pe) (map Imp.le64 is) se []
-writeResult _ pe (WriteReturns _ arr idx_vals) = do
-  arr_t <- lookupType arr
-  let (iss, vs) = unzip idx_vals
-      rws' = map pe64 $ arrayDims arr_t
-  forM_ (zip iss vs) $ \(slice, v) -> do
-    let slice' = fmap pe64 slice
-    sWhen (inBounds slice' rws') $
-      copyDWIM (patElemName pe) (unSlice slice') v []
 writeResult _ _ res =
   error $ "writeResult: cannot handle " ++ prettyString res
 

--- a/src/Futhark/CodeGen/ImpGen/Multicore/SegMap.hs
+++ b/src/Futhark/CodeGen/ImpGen/Multicore/SegMap.hs
@@ -34,7 +34,7 @@ compileSegMapBody ::
   SegSpace ->
   KernelBody MCMem ->
   MulticoreGen Imp.MCCode
-compileSegMapBody pat space (KernelBody _ kstms kres) = collect $ do
+compileSegMapBody pat space (Body _ kstms kres) = collect $ do
   let (is, ns) = unzip $ unSegSpace space
       ns' = map pe64 ns
   dPrim_ (segFlat space) int64

--- a/src/Futhark/CodeGen/ImpGen/Multicore/SegRed.hs
+++ b/src/Futhark/CodeGen/ImpGen/Multicore/SegRed.hs
@@ -25,8 +25,8 @@ compileSegRed ::
   MulticoreGen Imp.MCCode
 compileSegRed pat space reds kbody nsubtasks =
   compileSegRed' pat space reds nsubtasks $ \red_cont ->
-    compileStms mempty (kernelBodyStms kbody) $ do
-      let (red_res, map_res) = splitAt (segBinOpResults reds) $ kernelBodyResult kbody
+    compileStms mempty (bodyStms kbody) $ do
+      let (red_res, map_res) = splitAt (segBinOpResults reds) $ bodyResult kbody
 
       sComment "save map-out results" $ do
         let map_arrs = drop (segBinOpResults reds) $ patElems pat

--- a/src/Futhark/CodeGen/ImpGen/Multicore/SegScan.hs
+++ b/src/Futhark/CodeGen/ImpGen/Multicore/SegScan.hs
@@ -184,12 +184,12 @@ genScanLoop ::
   ImpM MCMem HostEnv Imp.Multicore ()
 genScanLoop typ pat space kbody scan_ops local_accs i = do
   let (all_scan_res, map_res) =
-        splitAt (segBinOpResults scan_ops) $ kernelBodyResult kbody
+        splitAt (segBinOpResults scan_ops) $ bodyResult kbody
   let (is, ns) = unzip $ unSegSpace space
       ns' = map pe64 ns
 
   zipWithM_ dPrimV_ is $ unflattenIndex ns' i
-  compileStms mempty (kernelBodyStms kbody) $ do
+  compileStms mempty (bodyStms kbody) $ do
     let map_arrs = drop (segBinOpResults scan_ops) $ patElems pat
     sComment "write mapped values results to memory" $
       zipWithM_ (compileThreadResult space) map_arrs map_res
@@ -460,8 +460,8 @@ compileSegScanBody pat space scan_ops kbody = collect $ do
       sFor "i" inner_bound $ \i -> do
         zipWithM_ dPrimV_ (init is) $ unflattenIndex (init ns_64) segment_i
         dPrimV_ (last is) i
-        compileStms mempty (kernelBodyStms kbody) $ do
-          let (scan_res, map_res) = splitAt (length $ segBinOpNeutral scan_op) $ kernelBodyResult kbody
+        compileStms mempty (bodyStms kbody) $ do
+          let (scan_res, map_res) = splitAt (length $ segBinOpNeutral scan_op) $ bodyResult kbody
           sComment "write to-scan values to parameters" $
             forM_ (zip scan_y_params scan_res) $ \(p, se) ->
               copyDWIMFix (paramName p) [] (kernelResultSubExp se) []

--- a/src/Futhark/Construct.hs
+++ b/src/Futhark/Construct.hs
@@ -605,9 +605,9 @@ insertStmsM m = do
 -- value, then return the body constructed from the 'Result' and any
 -- statements added during the action, along the auxiliary value.
 buildBody ::
-  (MonadBuilder m) =>
-  m (Result, a) ->
-  m (Body (Rep m), a)
+  (MonadBuilder m, FreeIn res) =>
+  m ([res], a) ->
+  m (GBody (Rep m) res, a)
 buildBody m = do
   ((res, v), stms) <- collectStms m
   body <- mkBodyM stms res
@@ -615,9 +615,9 @@ buildBody m = do
 
 -- | As 'buildBody', but there is no auxiliary value.
 buildBody_ ::
-  (MonadBuilder m) =>
-  m Result ->
-  m (Body (Rep m))
+  (MonadBuilder m, FreeIn res) =>
+  m [res] ->
+  m (GBody (Rep m) res)
 buildBody_ m = fst <$> buildBody ((,()) <$> m)
 
 -- | Change that result where evaluation of the body would stop.  Also

--- a/src/Futhark/IR/Aliases.hs
+++ b/src/Futhark/IR/Aliases.hs
@@ -269,11 +269,15 @@ removePatAliases = runIdentity . rephrasePat (pure . snd)
 -- | Augment a body decoration with aliasing information provided by
 -- the statements and result of that body.
 mkAliasedBody ::
-  (ASTRep rep, AliasedOp (OpC rep), ASTConstraints (OpC rep (Aliases rep))) =>
+  ( ASTRep rep,
+    AliasedOp (OpC rep),
+    ASTConstraints (OpC rep (Aliases rep)),
+    FreeIn res
+  ) =>
   BodyDec rep ->
   Stms (Aliases rep) ->
-  Result ->
-  Body (Aliases rep)
+  [res] ->
+  GBody (Aliases rep) res
 mkAliasedBody dec stms res =
   Body (mkBodyAliasing stms res, dec) stms res
 
@@ -301,9 +305,9 @@ mkAliasedPat (Pat pes) e =
 -- in scope outside of it.  Note that this does *not* include aliases
 -- of results that are not bound in the statements!
 mkBodyAliasing ::
-  (Aliased rep) =>
+  (Aliased rep, FreeIn res) =>
   Stms rep ->
-  Result ->
+  [res] ->
   BodyAliasing
 mkBodyAliasing stms res =
   -- We need to remove the names that are bound in stms from the alias
@@ -318,14 +322,14 @@ mkBodyAliasing stms res =
 -- | The aliases of the result and everything consumed in the given
 -- statements.
 mkStmsAliases ::
-  (Aliased rep) =>
+  (Aliased rep, FreeIn res) =>
   Stms rep ->
-  Result ->
+  [res] ->
   ([Names], Names)
 mkStmsAliases stms res = delve mempty $ stmsToList stms
   where
     delve (aliasmap, consumed) [] =
-      ( map (aliasClosure aliasmap . subExpAliases . resSubExp) res,
+      ( map (aliasClosure aliasmap . freeIn) res,
         consumed
       )
     delve (aliasmap, consumed) (stm : stms') =
@@ -344,7 +348,7 @@ type AliasesAndConsumed =
 
 -- | The variables consumed in these statements.
 consumedInStms :: (Aliased rep) => Stms rep -> Names
-consumedInStms = snd . flip mkStmsAliases []
+consumedInStms = snd . flip mkStmsAliases ([] :: [()])
 
 -- | A helper function for computing the aliases of a sequence of
 -- statements.  You'd use this while recursing down the statements

--- a/src/Futhark/IR/GPUMem.hs
+++ b/src/Futhark/IR/GPUMem.hs
@@ -95,7 +95,7 @@ simpleGPUMem =
     -- importantly, past the versioning If, but see also #1569).
     usage (SegOp (SegMap _ _ _ kbody)) = localAllocs kbody
     usage _ = mempty
-    localAllocs = foldMap stmSharedAlloc . kernelBodyStms
+    localAllocs = foldMap stmSharedAlloc . bodyStms
     stmSharedAlloc = expSharedAlloc . stmExp
     expSharedAlloc (Op (Alloc (Var v) _)) =
       UT.sizeUsage v

--- a/src/Futhark/IR/Parse.hs
+++ b/src/Futhark/IR/Parse.hs
@@ -901,11 +901,6 @@ pKernelResult = do
           ]
         <*> pure cs
         <*> pSubExp,
-      try $
-        SegOp.WriteReturns cs
-          <$> pVName
-          <* keyword "with"
-          <*> parens (pWrite `sepBy` pComma),
       try "tile"
         *> parens (SegOp.TileReturns cs <$> (pTile `sepBy` pComma))
         <*> pVName,
@@ -921,7 +916,6 @@ pKernelResult = do
         blk_tile <- pSubExp <* pAsterisk
         reg_tile <- pSubExp
         pure (dim, blk_tile, reg_tile)
-    pWrite = (,) <$> pSlice <* pEqual <*> pSubExp
 
 pKernelBody :: PR rep -> Parser (SegOp.KernelBody rep)
 pKernelBody pr =

--- a/src/Futhark/IR/Parse.hs
+++ b/src/Futhark/IR/Parse.hs
@@ -925,7 +925,7 @@ pKernelResult = do
 
 pKernelBody :: PR rep -> Parser (SegOp.KernelBody rep)
 pKernelBody pr =
-  SegOp.KernelBody (pBodyDec pr)
+  Body (pBodyDec pr)
     <$> pStms pr
     <* keyword "return"
     <*> braces (pKernelResult `sepBy` pComma)

--- a/src/Futhark/IR/Prop/Aliases.hs
+++ b/src/Futhark/IR/Prop/Aliases.hs
@@ -45,7 +45,7 @@ class (ASTRep rep, AliasedOp (OpC rep), AliasesOf (LetDec rep)) => Aliased rep w
   bodyAliases :: Body rep -> [Names]
 
   -- | The variables consumed in the body.
-  consumedInBody :: Body rep -> Names
+  consumedInBody :: GBody rep res -> Names
 
 vnameAliases :: VName -> Names
 vnameAliases = oneName

--- a/src/Futhark/IR/Prop/Names.hs
+++ b/src/Futhark/IR/Prop/Names.hs
@@ -176,10 +176,11 @@ freeInStmsAndRes ::
     FreeDec (BodyDec rep),
     FreeIn (RetType rep),
     FreeIn (BranchType rep),
-    FreeDec (ExpDec rep)
+    FreeDec (ExpDec rep),
+    FreeIn res
   ) =>
   Stms rep ->
-  Result ->
+  res ->
   FV
 freeInStmsAndRes stms res =
   fvBind (boundByStms stms) $ foldMap freeIn' stms <> freeIn' res
@@ -264,9 +265,10 @@ instance
     FreeIn (LetDec rep),
     FreeIn (RetType rep),
     FreeIn (BranchType rep),
-    FreeIn (Op rep)
+    FreeIn (Op rep),
+    FreeIn res
   ) =>
-  FreeIn (Body rep)
+  FreeIn (GBody rep res)
   where
   freeIn' (Body dec stms res) =
     precomputed dec $ freeIn' dec <> freeInStmsAndRes stms res

--- a/src/Futhark/IR/Rephrase.hs
+++ b/src/Futhark/IR/Rephrase.hs
@@ -81,7 +81,7 @@ rephraseParam rephraser (Param attrs name from) =
   Param attrs name <$> rephraser from
 
 -- | Rephrase a body.
-rephraseBody :: (Monad m) => Rephraser m from to -> Body from -> m (Body to)
+rephraseBody :: (Monad m) => Rephraser m from to -> GBody from res -> m (GBody to res)
 rephraseBody rephraser (Body rep stms res) =
   Body
     <$> rephraseBodyDec rephraser rep

--- a/src/Futhark/IR/Syntax.hs
+++ b/src/Futhark/IR/Syntax.hs
@@ -125,7 +125,8 @@ module Futhark.IR.Syntax
     Stms,
     SubExpRes (..),
     Result,
-    Body (..),
+    GBody (..),
+    Body,
     BasicOp (..),
     UnOp (..),
     BinOp (..),
@@ -300,19 +301,23 @@ subExpResVName _ = Nothing
 -- | The result of a body is a sequence of subexpressions.
 type Result = [SubExpRes]
 
--- | A body consists of a sequence of statements, terminating in a
--- list of result values.
-data Body rep = Body
+-- | A generalised body consists of a sequence of statements, terminated in some
+-- kind of result.
+data GBody rep res = Body
   { bodyDec :: BodyDec rep,
     bodyStms :: Stms rep,
-    bodyResult :: Result
+    bodyResult :: [res]
   }
 
-deriving instance (RepTypes rep) => Ord (Body rep)
+-- | A body consists of a sequence of statements, terminating in a
+-- list of result values.
+type Body rep = GBody rep SubExpRes
 
-deriving instance (RepTypes rep) => Show (Body rep)
+deriving instance (RepTypes rep, Ord res) => Ord (GBody rep res)
 
-deriving instance (RepTypes rep) => Eq (Body rep)
+deriving instance (RepTypes rep, Show res) => Show (GBody rep res)
+
+deriving instance (RepTypes rep, Eq res) => Eq (GBody rep res)
 
 -- | Apart from being Opaque, what else is going on here?
 data OpaqueOp

--- a/src/Futhark/Optimise/ArrayShortCircuiting.hs
+++ b/src/Futhark/Optimise/ArrayShortCircuiting.hs
@@ -164,17 +164,17 @@ replaceInSegOp ::
   SegOp lvl rep ->
   UpdateM (inner rep) (SegOp lvl rep)
 replaceInSegOp (SegMap lvl sp tps body) = do
-  stms <- updateStms $ kernelBodyStms body
-  pure $ SegMap lvl sp tps $ body {kernelBodyStms = stms}
+  stms <- updateStms $ bodyStms body
+  pure $ SegMap lvl sp tps $ body {bodyStms = stms}
 replaceInSegOp (SegRed lvl sp tps body binops) = do
-  stms <- updateStms $ kernelBodyStms body
-  pure $ SegRed lvl sp tps (body {kernelBodyStms = stms}) binops
+  stms <- updateStms $ bodyStms body
+  pure $ SegRed lvl sp tps (body {bodyStms = stms}) binops
 replaceInSegOp (SegScan lvl sp tps body binops) = do
-  stms <- updateStms $ kernelBodyStms body
-  pure $ SegScan lvl sp tps (body {kernelBodyStms = stms}) binops
+  stms <- updateStms $ bodyStms body
+  pure $ SegScan lvl sp tps (body {bodyStms = stms}) binops
 replaceInSegOp (SegHist lvl sp tps body hist_ops) = do
-  stms <- updateStms $ kernelBodyStms body
-  pure $ SegHist lvl sp tps (body {kernelBodyStms = stms}) hist_ops
+  stms <- updateStms $ bodyStms body
+  pure $ SegHist lvl sp tps (body {bodyStms = stms}) hist_ops
 
 replaceInHostOp :: HostOp NoOp GPUMem -> UpdateM (HostOp NoOp GPUMem) (HostOp NoOp GPUMem)
 replaceInHostOp (SegOp op) = SegOp <$> replaceInSegOp op

--- a/src/Futhark/Optimise/ArrayShortCircuiting/ArrayCoalescing.hs
+++ b/src/Futhark/Optimise/ArrayShortCircuiting/ArrayCoalescing.hs
@@ -336,7 +336,7 @@ threadSlice _ _ = Nothing
 
 bodyToKernelBody :: Body (Aliases GPUMem) -> KernelBody (Aliases GPUMem)
 bodyToKernelBody (Body dec stms res) =
-  KernelBody dec stms $ map (\(SubExpRes cert subexps) -> Returns ResultNoSimplify cert subexps) res
+  Body dec stms $ map (\(SubExpRes cert subexps) -> Returns ResultNoSimplify cert subexps) res
 
 -- | A helper for all the different kinds of 'SegOp'.
 --
@@ -371,7 +371,7 @@ shortCircuitSegOpHelper num_reds lvlOK lvl lutab pat@(Pat ps0) pat_certs space0 
   -- that correspond to reductions.
   let ps_space_and_res =
         zip3 ps0 (replicate num_reds (dropLastSegSpace space0) <> repeat space0) $
-          kernelBodyResult kernel_body
+          bodyResult kernel_body
   -- Create coalescing relations between pattern elements and kernel body
   -- results
   let (actv0, inhibit0) =
@@ -390,7 +390,7 @@ shortCircuitSegOpHelper num_reds lvlOK lvl lutab pat@(Pat ps0) pat_certs space0 
   let actv0' = M.map (\etry -> etry {memrefs = mempty}) $ actv0 <> actv_return
   -- Process kernel body statements
   bu_env' <-
-    mkCoalsTabStms lutab (kernelBodyStms kernel_body) td_env $
+    mkCoalsTabStms lutab (bodyStms kernel_body) td_env $
       bu_env {activeCoals = actv0', inhibit = inhibit_return}
 
   let actv_coals_after =
@@ -522,11 +522,11 @@ makeSegMapCoals ::
   (CoalsTab, InhibitTab)
 makeSegMapCoals lvlOK lvl td_env kernel_body pat_certs (active, inhb) (PatElem pat_name (_, MemArray _ _ _ (ArrayIn pat_mem pat_ixf)), space, Returns _ _ (Var return_name))
   | Just (MemBlock tp return_shp return_mem _) <-
-      getScopeMemInfo return_name $ scope td_env <> scopeOf (kernelBodyStms kernel_body),
+      getScopeMemInfo return_name $ scope td_env <> scopeOf (bodyStms kernel_body),
     lvlOK lvl,
     MemMem pat_space <- runReader (lookupMemInfo pat_mem) $ removeScopeAliases $ scope td_env,
     MemMem return_space <-
-      scope td_env <> scopeOf (kernelBodyStms kernel_body) <> scopeOfSegSpace space
+      scope td_env <> scopeOf (bodyStms kernel_body) <> scopeOfSegSpace space
         & removeScopeAliases
         & runReader (lookupMemInfo return_mem),
     pat_space == return_space =
@@ -1467,11 +1467,9 @@ genSSPointInfoSegOp
   scopetab
   (Pat [PatElem dst (_, MemArray dst_pt _ _ (ArrayIn dst_mem dst_ixf))])
   certs
-  (SegMap _ space _ kernel_body@KernelBody {kernelBodyResult = [Returns {}]})
+  (SegMap _ space _ kernel_body@Body {bodyResult = [Returns {}]})
     | (src, MemBlock src_pt shp src_mem src_ixf) : _ <-
-        mapMaybe getPotentialMapShortCircuit $
-          stmsToList $
-            kernelBodyStms kernel_body =
+        mapMaybe getPotentialMapShortCircuit $ stmsToList $ bodyStms kernel_body =
         Just [(MapCoal, id, dst, dst_mem, dst_ixf, src, src_mem, src_ixf, src_pt, shp, certs)]
     where
       iterators = map fst $ unSegSpace space
@@ -1744,10 +1742,10 @@ computeScalarTableSegOp scope_table segop = do
   concatMapM
     ( computeScalarTable $
         scope_table
-          <> scopeOf (kernelBodyStms $ segBody segop)
+          <> scopeOf (bodyStms $ segBody segop)
           <> scopeOfSegSpace (segSpace segop)
     )
-    (stmsToList $ kernelBodyStms $ segBody segop)
+    (stmsToList $ bodyStms $ segBody segop)
 
 computeScalarTableGPUMem ::
   ComputeScalarTable GPUMem (GPU.HostOp NoOp (Aliases GPUMem))

--- a/src/Futhark/Optimise/ArrayShortCircuiting/ArrayCoalescing.hs
+++ b/src/Futhark/Optimise/ArrayShortCircuiting/ArrayCoalescing.hs
@@ -586,10 +586,6 @@ makeSegMapCoals lvlOK lvl td_env kernel_body pat_certs (active, inhb) (PatElem p
         & map (DimFix . TPrimExp . flip LeafExp (IntType Int64) . fst)
         & Slice
     resultSlice ixf = LMAD.slice ixf $ fullSlice (LMAD.shape ixf) thread_slice
-makeSegMapCoals _ _ td_env _ _ x (_, _, WriteReturns _ return_name _) =
-  case getScopeMemInfo return_name $ scope td_env of
-    Just (MemBlock _ _ return_mem _) -> markFailedCoal x return_mem
-    Nothing -> error "Should not happen?"
 makeSegMapCoals _ _ td_env _ _ x (_, _, result) =
   freeIn result
     & namesToList

--- a/src/Futhark/Optimise/BlkRegTiling.hs
+++ b/src/Futhark/Optimise/BlkRegTiling.hs
@@ -267,7 +267,7 @@ mmBlkRegTiling env stm = do
 
 mmBlkRegTilingAcc :: Env -> Stm GPU -> TileM (Maybe (Stms GPU, Stm GPU))
 mmBlkRegTilingAcc env (Let pat aux (Op (SegOp (SegMap SegThread {} seg_space ts old_kbody))))
-  | KernelBody () kstms [Returns ResultMaySimplify cs (Var res_nm)] <- old_kbody,
+  | Body () kstms [Returns ResultMaySimplify cs (Var res_nm)] <- old_kbody,
     cs == mempty,
     -- check kernel has one result of primitive type
     [res_tp] <- ts,
@@ -389,7 +389,7 @@ mmBlkRegTilingAcc env (Let pat aux (Op (SegOp (SegMap SegThread {} seg_space ts 
         let grid = KernelGrid (Count grid_size) (Count tblock_size)
             level' = SegBlock SegNoVirt (Just grid)
             space' = SegSpace gid_flat (rem_outer_dims ++ [(gid_t, gridDim_t), (gid_y, gridDim_y), (gid_x, gridDim_x)])
-            kbody' = KernelBody () stms_seggroup ret_seggroup
+            kbody' = Body () stms_seggroup ret_seggroup
         pure $ Let pat aux $ Op $ SegOp $ SegMap level' space' ts kbody'
       pure $ Just (host_stms, new_kernel)
   where
@@ -462,7 +462,7 @@ mmBlkRegTilingAcc _ _ = pure Nothing
 
 mmBlkRegTilingNrm :: Env -> Stm GPU -> TileM (Maybe (Stms GPU, Stm GPU))
 mmBlkRegTilingNrm env (Let pat aux (Op (SegOp (SegMap SegThread {} seg_space ts old_kbody))))
-  | KernelBody () kstms [Returns ResultMaySimplify cs (Var res_nm)] <- old_kbody,
+  | Body () kstms [Returns ResultMaySimplify cs (Var res_nm)] <- old_kbody,
     cs == mempty,
     -- check kernel has one result of primitive type
     [res_tp] <- ts,
@@ -562,7 +562,7 @@ mmBlkRegTilingNrm env (Let pat aux (Op (SegOp (SegMap SegThread {} seg_space ts 
         let grid = KernelGrid (Count grid_size) (Count tblock_size)
             level' = SegBlock SegNoVirt (Just grid)
             space' = SegSpace gid_flat (rem_outer_dims ++ [(gid_y, gridDim_y), (gid_x, gridDim_x)])
-            kbody' = KernelBody () stms_seggroup ret_seggroup
+            kbody' = Body () stms_seggroup ret_seggroup
         pure $ Let pat aux $ Op $ SegOp $ SegMap level' space' ts kbody'
       pure $ Just (host_stms, new_kernel)
   where
@@ -992,7 +992,7 @@ isInvarTo2of3InnerDims branch_variant kspace variance arrs =
 -- mmBlkRegTiling (Let pat aux (Op (SegOp (SegMap SegThread{} seg_space ts old_kbody))))
 doRegTiling3D :: Stm GPU -> TileM (Maybe (Stms GPU, Stm GPU))
 doRegTiling3D (Let pat aux (Op (SegOp old_kernel)))
-  | SegMap SegThread {} space kertp (KernelBody () kstms kres) <- old_kernel,
+  | SegMap SegThread {} space kertp (Body () kstms kres) <- old_kernel,
     -- build the variance table, that records, for
     -- each variable name, the variables it depends on
     initial_variance <- M.map mempty $ scopeOfSegSpace space,
@@ -1141,7 +1141,7 @@ doRegTiling3D (Let pat aux (Op (SegOp old_kernel)))
                           pure (y_elm, y_ind)
 
                         let ret = WriteReturns mempty loc_Y_nm [(Slice [DimFix res_i], res_v)]
-                        let body = KernelBody () stms [ret]
+                        let body = Body () stms [ret]
                         loc_Y_nm_t <- lookupType loc_Y_nm
 
                         res_nms <-
@@ -1280,7 +1280,7 @@ doRegTiling3D (Let pat aux (Op (SegOp old_kernel)))
         let grid = KernelGrid (Count grid_size) (Count tblock_size)
             level' = SegBlock SegNoVirt (Just grid)
             space' = SegSpace gid_flat (rem_outer_dims ++ [(gid_z, gridDim_z), (gid_y, gridDim_y), (gid_x, gridDim_x)])
-            kbody' = KernelBody () stms_seggroup ret_seggroup
+            kbody' = Body () stms_seggroup ret_seggroup
 
         pure $ Let pat aux $ Op $ SegOp $ SegMap level' space' kertp kbody'
       -- END (new_kernel, host_stms) <- runBuilder $ do

--- a/src/Futhark/Optimise/CSE.hs
+++ b/src/Futhark/Optimise/CSE.hs
@@ -318,9 +318,9 @@ cseInKernelBody ::
   (Aliased rep, CSEInOp (Op rep)) =>
   GPU.KernelBody rep ->
   CSEM rep (GPU.KernelBody rep)
-cseInKernelBody (GPU.KernelBody bodydec stms res) = do
+cseInKernelBody (GPU.Body bodydec stms res) = do
   Body _ stms' _ <- cseInBody (map (const Observe) res) $ Body bodydec stms []
-  pure $ GPU.KernelBody bodydec stms' res
+  pure $ GPU.Body bodydec stms' res
 
 instance (CSEInOp (op rep)) => CSEInOp (Memory.MemOp op rep) where
   cseInOp o@Memory.Alloc {} = pure o

--- a/src/Futhark/Optimise/DoubleBuffer.hs
+++ b/src/Futhark/Optimise/DoubleBuffer.hs
@@ -180,8 +180,8 @@ optimiseKernelBody ::
   KernelBody rep ->
   DoubleBufferM rep (KernelBody rep)
 optimiseKernelBody kbody = do
-  stms' <- optimiseStms $ stmsToList $ kernelBodyStms kbody
-  pure $ kbody {kernelBodyStms = stms'}
+  stms' <- optimiseStms $ stmsToList $ bodyStms kbody
+  pure $ kbody {bodyStms = stms'}
 
 optimiseLambda ::
   (ASTRep rep) =>

--- a/src/Futhark/Optimise/MemoryBlockMerging.hs
+++ b/src/Futhark/Optimise/MemoryBlockMerging.hs
@@ -36,13 +36,13 @@ getAllocsStm _ = mempty
 
 getAllocsSegOp :: SegOp lvl GPUMem -> Allocs
 getAllocsSegOp (SegMap _ _ _ body) =
-  foldMap getAllocsStm (kernelBodyStms body)
+  foldMap getAllocsStm (bodyStms body)
 getAllocsSegOp (SegRed _ _ _ body _) =
-  foldMap getAllocsStm (kernelBodyStms body)
+  foldMap getAllocsStm (bodyStms body)
 getAllocsSegOp (SegScan _ _ _ body _) =
-  foldMap getAllocsStm (kernelBodyStms body)
+  foldMap getAllocsStm (bodyStms body)
 getAllocsSegOp (SegHist _ _ _ body _) =
-  foldMap getAllocsStm (kernelBodyStms body)
+  foldMap getAllocsStm (bodyStms body)
 
 setAllocsStm :: Map VName SubExp -> Stm GPUMem -> Stm GPUMem
 setAllocsStm m stm@(Let (Pat [PatElem name _]) _ (Op (Alloc _ _)))
@@ -68,19 +68,19 @@ setAllocsSegOp ::
   SegOp lvl GPUMem
 setAllocsSegOp m (SegMap lvl sp tps body) =
   SegMap lvl sp tps $
-    body {kernelBodyStms = setAllocsStm m <$> kernelBodyStms body}
+    body {bodyStms = setAllocsStm m <$> bodyStms body}
 setAllocsSegOp m (SegRed lvl sp tps body ops) =
   SegRed lvl sp tps body' ops
   where
-    body' = body {kernelBodyStms = setAllocsStm m <$> kernelBodyStms body}
+    body' = body {bodyStms = setAllocsStm m <$> bodyStms body}
 setAllocsSegOp m (SegScan lvl sp tps body ops) =
   SegScan lvl sp tps body' ops
   where
-    body' = body {kernelBodyStms = setAllocsStm m <$> kernelBodyStms body}
+    body' = body {bodyStms = setAllocsStm m <$> bodyStms body}
 setAllocsSegOp m (SegHist lvl sp tps body ops) =
   SegHist lvl sp tps body' ops
   where
-    body' = body {kernelBodyStms = setAllocsStm m <$> kernelBodyStms body}
+    body' = body {bodyStms = setAllocsStm m <$> bodyStms body}
 
 maxSubExp :: (MonadBuilder m) => Set SubExp -> m SubExp
 maxSubExp = helper . S.toList
@@ -106,17 +106,17 @@ onKernelBodyStms ::
   (Stms GPUMem -> m (Stms GPUMem)) ->
   m (SegOp lvl GPUMem)
 onKernelBodyStms (SegMap lvl space ts body) f = do
-  stms <- f $ kernelBodyStms body
-  pure $ SegMap lvl space ts $ body {kernelBodyStms = stms}
+  stms <- f $ bodyStms body
+  pure $ SegMap lvl space ts $ body {bodyStms = stms}
 onKernelBodyStms (SegRed lvl space ts body binops) f = do
-  stms <- f $ kernelBodyStms body
-  pure $ SegRed lvl space ts (body {kernelBodyStms = stms}) binops
+  stms <- f $ bodyStms body
+  pure $ SegRed lvl space ts (body {bodyStms = stms}) binops
 onKernelBodyStms (SegScan lvl space ts body binops) f = do
-  stms <- f $ kernelBodyStms body
-  pure $ SegScan lvl space ts (body {kernelBodyStms = stms}) binops
+  stms <- f $ bodyStms body
+  pure $ SegScan lvl space ts (body {bodyStms = stms}) binops
 onKernelBodyStms (SegHist lvl space ts body binops) f = do
-  stms <- f $ kernelBodyStms body
-  pure $ SegHist lvl space ts (body {kernelBodyStms = stms}) binops
+  stms <- f $ bodyStms body
+  pure $ SegHist lvl space ts (body {bodyStms = stms}) binops
 
 -- | This is the actual optimiser. Given an interference graph and a @SegOp@,
 -- replace allocations and references to memory blocks inside with a (hopefully)
@@ -150,19 +150,19 @@ optimiseKernel graph segop0 = do
   pure $ case segop' of
     SegMap lvl sp tps body ->
       SegMap lvl sp tps $
-        body {kernelBodyStms = maxstms <> stms <> kernelBodyStms body}
+        body {bodyStms = maxstms <> stms <> bodyStms body}
     SegRed lvl sp tps body ops ->
       SegRed lvl sp tps body' ops
       where
-        body' = body {kernelBodyStms = maxstms <> stms <> kernelBodyStms body}
+        body' = body {bodyStms = maxstms <> stms <> bodyStms body}
     SegScan lvl sp tps body ops ->
       SegScan lvl sp tps body' ops
       where
-        body' = body {kernelBodyStms = maxstms <> stms <> kernelBodyStms body}
+        body' = body {bodyStms = maxstms <> stms <> bodyStms body}
     SegHist lvl sp tps body ops ->
       SegHist lvl sp tps body' ops
       where
-        body' = body {kernelBodyStms = maxstms <> stms <> kernelBodyStms body}
+        body' = body {bodyStms = maxstms <> stms <> bodyStms body}
 
 -- | Helper function that modifies kernels found inside some statements.
 onKernels ::

--- a/src/Futhark/Optimise/ReduceDeviceSyncs.hs
+++ b/src/Futhark/Optimise/ReduceDeviceSyncs.hs
@@ -326,18 +326,18 @@ optimizeWithAccInput acc (shape, arrs, Just (op, nes)) = do
 -- that depends on migrated scalars.
 optimizeHostOp :: HostOp op GPU -> ReduceM (HostOp op GPU)
 optimizeHostOp (SegOp (SegMap lvl space types kbody)) =
-  SegOp . SegMap lvl space types <$> addReadsToKernelBody kbody
+  SegOp . SegMap lvl space types <$> addReadsToBody kbody
 optimizeHostOp (SegOp (SegRed lvl space types kbody ops)) = do
   ops' <- mapM addReadsToSegBinOp ops
-  kbody' <- addReadsToKernelBody kbody
+  kbody' <- addReadsToBody kbody
   pure . SegOp $ SegRed lvl space types kbody' ops'
 optimizeHostOp (SegOp (SegScan lvl space types kbody ops)) = do
   ops' <- mapM addReadsToSegBinOp ops
-  kbody' <- addReadsToKernelBody kbody
+  kbody' <- addReadsToBody kbody
   pure . SegOp $ SegScan lvl space types kbody' ops'
 optimizeHostOp (SegOp (SegHist lvl space types kbody ops)) = do
   ops' <- mapM addReadsToHistOp ops
-  kbody' <- addReadsToKernelBody kbody
+  kbody' <- addReadsToBody kbody
   pure . SegOp $ SegHist lvl space types kbody' ops'
 optimizeHostOp (SizeOp op) =
   pure (SizeOp op)
@@ -658,16 +658,13 @@ addReadsToLambda f = do
   pure (f {lambdaBody = body'})
 
 -- | Rewrite generic body dependencies to scalars that have been migrated.
-addReadsToBody :: Body GPU -> ReduceM (Body GPU)
+addReadsToBody ::
+  (FreeIn res, Substitute res) =>
+  GBody GPU res ->
+  ReduceM (GBody GPU res)
 addReadsToBody body = do
   (body', prologue) <- addReadsHelper body
   pure body' {bodyStms = prologue >< bodyStms body'}
-
--- | Rewrite kernel body dependencies to scalars that have been migrated.
-addReadsToKernelBody :: KernelBody GPU -> ReduceM (KernelBody GPU)
-addReadsToKernelBody kbody = do
-  (kbody', prologue) <- addReadsHelper kbody
-  pure kbody' {kernelBodyStms = prologue >< kernelBodyStms kbody'}
 
 -- | Rewrite migrated scalar dependencies within anything. The returned
 -- statements must be added to the scope of the rewritten construct.

--- a/src/Futhark/Optimise/Simplify/Rep.hs
+++ b/src/Futhark/Optimise/Simplify/Rep.hs
@@ -230,11 +230,11 @@ addWisdomToPat pat e =
 
 -- | Produce a body with simplifier information.
 mkWiseBody ::
-  (Informing rep) =>
+  (Informing rep, FreeIn res) =>
   BodyDec rep ->
   Stms (Wise rep) ->
-  Result ->
-  Body (Wise rep)
+  [res] ->
+  GBody (Wise rep) res
 mkWiseBody dec stms res =
   Body
     ( BodyWisdom aliases consumed (AliasDec $ freeIn $ freeInStmsAndRes stms res),
@@ -314,7 +314,7 @@ informStms :: (Informing rep) => Stms rep -> Stms (Wise rep)
 informStms = fmap informStm
 
 -- | Construct a 'Wise' body.
-informBody :: (Informing rep) => Body rep -> Body (Wise rep)
+informBody :: (Informing rep, FreeIn res) => GBody rep res -> GBody (Wise rep) res
 informBody (Body dec stms res) = mkWiseBody dec (informStms stms) res
 
 -- | Construct a 'Wise' lambda.

--- a/src/Futhark/Optimise/Sink.hs
+++ b/src/Futhark/Optimise/Sink.hs
@@ -208,9 +208,9 @@ optimiseKernelBody ::
   (Constraints rep) =>
   Sinker rep (Op rep) ->
   Sinker rep (KernelBody rep)
-optimiseKernelBody onOp vtable sinking (KernelBody attr stms res) =
+optimiseKernelBody onOp vtable sinking (Body attr stms res) =
   let (stms', sunk) = optimiseStms onOp vtable sinking stms $ freeIn res
-   in (KernelBody attr stms' res, sunk)
+   in (Body attr stms' res, sunk)
 
 optimiseSegOp ::
   (Constraints rep) =>

--- a/src/Futhark/Optimise/TileLoops.hs
+++ b/src/Futhark/Optimise/TileLoops.hs
@@ -80,10 +80,10 @@ tileInKernelBody ::
   KernelBody GPU ->
   TileM (Stms GPU, (SegLevel, SegSpace, KernelBody GPU))
 tileInKernelBody branch_variant initial_variance lvl initial_kspace ts kbody
-  | Just kbody_res <- mapM isSimpleResult $ kernelBodyResult kbody = do
+  | Just kbody_res <- mapM isSimpleResult $ bodyResult kbody = do
       maybe_tiled <-
         tileInBody branch_variant initial_variance lvl initial_kspace ts $
-          Body () (kernelBodyStms kbody) kbody_res
+          Body () (bodyStms kbody) kbody_res
       case maybe_tiled of
         Just (host_stms, tiling, tiledBody) -> do
           (res', stms') <-
@@ -92,7 +92,7 @@ tileInKernelBody branch_variant initial_variance lvl initial_kspace ts kbody
             ( host_stms,
               ( tilingLevel tiling,
                 tilingSpace tiling,
-                KernelBody () stms' res'
+                Body () stms' res'
               )
             )
         Nothing ->

--- a/src/Futhark/Optimise/TileLoops/Shared.hs
+++ b/src/Futhark/Optimise/TileLoops/Shared.hs
@@ -161,7 +161,7 @@ segScatter2D ::
   ([VName] -> (VName, VName) -> Builder GPU (SubExp, SubExp)) -> -- f
   Builder GPU VName
 segScatter2D desc updt_arr seq_dims (dim_x, dim_y) f =
-  letExp desc <=< withAcc [updt_arr] $ \ ~[acc] -> do
+  letExp desc <=< withAcc [updt_arr] 1 $ \ ~[acc] -> do
     ltid_flat <- newVName "ltid_flat"
     ltid_y <- newVName "ltid_y"
     ltid_x <- newVName "ltid_x"

--- a/src/Futhark/Optimise/Unstream.hs
+++ b/src/Futhark/Optimise/Unstream.hs
@@ -75,21 +75,10 @@ optimiseStms onOp stms =
 optimiseBody ::
   (ASTRep rep) =>
   OnOp rep ->
-  Body rep ->
-  UnstreamM rep (Body rep)
+  GBody rep res ->
+  UnstreamM rep (GBody rep res)
 optimiseBody onOp (Body aux stms res) =
   Body aux <$> optimiseStms onOp stms <*> pure res
-
-optimiseKernelBody ::
-  (ASTRep rep) =>
-  OnOp rep ->
-  KernelBody rep ->
-  UnstreamM rep (KernelBody rep)
-optimiseKernelBody onOp (KernelBody attr stms res) =
-  localScope (scopeOf stms) $
-    KernelBody attr
-      <$> (stmsFromList . concat <$> mapM (optimiseStm onOp) (stmsToList stms))
-      <*> pure res
 
 optimiseLambda ::
   (ASTRep rep) =>
@@ -126,7 +115,7 @@ optimiseSegOp onOp op =
   where
     optimise =
       identitySegOpMapper
-        { mapOnSegOpBody = optimiseKernelBody onOp,
+        { mapOnSegOpBody = optimiseBody onOp,
           mapOnSegOpLambda = optimiseLambda onOp
         }
 

--- a/src/Futhark/Pass/ExpandAllocations.hs
+++ b/src/Futhark/Pass/ExpandAllocations.hs
@@ -259,11 +259,11 @@ transformScanRed lvl space ops kbody = do
         <> boundInKernelBody kbody
 
 boundInKernelBody :: KernelBody GPUMem -> Names
-boundInKernelBody = namesFromList . M.keys . scopeOf . kernelBodyStms
+boundInKernelBody = namesFromList . M.keys . scopeOf . bodyStms
 
 addStmsToKernelBody :: Stms GPUMem -> KernelBody GPUMem -> KernelBody GPUMem
 addStmsToKernelBody stms kbody =
-  kbody {kernelBodyStms = stms <> kernelBodyStms kbody}
+  kbody {bodyStms = stms <> bodyStms kbody}
 
 allocsForBody ::
   Extraction ->
@@ -279,7 +279,7 @@ allocsForBody variant_allocs invariant_allocs grid space kbody kbody' m = do
     memoryRequirements
       grid
       space
-      (kernelBodyStms kbody)
+      (bodyStms kbody)
       variant_allocs
       invariant_allocs
 
@@ -358,8 +358,8 @@ extractKernelBodyAllocations ::
     Extraction
   )
 extractKernelBodyAllocations lvl bound_outside bound_kernel =
-  extractGenericBodyAllocations lvl bound_outside bound_kernel kernelBodyStms $
-    \stms kbody -> kbody {kernelBodyStms = stms}
+  extractGenericBodyAllocations lvl bound_outside bound_kernel bodyStms $
+    \stms kbody -> kbody {bodyStms = stms}
 
 extractBodyAllocations ::
   User ->
@@ -615,8 +615,8 @@ offsetMemoryInKernelBody :: RebaseMap -> KernelBody GPUMem -> OffsetM (KernelBod
 offsetMemoryInKernelBody offsets kbody = do
   stms' <-
     collectStms_ $
-      mapM_ (addStm <=< offsetMemoryInStm offsets) (kernelBodyStms kbody)
-  pure kbody {kernelBodyStms = stms'}
+      mapM_ (addStm <=< offsetMemoryInStm offsets) (bodyStms kbody)
+  pure kbody {bodyStms = stms'}
 
 offsetMemoryInBody :: RebaseMap -> Body GPUMem -> OffsetM (Body GPUMem)
 offsetMemoryInBody offsets (Body _ stms res) = do
@@ -870,8 +870,8 @@ unAllocGPUStms = unAllocStms False
     unAllocBody (Body dec stms res) =
       Body dec <$> unAllocStms True stms <*> pure res
 
-    unAllocKernelBody (KernelBody dec stms res) =
-      KernelBody dec <$> unAllocStms True stms <*> pure res
+    unAllocKernelBody (Body dec stms res) =
+      Body dec <$> unAllocStms True stms <*> pure res
 
     unAllocStms nested = mapM (unAllocStm nested)
 

--- a/src/Futhark/Pass/ExplicitAllocations/SegOp.hs
+++ b/src/Futhark/Pass/ExplicitAllocations/SegOp.hs
@@ -18,9 +18,8 @@ allocInKernelBody ::
   (Allocable fromrep torep inner) =>
   KernelBody fromrep ->
   AllocM fromrep torep (KernelBody torep)
-allocInKernelBody (KernelBody () stms res) =
-  uncurry (flip (KernelBody ()))
-    <$> collectStms (allocInStms stms (pure res))
+allocInKernelBody (Body () stms res) =
+  uncurry (flip (Body ())) <$> collectStms (allocInStms stms (pure res))
 
 allocInLambda ::
   (Allocable fromrep torep inner) =>

--- a/src/Futhark/Pass/ExtractKernels/BlockedKernel.hs
+++ b/src/Futhark/Pass/ExtractKernels/BlockedKernel.hs
@@ -59,7 +59,7 @@ prepareRedOrScan ::
 prepareRedOrScan cs w map_lam arrs ispace inps = do
   gtid <- newVName "gtid"
   space <- mkSegSpace $ ispace ++ [(gtid, w)]
-  kbody <- fmap (uncurry (flip (KernelBody ()))) $
+  kbody <- fmap (uncurry (flip (Body ()))) $
     runBuilder $
       localScope (scopeOfSegSpace space) $ do
         mapM_ readKernelInput inps
@@ -183,7 +183,7 @@ segHist lvl pat arr_w ispace inps ops lam arrs = runBuilder_ $ do
   gtid <- newVName "gtid"
   space <- mkSegSpace $ ispace ++ [(gtid, arr_w)]
 
-  kbody <- fmap (uncurry (flip $ KernelBody ())) $
+  kbody <- fmap (uncurry (flip $ Body ())) $
     runBuilder $
       localScope (scopeOfSegSpace space) $ do
         mapM_ readKernelInput inps
@@ -218,10 +218,10 @@ mapKernel ::
   [Type] ->
   KernelBody rep ->
   m (SegOp (SegOpLevel rep) rep, Stms rep)
-mapKernel mk_lvl ispace inputs rts (KernelBody () kstms krets) = runBuilderT' $ do
+mapKernel mk_lvl ispace inputs rts (Body () kstms krets) = runBuilderT' $ do
   (space, read_input_stms) <- mapKernelSkeleton ispace inputs
 
-  let kbody' = KernelBody () (read_input_stms <> kstms) krets
+  let kbody' = Body () (read_input_stms <> kstms) krets
 
   -- If the kernel creates arrays (meaning it will require memory
   -- expansion), we want to truncate the amount of threads.

--- a/src/Futhark/Pass/ExtractKernels/DistributeNests.hs
+++ b/src/Futhark/Pass/ExtractKernels/DistributeNests.hs
@@ -747,47 +747,46 @@ segmentedUpdateKernel ::
   Slice SubExp ->
   VName ->
   DistNestT rep m (Stms rep)
-segmentedUpdateKernel nest perm cs arr slice v = do
+segmentedUpdateKernel nest perm cs arr slice v = runBuilderT'_ $ do
   (base_ispace, kernel_inps) <- flatKernel nest
-  let slice_dims = sliceDims slice
-  slice_gtids <- replicateM (length slice_dims) (newVName "gtid_slice")
+  let rank = length base_ispace + length (sliceDims slice)
+      arr' =
+        maybe (error "incorrectly typed Update") kernelInputArray $
+          find ((== arr) . kernelInputName) kernel_inps
+  e <- withAcc [arr'] rank $ \ ~[acc] -> do
+    let slice_dims = sliceDims slice
+    slice_gtids <- replicateM (length slice_dims) (newVName "gtid_slice")
 
-  let ispace = base_ispace ++ zip slice_gtids slice_dims
+    let ispace = base_ispace ++ zip slice_gtids slice_dims
 
-  ((dest_t, res), kstms) <- runBuilder $ do
-    -- Compute indexes into full array.
-    v' <-
-      certifying cs . letSubExp "v" . BasicOp . Index v $
-        Slice (map (DimFix . Var) slice_gtids)
-    slice_is <-
-      traverse (toSubExp "index") $
-        fixSlice (fmap pe64 slice) $
-          map (pe64 . Var) slice_gtids
+    body <- runBodyBuilder $ do
+      -- Compute indexes into full array.
+      v' <-
+        certifying cs . letSubExp "v" . BasicOp . Index v $
+          Slice (map (DimFix . Var) slice_gtids)
+      slice_is <-
+        traverse (toSubExp "index") $
+          fixSlice (fmap pe64 slice) $
+            map (pe64 . Var) slice_gtids
 
-    let write_is = map (Var . fst) base_ispace ++ slice_is
-        arr' =
-          maybe (error "incorrectly typed Update") kernelInputArray $
-            find ((== arr) . kernelInputName) kernel_inps
-    arr_t <- lookupType arr'
-    pure
-      ( arr_t,
-        WriteReturns mempty arr' [(Slice $ map DimFix write_is, v')]
-      )
+      let write_is = map (Var . fst) base_ispace ++ slice_is
+      acc' <- letExp "acc" $ BasicOp $ UpdateAcc Safe acc write_is [v']
+      pure [Returns ResultMaySimplify mempty $ Var acc']
 
-  -- Remove unused kernel inputs, since some of these might
-  -- reference the array we are scattering into.
-  let kernel_inps' =
-        filter ((`nameIn` (freeIn kstms <> freeIn res)) . kernelInputName) kernel_inps
+    -- Remove unused kernel inputs, since some of these might
+    -- reference the array we are scattering into.
+    let kernel_inps' =
+          filter ((`nameIn` freeIn body) . kernelInputName) kernel_inps
 
-  mk_lvl <- mkSegLevel
-  (k, prestms) <-
-    mapKernel mk_lvl ispace kernel_inps' [dest_t] $
-      Body () kstms [res]
-
-  traverse renameStm <=< runBuilder_ $ do
+    mk_lvl <- lift mkSegLevel
+    acc_t <- lookupType acc
+    (k, prestms) <-
+      lift $ mapKernel mk_lvl ispace kernel_inps' [acc_t] body
     addStms prestms
-    let pat = Pat . rearrangeShape perm $ patElems $ loopNestingPat $ fst nest
-    letBind pat $ Op $ segOp k
+    fmap pure $ letSubExp "segmented_upd" $ Op $ segOp k
+
+  let pat = Pat . rearrangeShape perm $ patElems $ loopNestingPat $ fst nest
+  letBind pat e
 
 segmentedGatherKernel ::
   (MonadFreshNames m, LocalScope rep m, DistRep rep) =>

--- a/src/Futhark/Pass/ExtractKernels/DistributeNests.hs
+++ b/src/Futhark/Pass/ExtractKernels/DistributeNests.hs
@@ -782,7 +782,7 @@ segmentedUpdateKernel nest perm cs arr slice v = do
   mk_lvl <- mkSegLevel
   (k, prestms) <-
     mapKernel mk_lvl ispace kernel_inps' [dest_t] $
-      KernelBody () kstms [res]
+      Body () kstms [res]
 
   traverse renameStm <=< runBuilder_ $ do
     addStms prestms
@@ -817,7 +817,7 @@ segmentedGatherKernel nest cs arr slice = do
   mk_lvl <- mkSegLevel
   (k, prestms) <-
     mapKernel mk_lvl ispace kernel_inps [res_t] $
-      KernelBody () kstms [res]
+      Body () kstms [res]
 
   traverse renameStm <=< runBuilder_ $ do
     addStms prestms

--- a/src/Futhark/Pass/ExtractKernels/Distribution.hs
+++ b/src/Futhark/Pass/ExtractKernels/Distribution.hs
@@ -252,7 +252,7 @@ constructKernel mk_lvl kernel_nest inner_body = runBuilderT' $ do
       pat = loopNestingPat first_nest
       rts = map (stripArray (length ispace)) $ patTypes pat
 
-  inner_body' <- fmap (uncurry (flip (KernelBody ()))) $
+  inner_body' <- fmap (uncurry (flip (Body ()))) $
     runBuilder . localScope ispace_scope $ do
       mapM_ readKernelInput $ filter inputIsUsed inps
       res <- bodyBind inner_body

--- a/src/Futhark/Pass/ExtractKernels/Intrablock.hs
+++ b/src/Futhark/Pass/ExtractKernels/Intrablock.hs
@@ -109,14 +109,13 @@ intrablockParallelise knest lam = runMaybeT $ do
       space <- SegSpace <$> newVName "phys_tblock_id" <*> pure ispace
       pure (intra_avail_par, space, read_input_stms)
 
-  let kbody' = kbody {kernelBodyStms = read_input_stms <> kernelBodyStms kbody}
+  let kbody' = kbody {bodyStms = read_input_stms <> bodyStms kbody}
 
   let nested_pat = loopNestingPat first_nest
       rts = map (length ispace `stripArray`) $ patTypes nested_pat
       grid = KernelGrid (Count num_tblocks) (Count $ Var tblock_size)
       lvl = SegBlock SegNoVirt (Just grid)
-      kstm =
-        Let nested_pat aux $ Op $ SegOp $ SegMap lvl kspace rts kbody'
+      kstm = Let nested_pat aux $ Op $ SegOp $ SegMap lvl kspace rts kbody'
 
   let intra_min_par = intra_avail_par
   pure
@@ -312,7 +311,7 @@ intrablockParalleliseBody body = do
     ( S.toList min_ws,
       S.toList avail_ws,
       log,
-      KernelBody () kstms $ map ret $ bodyResult body
+      Body () kstms $ map ret $ bodyResult body
     )
   where
     ret (SubExpRes cs se) = Returns ResultMaySimplify cs se

--- a/src/Futhark/Pass/ExtractMulticore.hs
+++ b/src/Futhark/Pass/ExtractMulticore.hs
@@ -70,7 +70,7 @@ mapLambdaToKernelBody ::
 mapLambdaToKernelBody onBody i lam arrs = do
   Body () stms res <- mapLambdaToBody onBody i lam arrs
   let ret (SubExpRes cs se) = Returns ResultMaySimplify cs se
-  pure $ KernelBody () stms $ map ret res
+  pure $ Body () stms $ map ret res
 
 reduceToSegBinOp :: Reduce SOACS -> ExtractM (Stms MC, SegBinOp MC)
 reduceToSegBinOp (Reduce comm lam nes) = do

--- a/src/Futhark/Pass/LiftAllocations.hs
+++ b/src/Futhark/Pass/LiftAllocations.hs
@@ -132,17 +132,17 @@ liftAllocationsInSegOp ::
   SegOp lvl rep ->
   LiftM (inner rep) (SegOp lvl rep)
 liftAllocationsInSegOp (SegMap lvl sp tps body) = do
-  stms <- liftAllocationsInStms (kernelBodyStms body)
-  pure $ SegMap lvl sp tps $ body {kernelBodyStms = stms}
+  stms <- liftAllocationsInStms (bodyStms body)
+  pure $ SegMap lvl sp tps $ body {bodyStms = stms}
 liftAllocationsInSegOp (SegRed lvl sp tps body binops) = do
-  stms <- liftAllocationsInStms (kernelBodyStms body)
-  pure $ SegRed lvl sp tps (body {kernelBodyStms = stms}) binops
+  stms <- liftAllocationsInStms (bodyStms body)
+  pure $ SegRed lvl sp tps (body {bodyStms = stms}) binops
 liftAllocationsInSegOp (SegScan lvl sp tps body binops) = do
-  stms <- liftAllocationsInStms (kernelBodyStms body)
-  pure $ SegScan lvl sp tps (body {kernelBodyStms = stms}) binops
+  stms <- liftAllocationsInStms (bodyStms body)
+  pure $ SegScan lvl sp tps (body {bodyStms = stms}) binops
 liftAllocationsInSegOp (SegHist lvl sp tps body histops) = do
-  stms <- liftAllocationsInStms (kernelBodyStms body)
-  pure $ SegHist lvl sp tps (body {kernelBodyStms = stms}) histops
+  stms <- liftAllocationsInStms (bodyStms body)
+  pure $ SegHist lvl sp tps (body {bodyStms = stms}) histops
 
 liftAllocationsInHostOp ::
   HostOp NoOp (Aliases GPUMem) ->

--- a/src/Futhark/Pass/LowerAllocations.hs
+++ b/src/Futhark/Pass/LowerAllocations.hs
@@ -109,17 +109,17 @@ lowerAllocationsInSegOp ::
   SegOp lvl rep ->
   LowerM (inner rep) (SegOp lvl rep)
 lowerAllocationsInSegOp (SegMap lvl sp tps body) = do
-  stms <- lowerAllocationsInStms (kernelBodyStms body) mempty mempty
-  pure $ SegMap lvl sp tps $ body {kernelBodyStms = stms}
+  stms <- lowerAllocationsInStms (bodyStms body) mempty mempty
+  pure $ SegMap lvl sp tps $ body {bodyStms = stms}
 lowerAllocationsInSegOp (SegRed lvl sp tps body binops) = do
-  stms <- lowerAllocationsInStms (kernelBodyStms body) mempty mempty
-  pure $ SegRed lvl sp tps (body {kernelBodyStms = stms}) binops
+  stms <- lowerAllocationsInStms (bodyStms body) mempty mempty
+  pure $ SegRed lvl sp tps (body {bodyStms = stms}) binops
 lowerAllocationsInSegOp (SegScan lvl sp tps body binops) = do
-  stms <- lowerAllocationsInStms (kernelBodyStms body) mempty mempty
-  pure $ SegScan lvl sp tps (body {kernelBodyStms = stms}) binops
+  stms <- lowerAllocationsInStms (bodyStms body) mempty mempty
+  pure $ SegScan lvl sp tps (body {bodyStms = stms}) binops
 lowerAllocationsInSegOp (SegHist lvl sp tps body histops) = do
-  stms <- lowerAllocationsInStms (kernelBodyStms body) mempty mempty
-  pure $ SegHist lvl sp tps (body {kernelBodyStms = stms}) histops
+  stms <- lowerAllocationsInStms (bodyStms body) mempty mempty
+  pure $ SegHist lvl sp tps (body {bodyStms = stms}) histops
 
 lowerAllocationsInHostOp :: HostOp NoOp GPUMem -> LowerM (HostOp NoOp GPUMem) (HostOp NoOp GPUMem)
 lowerAllocationsInHostOp (SegOp op) = SegOp <$> lowerAllocationsInSegOp op

--- a/src/Futhark/Tools.hs
+++ b/src/Futhark/Tools.hs
@@ -185,9 +185,10 @@ partitionChunkedFoldParameters num_accs (chunk_param : params) =
 withAcc ::
   (MonadBuilder m, LParam (Rep m) ~ Param Type) =>
   [VName] ->
+  Int ->
   ([VName] -> m [SubExp]) ->
   m (Exp (Rep m))
-withAcc dest mk = do
+withAcc dest rank mk = do
   cert_ps <- replicateM (length dest) $ newParam "acc_cert" $ Prim Unit
   dest_ts <- mapM lookupType dest
   let acc_shape = Shape $ take rank $ arrayDims $ head dest_ts
@@ -200,8 +201,6 @@ withAcc dest mk = do
   withacc_lam <- mkLambda (cert_ps <> acc_ps) $ subExpsRes <$> mk (map paramName acc_ps)
 
   pure $ WithAcc [(acc_shape, [v], Nothing) | v <- dest] withacc_lam
-  where
-    rank = 1
 
 -- | Perform a scatter-like operation using accumulators and map.
 doScatter ::

--- a/src/Futhark/Transform/Rename.hs
+++ b/src/Futhark/Transform/Rename.hs
@@ -86,9 +86,9 @@ renameStm binding = do
 -- of the body is unaffected, under the assumption that the body was
 -- correct to begin with.  Any free variables are left untouched.
 renameBody ::
-  (Renameable rep, MonadFreshNames m) =>
-  Body rep ->
-  m (Body rep)
+  (Renameable rep, Rename res, MonadFreshNames m) =>
+  GBody rep res ->
+  m (GBody rep res)
 renameBody = modifyNameSource . runRenamer . rename
 
 -- | Rename bound variables such that each is unique.  The semantics
@@ -251,7 +251,7 @@ instance (Rename dec) => Rename (StmAux dec) where
 instance Rename SubExpRes where
   rename (SubExpRes cs se) = SubExpRes <$> rename cs <*> rename se
 
-instance (Renameable rep) => Rename (Body rep) where
+instance (Renameable rep, Rename res) => Rename (GBody rep res) where
   rename (Body dec stms res) = do
     dec' <- rename dec
     renamingStms stms $ \stms' ->

--- a/src/Futhark/Transform/Substitute.hs
+++ b/src/Futhark/Transform/Substitute.hs
@@ -113,7 +113,7 @@ instance (Substitutable rep) => Substitute (Stm rep) where
       (substituteNames substs annot)
       (substituteNames substs e)
 
-instance (Substitutable rep) => Substitute (Body rep) where
+instance (Substitutable rep, Substitute res) => Substitute (GBody rep res) where
   substituteNames substs (Body dec stms res) =
     Body
       (substituteNames substs dec)


### PR DESCRIPTION
Create GBody as a generalisation of Body and KernelBody.

Get rid of WriteReturns.