### PR TITLE
Fix #2314.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Correct source locations when warning about unused local functions.
 
+* Unpacking a unary sum type directly in a parameter or `let`-binding was
+  defective. (#2314)
+
 ## [0.25.32]
 
 ### Added

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -257,6 +257,12 @@ is represented as
 which is not great.  Take caution when you use sum types with large
 arrays in their payloads.
 
+Unary sum types
+!!!!!!!!!!!!!!!
+
+As an optimisation, the ``i8`` tag is elided when a sum type has only a single
+constructor. This means you can always use unary sum types with zero overhead.
+
 Functions
 ~~~~~~~~~
 

--- a/src/Futhark/Internalise/TypesValues.hs
+++ b/src/Futhark/Internalise/TypesValues.hs
@@ -274,7 +274,10 @@ internaliseTypeM exts orig_t =
       (ts, _) <-
         internaliseConstructors
           <$> traverse (fmap concat . mapM (internaliseTypeM exts)) cs
-      pure $ Pure (I.Prim (I.IntType I.Int8)) : ts
+      pure $
+        if length cs == 1
+          then ts
+          else Pure (I.Prim (I.IntType I.Int8)) : ts
   where
     internaliseShape = mapM (internaliseDim exts) . E.shapeDims
     array [Free ts] = Free ts

--- a/tests/sumtypes/irrefutable_case.fut
+++ b/tests/sumtypes/irrefutable_case.fut
@@ -1,0 +1,8 @@
+-- Irrefutable pattern in case.
+
+type t = #x i32
+
+entry main (x: i32) =
+  match #x x : t
+  case #x x -> x
+  case _ -> 123

--- a/tests/sumtypes/irrefutable_let.fut
+++ b/tests/sumtypes/irrefutable_let.fut
@@ -1,0 +1,7 @@
+-- Irrefutable pattern in let-binding.
+
+type t = #x i32
+
+entry main (x: i32) =
+  let #x y = #x x : t
+  in y

--- a/tests/sumtypes/irrefutable_param.fut
+++ b/tests/sumtypes/irrefutable_param.fut
@@ -1,0 +1,8 @@
+-- Irrefutable pattern in parameter.
+
+type t = #x i32
+
+def f ((#x y): t) = y
+
+entry main (x: i32) =
+  f (#x x)

--- a/tests_lib/c/sum.fut
+++ b/tests_lib/c/sum.fut
@@ -1,10 +1,14 @@
 -- Tests various complicated sum types and destructing/constructing
 -- them.
 
+type unary = #unary i32
+
 type~ contrived = #foo ([]i32) bool | #bar bool ([]u32) | #baz ([]i32) ([]i32)
 
 entry next (c: contrived) : contrived =
   match c
-  case #foo arr b -> #bar (!b) (map u32.i32 (map (+1) arr))
-  case #bar b arr -> #baz (map i32.u32 (map (*2) arr)) (map i32.u32 (map (+u32.bool b) arr))
+  case #foo arr b -> #bar (!b) (map u32.i32 (map (+ 1) arr))
+  case #bar b arr -> #baz (map i32.u32 (map (* 2) arr)) (map i32.u32 (map (+ u32.bool b) arr))
   case #baz x y -> #foo (map2 (+) x y) (i32.sum x % 2 == 0)
+
+entry unary_id (x: unary) : unary = x

--- a/tests_lib/c/test_sum.c
+++ b/tests_lib/c/test_sum.c
@@ -9,6 +9,20 @@ int main() {
   struct futhark_context_config *cfg = futhark_context_config_new();
   struct futhark_context *ctx = futhark_context_new(cfg);
 
+
+  struct futhark_opaque_unary *u1, *u2;
+  int32_t x;
+
+  // Check that unary variants work OK.
+  assert(futhark_new_opaque_unary_unary(ctx, &u1, 1337) == FUTHARK_SUCCESS);
+  assert(futhark_variant_opaque_unary(ctx, u1) == 0);
+  assert(futhark_entry_unary_id(ctx, &u2, u1) == FUTHARK_SUCCESS);
+  assert(futhark_context_sync(ctx) == FUTHARK_SUCCESS);
+  assert(futhark_variant_opaque_unary(ctx, u2) == 0);
+  assert(futhark_destruct_opaque_unary_unary(ctx, &x, u1) == FUTHARK_SUCCESS);
+  assert(x == 1337);
+  assert(futhark_destruct_opaque_unary_unary(ctx, &x, u2) == FUTHARK_SUCCESS);
+
   struct futhark_opaque_contrived* v;
   {
     int32_t data[] = { 1, 2, 3 };


### PR DESCRIPTION
Another solution would be to change the representation of unary sum types to not have a tag at all, but that is more invasive.