### PR TITLE
Maximise disk space when testing ISPC.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -319,8 +319,8 @@ jobs:
 
     - run: |
         export CFLAGS="-fsanitize=undefined -fno-sanitize-recover -O"
-        nix-shell -p ispc --run 'futhark test -c --backend=ispc tests --no-tuning'
-        nix-shell -p ispc python3Packages.jsonschema --run 'make -C tests_lib/c FUTHARK_BACKEND=ispc'
+        nix-shell -E 'with import (import ./nix/sources.nix {}).nixpkgs {}; mkShell { buildInputs = [ ispc python3Packages.jsonschema ]; }' --run 'futhark test -c --backend=ispc tests --no-tuning'
+        nix-shell -E 'with import (import ./nix/sources.nix {}).nixpkgs {}; mkShell { buildInputs = [ ispc python3Packages.jsonschema ]; }' --run 'make -C tests_lib/c FUTHARK_BACKEND=ispc'
 
   test-python:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Apparently ISPC now needs a lot of disk space (although the large Nix environment we have doesn't help).