### PR TITLE
Use dedicated shell-style.nix for CI.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -161,7 +161,7 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('nix/sources.json') }}-style
 
     - name: Style check
-      run: nix-shell --pure --run "make check"
+      run: nix-shell shell-style.nix --pure --run "make check"
 
 
   python-test-style:
@@ -174,10 +174,10 @@ jobs:
       uses: cachix/install-nix-action@v27
 
     - name: Style check
-      run: nix-shell --pure --run "black --check ."
+      run: nix-shell shell-style.nix --pure --run "black --check rts docs"
 
     - name: Type check
-      run: nix-shell --pure --run "mypy ."
+      run: nix-shell shell-style.nix --pure --run "mypy rts"
 
   # Fails mysteriously right now.
   #

--- a/nix/pkgs-style.nix
+++ b/nix/pkgs-style.nix
@@ -1,0 +1,8 @@
+{ pkgs, python, haskell }:
+with pkgs;
+[hlint
+ ormolu
+ parallel
+ python.mypy
+ python.black
+]

--- a/shell-style.nix
+++ b/shell-style.nix
@@ -1,0 +1,11 @@
+let
+  sources = import ./nix/sources.nix;
+  pkgs = import sources.nixpkgs {};
+  python = pkgs.python313Packages;
+  haskell = pkgs.haskell.packages.ghc98;
+in
+pkgs.stdenv.mkDerivation {
+  name = "futhark-style";
+  buildInputs =
+    (import ./nix/pkgs-style.nix {pkgs=pkgs; haskell=haskell; python=python;});
+}

--- a/shell.nix
+++ b/shell.nix
@@ -8,22 +8,20 @@ in
 pkgs.stdenv.mkDerivation {
   name = "futhark";
   buildInputs =
-    with pkgs;
+    (import ./nix/pkgs-style.nix {pkgs=pkgs; haskell=haskell; python=python;}) ++
+    (with pkgs;
     [
       cabal-install
       cacert
       curl
       file
       git
-      parallel
       haskell.ghc
-      ormolu
       haskell.weeder
       haskell.haskell-language-server
       haskellPackages.graphmod
       haskellPackages.apply-refact
       xdot
-      hlint
       pkg-config
       zlib
       zlib.out
@@ -48,6 +46,6 @@ pkgs.stdenv.mkDerivation {
         ocl-icd
         oclgrind
         rocmPackages.clr
-      ]
+      ])
   ;
 }


### PR DESCRIPTION
This is because the full shell.nix requires so much disk space (thanks AMD!) that GitHub Actions begins choking on it.