### PR TITLE
Output f32 and f64 values unambiguously

### DIFF
--- a/rts/c/values.h
+++ b/rts/c/values.h
@@ -431,14 +431,14 @@ static int write_str_u64(FILE *out, const uint64_t *src) {
 // If we want C99 compatibility, we must define them ourselves.
 // We choose the standard values on platforms that use the IEEE754 defaults, with fallback to an overestimate.
 #ifndef FLT_DECIMAL_DIG
-  #if FLT_RADIX == 2 && FLT_MANT_DIG <= 24
+  #if FLT_RADIX == 2 && FLT_MANT_DIG <= 24 && 9 < DECIMAL_DIG
     #define FLT_DECIMAL_DIG 9
   #else
     #define FLT_DECIMAL_DIG DECIMAL_DIG
   #endif
 #endif
 #ifndef DBL_DECIMAL_DIG
-  #if FLT_RADIX == 2 && DBL_MANT_DIG <= 53
+  #if FLT_RADIX == 2 && DBL_MANT_DIG <= 53 && 17 < DECIMAL_DIG
     #define DBL_DECIMAL_DIG 17
   #else
     #define DBL_DECIMAL_DIG DECIMAL_DIG


### PR DESCRIPTION
The C backend's output fails to distinguish between adjacent floating-point values even when those values are between 4 and 8, and for values with small exponents it fails to even distinguish them from 0. Meanwhile, values very far from 0 get printed with way too many digits. The `g` format specifier has been in the standard for a long time, so let's use it.

`FLT_DIG` and `DBL_DIG` are the wrong values to use for unambiguous output. `FLT_DECIMAL_DIG` and `DBL_DECIMAL_DIG` were introduced in C11 for this purpose. Assuming we want to keep C99 support, I have included a workaround.