### PR TITLE
Correctly-rounded fma primitive

### DIFF
--- a/src/Language/Futhark/Primitive.hs
+++ b/src/Language/Futhark/Primitive.hs
@@ -139,7 +139,7 @@ import Foreign.C.Types (CUShort (..))
 import Futhark.Util (convFloat)
 import Futhark.Util.CMath
 import Futhark.Util.Pretty
-import GHC.Exts (Double(D#), Float(F#), fmaddDouble#, fmaddFloat#)
+import GHC.Exts (Double (D#), Float (F#), fmaddDouble#, fmaddFloat#)
 import Numeric (log1p)
 import Numeric.Half
 import Prelude hiding (id, (.))


### PR DESCRIPTION
Fixes #2377. If you want to avoid depending on GHC.Exts in this file, I think the implementation I wrote for `f16.fma` should also work for f32 and f64, but I believe futhark already depends on GHC so I think using the fast implementation should be fine.