### PR TITLE
Special-case code generation for -9223372036854775808.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+* The C-based backends no longer emit constants `-9223372036854775808`, as these
+  cause C compilers to issue warnings.
+
 ## [0.25.37]
 
 ### Added

--- a/src/Futhark/CodeGen/Backends/SimpleRep.hs
+++ b/src/Futhark/CodeGen/Backends/SimpleRep.hs
@@ -248,7 +248,13 @@ instance C.ToExp IntValue where
   toExp (Int8Value k) _ = [C.cexp|(typename int8_t)$int:k|]
   toExp (Int16Value k) _ = [C.cexp|(typename int16_t)$int:k|]
   toExp (Int32Value k) _ = [C.cexp|$int:k|]
-  toExp (Int64Value k) _ = [C.cexp|(typename int64_t)$int:k|]
+  toExp (Int64Value k) _
+    -- C compilers warn on encountering -9223372036854775808, because this is
+    -- read as the negation operator applied to 9223372036854775808, and this
+    -- number is larger than the largest signed number. As a dumb workaround, we
+    -- construct an equivalent expression.
+    | k == minBound = [C.cexp|(typename int64_t)$int:(minBound+1::Int64)-1|]
+    | otherwise = [C.cexp|(typename int64_t)$int:k|]
 
 instance C.ToExp FloatValue where
   toExp (Float16Value x) _


### PR DESCRIPTION
C compilers warn on encountering -9223372036854775808, because this is read as the negation operator applied to 9223372036854775808, and this number is larger than the largest signed number. As a dumb workaround, we construct an equivalent expression.