### PR TITLE
Fix script6.fut test on windows

### DIFF
--- a/tests/script/script6.fut
+++ b/tests/script/script6.fut
@@ -1,6 +1,8 @@
 -- Can we read our own source code?
+-- Handle the fact that a text file in a windows checkout can have a longer
+-- byte length because of automatic CRLF conversions
 -- ==
 -- script input { $loadbytes "script6.fut" }
--- output { 139i64 }
+-- output { 308i64 }
 
-def main (s: []u8) = length s
+def main (s: []u8) = i64.sum (map (\x -> if x == 13 then 0 else 1) s)


### PR DESCRIPTION
This PR fixes tests/script/script6.fut test on a windows platform with default git configurations

by default git will automatically translate the line endings of the text files (.fut in this case) and it will have CRLF endings on disk despite beeing stored with LF endings in the remote

the PR discards the CRs from the bytes to so that it works on all platforms