### PR TITLE
Fix 'cleanSource' function, re-add nixpkgs Nix formatter.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,18 +52,27 @@
       # --- Source filtering (shared) ---
       cleanSource =
         src:
-        lib.sourceByRegex src [
-          "futhark.cabal"
-          "Setup.hs"
-          "LICENSE"
-          "^src.*"
-          "^rts.*"
-          "^docs.*"
-          "^prelude.*"
-          "^assets.*"
-          "^src-testing.*"
-          "^tools.*"
-        ];
+        builtins.path {
+          name = "futhark-${commit}-src";
+          path = src;
+          filter =
+            path: type:
+            let
+              relPath = lib.removePrefix (toString src + "/") (toString path);
+            in
+            builtins.any (regex: builtins.match regex relPath != null) [
+              "futhark.cabal"
+              "Setup.hs"
+              "LICENSE"
+              "^src.*"
+              "^rts.*"
+              "^docs.*"
+              "^prelude.*"
+              "^assets.*"
+              "^src-testing.*"
+              "^tools.*"
+            ];
+        };
     in
     {
       packages = forAllSystems (
@@ -293,5 +302,7 @@
           };
         }
       );
+
+      formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixfmt-tree);
     };
 }


### PR DESCRIPTION
## The problem with the current `cleanSource`

Currently the `cleanSource` function grabs any files matching the list of regular expressions. In flakes, these files will be put in a new derivation, with a name based on the NAR info of the flake that has been evaluated.

This means that any changes to anything that is tracked by git, will result in a `src` input with a new name, triggering a full rebuild of anything that uses `./.` as a source, even if all of the files found through the regex are the exact same as the previous derivation with a different name.

To test this, run `nix build`, then change one character in any file tracked by git in the repo, and run `nix build` again.


## The solution

Use the `builtins.path` function to import the path, set a name (I've arbitrarily chodsen `futhark-${commit}-src`), and use the regex from the old  `cleanSource` in the `filter` attribute. The result is that any changes to anything that does not relate to the actual build will have no impact on the build, and unnecessary rebuilds are avoided.

The code added is lifted from the [nixpkgs lib][lib], and edited to match the existing `cleanSource` function. Therefore it should be super robust, and unlikely to ever break.

[lib]: https://github.com/NixOS/nixpkgs/blob/1c3fe55ad329cbcb28471bb30f05c9827f724c76/lib/sources.nix#L215

I have built every package in the repo, and everything builds successfully, works, and it resilient to being needlessly rebuilt on arbitrary changes.

## Other changes

I have re-added the nixpkgs Nix formatter as `formatter` in the flake output. It only takes up one line of code, and will be immensely useful for making changes to the Nix code in the future.