### PR TITLE
Fixing name of src made from 'cleanSource'.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -53,7 +53,7 @@
       cleanSource =
         src:
         builtins.path {
-          name = "futhark-${commit}-src";
+          name = "futhark-src";
           path = src;
           filter =
             path: type:


### PR DESCRIPTION
## The problem

Fixing my last PR #2443, by removing the commit rev from the name of the src made by `cleanSource`.
The whole point of the PR was to decouple the archive name of the src and the flake it was made from, which this obviously isn't going to do, as it has the commit manually inserted into its name again.


## The solution

Just remove the commit from the name!