### PR TITLE
tests_adhoc: add test for no warnings.

### DIFF
--- a/rts/c/backends/c.h
+++ b/rts/c/backends/c.h
@@ -6,7 +6,7 @@ struct futhark_context_config {
   int profiling;
   int logging;
   char *cache_fname;
-  struct tuning_param tuning_params[NUM_TUNING_PARAMS];
+  struct tuning_param tuning_params[NUM_TUNING_PARAMS+1];
 };
 
 static void backend_context_config_setup(struct futhark_context_config* cfg) {

--- a/rts/c/cache.h
+++ b/rts/c/cache.h
@@ -44,7 +44,7 @@ static void cache_hash(struct cache_hash *out, const char *in, size_t n) {
 }
 
 #define CACHE_HEADER_SIZE 8
-static const char cache_header[CACHE_HEADER_SIZE] = "FUTHARK\0";
+static const char cache_header[CACHE_HEADER_SIZE] = "FUTHARK";
 
 static int cache_restore(const char *fname, const struct cache_hash *hash,
                          unsigned char **buf, size_t *buflen) {

--- a/rts/c/values.h
+++ b/rts/c/values.h
@@ -529,7 +529,7 @@ static int read_byte(FILE *f, void* dest) {
 //// Types
 
 struct primtype_info_t {
-  const char binname[4]; // Used for parsing binary data.
+  const char binname[5]; // Used for parsing binary data.
   const char* type_name; // Same name as in Futhark.
   const int64_t size; // in bytes
   const writer write_str; // Write in text format.

--- a/tests_adhoc/werror/.gitignore
+++ b/tests_adhoc/werror/.gitignore
@@ -1,0 +1,2 @@
+program
+program.c

--- a/tests_adhoc/werror/program.fut
+++ b/tests_adhoc/werror/program.fut
@@ -1,0 +1,1 @@
+entry main (x: i32) = [(x, x + 1)]

--- a/tests_adhoc/werror/test.sh
+++ b/tests_adhoc/werror/test.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# Check that we don't have any warnings in the generated C code. Obviously quite
+# fragile, but we do our best.
+
+set -e
+
+BACKEND=c
+
+futhark $BACKEND --server program.fut
+
+cc -c program.c -Wall -Wextra -pedantic -Werror


### PR DESCRIPTION
This is not a correctness issue, but it is slightly nicer for users if Futhark-generated C code does not have too many warnings.