### PR TITLE
Custom derivatives for reverse-mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * The restrictions for passing tuples as consumed function parameters have been
   loosened. (#2456)
 
+* The reverse-mode AD transformation now supports custom adjoints through a new
+  prelude function, `vjp_by`.
+
 ### Removed
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   loosened. (#2456)
 
 * The reverse-mode AD transformation now supports custom adjoints through a new
-  prelude function, `vjp_by`.
+  prelude function, `with_vjp`.
 
 ### Removed
 

--- a/prelude/ad.fut
+++ b/prelude/ad.fut
@@ -117,7 +117,7 @@ def vjp 'a 'b (f: a -> b) (x: a) (y': b) : a =
   (vjp2 f x y').1
 
 -- | Provide custom reverse-mode adjoint code for a given function. This is
--- useful when the adjoint synthesised by AD is as good as one that is known
+-- useful when the adjoint synthesised by AD is not as good as one that is known
 -- analytically.
 --
 -- The function `f` returns a result of type `b`. In the return sweep, the

--- a/prelude/ad.fut
+++ b/prelude/ad.fut
@@ -12,6 +12,21 @@
 -- purpose where you might need derivatives, such as for example
 -- computing surface normals for signed distance functions.
 --
+-- Futhark's AD support includes the following:
+--
+--   * Differentiation operators for forward-mode (`jvp`) and reverse-mode
+--     (`vjp`).
+--
+--   * Arbitrary control flow in differentiable code.
+--
+--   * Higher order derivatives by nesting differentiation operators, including
+--     arbitrary mixing of forward- and reverse mode (although using multiple
+--     rounds of reverse mode is rarely useful and often slow).
+--
+--   * Custom derivatives (`vjp_by`).
+--
+--   * Checkpointing of sequential loops.
+--
 -- ## Jacobians
 --
 -- For a differentiable function *f* whose input comprise *n* scalars

--- a/prelude/ad.fut
+++ b/prelude/ad.fut
@@ -131,5 +131,5 @@ def vjp 'a 'b (f: a -> b) (x: a) (y': b) : a =
 -- **Beware:** if `f` uses any free variables, these will not be taken into
 -- **account when computing the adjoint. Make these part of the argument
 -- **instead.
-def vjp_by 'a 'b 'c (f: a -> b) (f': (res: b) -> (b_adj: b) -> a) (x: a) : b =
+def vjp_by 'a 'b (f: a -> b) (f': (res: b) -> (b_adj: b) -> a) (x: a) : b =
   intrinsics.vjp_by f f' x

--- a/prelude/ad.fut
+++ b/prelude/ad.fut
@@ -115,3 +115,21 @@ def jvp 'a 'b (f: a -> b) (x: a) (x': a) : b =
 -- | Vector-Jacobian Product ("reverse mode").
 def vjp 'a 'b (f: a -> b) (x: a) (y': b) : a =
   (vjp2 f x y').1
+
+-- | Provide custom reverse-mode adjoint code for a given function. This is
+-- useful when the adjoint synthesised by AD is as good as one that is known
+-- analytically.
+--
+-- The function `f` must return a primal result of type `b`, as well as a
+-- "cache" of type `c`. In the return sweep, the function `f'` is invoked with
+-- the cotangents of the result as well as the cache originally produced by `b`,
+-- and must return the sensitivity with respect to the input.
+--
+-- The primal result, including when this function is used outside of AD, is
+-- simply the `b` returned by `f`.
+--
+-- **Beware:** if `f` uses any free variables, these will not be taken into
+-- **account when computing the adjoint. Make these part of the argument
+-- **instead.
+def vjp_by 'a 'b 'c (f: a -> (b, c)) (f': (b, c) -> a) (x: a) : b =
+  (intrinsics.vjp_by f f' x).0

--- a/prelude/ad.fut
+++ b/prelude/ad.fut
@@ -23,7 +23,7 @@
 --     arbitrary mixing of forward- and reverse mode (although using multiple
 --     rounds of reverse mode is rarely useful and often slow).
 --
---   * Custom derivatives (`vjp_by`).
+--   * Custom derivatives (`with_vjp`).
 --
 --   * Checkpointing of sequential loops.
 --
@@ -141,10 +141,15 @@ def vjp 'a 'b (f: a -> b) (x: a) (y': b) : a =
 -- return the sensitivity with respect to the input.
 --
 -- A common pattern is that `b` is a tuple where some part is the intended
--- primal result of `vjp_by`, and some part is only used in `f'`.
+-- primal result of `with_vjp`, and some part is only used in `f'`.
 --
 -- **Beware:** if `f` uses any free variables, these will not be taken into
 -- **account when computing the adjoint. Make these part of the argument
 -- **instead.
-def vjp_by 'a 'b (f: a -> b) (f': (res: b) -> (b_adj: b) -> a) (x: a) : b =
-  intrinsics.vjp_by f f' x
+def with_vjp 'a 'b (f: a -> b) (f': (res: b) -> (b_adj: b) -> a) (x: a) : b =
+  intrinsics.with_vjp f f' x
+
+-- | A variant of `with_vjp` where the intermediate result necessary for the
+-- adjoint (`c`) is explicitly separated from the primal result (`b`).
+def with_vjp_tape 'a 'b 'c (f: a -> (c, b)) (f': (c, b) -> a) (x: a) : b =
+  (with_vjp f (\(tape, _) (_, adj) -> f' (tape, adj)) x).1

--- a/prelude/ad.fut
+++ b/prelude/ad.fut
@@ -120,16 +120,16 @@ def vjp 'a 'b (f: a -> b) (x: a) (y': b) : a =
 -- useful when the adjoint synthesised by AD is as good as one that is known
 -- analytically.
 --
--- The function `f` must return a primal result of type `b`, as well as a
--- "cache" of type `c`. In the return sweep, the function `f'` is invoked with
--- the cotangents of the result as well as the cache originally produced by `b`,
--- and must return the sensitivity with respect to the input.
+-- The function `f` returns a result of type `b`. In the return sweep, the
+-- function `f'` is invoked first with the result of `f` and second with the
+-- cotangents of the result (be careful not to mix up the order), and must
+-- return the sensitivity with respect to the input.
 --
--- The primal result, including when this function is used outside of AD, is
--- simply the `b` returned by `f`.
+-- A common pattern is that `b` is a tuple where some part is the intended
+-- primal result of `vjp_by`, and some part is only used in `f'`.
 --
 -- **Beware:** if `f` uses any free variables, these will not be taken into
 -- **account when computing the adjoint. Make these part of the argument
 -- **instead.
-def vjp_by 'a 'b 'c (f: a -> (b, c)) (f': (b, c) -> a) (x: a) : b =
-  (intrinsics.vjp_by f f' x).0
+def vjp_by 'a 'b 'c (f: a -> b) (f': (res: b) -> (b_adj: b) -> a) (x: a) : b =
+  intrinsics.vjp_by f f' x

--- a/src/Futhark/AD/Fwd.hs
+++ b/src/Futhark/AD/Fwd.hs
@@ -335,10 +335,8 @@ fwdSOAC pat aux (WithVJP args lam _) = do
   -- You have a custom adjoint? Too bad we are in tangent land.
   (mapM_ fwdStm <=< runBuilder_) $ do
     lam_res <- auxing aux $ eLambda lam $ map eSubExp args
-    forM (zip (patNames pat) lam_res) $ \(v, res) ->
-      letBindNames [v] $
-        certifying (resCerts res) $
-          BasicOp $ SubExp $ resSubExp res
+    forM (zip (patNames pat) lam_res) $ \(v, SubExpRes cs se) ->
+      certifying cs $ letBindNames [v] $ BasicOp $ SubExp se
 fwdSOAC _ _ JVP {} =
   error "fwdSOAC: nested JVP not allowed."
 fwdSOAC _ _ VJP {} =

--- a/src/Futhark/AD/Fwd.hs
+++ b/src/Futhark/AD/Fwd.hs
@@ -336,7 +336,9 @@ fwdSOAC pat aux (WithVJP args lam _) = do
   (mapM_ fwdStm <=< runBuilder_) $ do
     lam_res <- auxing aux $ eLambda lam $ map eSubExp args
     forM (zip (patNames pat) lam_res) $ \(v, res) ->
-      letBindNames [v] $ BasicOp $ SubExp $ resSubExp res
+      letBindNames [v] $
+        certifying (resCerts res) $
+          BasicOp $ SubExp $ resSubExp res
 fwdSOAC _ _ JVP {} =
   error "fwdSOAC: nested JVP not allowed."
 fwdSOAC _ _ VJP {} =

--- a/src/Futhark/AD/Fwd.hs
+++ b/src/Futhark/AD/Fwd.hs
@@ -331,6 +331,12 @@ fwdSOAC pat aux (Hist w arrs ops bucket_fun) = do
             histNeutral = interleave nes nes_tan,
             histOp = op'
           }
+fwdSOAC pat aux (VJPBy args lam _) = do
+  -- You have a custom adjoint? Too bad we are in tangent land.
+  (mapM_ fwdStm <=< runBuilder_) $ do
+    lam_res <- auxing aux $ eLambda lam $ map eSubExp args
+    forM (zip (patNames pat) lam_res) $ \(v, res) ->
+      letBindNames [v] $ BasicOp $ SubExp $ resSubExp res
 fwdSOAC _ _ JVP {} =
   error "fwdSOAC: nested JVP not allowed."
 fwdSOAC _ _ VJP {} =

--- a/src/Futhark/AD/Fwd.hs
+++ b/src/Futhark/AD/Fwd.hs
@@ -331,7 +331,7 @@ fwdSOAC pat aux (Hist w arrs ops bucket_fun) = do
             histNeutral = interleave nes nes_tan,
             histOp = op'
           }
-fwdSOAC pat aux (VJPBy args lam _) = do
+fwdSOAC pat aux (WithVJP args lam _) = do
   -- You have a custom adjoint? Too bad we are in tangent land.
   (mapM_ fwdStm <=< runBuilder_) $ do
     lam_res <- auxing aux $ eLambda lam $ map eSubExp args

--- a/src/Futhark/AD/Rev/SOAC.hs
+++ b/src/Futhark/AD/Rev/SOAC.hs
@@ -190,13 +190,13 @@ vjpSOAC ops pat aux (Stream w as accs lam) m = do
   stms <- collectStms_ $ auxing aux $ sequentialStreamWholeArray pat w accs lam as
   foldr (vjpStm ops) m stms
 vjpSOAC _ops pat aux (WithVJP args lam lam_adj) m = do
-  lam_res <- map resSubExp <$> auxing aux (eLambda lam (map eSubExp args))
-  forM_ (zip (patNames pat) lam_res) $ \(v, se) ->
-    letBindNames [v] $ BasicOp $ SubExp se
+  lam_res <- auxing aux (eLambda lam (map eSubExp args))
+  forM_ (zip (patNames pat) lam_res) $ \(v, SubExpRes cs se) ->
+    certifying cs $ letBindNames [v] $ BasicOp $ SubExp se
   m
   pat_adj <- mapM lookupAdjVal $ patNames pat
   contribs <-
-    eLambda lam_adj (map eSubExp lam_res ++ map (eSubExp . Var) pat_adj)
+    eLambda lam_adj (map (eSubExp . resSubExp) lam_res ++ map (eSubExp . Var) pat_adj)
   forM_ (zip args contribs) $ \(arg, contrib) ->
     (updateSubExpAdj arg <=< letExp "contrib") $
       BasicOp . SubExp . resSubExp $

--- a/src/Futhark/AD/Rev/SOAC.hs
+++ b/src/Futhark/AD/Rev/SOAC.hs
@@ -190,16 +190,13 @@ vjpSOAC ops pat aux (Stream w as accs lam) m = do
   stms <- collectStms_ $ auxing aux $ sequentialStreamWholeArray pat w accs lam as
   foldr (vjpStm ops) m stms
 vjpSOAC _ops pat aux (VJPBy args lam lam_adj) m = do
-  let num_prim_ts = patSize pat
-  (lam_primal_res, lam_tape_res) <-
-    splitAt num_prim_ts . map resSubExp
-      <$> auxing aux (eLambda lam (map eSubExp args))
-  forM_ (zip (patNames pat) lam_primal_res) $ \(v, se) ->
+  lam_res <- map resSubExp <$> auxing aux (eLambda lam (map eSubExp args))
+  forM_ (zip (patNames pat) lam_res) $ \(v, se) ->
     letBindNames [v] $ BasicOp $ SubExp se
   m
   pat_adj <- mapM lookupAdjVal $ patNames pat
   contribs <-
-    eLambda lam_adj (map (eSubExp . Var) pat_adj ++ map eSubExp lam_tape_res)
+    eLambda lam_adj (map eSubExp lam_res ++ map (eSubExp . Var) pat_adj)
   forM_ (zip args contribs) $ \(arg, contrib) ->
     (updateSubExpAdj arg <=< letExp "contrib") $
       BasicOp . SubExp . resSubExp $

--- a/src/Futhark/AD/Rev/SOAC.hs
+++ b/src/Futhark/AD/Rev/SOAC.hs
@@ -189,7 +189,7 @@ vjpSOAC ops pat _aux (Hist n as histops f) m
 vjpSOAC ops pat aux (Stream w as accs lam) m = do
   stms <- collectStms_ $ auxing aux $ sequentialStreamWholeArray pat w accs lam as
   foldr (vjpStm ops) m stms
-vjpSOAC _ops pat aux (VJPBy args lam lam_adj) m = do
+vjpSOAC _ops pat aux (WithVJP args lam lam_adj) m = do
   lam_res <- map resSubExp <$> auxing aux (eLambda lam (map eSubExp args))
   forM_ (zip (patNames pat) lam_res) $ \(v, se) ->
     letBindNames [v] $ BasicOp $ SubExp se

--- a/src/Futhark/AD/Rev/SOAC.hs
+++ b/src/Futhark/AD/Rev/SOAC.hs
@@ -189,6 +189,21 @@ vjpSOAC ops pat _aux (Hist n as histops f) m
 vjpSOAC ops pat aux (Stream w as accs lam) m = do
   stms <- collectStms_ $ auxing aux $ sequentialStreamWholeArray pat w accs lam as
   foldr (vjpStm ops) m stms
+vjpSOAC _ops pat aux (VJPBy args lam lam_adj) m = do
+  let num_prim_ts = patSize pat
+  (lam_primal_res, lam_tape_res) <-
+    splitAt num_prim_ts . map resSubExp
+      <$> auxing aux (eLambda lam (map eSubExp args))
+  forM_ (zip (patNames pat) lam_primal_res) $ \(v, se) ->
+    letBindNames [v] $ BasicOp $ SubExp se
+  m
+  pat_adj <- mapM lookupAdjVal $ patNames pat
+  contribs <-
+    eLambda lam_adj (map (eSubExp . Var) pat_adj ++ map eSubExp lam_tape_res)
+  forM_ (zip args contribs) $ \(arg, contrib) ->
+    (updateSubExpAdj arg <=< letExp "contrib") $
+      BasicOp . SubExp . resSubExp $
+        contrib
 vjpSOAC _ _ _ soac _ =
   error $ "vjpSOAC unhandled:\n" ++ prettyString soac
 

--- a/src/Futhark/IR/SOACS.hs
+++ b/src/Futhark/IR/SOACS.hs
@@ -54,6 +54,7 @@ usesAD prog = any stmUsesAD (progConsts prog) || any funUsesAD (progFuns prog)
     lamUsesAD = bodyUsesAD . lambdaBody
     expUsesAD (Op JVP {}) = True
     expUsesAD (Op VJP {}) = True
+    expUsesAD (Op VJPBy {}) = True
     expUsesAD (Op (Stream _ _ _ lam)) = lamUsesAD lam
     expUsesAD (Op (Screma _ _ (ScremaForm lam scans reds post_lam))) =
       lamUsesAD lam

--- a/src/Futhark/IR/SOACS.hs
+++ b/src/Futhark/IR/SOACS.hs
@@ -54,7 +54,7 @@ usesAD prog = any stmUsesAD (progConsts prog) || any funUsesAD (progFuns prog)
     lamUsesAD = bodyUsesAD . lambdaBody
     expUsesAD (Op JVP {}) = True
     expUsesAD (Op VJP {}) = True
-    expUsesAD (Op VJPBy {}) = True
+    expUsesAD (Op WithVJP {}) = True
     expUsesAD (Op (Stream _ _ _ lam)) = lamUsesAD lam
     expUsesAD (Op (Screma _ _ (ScremaForm lam scans reds post_lam))) =
       lamUsesAD lam

--- a/src/Futhark/IR/SOACS/SOAC.hs
+++ b/src/Futhark/IR/SOACS/SOAC.hs
@@ -83,7 +83,7 @@ data SOAC rep
   | -- FIXME: this should not be here
     VJP [SubExp] [SubExp] (Lambda rep)
   | -- FIXME: this should not be here
-    VJPBy [SubExp] (Lambda rep) (Lambda rep)
+    WithVJP [SubExp] (Lambda rep) (Lambda rep)
   | -- | A combination of scan, reduction, and map.  The first
     -- t'SubExp' is the size of the input arrays.
     Screma SubExp [VName] (ScremaForm rep)
@@ -411,8 +411,8 @@ mapSOACM tv (VJP args vec lam) =
     <$> mapM (mapOnSOACSubExp tv) args
     <*> mapM (mapOnSOACSubExp tv) vec
     <*> mapOnSOACLambda tv lam
-mapSOACM tv (VJPBy args lam0 lam1) =
-  VJPBy
+mapSOACM tv (WithVJP args lam0 lam1) =
+  WithVJP
     <$> mapM (mapOnSOACSubExp tv) args
     <*> mapOnSOACLambda tv lam0
     <*> mapOnSOACLambda tv lam1
@@ -513,7 +513,7 @@ soacType (JVP _ _ lam) =
   lambdaReturnType lam ++ lambdaReturnType lam
 soacType (VJP _ _ lam) =
   lambdaReturnType lam ++ map paramType (lambdaParams lam)
-soacType (VJPBy _ lam _) =
+soacType (WithVJP _ lam _) =
   lambdaReturnType lam
 soacType (Stream outersize _ accs lam) =
   map (substNamesInType substs) rtp
@@ -535,7 +535,7 @@ instance AliasedOp SOAC where
 
   consumedInOp JVP {} = mempty
   consumedInOp VJP {} = mempty
-  consumedInOp VJPBy {} = mempty
+  consumedInOp WithVJP {} = mempty
   -- Only map functions can consume anything.  The operands to scan
   -- and reduce functions are always considered "fresh".
   consumedInOp (Screma _ arrs (ScremaForm map_lam _ _ _)) =
@@ -565,8 +565,8 @@ instance CanBeAliased SOAC where
     JVP args vec (Alias.analyseLambda aliases lam)
   addOpAliases aliases (VJP args vec lam) =
     VJP args vec (Alias.analyseLambda aliases lam)
-  addOpAliases aliases (VJPBy args lam lam_adj) =
-    VJPBy
+  addOpAliases aliases (WithVJP args lam lam_adj) =
+    WithVJP
       args
       (Alias.analyseLambda aliases lam)
       (Alias.analyseLambda aliases lam_adj)
@@ -629,7 +629,7 @@ instance IsOp SOAC where
       lam
       (zipWith (<>) (map depsOf' args) (map depsOf' vec))
       <> map (const $ freeIn args <> freeIn lam) (lambdaParams lam)
-  opDependencies (VJPBy args lam _lam_adj) =
+  opDependencies (WithVJP args lam _lam_adj) =
     lambdaDependencies
       mempty
       lam
@@ -728,7 +728,7 @@ typeCheckSOAC (JVP args vec lam) = do
         </> PP.indent 2 (pretty $ map TC.argType args')
         </> "does not match type of seed vector"
         </> PP.indent 2 (pretty vec_ts)
-typeCheckSOAC (VJPBy args lam lam_adj) = do
+typeCheckSOAC (WithVJP args lam lam_adj) = do
   args' <- mapM TC.checkArg args
   TC.checkLambda lam $ map TC.noArgAliases args'
   TC.checkLambda lam_adj $
@@ -855,8 +855,8 @@ instance RephraseOp SOAC where
     VJP args vec <$> rephraseLambda r lam
   rephraseInOp r (JVP args vec lam) =
     JVP args vec <$> rephraseLambda r lam
-  rephraseInOp r (VJPBy args lam lam_adj) =
-    VJPBy args <$> rephraseLambda r lam <*> rephraseLambda r lam_adj
+  rephraseInOp r (WithVJP args lam lam_adj) =
+    WithVJP args <$> rephraseLambda r lam <*> rephraseLambda r lam_adj
   rephraseInOp r (Stream w arrs acc lam) =
     Stream w arrs acc <$> rephraseLambda r lam
   rephraseInOp r (Hist w arrs ops lam) =
@@ -886,9 +886,9 @@ instance (OpMetrics (Op rep)) => OpMetrics (SOAC rep) where
     inside "VJP" $ lambdaMetrics lam
   opMetrics (JVP _ _ lam) =
     inside "JVP" $ lambdaMetrics lam
-  opMetrics (VJPBy _ lam lam_adj) = do
-    inside "VJPBy" $ lambdaMetrics lam
-    inside "VJPBy" $ lambdaMetrics lam_adj
+  opMetrics (WithVJP _ lam lam_adj) = do
+    inside "WithVJP" $ lambdaMetrics lam
+    inside "WithVJP" $ lambdaMetrics lam_adj
   opMetrics (Stream _ _ _ lam) =
     inside "Stream" $ lambdaMetrics lam
   opMetrics (Hist _ _ ops bucket_fun) =
@@ -917,8 +917,8 @@ instance (PrettyRep rep) => PP.Pretty (SOAC rep) where
               <> comma </> PP.braces (commasep $ map pretty vec)
               <> comma </> pretty lam
         )
-  pretty (VJPBy args lam lam_adj) =
-    "vjp_by"
+  pretty (WithVJP args lam lam_adj) =
+    "with_vjp"
       <> parens
         ( PP.align $
             PP.braces (commasep $ map pretty args)

--- a/src/Futhark/IR/SOACS/SOAC.hs
+++ b/src/Futhark/IR/SOACS/SOAC.hs
@@ -82,6 +82,8 @@ data SOAC rep
     JVP [SubExp] [SubExp] (Lambda rep)
   | -- FIXME: this should not be here
     VJP [SubExp] [SubExp] (Lambda rep)
+  | -- FIXME: this should not be here
+    VJPBy [SubExp] (Lambda rep) (Lambda rep)
   | -- | A combination of scan, reduction, and map.  The first
     -- t'SubExp' is the size of the input arrays.
     Screma SubExp [VName] (ScremaForm rep)
@@ -409,6 +411,11 @@ mapSOACM tv (VJP args vec lam) =
     <$> mapM (mapOnSOACSubExp tv) args
     <*> mapM (mapOnSOACSubExp tv) vec
     <*> mapOnSOACLambda tv lam
+mapSOACM tv (VJPBy args lam0 lam1) =
+  VJPBy
+    <$> mapM (mapOnSOACSubExp tv) args
+    <*> mapOnSOACLambda tv lam0
+    <*> mapOnSOACLambda tv lam1
 mapSOACM tv (Stream size arrs accs lam) =
   Stream
     <$> mapOnSOACSubExp tv size
@@ -506,6 +513,8 @@ soacType (JVP _ _ lam) =
   lambdaReturnType lam ++ lambdaReturnType lam
 soacType (VJP _ _ lam) =
   lambdaReturnType lam ++ map paramType (lambdaParams lam)
+soacType (VJPBy _ _ lam_adj) =
+  lambdaReturnType lam_adj
 soacType (Stream outersize _ accs lam) =
   map (substNamesInType substs) rtp
   where
@@ -526,6 +535,7 @@ instance AliasedOp SOAC where
 
   consumedInOp JVP {} = mempty
   consumedInOp VJP {} = mempty
+  consumedInOp VJPBy {} = mempty
   -- Only map functions can consume anything.  The operands to scan
   -- and reduce functions are always considered "fresh".
   consumedInOp (Screma _ arrs (ScremaForm map_lam _ _ _)) =
@@ -555,6 +565,11 @@ instance CanBeAliased SOAC where
     JVP args vec (Alias.analyseLambda aliases lam)
   addOpAliases aliases (VJP args vec lam) =
     VJP args vec (Alias.analyseLambda aliases lam)
+  addOpAliases aliases (VJPBy args lam lam_adj) =
+    VJPBy
+      args
+      (Alias.analyseLambda aliases lam)
+      (Alias.analyseLambda aliases lam_adj)
   addOpAliases aliases (Stream size arr accs lam) =
     Stream size arr accs $ Alias.analyseLambda aliases lam
   addOpAliases aliases (Hist w arrs ops bucket_fun) =
@@ -613,6 +628,12 @@ instance IsOp SOAC where
       mempty
       lam
       (zipWith (<>) (map depsOf' args) (map depsOf' vec))
+      <> map (const $ freeIn args <> freeIn lam) (lambdaParams lam)
+  opDependencies (VJPBy args lam _lam_adj) =
+    lambdaDependencies
+      mempty
+      lam
+      (map depsOf' args)
       <> map (const $ freeIn args <> freeIn lam) (lambdaParams lam)
   opDependencies (Screma w arrs (ScremaForm map_lam scans reds post_lam)) =
     let (scans_in, reds_in, map_deps) =
@@ -707,6 +728,16 @@ typeCheckSOAC (JVP args vec lam) = do
         </> PP.indent 2 (pretty $ map TC.argType args')
         </> "does not match type of seed vector"
         </> PP.indent 2 (pretty vec_ts)
+typeCheckSOAC (VJPBy args lam lam_adj) = do
+  args' <- mapM TC.checkArg args
+  TC.checkLambda lam $ map TC.noArgAliases args'
+  TC.checkLambda lam_adj $ map (,mempty) $ lambdaReturnType lam
+  unless (lambdaReturnType lam_adj == map TC.argType args') $
+    TC.bad . TC.TypeError . docText $
+      "Adjoint lambda return type"
+        </> PP.indent 2 (pretty $ lambdaReturnType lam_adj)
+        </> "does not match type of arguments"
+        </> PP.indent 2 (pretty $ map TC.argType args')
 typeCheckSOAC (Stream size arrexps accexps lam) = do
   TC.require (Prim int64) size
   accargs <- mapM TC.checkArg accexps
@@ -823,6 +854,8 @@ instance RephraseOp SOAC where
     VJP args vec <$> rephraseLambda r lam
   rephraseInOp r (JVP args vec lam) =
     JVP args vec <$> rephraseLambda r lam
+  rephraseInOp r (VJPBy args lam lam_adj) =
+    VJPBy args <$> rephraseLambda r lam <*> rephraseLambda r lam_adj
   rephraseInOp r (Stream w arrs acc lam) =
     Stream w arrs acc <$> rephraseLambda r lam
   rephraseInOp r (Hist w arrs ops lam) =
@@ -852,6 +885,9 @@ instance (OpMetrics (Op rep)) => OpMetrics (SOAC rep) where
     inside "VJP" $ lambdaMetrics lam
   opMetrics (JVP _ _ lam) =
     inside "JVP" $ lambdaMetrics lam
+  opMetrics (VJPBy _ lam lam_adj) = do
+    inside "VJPBy" $ lambdaMetrics lam
+    inside "VJPBy" $ lambdaMetrics lam_adj
   opMetrics (Stream _ _ _ lam) =
     inside "Stream" $ lambdaMetrics lam
   opMetrics (Hist _ _ ops bucket_fun) =
@@ -879,6 +915,14 @@ instance (PrettyRep rep) => PP.Pretty (SOAC rep) where
             PP.braces (commasep $ map pretty args)
               <> comma </> PP.braces (commasep $ map pretty vec)
               <> comma </> pretty lam
+        )
+  pretty (VJPBy args lam lam_adj) =
+    "vjp_by"
+      <> parens
+        ( PP.align $
+            PP.braces (commasep $ map pretty args)
+              <> comma </> pretty lam
+              <> comma </> pretty lam_adj
         )
   pretty (Stream size arrs acc lam) =
     ppStream size arrs acc lam

--- a/src/Futhark/IR/SOACS/SOAC.hs
+++ b/src/Futhark/IR/SOACS/SOAC.hs
@@ -513,8 +513,8 @@ soacType (JVP _ _ lam) =
   lambdaReturnType lam ++ lambdaReturnType lam
 soacType (VJP _ _ lam) =
   lambdaReturnType lam ++ map paramType (lambdaParams lam)
-soacType (VJPBy _ _ lam_adj) =
-  lambdaReturnType lam_adj
+soacType (VJPBy _ lam _) =
+  lambdaReturnType lam
 soacType (Stream outersize _ accs lam) =
   map (substNamesInType substs) rtp
   where
@@ -731,7 +731,8 @@ typeCheckSOAC (JVP args vec lam) = do
 typeCheckSOAC (VJPBy args lam lam_adj) = do
   args' <- mapM TC.checkArg args
   TC.checkLambda lam $ map TC.noArgAliases args'
-  TC.checkLambda lam_adj $ map (,mempty) $ lambdaReturnType lam
+  TC.checkLambda lam_adj $
+    map (,mempty) (lambdaReturnType lam <> lambdaReturnType lam)
   unless (lambdaReturnType lam_adj == map TC.argType args') $
     TC.bad . TC.TypeError . docText $
       "Adjoint lambda return type"

--- a/src/Futhark/IR/SOACS/Simplify.hs
+++ b/src/Futhark/IR/SOACS/Simplify.hs
@@ -101,11 +101,11 @@ simplifySOAC (JVP arr vec lam) = do
   arr' <- mapM Engine.simplify arr
   vec' <- mapM Engine.simplify vec
   pure (JVP arr' vec' lam', hoisted)
-simplifySOAC (VJPBy args lam lam_adj) = do
+simplifySOAC (WithVJP args lam lam_adj) = do
   args' <- mapM Engine.simplify args
   (lam', hoisted) <- Engine.simplifyLambda mempty lam
   (lam_adj', hoisted_adj) <- Engine.simplifyLambda mempty lam_adj
-  pure (VJPBy args' lam' lam_adj', hoisted <> hoisted_adj)
+  pure (WithVJP args' lam' lam_adj', hoisted <> hoisted_adj)
 simplifySOAC (Stream outerdim arr nes lam) = do
   outerdim' <- Engine.simplify outerdim
   nes' <- mapM Engine.simplify nes

--- a/src/Futhark/IR/SOACS/Simplify.hs
+++ b/src/Futhark/IR/SOACS/Simplify.hs
@@ -101,6 +101,11 @@ simplifySOAC (JVP arr vec lam) = do
   arr' <- mapM Engine.simplify arr
   vec' <- mapM Engine.simplify vec
   pure (JVP arr' vec' lam', hoisted)
+simplifySOAC (VJPBy args lam lam_adj) = do
+  args' <- mapM Engine.simplify args
+  (lam', hoisted) <- Engine.simplifyLambda mempty lam
+  (lam_adj', hoisted_adj) <- Engine.simplifyLambda mempty lam_adj
+  pure (VJPBy args' lam' lam_adj', hoisted <> hoisted_adj)
 simplifySOAC (Stream outerdim arr nes lam) = do
   outerdim' <- Engine.simplify outerdim
   nes' <- mapM Engine.simplify nes

--- a/src/Futhark/Internalise/Exps.hs
+++ b/src/Futhark/Internalise/Exps.hs
@@ -1858,13 +1858,13 @@ isIntrinsicFunction qname args = do
             case fname of
               "jvp2" -> JVP x' v' lam
               _ -> VJP x' v' lam
-    handleAD [f, f_adj, x] "vjp_by" = Just $ \desc -> do
+    handleAD [f, f_adj, x] "with_vjp" = Just $ \desc -> do
       x' <- internaliseExp "ad_x" x
       lam <- internaliseLambdaCoerce f =<< mapM subExpType x'
       lam_adj <-
         internaliseLambdaCoerce f_adj $
           lambdaReturnType lam ++ lambdaReturnType lam
-      fmap (map I.Var) . letTupExp desc . Op $ VJPBy x' lam lam_adj
+      fmap (map I.Var) . letTupExp desc . Op $ WithVJP x' lam lam_adj
     handleAD _ _ = Nothing
 
     handleRest [a, si, v] "scatter" = Just $ scatterF 1 a si v

--- a/src/Futhark/Internalise/Exps.hs
+++ b/src/Futhark/Internalise/Exps.hs
@@ -1861,11 +1861,10 @@ isIntrinsicFunction qname args = do
     handleAD [f, f_adj, x] "vjp_by" = Just $ \desc -> do
       x' <- internaliseExp "ad_x" x
       lam <- internaliseLambdaCoerce f =<< mapM subExpType x'
-      lam_adj <- internaliseLambdaCoerce f_adj $ lambdaReturnType lam
-      real <- fmap (map I.Var) . letTupExp desc . Op $ VJPBy x' lam lam_adj
-      let cache_ts = drop (length real) $ lambdaReturnType lam
-      dummy <- mapM (letSubExp "dummy" <=< eBlank) cache_ts
-      pure $ real <> dummy
+      lam_adj <-
+        internaliseLambdaCoerce f_adj $
+          lambdaReturnType lam ++ lambdaReturnType lam
+      fmap (map I.Var) . letTupExp desc . Op $ VJPBy x' lam lam_adj
     handleAD _ _ = Nothing
 
     handleRest [a, si, v] "scatter" = Just $ scatterF 1 a si v

--- a/src/Futhark/Internalise/Exps.hs
+++ b/src/Futhark/Internalise/Exps.hs
@@ -1858,6 +1858,14 @@ isIntrinsicFunction qname args = do
             case fname of
               "jvp2" -> JVP x' v' lam
               _ -> VJP x' v' lam
+    handleAD [f, f_adj, x] "vjp_by" = Just $ \desc -> do
+      x' <- internaliseExp "ad_x" x
+      lam <- internaliseLambdaCoerce f =<< mapM subExpType x'
+      lam_adj <- internaliseLambdaCoerce f_adj $ lambdaReturnType lam
+      real <- fmap (map I.Var) . letTupExp desc . Op $ VJPBy x' lam lam_adj
+      let cache_ts = drop (length real) $ lambdaReturnType lam
+      dummy <- mapM (letSubExp "dummy" <=< eBlank) cache_ts
+      pure $ real <> dummy
     handleAD _ _ = Nothing
 
     handleRest [a, si, v] "scatter" = Just $ scatterF 1 a si v

--- a/src/Futhark/Optimise/Fusion/GraphRep.hs
+++ b/src/Futhark/Optimise/Fusion/GraphRep.hs
@@ -394,7 +394,7 @@ expInputs (Op soac) = case soac of
   Futhark.Stream w is nes lam -> inputs is <> freeClassifications (w, nes, lam)
   Futhark.JVP {} -> freeClassifications soac
   Futhark.VJP {} -> freeClassifications soac
-  Futhark.VJPBy {} -> freeClassifications soac
+  Futhark.WithVJP {} -> freeClassifications soac
   where
     inputs = S.fromList . (`zip` repeat SOACInput)
 expInputs e

--- a/src/Futhark/Optimise/Fusion/GraphRep.hs
+++ b/src/Futhark/Optimise/Fusion/GraphRep.hs
@@ -394,6 +394,7 @@ expInputs (Op soac) = case soac of
   Futhark.Stream w is nes lam -> inputs is <> freeClassifications (w, nes, lam)
   Futhark.JVP {} -> freeClassifications soac
   Futhark.VJP {} -> freeClassifications soac
+  Futhark.VJPBy {} -> freeClassifications soac
   where
     inputs = S.fromList . (`zip` repeat SOACInput)
 expInputs e

--- a/src/Futhark/Pass/AD.hs
+++ b/src/Futhark/Pass/AD.hs
@@ -35,48 +35,53 @@ bindLambda pat aux (Lambda params _ body) args = do
   forM_ (zip (patNames pat) res) $ \(v, SubExpRes cs se) ->
     certifying cs $ letBindNames [v] $ BasicOp $ SubExp se
 
-onStm :: Mode -> Scope SOACS -> Stm SOACS -> PassM (Stms SOACS)
-onStm mode scope (Let pat aux (Op (VJP args vec lam))) = do
-  lam' <- onLambda mode scope lam
+onStm :: Bool -> Mode -> Scope SOACS -> Stm SOACS -> PassM (Stms SOACS)
+onStm _ mode scope (Let pat aux (Op (VJP args vec lam))) = do
+  lam' <- onLambda True mode scope lam
   if mode == All || lam == lam'
     then do
       lam'' <- (`runReaderT` scope) . simplifyLambda =<< revVJP scope lam'
       runBuilderT_ (bindLambda pat aux lam'' $ args ++ vec) scope
     else pure $ oneStm $ Let pat aux $ Op $ VJP args vec lam'
-onStm mode scope (Let pat aux (Op (JVP args vec lam))) = do
-  lam' <- onLambda mode scope lam
+onStm _ mode scope (Let pat aux (Op (JVP args vec lam))) = do
+  lam' <- onLambda True mode scope lam
   if mode == All || lam == lam'
     then do
       lam'' <- fwdJVP scope lam'
       runBuilderT_ (bindLambda pat aux lam'' $ args ++ vec) scope
     else pure $ oneStm $ Let pat aux $ Op $ JVP args vec lam'
-onStm mode scope (Let pat aux e) = oneStm . Let pat aux <$> mapExpM mapper e
+--
+-- This corresponds to a VJPBy that is not inside of a differential operator.
+-- FIXME: this assumption will go bad when we don't inline so much.
+onStm False _ scope (Let pat aux (Op (VJPBy args lam _))) =
+  runBuilderT_ (bindLambda pat aux lam args) scope
+onStm ad mode scope (Let pat aux e) = oneStm . Let pat aux <$> mapExpM mapper e
   where
     mapper =
       (identityMapper @SOACS)
-        { mapOnBody = \bscope -> onBody mode (bscope <> scope),
+        { mapOnBody = \bscope -> onBody ad mode (bscope <> scope),
           mapOnOp = mapSOACM soac_mapper
         }
-    soac_mapper = identitySOACMapper {mapOnSOACLambda = onLambda mode scope}
+    soac_mapper = identitySOACMapper {mapOnSOACLambda = onLambda ad mode scope}
 
-onStms :: Mode -> Scope SOACS -> Stms SOACS -> PassM (Stms SOACS)
-onStms mode scope stms = mconcat <$> mapM (onStm mode scope') (stmsToList stms)
+onStms :: Bool -> Mode -> Scope SOACS -> Stms SOACS -> PassM (Stms SOACS)
+onStms ad mode scope stms = mconcat <$> mapM (onStm ad mode scope') (stmsToList stms)
   where
     scope' = scopeOf stms <> scope
 
-onBody :: Mode -> Scope SOACS -> Body SOACS -> PassM (Body SOACS)
-onBody mode scope body = do
-  stms <- onStms mode scope $ bodyStms body
+onBody :: Bool -> Mode -> Scope SOACS -> Body SOACS -> PassM (Body SOACS)
+onBody ad mode scope body = do
+  stms <- onStms ad mode scope $ bodyStms body
   pure $ body {bodyStms = stms}
 
-onLambda :: Mode -> Scope SOACS -> Lambda SOACS -> PassM (Lambda SOACS)
-onLambda mode scope lam = do
-  body <- onBody mode (scopeOfLParams (lambdaParams lam) <> scope) $ lambdaBody lam
+onLambda :: Bool -> Mode -> Scope SOACS -> Lambda SOACS -> PassM (Lambda SOACS)
+onLambda ad mode scope lam = do
+  body <- onBody ad mode (scopeOfLParams (lambdaParams lam) <> scope) $ lambdaBody lam
   pure $ lam {lambdaBody = body}
 
 onFun :: Mode -> Stms SOACS -> FunDef SOACS -> PassM (FunDef SOACS)
 onFun mode consts fd = do
-  body <- onBody mode (scopeOf consts <> scopeOf fd) $ funDefBody fd
+  body <- onBody False mode (scopeOf consts <> scopeOf fd) $ funDefBody fd
   pure $ fd {funDefBody = body}
 
 applyAD :: Pass SOACS SOACS
@@ -86,7 +91,7 @@ applyAD =
       passDescription = "Apply AD operators",
       passFunction =
         intraproceduralTransformationWithConsts
-          (onStms All mempty)
+          (onStms False All mempty)
           (onFun All)
     }
 
@@ -97,6 +102,6 @@ applyADInnermost =
       passDescription = "Apply innermost AD operators",
       passFunction =
         intraproceduralTransformationWithConsts
-          (onStms Innermost mempty)
+          (onStms False Innermost mempty)
           (onFun Innermost)
     }

--- a/src/Futhark/Pass/AD.hs
+++ b/src/Futhark/Pass/AD.hs
@@ -51,9 +51,9 @@ onStm _ mode scope (Let pat aux (Op (JVP args vec lam))) = do
       runBuilderT_ (bindLambda pat aux lam'' $ args ++ vec) scope
     else pure $ oneStm $ Let pat aux $ Op $ JVP args vec lam'
 --
--- This corresponds to a VJPBy that is not inside of a differential operator.
+-- This corresponds to a WithVJP that is not inside of a differential operator.
 -- FIXME: this assumption will go bad when we don't inline so much.
-onStm False _ scope (Let pat aux (Op (VJPBy args lam _))) =
+onStm False _ scope (Let pat aux (Op (WithVJP args lam _))) =
   runBuilderT_ (bindLambda pat aux lam args) scope
 onStm ad mode scope (Let pat aux e) = oneStm . Let pat aux <$> mapExpM mapper e
   where

--- a/src/Futhark/Pass/ExtractMulticore.hs
+++ b/src/Futhark/Pass/ExtractMulticore.hs
@@ -213,6 +213,8 @@ transformSOAC _ _ JVP {} =
   error "transformSOAC: unhandled JVP"
 transformSOAC _ _ VJP {} =
   error "transformSOAC: unhandled VJP"
+transformSOAC _ _ VJPBy {} =
+  error "transformSOAC: unhandled VJPBy"
 transformSOAC pat _ (Screma w arrs form)
   | Just lam <- isMapSOAC form = do
       seq_op <- transformMap DoNotRename sequentialiseBody w lam arrs

--- a/src/Futhark/Pass/ExtractMulticore.hs
+++ b/src/Futhark/Pass/ExtractMulticore.hs
@@ -213,8 +213,8 @@ transformSOAC _ _ JVP {} =
   error "transformSOAC: unhandled JVP"
 transformSOAC _ _ VJP {} =
   error "transformSOAC: unhandled VJP"
-transformSOAC _ _ VJPBy {} =
-  error "transformSOAC: unhandled VJPBy"
+transformSOAC _ _ WithVJP {} =
+  error "transformSOAC: unhandled WithVJP"
 transformSOAC pat _ (Screma w arrs form)
   | Just lam <- isMapSOAC form = do
       seq_op <- transformMap DoNotRename sequentialiseBody w lam arrs

--- a/src/Futhark/Transform/FirstOrderTransform.hs
+++ b/src/Futhark/Transform/FirstOrderTransform.hs
@@ -235,6 +235,8 @@ transformSOAC _ JVP {} =
   error "transformSOAC: unhandled JVP"
 transformSOAC _ VJP {} =
   error "transformSOAC: unhandled VJP"
+transformSOAC _ VJPBy {} =
+  error "transformSOAC: unhandled VJPBy"
 transformSOAC pat (Screma w arrs form) =
   transformScrema pat w arrs form
 transformSOAC pat (Stream w arrs nes lam) = do

--- a/src/Futhark/Transform/FirstOrderTransform.hs
+++ b/src/Futhark/Transform/FirstOrderTransform.hs
@@ -235,8 +235,8 @@ transformSOAC _ JVP {} =
   error "transformSOAC: unhandled JVP"
 transformSOAC _ VJP {} =
   error "transformSOAC: unhandled VJP"
-transformSOAC _ VJPBy {} =
-  error "transformSOAC: unhandled VJPBy"
+transformSOAC _ WithVJP {} =
+  error "transformSOAC: unhandled WithVJP"
 transformSOAC pat (Screma w arrs form) =
   transformScrema pat w arrs form
 transformSOAC pat (Stream w arrs nes lam) = do

--- a/src/Language/Futhark/Interpreter.hs
+++ b/src/Language/Futhark/Interpreter.hs
@@ -2156,7 +2156,7 @@ initialCtx =
     def "manifest" = Just $ fun1 pure
     def "jvp2" = Just $ fun3 doJVP2
     def "vjp2" = Just $ fun3 doVJP2
-    def "vjp_by" = Just $ fun3 $ \f _ arg ->
+    def "with_vjp" = Just $ fun3 $ \f _ arg ->
       -- XXX? We simply ignore the custom derivative. This is correct, but makes
       -- it more of a hassle to test them.
       apply noLoc mempty f arg

--- a/src/Language/Futhark/Interpreter.hs
+++ b/src/Language/Futhark/Interpreter.hs
@@ -2156,6 +2156,10 @@ initialCtx =
     def "manifest" = Just $ fun1 pure
     def "jvp2" = Just $ fun3 doJVP2
     def "vjp2" = Just $ fun3 doVJP2
+    def "vjp_by" = Just $ fun3 $ \f _ arg ->
+      -- XXX? We simply ignore the custom derivative. This is correct, but makes
+      -- it more of a hassle to test them.
+      apply noLoc mempty f arg
     def "acc" = Nothing
     def s | nameFromText s `M.member` namesToPrimTypes = Nothing
     def s = error $ "Missing intrinsic: " ++ T.unpack s

--- a/src/Language/Futhark/Prop.hs
+++ b/src/Language/Futhark/Prop.hs
@@ -967,6 +967,32 @@ intrinsics =
                   $ RetType []
                   $ Scalar
                   $ tupleRecord [Scalar $ t_b Nonunique, Scalar $ t_a Nonunique]
+              ),
+              ( "vjp_by",
+                IntrinsicPolyFun
+                  [tp_a, tp_b, tp_c]
+                  [ Scalar (t_a NoUniqueness)
+                      `arr` Scalar
+                        ( tupleRecord
+                            [ Scalar (t_b Nonunique),
+                              Scalar (t_c Nonunique)
+                            ]
+                        ),
+                    Scalar
+                      ( tupleRecord
+                          [ Scalar (t_b NoUniqueness),
+                            Scalar (t_c NoUniqueness)
+                          ]
+                      )
+                      `arr` Scalar (t_a Nonunique),
+                    Scalar (t_a Observe)
+                  ]
+                  $ RetType []
+                  $ Scalar
+                  $ tupleRecord
+                    [ Scalar (t_b Nonunique),
+                      Scalar (t_c Nonunique)
+                    ]
               )
             ]
               ++
@@ -1109,7 +1135,7 @@ intrinsics =
 
     intrinsicStart = 1 + baseTag (fst $ last primOp)
 
-    [a, b, n, m, k, l, p, q] = zipWith VName (map nameFromText ["a", "b", "n", "m", "k", "l", "p", "q"]) [0 ..]
+    [a, b, c, n, m, k, l, p, q] = zipWith VName (map nameFromText ["a", "b", "c", "n", "m", "k", "l", "p", "q"]) [0 ..]
 
     t_a u = TypeVar u (qualName a) []
     array_a u s = Array u s $ t_a mempty
@@ -1118,6 +1144,9 @@ intrinsics =
     t_b u = TypeVar u (qualName b) []
     array_b u s = Array u s $ t_b mempty
     tp_b = TypeParamType Unlifted b mempty
+
+    t_c u = TypeVar u (qualName c) []
+    tp_c = TypeParamType Unlifted c mempty
 
     [sp_n, sp_m, sp_k, sp_l, sp_p, sp_q] = map (`TypeParamDim` mempty) [n, m, k, l, p, q]
 

--- a/src/Language/Futhark/Prop.hs
+++ b/src/Language/Futhark/Prop.hs
@@ -970,29 +970,16 @@ intrinsics =
               ),
               ( "vjp_by",
                 IntrinsicPolyFun
-                  [tp_a, tp_b, tp_c]
-                  [ Scalar (t_a NoUniqueness)
-                      `arr` Scalar
-                        ( tupleRecord
-                            [ Scalar (t_b Nonunique),
-                              Scalar (t_c Nonunique)
-                            ]
-                        ),
-                    Scalar
-                      ( tupleRecord
-                          [ Scalar (t_b NoUniqueness),
-                            Scalar (t_c NoUniqueness)
-                          ]
-                      )
-                      `arr` Scalar (t_a Nonunique),
+                  [tp_a, tp_b]
+                  [ Scalar (t_a NoUniqueness) `arr` Scalar (t_b Nonunique),
+                    Scalar (t_b NoUniqueness)
+                      `arr` ( Scalar (t_b NoUniqueness)
+                                `arr` Scalar (t_a Nonunique)
+                            ),
                     Scalar (t_a Observe)
                   ]
                   $ RetType []
-                  $ Scalar
-                  $ tupleRecord
-                    [ Scalar (t_b Nonunique),
-                      Scalar (t_c Nonunique)
-                    ]
+                  $ Scalar (t_b Nonunique)
               )
             ]
               ++
@@ -1135,7 +1122,7 @@ intrinsics =
 
     intrinsicStart = 1 + baseTag (fst $ last primOp)
 
-    [a, b, c, n, m, k, l, p, q] = zipWith VName (map nameFromText ["a", "b", "c", "n", "m", "k", "l", "p", "q"]) [0 ..]
+    [a, b, n, m, k, l, p, q] = zipWith VName (map nameFromText ["a", "b", "n", "m", "k", "l", "p", "q"]) [0 ..]
 
     t_a u = TypeVar u (qualName a) []
     array_a u s = Array u s $ t_a mempty
@@ -1144,9 +1131,6 @@ intrinsics =
     t_b u = TypeVar u (qualName b) []
     array_b u s = Array u s $ t_b mempty
     tp_b = TypeParamType Unlifted b mempty
-
-    t_c u = TypeVar u (qualName c) []
-    tp_c = TypeParamType Unlifted c mempty
 
     [sp_n, sp_m, sp_k, sp_l, sp_p, sp_q] = map (`TypeParamDim` mempty) [n, m, k, l, p, q]
 

--- a/src/Language/Futhark/Prop.hs
+++ b/src/Language/Futhark/Prop.hs
@@ -968,7 +968,7 @@ intrinsics =
                   $ Scalar
                   $ tupleRecord [Scalar $ t_b Nonunique, Scalar $ t_a Nonunique]
               ),
-              ( "vjp_by",
+              ( "with_vjp",
                 IntrinsicPolyFun
                   [tp_a, tp_b]
                   [ Scalar (t_a NoUniqueness) `arr` Scalar (t_b Nonunique),

--- a/tests/ad/custom/README.md
+++ b/tests/ad/custom/README.md
@@ -1,0 +1,1 @@
+# Tests for custom derivatives

--- a/tests/ad/custom/radixsort.fut
+++ b/tests/ad/custom/radixsort.fut
@@ -1,0 +1,30 @@
+-- Custom derivative for radix sort.
+-- ==
+-- entry: main_standard main_custom
+-- input { [4f32,3f32,2f32,1f32] [0.1f32,0.2f32,0.3f32,0.4f32] }
+-- output { [0.4f32, 0.3f32, 0.2f32, 0.1f32 ] }
+
+def radix_sort_step [n] 't (f: t -> u32) (xs: [n]t) (b: i32) : [n]t =
+  let bits = map (\x -> (i32.u32 (f x >> u32.i32 b)) & 1) xs
+  let bits_neg = map (1 -) bits
+  let offs = reduce (+) 0 bits_neg
+  let idxs0 = map2 (*) bits_neg (scan (+) 0 bits_neg)
+  let idxs1 = map2 (*) bits (map (+ offs) (scan (+) 0 bits))
+  let idxs2 = map2 (+) idxs0 idxs1
+  let idxs = map (\x -> x - 1) idxs2
+  let xs' = scatter (copy xs) (map i64.i32 idxs) xs
+  in xs'
+
+def radix_sort [n] 't (f: t -> u32) (xs: [n]t) : [n]t =
+  loop xs for i < 32 do radix_sort_step f xs i
+
+def differentiable_radix_sort [n] 't (f: t -> u32) (xs: [n]t) =
+  vjp_by (\xs ->
+            let (xs', perm) = unzip (radix_sort (f <-< (.0)) (zip xs (iota n)))
+            in (xs', perm))
+         (\(xs_adj, perm) ->
+            scatter (copy xs_adj) perm xs_adj)
+         xs
+
+entry main_standard = vjp (radix_sort f32.to_bits)
+entry main_custom = vjp (differentiable_radix_sort f32.to_bits)

--- a/tests/ad/custom/radixsort.fut
+++ b/tests/ad/custom/radixsort.fut
@@ -19,12 +19,11 @@ def radix_sort [n] 't (f: t -> u32) (xs: [n]t) : [n]t =
   loop xs for i < 32 do radix_sort_step f xs i
 
 def differentiable_radix_sort [n] 't (f: t -> u32) (xs: [n]t) =
-  vjp_by (\xs ->
-            let (xs', perm) = unzip (radix_sort (f <-< (.0)) (zip xs (iota n)))
-            in (xs', perm))
-         (\(xs_adj, perm) ->
-            scatter (copy xs_adj) perm xs_adj)
-         xs
+  (vjp_by (\xs ->
+             unzip (radix_sort (f <-< (.0)) (zip xs (iota n))))
+          (\(_, perm) (xs_adj, _) ->
+             scatter (copy xs_adj) perm xs_adj)
+          xs).0
 
 entry main_standard = vjp (radix_sort f32.to_bits)
 entry main_custom = vjp (differentiable_radix_sort f32.to_bits)

--- a/tests/ad/custom/radixsort.fut
+++ b/tests/ad/custom/radixsort.fut
@@ -19,7 +19,7 @@ def radix_sort [n] 't (f: t -> u32) (xs: [n]t) : [n]t =
   loop xs for i < 32 do radix_sort_step f xs i
 
 def differentiable_radix_sort [n] 't (f: t -> u32) (xs: [n]t) =
-  (vjp_by (\xs ->
+  (with_vjp (\xs ->
              unzip (radix_sort (f <-< (.0)) (zip xs (iota n))))
           (\(_, perm) (xs_adj, _) ->
              scatter (copy xs_adj) perm xs_adj)

--- a/tests/ad/custom/toplevel.fut
+++ b/tests/ad/custom/toplevel.fut
@@ -6,11 +6,11 @@
 
 -- ==
 -- entry: do_vjp
--- compiled input { 2.5 } output { 2.58113883008419 }
+-- compiled input { 2.5 } output { 3.23606797749979 }
 
 def primal (x: f64) =
-  vjp_by (\x -> (x * 2, x))
-         (\(x_adj, c) -> x_adj + f64.sqrt c)
+  vjp_by (\x -> x * 2)
+         (\c x_adj -> x_adj + f64.sqrt c)
          x
 
 entry do_vjp x = vjp primal x 1

--- a/tests/ad/custom/toplevel.fut
+++ b/tests/ad/custom/toplevel.fut
@@ -9,7 +9,7 @@
 -- compiled input { 2.5 } output { 3.23606797749979 }
 
 def primal (x: f64) =
-  vjp_by (\x -> x * 2)
+  with_vjp (\x -> x * 2)
          (\c x_adj -> x_adj + f64.sqrt c)
          x
 

--- a/tests/ad/custom/toplevel.fut
+++ b/tests/ad/custom/toplevel.fut
@@ -1,0 +1,17 @@
+-- | If a custom derivative occurs at top level, just get rid of it.
+
+-- ==
+-- entry: do_primal
+-- input { 2.5 } output { 5.0 }
+
+-- ==
+-- entry: do_vjp
+-- compiled input { 2.5 } output { 2.58113883008419 }
+
+def primal (x: f64) =
+  vjp_by (\x -> (x * 2, x))
+         (\(x_adj, c) -> x_adj + f64.sqrt c)
+         x
+
+entry do_vjp x = vjp primal x 1
+entry do_primal x = primal x


### PR DESCRIPTION
This morning I realised that it would actually be quite easy to support custom derivatives for reverse mode (and possibly for forward mode, although it's less important). The idea is basically to provide a way for users to specify a different "VJP" operation for some fragment of code, which the AD transform will then just insert.

The user interface is this new intrinsic function:

```Futhark
-- | Provide custom reverse-mode adjoint code for a given function. This is
-- useful when the adjoint synthesised by AD is as good as one that is known
-- analytically.
--
-- The function `f` returns a result of type `b`. In the return sweep, the
-- function `f'` is invoked first with the result of `f` and second with the
-- cotangents of the result (be careful not to mix up the order), and must
-- return the sensitivity with respect to the input.
--
-- A common pattern is that `b` is a tuple where some part is the intended
-- primal result of `vjp_by`, and some part is only used in `f'`.
--
-- **Beware:** if `f` uses any free variables, these will not be taken into
-- **account when computing the adjoint. Make these part of the argument
-- **instead.
def vjp_by 'a 'b 'c (f: a -> b) (f': (res: b) -> (b_adj: b) -> a) (x: a) : b =
  intrinsics.vjp_by f f' x
```

I have written all of one test, but it seems to work quite well. I have not pondered whether this interacts with nested AD in any interesting way. The interpreter just ignores any use of `vjp_by`.