### PR TITLE
Fix: support for long files was broken on windows

### DIFF
--- a/rts/c/cache.h
+++ b/rts/c/cache.h
@@ -67,8 +67,8 @@ static int cache_restore(const char *fname, const struct cache_hash *hash,
   if (fseek(f, 0, SEEK_END) != 0) {
     goto error;
   }
-  int64_t f_size = (int64_t)ftell(f);
-  if (fseek(f, CACHE_HEADER_SIZE, SEEK_SET) != 0) {
+  int64_t f_size = (int64_t)ftello(f);
+  if (fseeko(f, CACHE_HEADER_SIZE, SEEK_SET) != 0) {
     goto error;
   }
 

--- a/rts/c/server.h
+++ b/rts/c/server.h
@@ -1624,7 +1624,7 @@ int restore_opaque(const struct opaque_aux *aux, FILE *f,
   // (which doesn't care if there's extra at the end), then we compute
   // how much space the the object actually takes in serialised form
   // and rewind the file to that position.  The only downside is more IO.
-  size_t start = ftell(f);
+  size_t start = (size_t)ftello(f);
   size_t size;
   char *bytes = fslurp_file(f, &size);
   void *obj = aux->restore(ctx, bytes);
@@ -1633,10 +1633,10 @@ int restore_opaque(const struct opaque_aux *aux, FILE *f,
     *(void**)p = obj;
     size_t obj_size;
     (void)aux->store(ctx, obj, NULL, &obj_size);
-    fseek(f, start+obj_size, SEEK_SET);
+    fseeko(f, start+obj_size, SEEK_SET);
     return 0;
   } else {
-    fseek(f, start, SEEK_SET);
+    fseeko(f, start, SEEK_SET);
     return 1;
   }
 }

--- a/rts/c/util.h
+++ b/rts/c/util.h
@@ -60,10 +60,10 @@ static inline void check_err(int errval, int sets_errno, const char *fun, int li
 // Read the rest of an open file into a NUL-terminated string; returns
 // NULL on error.
 static void* fslurp_file(FILE *f, size_t *size) {
-  long start = ftell(f);
-  fseek(f, 0, SEEK_END);
-  long src_size = ftell(f)-start;
-  fseek(f, start, SEEK_SET);
+  off_t start = ftello(f);
+  fseeko(f, 0, SEEK_END);
+  off_t src_size = ftello(f)-start;
+  fseeko(f, start, SEEK_SET);
   unsigned char *s = (unsigned char*) malloc((size_t)src_size + 1);
   if (fread(s, 1, (size_t)src_size, f) != (size_t)src_size) {
     free(s);

--- a/src/Futhark/Actions.hs
+++ b/src/Futhark/Actions.hs
@@ -316,10 +316,10 @@ compileCAction fcfg mode outpath =
           liftIO $ T.writeFile jsonpath manifest
         ToExecutable -> do
           liftIO $ T.writeFile cpath $ SequentialC.asExecutable cprog
-          runCC cpath outpath ["-O3", "-std=c99"] ["-lm"]
+          runCC cpath outpath ["-O3", "-std=c99", "-D_FILE_OFFSET_BITS=64"] ["-lm"]
         ToServer -> do
           liftIO $ T.writeFile cpath $ SequentialC.asServer cprog
-          runCC cpath outpath ["-O3", "-std=c99"] ["-lm"]
+          runCC cpath outpath ["-O3", "-std=c99", "-D_FILE_OFFSET_BITS=64"] ["-lm"]
 
 -- | The @futhark opencl@ action.
 compileOpenCLAction :: FutharkConfig -> CompilerMode -> FilePath -> Action GPUMem
@@ -351,10 +351,10 @@ compileOpenCLAction fcfg mode outpath =
           liftIO $ T.writeFile jsonpath manifest
         ToExecutable -> do
           liftIO $ T.writeFile cpath $ cPrependHeader $ COpenCL.asExecutable cprog
-          runCC cpath outpath ["-O", "-std=c99"] ("-lm" : extra_options)
+          runCC cpath outpath ["-O", "-std=c99", "-D_FILE_OFFSET_BITS=64"] ("-lm" : extra_options)
         ToServer -> do
           liftIO $ T.writeFile cpath $ cPrependHeader $ COpenCL.asServer cprog
-          runCC cpath outpath ["-O", "-std=c99"] ("-lm" : extra_options)
+          runCC cpath outpath ["-O", "-std=c99", "-D_FILE_OFFSET_BITS=64"] ("-lm" : extra_options)
 
 -- | The @futhark cuda@ action.
 compileCUDAAction :: FutharkConfig -> CompilerMode -> FilePath -> Action GPUMem
@@ -383,10 +383,10 @@ compileCUDAAction fcfg mode outpath =
           liftIO $ T.writeFile jsonpath manifest
         ToExecutable -> do
           liftIO $ T.writeFile cpath $ cPrependHeader $ CCUDA.asExecutable cprog
-          runCC cpath outpath ["-O", "-std=c99"] ("-lm" : extra_options)
+          runCC cpath outpath ["-O", "-std=c99", "-D_FILE_OFFSET_BITS=64"] ("-lm" : extra_options)
         ToServer -> do
           liftIO $ T.writeFile cpath $ cPrependHeader $ CCUDA.asServer cprog
-          runCC cpath outpath ["-O", "-std=c99"] ("-lm" : extra_options)
+          runCC cpath outpath ["-O", "-std=c99", "-D_FILE_OFFSET_BITS=64"] ("-lm" : extra_options)
 
 -- | The @futhark hip@ action.
 compileHIPAction :: FutharkConfig -> CompilerMode -> FilePath -> Action GPUMem
@@ -414,10 +414,10 @@ compileHIPAction fcfg mode outpath =
           liftIO $ T.writeFile jsonpath manifest
         ToExecutable -> do
           liftIO $ T.writeFile cpath $ cPrependHeader $ HIP.asExecutable cprog
-          runCC cpath outpath ["-O", "-std=c99"] ("-lm" : extra_options)
+          runCC cpath outpath ["-O", "-std=c99", "-D_FILE_OFFSET_BITS=64"] ("-lm" : extra_options)
         ToServer -> do
           liftIO $ T.writeFile cpath $ cPrependHeader $ HIP.asServer cprog
-          runCC cpath outpath ["-O", "-std=c99"] ("-lm" : extra_options)
+          runCC cpath outpath ["-O", "-std=c99", "-D_FILE_OFFSET_BITS=64"] ("-lm" : extra_options)
 
 -- | The @futhark multicore@ action.
 compileMulticoreAction :: FutharkConfig -> CompilerMode -> FilePath -> Action MCMem
@@ -442,10 +442,10 @@ compileMulticoreAction fcfg mode outpath =
           liftIO $ T.writeFile jsonpath manifest
         ToExecutable -> do
           liftIO $ T.writeFile cpath $ cPrependHeader $ MulticoreC.asExecutable cprog
-          runCC cpath outpath ["-O3", "-std=c99"] ["-lm", "-pthread"]
+          runCC cpath outpath ["-O3", "-std=c99", "-D_FILE_OFFSET_BITS=64"] ["-lm", "-pthread"]
         ToServer -> do
           liftIO $ T.writeFile cpath $ cPrependHeader $ MulticoreC.asServer cprog
-          runCC cpath outpath ["-O3", "-std=c99"] ["-lm", "-pthread"]
+          runCC cpath outpath ["-O3", "-std=c99", "-D_FILE_OFFSET_BITS=64"] ["-lm", "-pthread"]
 
 -- | The @futhark ispc@ action.
 compileMulticoreToISPCAction :: FutharkConfig -> CompilerMode -> FilePath -> Action MCMem

--- a/src/Futhark/Actions.hs
+++ b/src/Futhark/Actions.hs
@@ -316,10 +316,10 @@ compileCAction fcfg mode outpath =
           liftIO $ T.writeFile jsonpath manifest
         ToExecutable -> do
           liftIO $ T.writeFile cpath $ SequentialC.asExecutable cprog
-          runCC cpath outpath ["-O3", "-std=c99", "-D_FILE_OFFSET_BITS=64"] ["-lm"]
+          runCC cpath outpath ["-O3", "-std=c99"] ["-lm"]
         ToServer -> do
           liftIO $ T.writeFile cpath $ SequentialC.asServer cprog
-          runCC cpath outpath ["-O3", "-std=c99", "-D_FILE_OFFSET_BITS=64"] ["-lm"]
+          runCC cpath outpath ["-O3", "-std=c99"] ["-lm"]
 
 -- | The @futhark opencl@ action.
 compileOpenCLAction :: FutharkConfig -> CompilerMode -> FilePath -> Action GPUMem
@@ -351,10 +351,10 @@ compileOpenCLAction fcfg mode outpath =
           liftIO $ T.writeFile jsonpath manifest
         ToExecutable -> do
           liftIO $ T.writeFile cpath $ cPrependHeader $ COpenCL.asExecutable cprog
-          runCC cpath outpath ["-O", "-std=c99", "-D_FILE_OFFSET_BITS=64"] ("-lm" : extra_options)
+          runCC cpath outpath ["-O", "-std=c99"] ("-lm" : extra_options)
         ToServer -> do
           liftIO $ T.writeFile cpath $ cPrependHeader $ COpenCL.asServer cprog
-          runCC cpath outpath ["-O", "-std=c99", "-D_FILE_OFFSET_BITS=64"] ("-lm" : extra_options)
+          runCC cpath outpath ["-O", "-std=c99"] ("-lm" : extra_options)
 
 -- | The @futhark cuda@ action.
 compileCUDAAction :: FutharkConfig -> CompilerMode -> FilePath -> Action GPUMem
@@ -383,10 +383,10 @@ compileCUDAAction fcfg mode outpath =
           liftIO $ T.writeFile jsonpath manifest
         ToExecutable -> do
           liftIO $ T.writeFile cpath $ cPrependHeader $ CCUDA.asExecutable cprog
-          runCC cpath outpath ["-O", "-std=c99", "-D_FILE_OFFSET_BITS=64"] ("-lm" : extra_options)
+          runCC cpath outpath ["-O", "-std=c99"] ("-lm" : extra_options)
         ToServer -> do
           liftIO $ T.writeFile cpath $ cPrependHeader $ CCUDA.asServer cprog
-          runCC cpath outpath ["-O", "-std=c99", "-D_FILE_OFFSET_BITS=64"] ("-lm" : extra_options)
+          runCC cpath outpath ["-O", "-std=c99"] ("-lm" : extra_options)
 
 -- | The @futhark hip@ action.
 compileHIPAction :: FutharkConfig -> CompilerMode -> FilePath -> Action GPUMem
@@ -414,10 +414,10 @@ compileHIPAction fcfg mode outpath =
           liftIO $ T.writeFile jsonpath manifest
         ToExecutable -> do
           liftIO $ T.writeFile cpath $ cPrependHeader $ HIP.asExecutable cprog
-          runCC cpath outpath ["-O", "-std=c99", "-D_FILE_OFFSET_BITS=64"] ("-lm" : extra_options)
+          runCC cpath outpath ["-O", "-std=c99"] ("-lm" : extra_options)
         ToServer -> do
           liftIO $ T.writeFile cpath $ cPrependHeader $ HIP.asServer cprog
-          runCC cpath outpath ["-O", "-std=c99", "-D_FILE_OFFSET_BITS=64"] ("-lm" : extra_options)
+          runCC cpath outpath ["-O", "-std=c99"] ("-lm" : extra_options)
 
 -- | The @futhark multicore@ action.
 compileMulticoreAction :: FutharkConfig -> CompilerMode -> FilePath -> Action MCMem
@@ -442,10 +442,10 @@ compileMulticoreAction fcfg mode outpath =
           liftIO $ T.writeFile jsonpath manifest
         ToExecutable -> do
           liftIO $ T.writeFile cpath $ cPrependHeader $ MulticoreC.asExecutable cprog
-          runCC cpath outpath ["-O3", "-std=c99", "-D_FILE_OFFSET_BITS=64"] ["-lm", "-pthread"]
+          runCC cpath outpath ["-O3", "-std=c99"] ["-lm", "-pthread"]
         ToServer -> do
           liftIO $ T.writeFile cpath $ cPrependHeader $ MulticoreC.asServer cprog
-          runCC cpath outpath ["-O3", "-std=c99", "-D_FILE_OFFSET_BITS=64"] ["-lm", "-pthread"]
+          runCC cpath outpath ["-O3", "-std=c99"] ["-lm", "-pthread"]
 
 -- | The @futhark ispc@ action.
 compileMulticoreToISPCAction :: FutharkConfig -> CompilerMode -> FilePath -> Action MCMem

--- a/src/Futhark/CodeGen/Backends/GenericC.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC.hs
@@ -314,6 +314,7 @@ gnuSource =
 #ifndef _GNU_SOURCE // Avoid possible double-definition warning.
 #define _GNU_SOURCE
 #endif
+#define _FILE_OFFSET_BITS 64
 |]
 
 -- We may generate variables that are never used (e.g. for


### PR DESCRIPTION
While testing https://futhark-lang.org/blog/2026-05-22-benchmarking-a-real-futhark-application.html on windows it appeared that the benchmark could not reload the data.in file generated by the application.

The issue ended up coming from the fslurp_file function in util.h because of a problem related to files > 2GB.

The main issue is that `ftell` returns a `long` and `long` is 32 bit on windows so this API cannot be used.

This PR changes all usage of `ftell`/`fseek` by the `ftello`/`fseeko` API which was designed to return `off_t` instead of  `long`

It is also necessary to define `_FILE_OFFSET_BITS=64` to make sure that `off_t` uses 64 bits.
The PR defines it as an argument in runCC for all platforms which I think is a good practice to enable large file support.

With this PR, the benchmarking works for me on windows
