### PR TITLE
Sort consecutive imports to be in alphabetical order.

### DIFF
--- a/src/Futhark/Fmt/Monad.hs
+++ b/src/Futhark/Fmt/Monad.hs
@@ -35,6 +35,7 @@ module Futhark.Fmt.Monad
     sepComments,
     sepLineComments,
     sepLine,
+    consecutive,
 
     -- * Formatting styles
     commentStyle,

--- a/src/Futhark/Fmt/Printer.hs
+++ b/src/Futhark/Fmt/Printer.hs
@@ -7,6 +7,7 @@ where
 
 import Data.Bifunctor (second)
 import Data.Foldable
+import Data.List qualified as L
 import Data.Loc (locStart)
 import Data.Text qualified as T
 import Futhark.Fmt.Monad
@@ -636,10 +637,25 @@ instance Format UncheckedDec where
   fmt (ImportDec path _tb loc) =
     addComments loc $ "import" <+> "\"" <> fmtPretty path <> "\""
 
+sortDecs :: [UncheckedDec] -> [UncheckedDec]
+sortDecs decs =
+  concatMap sortGroup $ L.groupBy sameKind decs
+  where
+    isImport (ImportDec {}) = True
+    isImport _ = False
+    sameKind a b = isImport a == isImport b
+    sortGroup grp@(ImportDec {} : _) =
+      let sorted = L.sortOn getPath grp
+          locs = [loc | ImportDec _ _ loc <- grp]
+       in zipWith (\(ImportDec path tb _) loc -> ImportDec path tb loc) sorted locs
+    sortGroup grp = grp
+    getPath (ImportDec path _ _) = prettyText path
+    getPath _ = ""
+
 instance Format UncheckedProg where
   fmt (Prog Nothing []) = popComments
-  fmt (Prog Nothing decs) = sepDecs fmt decs </> popComments
-  fmt (Prog (Just dc) decs) = fmt dc </> sepDecs fmt decs </> popComments
+  fmt (Prog Nothing decs) = sepDecs fmt (sortDecs decs) </> popComments
+  fmt (Prog (Just dc) decs) = fmt dc </> sepDecs fmt (sortDecs decs) </> popComments
 
 -- | Given a filename and a futhark program, formats the program.
 fmtToDoc :: String -> T.Text -> Either SyntaxError (Doc AnsiStyle)

--- a/src/Futhark/Fmt/Printer.hs
+++ b/src/Futhark/Fmt/Printer.hs
@@ -637,13 +637,23 @@ instance Format UncheckedDec where
   fmt (ImportDec path _tb loc) =
     addComments loc $ "import" <+> "\"" <> fmtPretty path <> "\""
 
+groupByConsecutive :: (Located a) => (a -> Bool) -> [a] -> [[a]]
+groupByConsecutive _ [] = []
+groupByConsecutive p (x : xs) = go [x] x xs
+  where
+    go grp _ [] = [grp]
+    go grp prev (y : ys)
+      | p prev == p y && consecutive (locOf prev) (locOf y) =
+          go (grp ++ [y]) y ys
+      | otherwise = grp : go [y] y ys
+
 sortDecs :: [UncheckedDec] -> [UncheckedDec]
-sortDecs decs =
-  concatMap sortGroup $ L.groupBy sameKind decs
+sortDecs =
+  concatMap sortGroup . groupByConsecutive isImport
   where
     isImport (ImportDec {}) = True
     isImport _ = False
-    sameKind a b = isImport a == isImport b
+
     sortGroup grp@(ImportDec {} : _) =
       let sorted = L.sortOn getPath grp
           locs = [loc | ImportDec _ _ loc <- grp]

--- a/tests_fmt/expected/import_order.fut
+++ b/tests_fmt/expected/import_order.fut
@@ -2,6 +2,8 @@ import "a/a"
 import "a/b/c"
 import "b/x"
 
+import "a/a/a"
+
 def identity x = x
 
 import "a/a"

--- a/tests_fmt/expected/import_order.fut
+++ b/tests_fmt/expected/import_order.fut
@@ -1,0 +1,7 @@
+import "a/a"
+import "a/b/c"
+import "b/x"
+
+def identity x = x
+
+import "a/a"

--- a/tests_fmt/import_order.fut
+++ b/tests_fmt/import_order.fut
@@ -1,6 +1,8 @@
 import "b/x"
-import "a/b/c"
 import "a/a"
+import "a/b/c"
+
+import "a/a/a"
 
 def identity x = x
 

--- a/tests_fmt/import_order.fut
+++ b/tests_fmt/import_order.fut
@@ -1,0 +1,7 @@
+import "b/x"
+import "a/b/c"
+import "a/a"
+
+def identity x = x
+
+import "a/a"


### PR DESCRIPTION
This pull request makes it so `futhark-fmt` will sort consecutive imports to be in alphabetical order.