### PR TITLE
FP16 support for HIP backend (no emulation)

### DIFF
--- a/rts/c/scalar_f16.h
+++ b/rts/c/scalar_f16.h
@@ -9,7 +9,10 @@
 // under emulation, so the compiler will have to be careful when
 // generating reads or writes.
 
-#if !defined(cl_khr_fp16) && !(defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 600) && !(defined(ISPC))
+#if !defined(cl_khr_fp16) && \
+     !(defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 600) && \
+     !(defined(__HIP_DEVICE_COMPILE__)) && \
+     !(defined(ISPC))
 #define EMULATE_F16
 #endif
 
@@ -30,6 +33,8 @@ typedef float16 f16;
 
 #ifdef __CUDA_ARCH__
 #include <cuda_fp16.h>
+#elif defined(__HIP_DEVICE_COMPILE__)
+#include <hip/hip_fp16.h>
 #endif
 
 typedef half f16;
@@ -41,8 +46,6 @@ typedef half f16;
 SCALAR_FUN_ATTR f16 fadd16(f16 x, f16 y) { return x + y; }
 SCALAR_FUN_ATTR f16 fsub16(f16 x, f16 y) { return x - y; }
 SCALAR_FUN_ATTR f16 fmul16(f16 x, f16 y) { return x * y; }
-SCALAR_FUN_ATTR bool cmplt16(f16 x, f16 y) { return x < y; }
-SCALAR_FUN_ATTR bool cmple16(f16 x, f16 y) { return x <= y; }
 SCALAR_FUN_ATTR f16 sitofp_i8_f16(int8_t x) { return (f16) x; }
 SCALAR_FUN_ATTR f16 sitofp_i16_f16(int16_t x) { return (f16) x; }
 SCALAR_FUN_ATTR f16 sitofp_i32_f16(int32_t x) { return (f16) x; }
@@ -66,6 +69,20 @@ SCALAR_FUN_ATTR f16 btof_bool_f16(bool x) { return x ? 1 : 0; }
 
 SCALAR_FUN_ATTR bool futrts_isnan16(f16 x) { return isnan((float)x); }
 
+// compare needs a custom implementation for HIP because of
+// https://github.com/ROCm/clr/issues/274
+#if defined(__HIP_DEVICE_COMPILE__)
+
+SCALAR_FUN_ATTR bool cmplt16(f16 x, f16 y) { return __hlt(x, y); }
+SCALAR_FUN_ATTR bool cmple16(f16 x, f16 y) { return __hle(x, y); }
+
+#else
+
+SCALAR_FUN_ATTR bool cmplt16(f16 x, f16 y) { return x < y; }
+SCALAR_FUN_ATTR bool cmple16(f16 x, f16 y) { return x <= y; }
+
+#endif
+
 #ifdef __OPENCL_VERSION__
 
 SCALAR_FUN_ATTR f16 fabs16(f16 x) { return fabs(x); }
@@ -80,7 +97,7 @@ SCALAR_FUN_ATTR f16 fmax16(f16 x, f16 y) { return futrts_isnan16(x) ? y : futrts
 SCALAR_FUN_ATTR f16 fmin16(f16 x, f16 y) { return futrts_isnan16(x) ? y : futrts_isnan16(y) ? x : min(x, y); }
 SCALAR_FUN_ATTR f16 fpow16(f16 x, f16 y) { return pow(x, y); }
 
-#else // Assuming CUDA.
+#else // Assuming CUDA or HIP.
 
 SCALAR_FUN_ATTR f16 fabs16(f16 x) { return fabsf(x); }
 SCALAR_FUN_ATTR f16 fmax16(f16 x, f16 y) { return fmaxf(x, y); }

--- a/rts/c/scalar_f16.h
+++ b/rts/c/scalar_f16.h
@@ -320,6 +320,8 @@ SCALAR_FUN_ATTR f16 bitstofp_i16_f16(int16_t x) {
 
 #else // No native f16 - emulate.
 
+SCALAR_FUN_ATTR bool cmplt16(f16 x, f16 y) { return x < y; }
+SCALAR_FUN_ATTR bool cmple16(f16 x, f16 y) { return x <= y; }
 SCALAR_FUN_ATTR f16 fabs16(f16 x) { return fabs32(x); }
 SCALAR_FUN_ATTR f16 fmax16(f16 x, f16 y) { return fmax32(x, y); }
 SCALAR_FUN_ATTR f16 fmin16(f16 x, f16 y) { return fmin32(x, y); }

--- a/src/Futhark/CodeGen/Backends/GenericC/Code.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC/Code.hs
@@ -76,6 +76,8 @@ compilePrimExp f (CmpOpExp cmp x y) = do
   y' <- compilePrimExp f y
   pure $ case cmp of
     CmpEq {} -> [C.cexp|$exp:x' == $exp:y'|]
+    FCmpLt Float16 -> [C.cexp|cmplt16($exp:x', $exp:y')|]
+    FCmpLe Float16 -> [C.cexp|cmple16($exp:x', $exp:y')|]
     FCmpLt {} -> [C.cexp|$exp:x' < $exp:y'|]
     FCmpLe {} -> [C.cexp|$exp:x' <= $exp:y'|]
     CmpLlt {} -> [C.cexp|$exp:x' < $exp:y'|]


### PR DESCRIPTION
This PR makes sure that FP16 has direct hardware support in HIP backend.

Currently, the FP16 support on HIP is emulated, which creates a performance hit for FP16 applications.
This PR was tested on `fuchat` and it makes the FP16 version faster than the FP32 version, as was expected since FP16 uses less memory bandwidth for the same calculations.

There was one difficulty related to what i think is a bug in rocm FP16 support for which i created an issue on [github.com/ROCm/clr/issues/274.](https://github.com/ROCm/clr/issues/274).

The "<=" operator does not always return False when a NaN is compared. It broke the `tests/primitive/naninf16.fut`.

The proposed solution until the rocm issue is fixed is to prettyPrint `comple16(x,y)` instead of `x <= y` when we are dealing with Float16 scalars.

All the tests with backend=HIP are passing.