### PR TITLE
Fix #2227 properly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Invalid fusion that could cause compiler crash. (#2474)
 
-* GPU code generation of segmented reductions with array operands. (#2227, properly this time.)
+* GPU code generation of segmented reductions with array operands. (#2227,
+  properly this time.)
 
 ## [0.26.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Invalid fusion that could cause compiler crash. (#2474)
 
+* GPU code generation of segmented reductions with array operands. (#2227, properly this time.)
+
 ## [0.26.3]
 
 ### Added

--- a/src/Futhark/CodeGen/ImpGen.hs
+++ b/src/Futhark/CodeGen/ImpGen.hs
@@ -1864,6 +1864,17 @@ sAlloc name size space = do
 sArray :: Name -> PrimType -> ShapeBase SubExp -> VName -> LMAD -> ImpM rep r op VName
 sArray name bt shape mem lmad = do
   name' <- newVName name
+  when (LMAD.rank lmad /= shapeRank shape) $
+    error $
+      unlines
+        [ "sArray: array "
+            <> prettyString name'
+            <> " of rank "
+            <> show (shapeRank shape)
+            <> " with LMAD of rank "
+            <> show (LMAD.rank lmad)
+            <> "."
+        ]
   dArray name' bt shape mem lmad
   pure name'
 

--- a/src/Futhark/CodeGen/ImpGen/GPU/SegRed.hs
+++ b/src/Futhark/CodeGen/ImpGen/GPU/SegRed.hs
@@ -218,7 +218,7 @@ makeIntermArrays tblock_id tblock_size chunk segbinops
     all isPrimSegBinOp segbinops =
       noncommPrimSegRedInterms
   | otherwise =
-      generalSegRedInterms False tblock_id tblock_size segbinops
+      generalSegRedInterms tblock_id tblock_size segbinops
   where
     params = map paramOf segbinops
 
@@ -272,24 +272,18 @@ makeIntermArrays tblock_id tblock_size chunk segbinops
     forAccumLM2D acc ls f = mapAccumLM (mapAccumLM f) acc ls
 
 generalSegRedInterms ::
-  Bool ->
   Imp.TExp Int64 ->
   SubExp ->
   [SegBinOp GPUMem] ->
   InKernelGen [SegRedIntermediateArrays]
-generalSegRedInterms segmented tblock_id tblock_size segbinops =
+generalSegRedInterms tblock_id tblock_size segbinops =
   fmap (map GeneralSegRedInterms) . forM (map paramOf segbinops) . mapM $ \p ->
     case paramDec p of
-      MemArray pt shape _ (ArrayIn mem ixfun) -> do
+      MemArray pt shape _ (ArrayIn mem _) -> do
         let shape' = Shape [tblock_size] <> shape
         let shape_E = map pe64 $ shapeDims shape'
         sArray ("red_arr_" <> nameFromText (prettyText pt)) pt shape' mem $
-          -- This 'segmented' thing here is a hack, related to #2227.
-          -- There absolutely must be some unifying principle we are
-          -- missing.
-          if segmented
-            then ixfun
-            else LMAD.iota (tblock_id * product shape_E) shape_E
+          LMAD.iota (tblock_id * product shape_E) shape_E
       _ -> do
         let pt = elemType $ paramType p
             shape = Shape [tblock_size]
@@ -426,10 +420,10 @@ smallSegmentsReduction (Pat segred_pes) num_tblocks tblock_size _ space segbinop
 
   sKernelThread "segred_small" (segFlat space) (defKernelAttrs num_tblocks tblock_size) $ do
     constants <- kernelConstants <$> askEnv
-    let tblock_id = kernelBlockSize constants
+    let tblock_id = kernelBlockId constants
         ltid = sExt64 $ kernelLocalThreadId constants
 
-    interms <- generalSegRedInterms True tblock_id tblock_size_se segbinops
+    interms <- generalSegRedInterms (sExt64 tblock_id) tblock_size_se segbinops
     let reds_arrs = map blockRedArrs interms
 
     -- We probably do not have enough actual threadblocks to cover the
@@ -449,10 +443,9 @@ smallSegmentsReduction (Pat segred_pes) num_tblocks tblock_size _ space segbinop
 
       let in_bounds =
             map_body_cont $ \red_res ->
-              sComment "save results to be reduced" $ do
-                let red_dests = map (,[ltid]) (concat reds_arrs)
-                forM2_ red_dests red_res $ \(d, d_is) (res, res_is) ->
-                  copyDWIMFix d d_is res res_is
+              sComment "save results to be reduced" $
+                forM2_ (concat reds_arrs) red_res $ \d (res, res_is) ->
+                  copyDWIMFix d [ltid] res res_is
           out_of_bounds =
             forM2_ segbinops reds_arrs $ \(SegBinOp _ _ nes _) red_arrs ->
               forM2_ red_arrs nes $ \arr ne ->

--- a/src/Futhark/IR/Mem/LMAD.hs
+++ b/src/Futhark/IR/Mem/LMAD.hs
@@ -17,6 +17,7 @@ module Futhark.IR.Mem.LMAD
     coerce,
     permute,
     shape,
+    rank,
     substitute,
     iota,
     equivalent,
@@ -276,6 +277,10 @@ substitute tab (LMAD offset dims) =
 -- | Shape of an LMAD.
 shape :: LMAD num -> Shape num
 shape = map ldShape . dims
+
+-- | Rank of an LMAD.
+rank :: LMAD num -> Int
+rank = length . shape
 
 iotaStrided ::
   (IntegralExp num) =>

--- a/tests/soacs/reduce10.fut
+++ b/tests/soacs/reduce10.fut
@@ -1,4 +1,4 @@
--- Based on #2226. A segmented reduction (with a somewhat contrived
+-- Based on #2227. A segmented reduction (with a somewhat contrived
 -- operator), where the operands are arrays.
 --
 -- ==

--- a/tests/soacs/reduce10.fut
+++ b/tests/soacs/reduce10.fut
@@ -3,8 +3,10 @@
 --
 -- ==
 -- input { [[1.0,2.0],[2.0,3.0],[4.0,5.0]] }
+-- structure gpu { /SegRed 1 }
 
 entry main [n] (input: [n][2]f64) : [2][2]f64 =
+  #[incremental_flattening(only_inner)]
   map (\i ->
          let t = map2 (\_ b -> [b[0], 0]) [0, 0] (input[i:i + 2] :> [2][2]f64)
          in reduce (\_ _ -> [0, 0]) [0, 0] t)


### PR DESCRIPTION
Fixes #2227 properly, which turned out to be a typo that I papered over
with dubious logic.

Also adds some conservative checking to ImpGen so this will never happen
again.