### PR TITLE
Make units and arrays of units decomposable in C FFI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   uses the hardware support for `f16`, similarly to the CUDA backend.
   Implemented by Jérôme Wagner. (#2470)
 
+* All opaque values available over the C API can now be decomposed into their
+  constituents.
+
 ### Removed
 
 ### Changed

--- a/src/Futhark/CodeGen/Backends/GenericC/CLI.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC/CLI.hs
@@ -285,13 +285,14 @@ printStm manifest tname e =
       where
         fields = recordFields record
         printField field =
-          printStm manifest (recordFieldType field) [C.cexp|field|]
+          printStm manifest (recordFieldType field) [C.cexp|field_val|]
         newline = [C.cstm|puts("");|]
         getField field =
           [C.cstm|{$ty:(recordFieldCType manifest field) field;
                    if ($id:(recordFieldProject field)(ctx, &field, $exp:e) != FUTHARK_SUCCESS) {
                      futhark_panic(1, "Failed to project field %s from result\n", $string:(T.unpack (recordFieldName field)));
                    } else {
+                     $ty:(recordFieldCType manifest field) field_val = field;
                      $stm:(printField field)
                    }
                    }|]

--- a/src/Futhark/CodeGen/Backends/GenericC/Types.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC/Types.hs
@@ -256,7 +256,6 @@ lookupOpaqueType v (OpaqueTypes types) =
     Nothing -> error $ "Unknown opaque type: " ++ show v
 
 opaquePayload :: OpaqueTypes -> OpaqueType -> [ValueType]
-opaquePayload _ (OpaqueType ts) = ts
 opaquePayload _ (OpaqueSum ts _) = ts
 opaquePayload _ (OpaqueArray _ _ ts) = ts
 opaquePayload types (OpaqueRecord fs) = concatMap f fs
@@ -468,13 +467,23 @@ recordArrayZipFunctions types desc fs vds rank = do
   ops <- asks envOperations
   new <- publicName $ "zip_" <> opaqueName desc
 
-  (param_names, params, new_stms) <- recordNewSetFields types fs vds
+  (param_names, params, new_stms) <-
+    case vds of
+      [] ->
+        pure
+          ( [],
+            [],
+            [ [C.citem|v->shape[$int:i] = shape[$int:i];|]
+            | i <- [0 .. rank - 1]
+            ]
+          )
+      _ -> recordNewSetFields types fs vds
 
   headerDecl
     (OpaqueDecl desc)
-    [C.cedecl|int $id:new($ty:ctx_ty *ctx, $ty:opaque_type** out, $params:params);|]
+    [C.cedecl|int $id:new($ty:ctx_ty *ctx, $ty:opaque_type** out, typename int64_t[$int:rank], $params:params);|]
   libDecl
-    [C.cedecl|int $id:new($ty:ctx_ty *ctx, $ty:opaque_type** out, $params:params) {
+    [C.cedecl|int $id:new($ty:ctx_ty *ctx, $ty:opaque_type** out, typename int64_t shape[$int:rank], $params:params) {
                 if (!$exp:(sameShape param_names)) {
                   set_error(ctx, strdup("Cannot zip arrays with different shapes."));
                   return 1;
@@ -487,17 +496,20 @@ recordArrayZipFunctions types desc fs vds rank = do
   pure new
   where
     valueShape TypeTransparent {} p =
-      [[C.cexp|$id:p->shape[$int:i]|] | i <- [0 .. rank - 1]]
+      [C.cexp|$id:p->shape|]
     -- We know that the opaque value must contain arrays.
     valueShape TypeOpaque {} p =
-      [[C.cexp|$id:p->$id:(tupleField 0)->shape[$int:i]|] | i <- [0 .. rank - 1]]
+      [C.cexp|$id:p->$id:(tupleField 0)->shape|]
+    matches param_shape =
+      [[C.cexp|$exp:param_shape[$int:i] == shape[$int:i]|] | i <- [0 .. rank - 1]]
     sameShape param_names =
-      allTrue $ map allEqual $ L.transpose $ zipWith valueShape (map snd fs) param_names
+      allTrue $ concatMap matches $ zipWith valueShape (map snd fs) param_names
 
 indexingDefs ::
   Int ->
+  C.Exp ->
   ([C.Param], PrimType -> Int -> C.Exp -> C.Exp, C.Exp)
-indexingDefs rank =
+indexingDefs rank outer_shape =
   (index_params, indexExp, in_bounds)
   where
     index_names = ["i" <> prettyText i | i <- [0 .. rank - 1]]
@@ -514,7 +526,7 @@ indexingDefs rank =
 
     in_bounds =
       allTrue
-        [ [C.cexp|$id:p >= 0 && $id:p < arr->$id:(tupleField 0)->shape[$int:i]|]
+        [ [C.cexp|$id:p >= 0 && $id:p < $exp:outer_shape[$int:i]|]
         | (p, i) <- zip index_names [0 .. rank - 1]
         ]
 
@@ -558,7 +570,11 @@ recordArrayIndexFunction space _types desc rank elemtype vds = do
 
   pure index_f
   where
-    (index_params, indexExp, in_bounds) = indexingDefs rank
+    (index_params, indexExp, in_bounds) =
+      indexingDefs rank $
+        if null vds
+          then [C.cexp|arr->shape|]
+          else [C.cexp|arr->$id:(tupleField 0)|]
 
     setField copy j (ValueType _ (Rank r) pt)
       | r == rank =
@@ -634,7 +650,11 @@ recordArraySetFunction space _types desc rank elemtype vds = do
 
   pure index_f
   where
-    (index_params, indexExp, in_bounds) = indexingDefs rank
+    (index_params, indexExp, in_bounds) =
+      indexingDefs rank $
+        if null vds
+          then [C.cexp|arr->shape|]
+          else [C.cexp|arr->$id:(tupleField 0)->shape|]
 
     same_shape = allTrue $ do
       (j, ValueType _ (Rank r) _) <- zip [0 ..] vds
@@ -669,22 +689,31 @@ recordArraySetFunction space _types desc rank elemtype vds = do
             space
             $ cproduct ([C.cexp|$int:(primByteSize pt::Int)|] : shape)
 
-recordArrayShapeFunction :: Name -> CompilerM op s Manifest.CFuncName
-recordArrayShapeFunction desc = do
+recordArrayShapeFunction ::
+  Name ->
+  [ValueType] ->
+  CompilerM op s Manifest.CFuncName
+recordArrayShapeFunction desc vds = do
   shape_f <- publicName $ "shape_" <> opaqueName desc
   ctx_ty <- contextType
   array_ct <- opaqueToCType desc
 
-  -- We know that the opaque value consists of arrays of at least the
-  -- expected rank, and which have the same outer shape, so we just
-  -- return the shape of the first one.
+  -- We know that the opaque value consists of arrays of at least the expected
+  -- rank, and which have the same outer shape, so we just return the shape of
+  -- the first one. However, in the special case of an array of units, there are
+  -- actually no embedded arrays, so we return the special shape field instead.
+
+  let shape = case vds of
+        [] -> [C.cexp|arr->shape|]
+        _ -> [C.cexp|arr->$id:(tupleField 0)->shape|]
+
   headerDecl
     (OpaqueDecl desc)
     [C.cedecl|const typename int64_t* $id:shape_f($ty:ctx_ty *ctx, $ty:array_ct *arr);|]
   libDecl
     [C.cedecl|const typename int64_t* $id:shape_f($ty:ctx_ty *ctx, $ty:array_ct *arr) {
                 (void)ctx;
-                return arr->$id:(tupleField 0)->shape;
+                return $exp:shape;
               }|]
 
   pure shape_f
@@ -815,7 +844,7 @@ opaqueArrayIndexFunction ::
   CompilerM op s Manifest.CFuncName
 opaqueArrayIndexFunction = recordArrayIndexFunction
 
-opaqueArrayShapeFunction :: Name -> CompilerM op s Manifest.CFuncName
+opaqueArrayShapeFunction :: Name -> [ValueType] -> CompilerM op s Manifest.CFuncName
 opaqueArrayShapeFunction = recordArrayShapeFunction
 
 opaqueArrayNewFunction ::
@@ -1004,15 +1033,13 @@ opaqueExtraOps
   _
   types
   "()"
-  (OpaqueType [ValueType Signed (Rank 0) Unit])
+  (OpaqueRecord [])
   [ValueType Signed (Rank 0) Unit] =
     Just . Manifest.OpaqueRecord
       <$> ( Manifest.RecordOps
               <$> recordProjectFunctions types "()" [] []
               <*> recordNewFunctions types "()" [] []
           )
-opaqueExtraOps _ _ _ (OpaqueType _) _ =
-  pure Nothing
 opaqueExtraOps _ _types desc (OpaqueSum _ cs) vds =
   Just . Manifest.OpaqueSum
     <$> ( Manifest.SumOps
@@ -1031,7 +1058,7 @@ opaqueExtraOps space types desc (OpaqueRecordArray rank elemtype fs) vds =
             <$> recordArrayProjectFunctions types desc fs vds
             <*> recordArrayZipFunctions types desc fs vds rank
             <*> recordArrayIndexFunction space types desc rank elemtype vds
-            <*> recordArrayShapeFunction desc
+            <*> recordArrayShapeFunction desc vds
             <*> recordArrayNewFunction space types desc rank elemtype vds
             <*> recordArraySetFunction space types desc rank elemtype vds
         )
@@ -1039,7 +1066,7 @@ opaqueExtraOps space types desc (OpaqueArray rank elemtype _) vds =
   Just . Manifest.OpaqueArray
     <$> ( Manifest.OpaqueArrayOps rank (nameToText elemtype)
             <$> opaqueArrayIndexFunction space types desc rank elemtype vds
-            <*> opaqueArrayShapeFunction desc
+            <*> opaqueArrayShapeFunction desc vds
             <*> opaqueArrayNewFunction space types desc rank elemtype vds
             <*> opaqueArraySetFunction space types desc rank elemtype vds
         )
@@ -1228,7 +1255,13 @@ generateOpaque ::
   CompilerM op s (T.Text, Manifest.Type)
 generateOpaque space types (desc, ot) = do
   name <- publicName $ opaqueName desc
-  members <- zipWithM field (opaquePayload types ot) [(0 :: Int) ..]
+  members <- case ot of
+    -- We need to treat arrays of unit specially, because otherwise they would
+    -- have no members.
+    OpaqueRecordArray rank _ [] ->
+      pure [[C.csdecl|typename int64_t shape[$int:rank];|]]
+    _ ->
+      zipWithM field (opaquePayload types ot) [(0 :: Int) ..]
   libDecl [C.cedecl|struct $id:name { $sdecls:members };|]
   (ops, extra_ops) <- opaqueLibraryFunctions space types desc ot
   let opaque_type = [C.cty|struct $id:name*|]
@@ -1258,8 +1291,6 @@ generateAPITypes arr_space types@(OpaqueTypes opaques) = do
     -- types that allow projection of them.  This is because the
     -- projection functions somewhat uglily directly poke around in
     -- the innards to increment reference counts.
-    findNecessaryArrays (OpaqueType _) =
-      pure ()
     findNecessaryArrays (OpaqueArray _ _ vts) =
       mapM_ (valueTypeToCType Private) vts
     findNecessaryArrays (OpaqueRecordArray _ _ fs) =

--- a/src/Futhark/CodeGen/Backends/GenericC/Types.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC/Types.hs
@@ -258,6 +258,7 @@ lookupOpaqueType v (OpaqueTypes types) =
 opaquePayload :: OpaqueTypes -> OpaqueType -> [ValueType]
 opaquePayload _ (OpaqueSum ts _) = ts
 opaquePayload _ (OpaqueArray _ _ ts) = ts
+opaquePayload _ (OpaqueRecord []) = [ValueType Signed (Rank 0) Unit]
 opaquePayload types (OpaqueRecord fs) = concatMap f fs
   where
     f (_, TypeOpaque s) = opaquePayload types $ lookupOpaqueType s types

--- a/src/Futhark/CodeGen/Backends/GenericC/Types.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC/Types.hs
@@ -456,36 +456,26 @@ recordArrayProjectFunctions ::
   CompilerM op s [Manifest.RecordField]
 recordArrayProjectFunctions = recordProjectFunctions
 
-recordArrayZipFunctions ::
+recordArrayZipFunction ::
   OpaqueTypes ->
   Name ->
   [(Name, EntryPointType)] ->
   [ValueType] ->
   Int ->
   CompilerM op s Manifest.CFuncName
-recordArrayZipFunctions types desc fs vds rank = do
+recordArrayZipFunction types desc fs vds rank = do
   opaque_type <- opaqueToCType desc
   ctx_ty <- contextType
   ops <- asks envOperations
   new <- publicName $ "zip_" <> opaqueName desc
 
-  (param_names, params, new_stms) <-
-    case vds of
-      [] ->
-        pure
-          ( [],
-            [],
-            [ [C.citem|v->shape[$int:i] = shape[$int:i];|]
-            | i <- [0 .. rank - 1]
-            ]
-          )
-      _ -> recordNewSetFields types fs vds
+  (param_names, params, new_stms) <- recordNewSetFields types fs vds
 
   headerDecl
     (OpaqueDecl desc)
-    [C.cedecl|int $id:new($ty:ctx_ty *ctx, $ty:opaque_type** out, typename int64_t[$int:rank], $params:params);|]
+    [C.cedecl|int $id:new($ty:ctx_ty *ctx, $ty:opaque_type** out, $params:params);|]
   libDecl
-    [C.cedecl|int $id:new($ty:ctx_ty *ctx, $ty:opaque_type** out, typename int64_t shape[$int:rank], $params:params) {
+    [C.cedecl|int $id:new($ty:ctx_ty *ctx, $ty:opaque_type** out, $params:params) {
                 if (!$exp:(sameShape param_names)) {
                   set_error(ctx, strdup("Cannot zip arrays with different shapes."));
                   return 1;
@@ -498,14 +488,12 @@ recordArrayZipFunctions types desc fs vds rank = do
   pure new
   where
     valueShape TypeTransparent {} p =
-      [C.cexp|$id:p->shape|]
+      [[C.cexp|$id:p->shape[$int:i]|] | i <- [0 .. rank - 1]]
     -- We know that the opaque value must contain arrays.
     valueShape TypeOpaque {} p =
-      [C.cexp|$id:p->$id:(tupleField 0)->shape|]
-    matches param_shape =
-      [[C.cexp|$exp:param_shape[$int:i] == shape[$int:i]|] | i <- [0 .. rank - 1]]
+      [[C.cexp|$id:p->$id:(tupleField 0)->shape[$int:i]|] | i <- [0 .. rank - 1]]
     sameShape param_names =
-      allTrue $ concatMap matches $ zipWith valueShape (map snd fs) param_names
+      allTrue $ map allEqual $ L.transpose $ zipWith valueShape (map snd fs) param_names
 
 indexingDefs ::
   Int ->
@@ -577,9 +565,10 @@ recordArrayIndexFunction space _types desc rank elemtype vds = do
       indexingDefs rank $
         if null vds
           then [C.cexp|arr->shape|]
-          else [C.cexp|arr->$id:(tupleField 0)|]
+          else [C.cexp|arr->$id:(tupleField 0)->shape|]
 
     setField copy j (ValueType _ (Rank r) pt)
+      | pt == Unit = pure ()
       | r == rank =
           -- Easy case: just copy the scalar from the array into the
           -- variable.
@@ -669,6 +658,7 @@ recordArraySetFunction space _types desc rank elemtype vds = do
                        $int:(r-rank) * sizeof(int64_t)) == 0|]
 
     setField copy j (ValueType _ (Rank r) pt)
+      | pt == Unit = pure ()
       | r == rank =
           copy
             CopyBarrier
@@ -790,6 +780,8 @@ recordArrayNewFunction space types desc rank elemtype vds = do
                     goto end;
                   }|]
 
+    handleField _ _ (ValueType _ _ Unit) =
+      pure ()
     handleField copy i (ValueType _ (Rank r) pt) = do
       let elem_size =
             cproduct $
@@ -838,39 +830,6 @@ recordArrayNewFunction space types desc rank elemtype vds = do
       stm
         [C.cstm|for (typename int64_t i = 1; i < n; i++)
                 { $items:check_one }|]
-
-opaqueArrayIndexFunction ::
-  Space ->
-  OpaqueTypes ->
-  Name ->
-  Int ->
-  Name ->
-  [ValueType] ->
-  CompilerM op s Manifest.CFuncName
-opaqueArrayIndexFunction = recordArrayIndexFunction
-
-opaqueArrayShapeFunction :: Name -> [ValueType] -> CompilerM op s Manifest.CFuncName
-opaqueArrayShapeFunction = recordArrayShapeFunction
-
-opaqueArrayNewFunction ::
-  Space ->
-  OpaqueTypes ->
-  Name ->
-  Int ->
-  Name ->
-  [ValueType] ->
-  CompilerM op s Manifest.CFuncName
-opaqueArrayNewFunction = recordArrayNewFunction
-
-opaqueArraySetFunction ::
-  Space ->
-  OpaqueTypes ->
-  Name ->
-  Int ->
-  Name ->
-  [ValueType] ->
-  CompilerM op s Manifest.CFuncName
-opaqueArraySetFunction = recordArraySetFunction
 
 sumVariants ::
   Name ->
@@ -1061,7 +1020,7 @@ opaqueExtraOps space types desc (OpaqueRecordArray rank elemtype fs) vds =
   Just . Manifest.OpaqueRecordArray
     <$> ( Manifest.RecordArrayOps rank (nameToText elemtype)
             <$> recordArrayProjectFunctions types desc fs vds
-            <*> recordArrayZipFunctions types desc fs vds rank
+            <*> recordArrayZipFunction types desc fs vds rank
             <*> recordArrayIndexFunction space types desc rank elemtype vds
             <*> recordArrayShapeFunction desc vds
             <*> recordArrayNewFunction space types desc rank elemtype vds
@@ -1070,10 +1029,10 @@ opaqueExtraOps space types desc (OpaqueRecordArray rank elemtype fs) vds =
 opaqueExtraOps space types desc (OpaqueArray rank elemtype _) vds =
   Just . Manifest.OpaqueArray
     <$> ( Manifest.OpaqueArrayOps rank (nameToText elemtype)
-            <$> opaqueArrayIndexFunction space types desc rank elemtype vds
-            <*> opaqueArrayShapeFunction desc vds
-            <*> opaqueArrayNewFunction space types desc rank elemtype vds
-            <*> opaqueArraySetFunction space types desc rank elemtype vds
+            <$> recordArrayIndexFunction space types desc rank elemtype vds
+            <*> recordArrayShapeFunction desc vds
+            <*> recordArrayNewFunction space types desc rank elemtype vds
+            <*> recordArraySetFunction space types desc rank elemtype vds
         )
 
 opaqueLibraryFunctions ::

--- a/src/Futhark/CodeGen/Backends/GenericC/Types.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC/Types.hs
@@ -345,7 +345,7 @@ recordProjectFunctions types desc fs vds = do
           [C.cedecl|int $id:project($ty:ctx_ty *ctx, $ty:et_ty *out, const $ty:opaque_type *obj);|]
         libDecl
           [C.cedecl|int $id:project($ty:ctx_ty *ctx, $ty:et_ty *out, const $ty:opaque_type *obj) {
-                      (void)ctx;
+                      (void)ctx; (void)obj;
                       $ty:et_ty v;
                       $items:project_items
                       *out = v;
@@ -412,7 +412,9 @@ recordNewSetFields types fs =
             ( offset + length f_vts,
               ( param_name,
                 [C.cparam|const $ty:ct* $id:param_name|],
-                [C.citem|{$stms:(zipWith3 setFieldField [offset ..] param_fields f_vts)}|]
+                if null f_vts
+                  then [C.citem|(void)$id:param_name;|]
+                  else [C.citem|{$stms:(zipWith3 setFieldField [offset ..] param_fields f_vts)}|]
               )
             )
 
@@ -554,6 +556,7 @@ recordArrayIndexFunction space _types desc rank elemtype vds = do
   libDecl
     [C.cedecl|int $id:index_f($ty:ctx_ty *ctx, $ty:obj_ct **out, $ty:array_ct *arr,
                               $params:index_params) {
+                (void)arr;
                 int err = 0;
                 if ($exp:in_bounds) {
                   $ty:obj_ct* v = malloc(sizeof($ty:obj_ct));
@@ -635,6 +638,7 @@ recordArraySetFunction space _types desc rank elemtype vds = do
                               $ty:array_ct *arr,
                               $ty:obj_ct *v,
                               $params:index_params) {
+                (void)arr; (void)v;
                 int err = 0;
                 if (!$exp:in_bounds) {
                   err = 1;
@@ -749,6 +753,7 @@ recordArrayNewFunction space types desc rank elemtype vds = do
   libDecl
     [C.cedecl|int $id:new_f($ty:ctx_ty *ctx, $ty:array_ct **out,
                             $ty:obj_ct **elems, $params:shape_params) {
+                (void)elems;
                 int err = 0;
                 typename int64_t n = $exp:(cproduct outer_shape);
                 $items:check_items
@@ -1194,7 +1199,7 @@ opaqueLibraryFunctions space types desc ot = do
 
           int $id:store_opaque($ty:ctx_ty *ctx,
                                const $ty:opaque_type *obj, void **p, size_t *n) {
-            (void)ctx;
+            (void)ctx; (void)obj;
             int ret = 0;
             $items:store_body
             return ret;
@@ -1261,7 +1266,7 @@ generateOpaque space types (desc, ot) = do
     OpaqueRecordArray rank _ [] ->
       pure [[C.csdecl|typename int64_t shape[$int:rank];|]]
     _ ->
-      zipWithM field (opaquePayload types ot) [(0 :: Int) ..]
+      dummyIfNone <$> zipWithM field (opaquePayload types ot) [(0 :: Int) ..]
   libDecl [C.cedecl|struct $id:name { $sdecls:members };|]
   (ops, extra_ops) <- opaqueLibraryFunctions space types desc ot
   let opaque_type = [C.cty|struct $id:name*|]
@@ -1276,6 +1281,11 @@ generateOpaque space types (desc, ot) = do
         if r == 0
           then [C.csdecl|$ty:ct $id:(tupleField i);|]
           else [C.csdecl|$ty:ct *$id:(tupleField i);|]
+
+    -- C compilers tend to warn about empty structs, so put in a dummy field if
+    -- we have no real fields.
+    dummyIfNone [] = [[C.csdecl|char dummy;|]]
+    dummyIfNone members = members
 
 generateAPITypes ::
   Space ->

--- a/src/Futhark/CodeGen/ImpGen.hs
+++ b/src/Futhark/CodeGen/ImpGen.hs
@@ -511,7 +511,6 @@ entryPointSignedness :: OpaqueTypes -> EntryPointType -> [Signedness]
 entryPointSignedness _ (TypeTransparent vt) = [valueTypeSign vt]
 entryPointSignedness types (TypeOpaque desc) =
   case lookupOpaqueType desc types of
-    OpaqueType vts -> map valueTypeSign vts
     OpaqueArray _ _ vts -> map valueTypeSign vts
     OpaqueRecordArray _ _ fs -> foldMap (entryPointSignedness types . snd) fs
     OpaqueRecord fs -> foldMap (entryPointSignedness types . snd) fs
@@ -525,7 +524,6 @@ entryPointSize :: OpaqueTypes -> EntryPointType -> Int
 entryPointSize _ (TypeTransparent _) = 1
 entryPointSize types (TypeOpaque desc) =
   case lookupOpaqueType desc types of
-    OpaqueType vts -> length vts
     OpaqueArray _ _ vts -> length vts
     OpaqueRecordArray _ _ fs -> sum $ map (entryPointSize types . snd) fs
     OpaqueRecord fs -> sum $ map (entryPointSize types . snd) fs

--- a/src/Futhark/CodeGen/ImpGen.hs
+++ b/src/Futhark/CodeGen/ImpGen.hs
@@ -513,6 +513,7 @@ entryPointSignedness types (TypeOpaque desc) =
   case lookupOpaqueType desc types of
     OpaqueArray _ _ vts -> map valueTypeSign vts
     OpaqueRecordArray _ _ fs -> foldMap (entryPointSignedness types . snd) fs
+    OpaqueRecord [] -> [Signed]
     OpaqueRecord fs -> foldMap (entryPointSignedness types . snd) fs
     OpaqueSum vts _ -> map valueTypeSign vts
 
@@ -526,6 +527,7 @@ entryPointSize types (TypeOpaque desc) =
   case lookupOpaqueType desc types of
     OpaqueArray _ _ vts -> length vts
     OpaqueRecordArray _ _ fs -> sum $ map (entryPointSize types . snd) fs
+    OpaqueRecord [] -> 1
     OpaqueRecord fs -> sum $ map (entryPointSize types . snd) fs
     OpaqueSum vts _ -> length vts
 

--- a/src/Futhark/IR/Parse.hs
+++ b/src/Futhark/IR/Parse.hs
@@ -690,7 +690,7 @@ pOpaqueType :: Parser (Name, OpaqueType)
 pOpaqueType =
   (,)
     <$> (keyword "type" *> (nameFromText <$> pStringLiteral) <* pEqual)
-    <*> choice [pRecord, pSum, pOpaque, pRecordArray, pOpaqueArray]
+    <*> choice [pRecord, pSum, pRecordArray, pOpaqueArray]
   where
     pFieldName = choice [pName, nameFromString . show <$> pInt]
     pField = (,) <$> pFieldName <* pColon <*> pEntryPointType
@@ -710,8 +710,6 @@ pOpaqueType =
               <$> brackets (pValueType `sepBy` pComma)
               <*> many pVariant
           )
-
-    pOpaque = keyword "opaque" $> OpaqueType <*> braces (many pValueType)
 
     pRecordArray =
       keyword "record_array"

--- a/src/Futhark/IR/Pretty.hs
+++ b/src/Futhark/IR/Pretty.hs
@@ -426,8 +426,6 @@ instance (PrettyRep rep) => Pretty (FunDef rep) where
               )
 
 instance Pretty OpaqueType where
-  pretty (OpaqueType ts) =
-    "opaque" <+> nestedBlock (stack $ map pretty ts)
   pretty (OpaqueRecord fs) =
     "record" <+> nestedBlock (stack $ map p fs)
     where

--- a/src/Futhark/IR/Syntax/Core.hs
+++ b/src/Futhark/IR/Syntax/Core.hs
@@ -625,8 +625,7 @@ data EntryPointType
 
 -- | The representation of an opaque type.
 data OpaqueType
-  = OpaqueType [ValueType]
-  | -- | Note that the field ordering here denote the actual
+  = -- | Note that the field ordering here denote the actual
     -- representation - make sure it is preserved.
     OpaqueRecord [(Name, EntryPointType)]
   | -- | Constructor ordering also denotes representation, in that the

--- a/src/Futhark/IR/TypeCheck.hs
+++ b/src/Futhark/IR/TypeCheck.hs
@@ -561,8 +561,6 @@ checkOpaques (OpaqueTypes types) = descend [] types
     check known (OpaqueRecordArray _ v fs) = do
       checkEntryPointType known (TypeOpaque v)
       mapM_ (checkEntryPointType known . snd) fs
-    check _ (OpaqueType _) =
-      pure ()
     checkEntryPointType known (TypeOpaque s) =
       unless (s `elem` known) $
         Left . Error [] . TypeError $

--- a/src/Futhark/Internalise/Entry.hs
+++ b/src/Futhark/Internalise/Entry.hs
@@ -236,7 +236,7 @@ entryPointType types t ts
               ts' = if length cs == 1 then ts else drop 1 ts
           addType desc . I.OpaqueSum (map valueType ts)
             =<< opaqueSum types cs'' ts'
-        E.Array _ shape (E.Record fs) -> do
+        E.Array _ shape (E.Record fs) | not $ null fs -> do
           let rank = E.shapeRank shape
               fs' = recordFields types fs $ rowTypeExp rank =<< E.entryAscribed t
               ts' = map (strip rank) ts

--- a/src/Futhark/Internalise/Entry.hs
+++ b/src/Futhark/Internalise/Entry.hs
@@ -226,10 +226,9 @@ entryPointType types t ts
       pure (u, I.TypeTransparent $ I.ValueType I.Signed r ts0)
   | otherwise = do
       case E.entryType t of
-        E.Scalar (E.Record fs)
-          | not $ null fs -> do
-              let fs' = recordFields types fs $ E.entryAscribed t
-              addType desc . I.OpaqueRecord =<< opaqueRecord types fs' ts
+        E.Scalar (E.Record fs) -> do
+          let fs' = recordFields types fs $ E.entryAscribed t
+          addType desc . I.OpaqueRecord =<< opaqueRecord types fs' ts
         E.Scalar (E.Sum cs) -> do
           let (_, places) = internaliseSumTypeRep cs
               cs' = sumConstrs types cs $ E.entryAscribed t
@@ -237,16 +236,15 @@ entryPointType types t ts
               ts' = if length cs == 1 then ts else drop 1 ts
           addType desc . I.OpaqueSum (map valueType ts)
             =<< opaqueSum types cs'' ts'
-        E.Array _ shape (E.Record fs)
-          | not $ null fs -> do
-              let rank = E.shapeRank shape
-                  fs' = recordFields types fs $ rowTypeExp rank =<< E.entryAscribed t
-                  ts' = map (strip rank) ts
-                  record_t = E.Scalar (E.Record fs)
-                  record_te = rowTypeExp rank =<< E.entryAscribed t
-              ept <- snd <$> entryPointType types (E.EntryType record_t record_te) ts'
-              addType desc . I.OpaqueRecordArray rank (entryPointTypeName ept)
-                =<< opaqueRecordArray types rank fs' ts
+        E.Array _ shape (E.Record fs) -> do
+          let rank = E.shapeRank shape
+              fs' = recordFields types fs $ rowTypeExp rank =<< E.entryAscribed t
+              ts' = map (strip rank) ts
+              record_t = E.Scalar (E.Record fs)
+              record_te = rowTypeExp rank =<< E.entryAscribed t
+          ept <- snd <$> entryPointType types (E.EntryType record_t record_te) ts'
+          addType desc . I.OpaqueRecordArray rank (entryPointTypeName ept)
+            =<< opaqueRecordArray types rank fs' ts
         E.Array _ shape et -> do
           let ts' = map (strip (E.shapeRank shape)) ts
               rank = E.shapeRank shape
@@ -254,7 +252,7 @@ entryPointType types t ts
           ept <- snd <$> entryPointType types (E.EntryType (E.Scalar et) elem_te) ts'
           addType desc . I.OpaqueArray (E.shapeRank shape) (entryPointTypeName ept) $
             map valueType ts
-        _ -> addType desc $ I.OpaqueType $ map valueType ts
+        _ -> error $ "entryPointType: " <> E.prettyString (E.entryType t)
 
       pure (u, I.TypeOpaque desc)
   where


### PR DESCRIPTION
With this change, *all* types exposed via the FFI can be decomposed: they are either a record, a sum type, an array of opaques, a primitive, or an array of primitives. This means any Futhark value can be reflected completely in other languages (yes, this does imply the FFI actually ignores abstract types - I'm willing to discuss whether this is the right thing).