### PR TITLE
Add documentation to manifest.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * All opaque values available over the C API can now be decomposed into their
   constituents.
 
+* The manifest now contains documentation for entry points and opaque types.
+
 ### Removed
 
 ### Changed

--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,5 @@
 packages: futhark.cabal
-index-state: 2026-05-14T15:59:02Z
+index-state: 2026-06-25T17:59:37Z
 multi-repl: True
 
 package futhark

--- a/docs/manifest.schema.json
+++ b/docs/manifest.schema.json
@@ -44,12 +44,18 @@
                             },
                             "additionalProperties": false
                         }
+                    },
+                    "doc": {
+                        "type": "string"
                     }
                 }
             }
         },
         "types": {
             "type": "object",
+            "doc": {
+                "type": "string"
+            },
             "additionalProperties": {
                 "oneOf": [
                     { "type": "object",

--- a/futhark.cabal
+++ b/futhark.cabal
@@ -479,7 +479,7 @@ library
     , free >=5.1.10
     , futhark-data >= 1.1.3.0
     , futhark-server >= 1.4.1.0
-    , futhark-manifest == 1.8.0.0
+    , futhark-manifest == 1.9.0.0
     , githash >=0.1.6.1
     , half >= 0.3
     , haskeline

--- a/nix/futhark-manifest.nix
+++ b/nix/futhark-manifest.nix
@@ -1,37 +1,16 @@
-{
-  mkDerivation,
-  aeson,
-  base,
-  bytestring,
-  containers,
-  lib,
-  QuickCheck,
-  quickcheck-instances,
-  tasty,
-  tasty-hunit,
-  tasty-quickcheck,
-  text,
+{ mkDerivation, aeson, base, bytestring, containers, lib
+, QuickCheck, quickcheck-instances, tasty, tasty-hunit
+, tasty-quickcheck, text
 }:
 mkDerivation {
   pname = "futhark-manifest";
-  version = "1.8.0.0";
-  sha256 = "34d02dd39fcc6f8b7d43d24c8455fbc4ed2d88e1103cd190b3c5f60467ce02eb";
-  libraryHaskellDepends = [
-    aeson
-    base
-    bytestring
-    containers
-    text
-  ];
+  version = "1.9.0.0";
+  sha256 = "54737ca36dc2b1df09f9ed74565ca539eba3edaab3cc61c64293bcc9c894e4ce";
+  libraryHaskellDepends = [ aeson base bytestring containers text ];
   testHaskellDepends = [
-    base
-    QuickCheck
-    quickcheck-instances
-    tasty
-    tasty-hunit
-    tasty-quickcheck
-    text
+    base QuickCheck quickcheck-instances tasty tasty-hunit
+    tasty-quickcheck text
   ];
   description = "Definition and serialisation instances for Futhark manifests";
-  license = lib.licenses.isc;
+  license = lib.licensesSpdx."ISC";
 }

--- a/src/Futhark/CodeGen/Backends/GenericC/CLI.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC/CLI.hs
@@ -191,7 +191,7 @@ readInput manifest i tname =
             [C.cstm|;|],
             [C.cexp|$id:dest|]
           )
-    Just (TypeOpaque desc _ _) ->
+    Just (TypeOpaque desc _ _ _) ->
       ( [C.citems|futhark_panic(1, "Cannot read input #%d of type %s\n", $int:i, $string:(T.unpack desc));|],
         [C.cstm|;|],
         [C.cstm|;|],
@@ -257,7 +257,7 @@ prepareOutputs manifest = zipWith prepareResult [(0 :: Int) ..]
             [C.cexp|$id:result|],
             [C.cstm|assert($id:(arrayFree ops)(ctx, $id:result) == 0);|]
           )
-        Just (TypeOpaque t ops _) ->
+        Just (TypeOpaque t ops _ _) ->
           ( [C.citem|typename $id:t $id:result;|],
             [C.cexp|$id:result|],
             [C.cstm|assert($id:(opaqueFree ops)(ctx, $id:result) == 0);|]
@@ -268,7 +268,7 @@ recordFieldCType manifest field =
   case M.lookup t $ manifestTypes manifest of
     Nothing -> uncurry primAPIType $ scalarToPrim t
     Just (TypeArray tname _ _ _) -> [C.cty|typename $id:tname|]
-    Just (TypeOpaque tname _ _) -> [C.cty|typename $id:tname|]
+    Just (TypeOpaque tname _ _ _) -> [C.cty|typename $id:tname|]
   where
     t = recordFieldType field
 
@@ -279,7 +279,7 @@ printStm manifest tname e =
     Nothing ->
       let info = tname <> "_info"
        in [C.cstm|write_scalar(stdout, binary_output, &$id:info, &$exp:e);|]
-    Just (TypeOpaque _ _ (Just (OpaqueRecord record)))
+    Just (TypeOpaque _ _ (Just (OpaqueRecord record)) _)
       | map recordFieldName fields == take (length fields) (map showText [0 :: Int ..]) ->
           [C.cstm|{$stms:(intersperse newline (map getField fields))}|]
       where
@@ -296,7 +296,7 @@ printStm manifest tname e =
                      $stm:(printField field)
                    }
                    }|]
-    Just (TypeOpaque desc _ _) ->
+    Just (TypeOpaque desc _ _ _) ->
       [C.cstm|{
          fprintf(stderr, "Values of type \"%s\" have no external representation.\n", $string:(T.unpack desc));
          retval = 1;
@@ -326,7 +326,7 @@ printResult manifest = concatMap f
 
 cliEntryPoint ::
   Manifest -> T.Text -> EntryPoint -> (C.Definition, C.Initializer)
-cliEntryPoint manifest entry_point_name (EntryPoint cfun _tuning_params output inputs _attrs) =
+cliEntryPoint manifest entry_point_name (EntryPoint cfun _tuning_params output inputs _attrs _doc) =
   let (input_items, pack_input, free_input, free_parsed, input_args) =
         unzip5 $ readInputs manifest $ map inputType inputs
 

--- a/src/Futhark/CodeGen/Backends/GenericC/EntryPoints.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC/EntryPoints.hs
@@ -137,7 +137,7 @@ onEntryPoint ::
   Function op ->
   CompilerM op s (Maybe (C.Definition, (T.Text, Manifest.EntryPoint)))
 onEntryPoint _ _ _ (Function Nothing _ _ _ _) = pure Nothing
-onEntryPoint get_consts relevant_params fname (Function (Just (EntryPoint ename results args)) outputs inputs attrs _) = inNewFunction $ do
+onEntryPoint get_consts relevant_params fname (Function (Just (EntryPoint ename results args doc)) outputs inputs attrs _) = inNewFunction $ do
   let out_args = map (\p -> [C.cexp|&$id:(paramName p)|]) outputs
       in_args = map (\p -> [C.cexp|$id:(paramName p)|]) inputs
 
@@ -216,7 +216,8 @@ onEntryPoint get_consts relevant_params fname (Function (Just (EntryPoint ename 
             -- manifest and ImpCode.
             Manifest.entryPointOutput = outputManifest results,
             Manifest.entryPointInputs = map inputManifest args,
-            Manifest.entryPointAttrs = map prettyText (S.toList (unAttrs attrs))
+            Manifest.entryPointAttrs = map prettyText (S.toList (unAttrs attrs)),
+            Manifest.entryPointDoc = doc
           }
 
   pure $ Just (cdef, (nameToText ename, manifest))

--- a/src/Futhark/CodeGen/Backends/GenericC/Server.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC/Server.hs
@@ -121,7 +121,7 @@ cType :: Manifest -> TypeName -> C.Type
 cType manifest tname =
   case M.lookup tname $ manifestTypes manifest of
     Just (TypeArray ctype _ _ _) -> [C.cty|typename $id:(T.unpack ctype)|]
-    Just (TypeOpaque ctype _ _) -> [C.cty|typename $id:(T.unpack ctype)|]
+    Just (TypeOpaque ctype _ _ _) -> [C.cty|typename $id:(T.unpack ctype)|]
     Nothing -> uncurry primAPIType $ scalarToPrim tname
 
 data Kind
@@ -208,7 +208,7 @@ typeBoilerplate manifest (tname, TypeArray c_type_name et rank ops) =
                 .info = &$id:array_name
               };|]
       )
-typeBoilerplate manifest (tname, TypeOpaque c_type_name ops extra_ops) =
+typeBoilerplate manifest (tname, TypeOpaque c_type_name ops extra_ops _) =
   let type_name = typeStructName tname
       aux_name = type_name <> "_aux"
       (transparent_edecls, transparent_init, kind) = transparentDefs type_name extra_ops
@@ -450,7 +450,7 @@ entryTypeBoilerplate manifest =
     manifest
 
 oneEntryBoilerplate :: Manifest -> (T.Text, EntryPoint) -> ([C.Definition], C.Initializer)
-oneEntryBoilerplate manifest (name, EntryPoint cfun tuning_params output inputs attrs) =
+oneEntryBoilerplate manifest (name, EntryPoint cfun tuning_params output inputs attrs _doc) =
   let call_f = "call_" <> nameFromText name
       out_type = outputType output
       in_types = map inputType inputs

--- a/src/Futhark/CodeGen/Backends/GenericC/Types.hs
+++ b/src/Futhark/CodeGen/Backends/GenericC/Types.hs
@@ -252,7 +252,7 @@ arrayLibraryFunctions pub space pt signed rank = do
 lookupOpaqueType :: Name -> OpaqueTypes -> OpaqueType
 lookupOpaqueType v (OpaqueTypes types) =
   case lookup v types of
-    Just t -> t
+    Just (t, _) -> t
     Nothing -> error $ "Unknown opaque type: " ++ show v
 
 opaquePayload :: OpaqueTypes -> OpaqueType -> [ValueType]
@@ -1216,9 +1216,9 @@ generateArray space ((signed, pt, rank), pub) = do
 generateOpaque ::
   Space ->
   OpaqueTypes ->
-  (Name, OpaqueType) ->
+  (Name, (OpaqueType, Maybe T.Text)) ->
   CompilerM op s (T.Text, Manifest.Type)
-generateOpaque space types (desc, ot) = do
+generateOpaque space types (desc, (ot, doc)) = do
   name <- publicName $ opaqueName desc
   members <- case ot of
     -- We need to treat arrays of unit specially, because otherwise they would
@@ -1232,7 +1232,7 @@ generateOpaque space types (desc, ot) = do
   let opaque_type = [C.cty|struct $id:name*|]
   pure
     ( nameToText desc,
-      Manifest.TypeOpaque (typeText opaque_type) ops extra_ops
+      Manifest.TypeOpaque (typeText opaque_type) ops extra_ops doc
     )
   where
     field vt@(ValueType _ (Rank r) _) i = do
@@ -1252,7 +1252,7 @@ generateAPITypes ::
   OpaqueTypes ->
   CompilerM op s (M.Map T.Text Manifest.Type)
 generateAPITypes arr_space types@(OpaqueTypes opaques) = do
-  mapM_ (findNecessaryArrays . snd) opaques
+  mapM_ (findNecessaryArrays . fst . snd) opaques
   array_ts <- mapM (generateArray arr_space) . M.toList =<< gets compArrayTypes
   opaque_ts <- mapM (generateOpaque arr_space types) opaques
   pure $ M.fromList $ catMaybes array_ts <> opaque_ts

--- a/src/Futhark/CodeGen/Backends/GenericPython.hs
+++ b/src/Futhark/CodeGen/Backends/GenericPython.hs
@@ -511,7 +511,7 @@ compileProg mode class_name constructor imports defines ops userstate sync optio
     opaqueTupleElems opaque_name =
       case opaques of
         Imp.OpaqueTypes m
-          | Just (Imp.OpaqueRecord ts) <- lookup (nameFromText opaque_name) m ->
+          | Just (Imp.OpaqueRecord ts, _) <- lookup (nameFromText opaque_name) m ->
               -- XXX: might not be tuple.
               Tuple $ map (String . p . snd) ts
           where
@@ -867,7 +867,7 @@ prepareEntry ::
       [PyStmt],
       (Imp.ExternalValue, PyExp)
     )
-prepareEntry (Imp.EntryPoint _ result args) (fname, Imp.Function _ outputs inputs _ _) = do
+prepareEntry (Imp.EntryPoint _ result args _doc) (fname, Imp.Function _ outputs inputs _ _) = do
   let output_paramNames = map (compileName . Imp.paramName) outputs
       funTuple = tupleOrSingle $ fmap Var output_paramNames
 
@@ -961,7 +961,7 @@ compileEntryFun sync timing fun
   | otherwise = pure Nothing
 
 entryTypes :: Imp.EntryPoint -> ([T.Text], T.Text)
-entryTypes (Imp.EntryPoint _ res args) =
+entryTypes (Imp.EntryPoint _ res args _doc) =
   (map descArg args, desc res)
   where
     descArg ((_, u), d) = desc (u, d)
@@ -976,7 +976,7 @@ callEntryFun ::
   CompilerM op s (Maybe (PyFunDef, T.Text, PyExp))
 callEntryFun _ (_, Imp.Function Nothing _ _ _ _) = pure Nothing
 callEntryFun pre_timing fun@(fname, Imp.Function (Just entry) _ _ _ _) = do
-  let Imp.EntryPoint ename _ decl_args = entry
+  let Imp.EntryPoint ename _ decl_args _doc = entry
   (_, prepare_in, body_bin, _, res) <- prepareEntry entry fun
 
   let str_input = map (readInput . snd) decl_args

--- a/src/Futhark/CodeGen/Backends/GenericWASM.hs
+++ b/src/Futhark/CodeGen/Backends/GenericWASM.hs
@@ -77,7 +77,7 @@ data JSOpaqueType
 opaqueToJS :: Imp.OpaqueTypes -> [(String, JSOpaqueType)]
 opaqueToJS (Imp.OpaqueTypes types) = map convertOne types
   where
-    convertOne (desc, Imp.OpaqueRecord fields) =
+    convertOne (desc, (Imp.OpaqueRecord fields, _)) =
       (T.unpack (opaqueName desc), JSOpaqueRecord (map (convertField desc) fields))
     convertOne (desc, _) =
       (T.unpack (opaqueName desc), JSOpaqueOther)

--- a/src/Futhark/CodeGen/Backends/MulticoreWASM.hs
+++ b/src/Futhark/CodeGen/Backends/MulticoreWASM.hs
@@ -67,7 +67,7 @@ fRepMyRep :: Imp.Definitions Imp.Multicore -> [JSEntryPoint]
 fRepMyRep prog =
   let Imp.Functions fs = Imp.defFuns prog
       function fun = do
-        Imp.EntryPoint n res args <- Imp.functionEntry fun
+        Imp.EntryPoint n res args _ <- Imp.functionEntry fun
         Just $
           JSEntryPoint
             { name = nameToString n,

--- a/src/Futhark/CodeGen/Backends/SequentialWASM.hs
+++ b/src/Futhark/CodeGen/Backends/SequentialWASM.hs
@@ -61,7 +61,7 @@ fRepMyRep :: Imp.Program -> [JSEntryPoint]
 fRepMyRep prog =
   let Imp.Functions fs = Imp.defFuns prog
       function (Imp.Function entry _ _ _ _) = do
-        Imp.EntryPoint n res args <- entry
+        Imp.EntryPoint n res args _doc <- entry
         Just $
           JSEntryPoint
             { name = nameToString n,

--- a/src/Futhark/CodeGen/ImpCode.hs
+++ b/src/Futhark/CodeGen/ImpCode.hs
@@ -217,7 +217,8 @@ data ExternalValue
 data EntryPoint = EntryPoint
   { entryPointName :: Name,
     entryPointResults :: (Uniqueness, ExternalValue),
-    entryPointArgs :: [((Name, Uniqueness), ExternalValue)]
+    entryPointArgs :: [((Name, Uniqueness), ExternalValue)],
+    entryPointDocs :: Maybe T.Text
   }
   deriving (Show)
 
@@ -515,7 +516,7 @@ instance (Pretty op) => Pretty (Constants op) where
       <+> nestedBlock (pretty code)
 
 instance Pretty EntryPoint where
-  pretty (EntryPoint name result args) =
+  pretty (EntryPoint name result args _doc) =
     stack
       [ "name" <+> nestedBlock (dquotes (pretty name)),
         "arguments" <+> nestedBlock (stack $ map ppArg args),
@@ -777,7 +778,7 @@ declaredIn (While _ body) = declaredIn body
 declaredIn _ = mempty
 
 instance FreeIn EntryPoint where
-  freeIn' (EntryPoint _ res args) =
+  freeIn' (EntryPoint _ res args _) =
     freeIn' (snd res) <> freeIn' (map snd args)
 
 instance (FreeIn a) => FreeIn (Functions a) where

--- a/src/Futhark/CodeGen/ImpGen.hs
+++ b/src/Futhark/CodeGen/ImpGen.hs
@@ -501,7 +501,7 @@ compileConsts used_consts stms = genConstants $ do
 lookupOpaqueType :: Name -> OpaqueTypes -> OpaqueType
 lookupOpaqueType v (OpaqueTypes types) =
   case lookup v types of
-    Just t -> t
+    Just (t, _) -> t
     Nothing -> error $ "Unknown opaque type: " ++ show v
 
 valueTypeSign :: ValueType -> Signedness
@@ -692,16 +692,16 @@ compileFunDef ::
 compileFunDef types (FunDef entry attrs fname rettype params body) =
   local (\env -> env {envFunction = name_entry `mplus` Just fname}) $ do
     ((outparams, inparams, results, args), body') <- collect' compile
-    let entry' = case (name_entry, results, args) of
-          (Just name_entry', Just results', Just args') ->
-            Just $ Imp.EntryPoint name_entry' results' args'
+    let entry' = case (name_entry, results, args, doc_entry) of
+          (Just name_entry', Just results', Just args', Just docs') ->
+            Just $ Imp.EntryPoint name_entry' results' args' docs'
           _ ->
             Nothing
     emitFunction fname $ Imp.Function entry' outparams inparams attrs body'
   where
-    (name_entry, params_entry, ret_entry) = case entry of
-      Nothing -> (Nothing, Nothing, Nothing)
-      Just (x, y, z) -> (Just x, Just y, Just z)
+    (name_entry, params_entry, ret_entry, doc_entry) = case entry of
+      Nothing -> (Nothing, Nothing, Nothing, Nothing)
+      Just (x, y, z, v) -> (Just x, Just y, Just z, Just v)
     compile = do
       (inparams, arrayds, args) <- compileInParams types params params_entry
       (results, outparams, dests) <- compileOutParams types (map fst rettype) ret_entry

--- a/src/Futhark/IR/Parse.hs
+++ b/src/Futhark/IR/Parse.hs
@@ -659,12 +659,16 @@ pEntryPointType =
 pEntry :: Parser EntryPoint
 pEntry =
   parens $
-    (,,)
+    (,,,)
       <$> (nameFromText <$> pStringLiteral)
       <* pComma
       <*> pEntryPointInputs
       <* pComma
       <*> pEntryPointResult
+      <*> choice
+        [ pComma *> (Just <$> pStringLiteral),
+          pure Nothing
+        ]
   where
     pEntryPointInputs = braces (pEntryPointInput `sepBy` pComma)
     pEntryPointInput =
@@ -686,11 +690,11 @@ pFunDef pr = do
   FunDef entry attrs fname ret fparams
     <$> (pEqual *> braces (pBody pr))
 
-pOpaqueType :: Parser (Name, OpaqueType)
+pOpaqueType :: Parser (Name, (OpaqueType, Maybe T.Text))
 pOpaqueType =
   (,)
     <$> (keyword "type" *> (nameFromText <$> pStringLiteral) <* pEqual)
-    <*> choice [pRecord, pSum, pRecordArray, pOpaqueArray]
+    <*> ((,Nothing) <$> choice [pRecord, pSum, pRecordArray, pOpaqueArray])
   where
     pFieldName = choice [pName, nameFromString . show <$> pInt]
     pField = (,) <$> pFieldName <* pColon <*> pEntryPointType

--- a/src/Futhark/IR/Pretty.hs
+++ b/src/Futhark/IR/Pretty.hs
@@ -14,6 +14,7 @@ where
 import Data.Foldable (toList)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Maybe
+import Data.Text qualified as T
 import Futhark.IR.Syntax
 import Futhark.Util.Pretty
 
@@ -413,16 +414,15 @@ instance (PrettyRep rep) => Pretty (FunDef rep) where
     where
       fun = case entry of
         Nothing -> "fun"
-        Just (p_name, p_entry, ret_entry) ->
+        Just (p_name, p_entry, ret_entry, doc_entry) ->
           "entry"
             <> (parens . align)
               ( "\""
                   <> pretty p_name
                   <> "\""
-                  <> comma
-                    </> ppTupleLines' (map pretty p_entry)
-                  <> comma
-                    </> pretty ret_entry
+                  <> comma </> ppTupleLines' (map pretty p_entry)
+                  <> comma </> pretty ret_entry
+                  <> maybe mempty ((comma </>) . pretty . show) doc_entry
               )
 
 instance Pretty OpaqueType where
@@ -447,7 +447,14 @@ instance Pretty OpaqueType where
 instance Pretty OpaqueTypes where
   pretty (OpaqueTypes ts) = "types" <+> nestedBlock (stack $ map p ts)
     where
-      p (name, t) = "type" <+> dquotes (pretty name) <+> equals <+> pretty t
+      p (name, (t, doc)) =
+        ( case doc of
+            Nothing -> mempty
+            Just doc' -> mconcat $ map wrap (T.lines doc')
+        )
+          <> "type" <+> dquotes (pretty name) <+> equals <+> pretty t
+        where
+          wrap x = "-- " <> pretty x <> line
 
 instance (PrettyRep rep) => Pretty (Prog rep) where
   pretty (Prog types consts funs) =

--- a/src/Futhark/IR/Syntax.hs
+++ b/src/Futhark/IR/Syntax.hs
@@ -610,7 +610,7 @@ data EntryResult = EntryResult
 
 -- | Information about the inputs and outputs (return value) of an entry
 -- point.
-type EntryPoint = (Name, [EntryParam], EntryResult)
+type EntryPoint = (Name, [EntryParam], EntryResult, Maybe T.Text)
 
 -- | An entire Futhark program.
 data Prog rep = Prog

--- a/src/Futhark/IR/Syntax/Core.hs
+++ b/src/Futhark/IR/Syntax/Core.hs
@@ -645,7 +645,7 @@ data OpaqueType
   deriving (Eq, Ord, Show)
 
 -- | Names of opaque types and their representation.
-newtype OpaqueTypes = OpaqueTypes [(Name, OpaqueType)]
+newtype OpaqueTypes = OpaqueTypes [(Name, (OpaqueType, Maybe T.Text))]
   deriving (Eq, Ord, Show)
 
 instance Monoid OpaqueTypes where

--- a/src/Futhark/IR/TypeCheck.hs
+++ b/src/Futhark/IR/TypeCheck.hs
@@ -549,7 +549,7 @@ checkOpaques :: OpaqueTypes -> Either (TypeError rep) ()
 checkOpaques (OpaqueTypes types) = descend [] types
   where
     descend _ [] = pure ()
-    descend known ((name, t) : ts) = do
+    descend known ((name, (t, _)) : ts) = do
       check known t
       descend (name : known) ts
     check known (OpaqueRecord fs) =

--- a/src/Futhark/Internalise/ApplyTypeAbbrs.hs
+++ b/src/Futhark/Internalise/ApplyTypeAbbrs.hs
@@ -43,8 +43,8 @@ removeTypeVariablesInType types =
   applySubst (`M.lookup` types)
 
 substEntry :: Types -> EntryPoint -> EntryPoint
-substEntry types (EntryPoint params ret) =
-  EntryPoint (map onEntryParam params) (onEntryType ret)
+substEntry types (EntryPoint params ret doc) =
+  EntryPoint (map onEntryParam params) (onEntryType ret) doc
   where
     onEntryParam (EntryParam v t) =
       EntryParam v $ onEntryType t

--- a/src/Futhark/Internalise/Defunctorise.hs
+++ b/src/Futhark/Internalise/Defunctorise.hs
@@ -275,8 +275,8 @@ transformExp :: Exp -> TransformM Exp
 transformExp = transformNames
 
 transformEntry :: EntryPoint -> TransformM EntryPoint
-transformEntry (EntryPoint params ret) =
-  EntryPoint <$> mapM onEntryParam params <*> onEntryType ret
+transformEntry (EntryPoint params ret doc) =
+  EntryPoint <$> mapM onEntryParam params <*> onEntryType ret <*> pure doc
   where
     onEntryParam (EntryParam v t) =
       EntryParam v <$> onEntryType t

--- a/src/Futhark/Internalise/Entry.hs
+++ b/src/Futhark/Internalise/Entry.hs
@@ -11,6 +11,7 @@ import Control.Monad.State.Strict
 import Data.Bifunctor (first)
 import Data.List (find, intersperse)
 import Data.Map qualified as M
+import Data.Text qualified as T
 import Futhark.IR qualified as I
 import Futhark.Internalise.TypesValues (internaliseSumTypeRep, internalisedTypeSize)
 import Futhark.Util (chunks)
@@ -81,17 +82,17 @@ type GenOpaque = State I.OpaqueTypes
 runGenOpaque :: GenOpaque a -> (a, I.OpaqueTypes)
 runGenOpaque = flip runState mempty
 
-addType :: Name -> I.OpaqueType -> GenOpaque ()
-addType name t = modify $ \(I.OpaqueTypes ts) ->
-  case find ((== name) . fst) ts of
-    Just (_, t')
+addType :: Name -> Maybe T.Text -> I.OpaqueType -> GenOpaque ()
+addType name doc t = modify $ \(I.OpaqueTypes ts) ->
+  case lookup name ts of
+    Just (t', _)
       | t /= t' ->
           error . unlines $
             [ "Duplicate definition of entry point type " <> E.prettyString name,
               show t,
               show t'
             ]
-    _ -> I.OpaqueTypes ts <> I.OpaqueTypes [(name, t)]
+    _ -> I.OpaqueTypes ts <> I.OpaqueTypes [(name, (t, doc))]
 
 isRecord ::
   VisibleTypes ->
@@ -228,13 +229,13 @@ entryPointType types t ts
       case E.entryType t of
         E.Scalar (E.Record fs) -> do
           let fs' = recordFields types fs $ E.entryAscribed t
-          addType desc . I.OpaqueRecord =<< opaqueRecord types fs' ts
+          addType desc doc . I.OpaqueRecord =<< opaqueRecord types fs' ts
         E.Scalar (E.Sum cs) -> do
           let (_, places) = internaliseSumTypeRep cs
               cs' = sumConstrs types cs $ E.entryAscribed t
               cs'' = zip (map fst cs') (zip (map snd cs') (map snd places))
               ts' = if length cs == 1 then ts else drop 1 ts
-          addType desc . I.OpaqueSum (map valueType ts)
+          addType desc doc . I.OpaqueSum (map valueType ts)
             =<< opaqueSum types cs'' ts'
         E.Array _ shape (E.Record fs) | not $ null fs -> do
           let rank = E.shapeRank shape
@@ -243,19 +244,20 @@ entryPointType types t ts
               record_t = E.Scalar (E.Record fs)
               record_te = rowTypeExp rank =<< E.entryAscribed t
           ept <- snd <$> entryPointType types (E.EntryType record_t record_te) ts'
-          addType desc . I.OpaqueRecordArray rank (entryPointTypeName ept)
+          addType desc doc . I.OpaqueRecordArray rank (entryPointTypeName ept)
             =<< opaqueRecordArray types rank fs' ts
         E.Array _ shape et -> do
           let ts' = map (strip (E.shapeRank shape)) ts
               rank = E.shapeRank shape
               elem_te = rowTypeExp rank =<< E.entryAscribed t
           ept <- snd <$> entryPointType types (E.EntryType (E.Scalar et) elem_te) ts'
-          addType desc . I.OpaqueArray (E.shapeRank shape) (entryPointTypeName ept) $
+          addType desc doc . I.OpaqueArray (E.shapeRank shape) (entryPointTypeName ept) $
             map valueType ts
         _ -> error $ "entryPointType: " <> E.prettyString (E.entryType t)
 
       pure (u, I.TypeOpaque desc)
   where
+    doc = Nothing
     u = foldl max Nonunique $ map I.uniqueness ts
     desc =
       maybe (nameFromText $ prettyTextOneLine t') typeExpOpaqueName $
@@ -268,14 +270,15 @@ entryPointType types t ts
 entryPoint ::
   VisibleTypes ->
   Name ->
+  Maybe T.Text ->
   [(E.EntryParam, [I.Param I.DeclType])] ->
   ( E.EntryType,
     [[I.TypeBase I.Rank I.Uniqueness]]
   ) ->
   (I.EntryPoint, I.OpaqueTypes)
-entryPoint types name params (eret, crets) =
+entryPoint types name doc params (eret, crets) =
   runGenOpaque $
-    (name,,)
+    (name,,,doc)
       <$> mapM onParam params
       <*> ( uncurry I.EntryResult
               <$> entryPointType types eret (concat crets)

--- a/src/Futhark/Internalise/Exps.hs
+++ b/src/Futhark/Internalise/Exps.hs
@@ -116,7 +116,7 @@ internaliseValBind types fb@(E.ValBind entry fname _ _ (Info rettype) tparams pa
     zeroExts ts = generaliseExtTypes ts ts
 
 generateEntryPoint :: VisibleTypes -> E.EntryPoint -> E.ValBind -> InternaliseM ()
-generateEntryPoint types (E.EntryPoint e_params e_rettype) vb = do
+generateEntryPoint types (E.EntryPoint e_params e_rettype doc) vb = do
   let (E.ValBind _ ofname _ _ (Info rettype) tparams params _ _ attrs _) = vb
   bindingFParams tparams params $ \shapeparams params' -> do
     let all_params = map pure shapeparams ++ concat params'
@@ -126,6 +126,7 @@ generateEntryPoint types (E.EntryPoint e_params e_rettype) vb = do
           entryPoint
             types
             (baseName ofname)
+            doc
             (zip e_params $ map (foldMap toList) params')
             (e_rettype, map (map I.rankShaped) entry_rettype)
         args = map (I.Var . I.paramName) $ foldMap (foldMap toList) params'

--- a/src/Futhark/Internalise/Monomorphise.hs
+++ b/src/Futhark/Internalise/Monomorphise.hs
@@ -1225,9 +1225,7 @@ transformValBind valbind = do
           M.insert (valBindName valbind) (removeEntryPoint valbind') $
             envPolyBindings env,
         envGlobalScope = global <> envGlobalScope env,
-        envScope =
-          S.insert (valBindName valbind) global
-            <> envScope env
+        envScope = S.insert (valBindName valbind) global <> envScope env
       }
 
 transformValBinds :: [ValBind] -> MonoM ()

--- a/src/Language/Futhark/Syntax.hs
+++ b/src/Language/Futhark/Syntax.hs
@@ -1092,7 +1092,8 @@ data EntryParam = EntryParam
 -- points, so the types can be either ascribed or inferred.
 data EntryPoint = EntryPoint
   { entryParams :: [EntryParam],
-    entryReturn :: EntryType
+    entryReturn :: EntryType,
+    entryDoc :: Maybe T.Text
   }
   deriving (Show)
 

--- a/src/Language/Futhark/TypeChecker.hs
+++ b/src/Language/Futhark/TypeChecker.hs
@@ -599,10 +599,14 @@ checkTypeBind (TypeBind name l tps te NoInfo doc loc) =
           TypeBind name' l tps' te' (Info elab_t) doc loc
         )
 
-entryPoint :: [Pat ParamType] -> Maybe (TypeExp Exp VName) -> ResRetType -> EntryPoint
-entryPoint params orig_ret_te (RetType _ret orig_ret) =
-  EntryPoint (map patternEntry params ++ more_params) rettype'
+entryPoint :: Maybe DocComment -> [Pat ParamType] -> Maybe (TypeExp Exp VName) -> ResRetType -> EntryPoint
+entryPoint doc params orig_ret_te (RetType _ret orig_ret) =
+  EntryPoint (map patternEntry params ++ more_params) rettype' doc'
   where
+    doc' = case doc of
+      Just (DocComment t _) -> Just t
+      _ -> Nothing
+
     (more_params, rettype') = onRetType orig_ret_te $ toStruct orig_ret
 
     patternEntry (PatParens p _) =
@@ -690,7 +694,7 @@ checkValBind vb = do
   (tparams', params', maybe_tdecl', rettype, body') <-
     checkFunDef (fname, maybe_tdecl, tparams, params, body, loc)
 
-  let entry' = Info (entryPoint params' maybe_tdecl' rettype) <$ entry
+  let entry' = Info (entryPoint doc params' maybe_tdecl' rettype) <$ entry
   case entry' of
     Just _ -> checkEntryPoint loc tparams' params' rettype
     _ -> pure ()

--- a/tests/entryexpr.fut
+++ b/tests/entryexpr.fut
@@ -2,4 +2,8 @@
 -- input { [1,2] [3] }
 -- output { [1,2,3] }
 
-def main [n] (xs: [n * 2]i32) (ys: [n]i32) = xs ++ ys
+-- | dummy
+
+-- | This entry point also has a docstring.
+entry main [n] (xs: [n * 2]i32) (ys: [n]i32) =
+  xs ++ ys


### PR DESCRIPTION
Currently only entry points are documented (based on the doc comment), but room has also been reserved for documenting opaque types - currently they will all be empty, however.