### PR TITLE
Fix non-exhaustive pattern detection when wildcards mix with constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+* Non-exhaustive pattern match warnings were not always emitted when wildcard
+  patterns and explicit constructors were mixed. (#2483)
+
 * Invalid fusion that could cause compiler crash. (#2474)
 
 * GPU code generation of segmented reductions with array operands. (#2227,

--- a/src/Language/Futhark/TypeChecker/Match.hs
+++ b/src/Language/Futhark/TypeChecker/Match.hs
@@ -81,6 +81,12 @@ isBool :: Match t -> Maybe Bool
 isBool (MatchConstr (ConstrLit (PatLitPrim (BoolValue b))) _ _) = Just b
 isBool _ = Nothing
 
+isStructuralConstr :: Match t -> Bool
+isStructuralConstr (MatchConstr (Constr _) _ _) = True
+isStructuralConstr (MatchConstr ConstrTuple _ _) = True
+isStructuralConstr (MatchConstr (ConstrRecord _) _ _) = True
+isStructuralConstr _ = False
+
 complete :: [Match StructType] -> Bool
 complete xs
   | Just x <- maybeHead xs,
@@ -154,16 +160,13 @@ findUnmatched pmat n
     -- When wildcards make the column complete, recurse on unique constructor
     -- heads (wildcard rows are included via specialise).
     recurseOnConstrHeads cs = do
-      c <- nubOrd [c | c@(MatchConstr {}) <- cs]
-      let ats = case c of MatchConstr _ args _ -> map matchType args; _ -> []
+      c@(MatchConstr c' args _) <- nubOrd $ filter isStructuralConstr cs
+      let ats = map matchType args
           a_k = length ats
           pmat' = specialise ats c pmat
       u <- findUnmatched pmat' (a_k + n - 1)
-      pure $ case c of
-        MatchConstr c' _ _ ->
-          let (r, rest) = splitAt a_k u
-           in MatchConstr c' r () : rest
-        _ -> MatchWild () : u
+      let (r, rest) = splitAt a_k u
+      pure $ MatchConstr c' r () : rest
 
     incompleteCase pt cs
       | null cs = do
@@ -184,13 +187,7 @@ findUnmatched pmat n
                 pure $ MatchConstr (Constr cname) (map (const (MatchWild ())) ts) () : u
            in sigmaWitnesses ++ missingWitnesses
       | any isWild cs,
-        not (null [() | MatchConstr (Constr _) _ _ <- cs]) =
-          recurseOnConstrHeads cs
-      | any isWild cs,
-        not (null [() | MatchConstr ConstrTuple _ _ <- cs]) =
-          recurseOnConstrHeads cs
-      | any isWild cs,
-        not (null [() | MatchConstr (ConstrRecord _) _ _ <- cs]) =
+        any isStructuralConstr cs =
           recurseOnConstrHeads cs
       | Scalar (Sum all_cs) <- pt = do
           let sigma = mapMaybe isConstr cs

--- a/src/Language/Futhark/TypeChecker/Match.hs
+++ b/src/Language/Futhark/TypeChecker/Match.hs
@@ -184,11 +184,14 @@ findUnmatched pmat n
                 pure $ MatchConstr (Constr cname) (map (const (MatchWild ())) ts) () : u
            in sigmaWitnesses ++ missingWitnesses
       | any isWild cs,
-        not (null [() | MatchConstr (Constr _) _ _ <- cs]) = recurseOnConstrHeads cs
+        not (null [() | MatchConstr (Constr _) _ _ <- cs]) =
+          recurseOnConstrHeads cs
       | any isWild cs,
-        not (null [() | MatchConstr ConstrTuple _ _ <- cs]) = recurseOnConstrHeads cs
+        not (null [() | MatchConstr ConstrTuple _ _ <- cs]) =
+          recurseOnConstrHeads cs
       | any isWild cs,
-        not (null [() | MatchConstr (ConstrRecord _) _ _ <- cs]) = recurseOnConstrHeads cs
+        not (null [() | MatchConstr (ConstrRecord _) _ _ <- cs]) =
+          recurseOnConstrHeads cs
       | Scalar (Sum all_cs) <- pt = do
           let sigma = mapMaybe isConstr cs
               notCovered (k, _) = k `notElem` sigma

--- a/src/Language/Futhark/TypeChecker/Match.hs
+++ b/src/Language/Futhark/TypeChecker/Match.hs
@@ -73,6 +73,10 @@ isConstr :: Match t -> Maybe Name
 isConstr (MatchConstr (Constr c) _ _) = Just c
 isConstr _ = Nothing
 
+isWild :: Match t -> Bool
+isWild MatchWild {} = True
+isWild _ = False
+
 isBool :: Match t -> Maybe Bool
 isBool (MatchConstr (ConstrLit (PatLitPrim (BoolValue b))) _ _) = Just b
 isBool _ = Nothing
@@ -147,28 +151,62 @@ findUnmatched pmat n
         MatchWild _ ->
           MatchWild () : u
 
-    incompleteCase pt cs = do
-      u <- findUnmatched (defaultMat pmat) (n - 1)
-      if null cs
-        then pure $ MatchWild () : u
-        else case pt of
-          Scalar (Sum all_cs) -> do
-            -- Figure out which constructors are missing.
-            let sigma = mapMaybe isConstr cs
-                notCovered (k, _) = k `notElem` sigma
-            (cname, ts) <- filter notCovered $ M.toList all_cs
-            pure $ MatchConstr (Constr cname) (map (const (MatchWild ())) ts) () : u
-          Scalar (Prim Bool) -> do
-            -- Figure out which constants are missing.
-            let sigma = mapMaybe isBool cs
-            b <- filter (`notElem` sigma) [True, False]
-            pure $ MatchConstr (ConstrLit (PatLitPrim (BoolValue b))) [] () : u
-          _ -> do
-            -- FIXME: this is wrong in the unlikely case where someone
-            -- is pattern-matching every single possible number for
-            -- some numeric type.  It should be handled more like Bool
-            -- above.
-            pure $ MatchWild () : u
+    -- When wildcards make the column complete, recurse on unique constructor
+    -- heads (wildcard rows are included via specialise).
+    recurseOnConstrHeads cs = do
+      c <- nubOrd [c | c@(MatchConstr {}) <- cs]
+      let ats = case c of MatchConstr _ args _ -> map matchType args; _ -> []
+          a_k = length ats
+          pmat' = specialise ats c pmat
+      u <- findUnmatched pmat' (a_k + n - 1)
+      pure $ case c of
+        MatchConstr c' _ _ ->
+          let (r, rest) = splitAt a_k u
+           in MatchConstr c' r () : rest
+        _ -> MatchWild () : u
+
+    incompleteCase pt cs
+      | null cs = do
+          u <- findUnmatched (defaultMat pmat) (n - 1)
+          pure $ MatchWild () : u
+      | any isWild cs,
+        Scalar (Sum all_cs) <- pt =
+          let sigma = mapMaybe isConstr cs
+              notCovered (k, _) = k `notElem` sigma
+              missingCs = filter notCovered $ M.toList all_cs
+              -- Sigma constructors: check sub-patterns (wildcard rows included via specialise).
+              sigmaWitnesses = recurseOnConstrHeads cs
+              -- Missing constructors: wildcard covers them, but sub-patterns
+              -- may still be unmatched (checked via default matrix).
+              missingWitnesses = do
+                u <- findUnmatched (defaultMat pmat) (n - 1)
+                (cname, ts) <- missingCs
+                pure $ MatchConstr (Constr cname) (map (const (MatchWild ())) ts) () : u
+           in sigmaWitnesses ++ missingWitnesses
+      | any isWild cs,
+        not (null [() | MatchConstr (Constr _) _ _ <- cs]) = recurseOnConstrHeads cs
+      | any isWild cs,
+        not (null [() | MatchConstr ConstrTuple _ _ <- cs]) = recurseOnConstrHeads cs
+      | any isWild cs,
+        not (null [() | MatchConstr (ConstrRecord _) _ _ <- cs]) = recurseOnConstrHeads cs
+      | Scalar (Sum all_cs) <- pt = do
+          let sigma = mapMaybe isConstr cs
+              notCovered (k, _) = k `notElem` sigma
+          (cname, ts) <- filter notCovered $ M.toList all_cs
+          u <- findUnmatched (defaultMat pmat) (n - 1)
+          pure $ MatchConstr (Constr cname) (map (const (MatchWild ())) ts) () : u
+      | Scalar (Prim Bool) <- pt = do
+          u <- findUnmatched (defaultMat pmat) (n - 1)
+          let sigma = mapMaybe isBool cs
+          b <- filter (`notElem` sigma) [True, False]
+          pure $ MatchConstr (ConstrLit (PatLitPrim (BoolValue b))) [] () : u
+      | otherwise = do
+          u <- findUnmatched (defaultMat pmat) (n - 1)
+          -- FIXME: this is wrong in the unlikely case where someone
+          -- is pattern-matching every single possible number for
+          -- some numeric type.  It should be handled more like Bool
+          -- above.
+          pure $ MatchWild () : u
 findUnmatched [] n = [replicate n $ MatchWild ()]
 findUnmatched _ _ = []
 

--- a/tests/issue2483.fut
+++ b/tests/issue2483.fut
@@ -1,0 +1,31 @@
+-- Non-exhaustive match with wildcard patterns in a sum type should trigger a warning.
+-- ==
+-- error: Unmatched
+
+type s = i64
+type t = #I (bool,s,s)
+       | #F (bool,s,s,s)
+       | #P
+       | #M
+       | #NE
+
+def op (a:t) (b:t) : t =
+  match (a,b)
+  case (#NE, _) -> b
+  case (_, #NE) -> a
+  case (#I(s1,x,b1), #I(s2,y,b2)) ->
+    assert (s2 == false) (#I(((s1, x * b2 + y, b1 * b2))))
+  case (#I(s1,x,b1), #F(s2,y,b2,f2)) ->
+    assert (s2 == false) (#F(((s1, x * b2 + y, b1 * b2, f2))))
+  case (#F(s1,x,b1,f1), #I(s2,y,b2)) ->
+    assert (s2 == false) (#F(((s1, x + y * f1, b1, f1 / b2))))
+  case (#I(s,x,b), #P) -> #F(((s, x, b, 1 / 10)))
+  case (#P, #I(s,x,b)) ->
+    assert (s == false) (#F(((false, x / b, 1, 1 / b))))
+  case (#M, #I(s,x,b)) ->
+    assert (s == false) (#I(true,x,b))
+  case (#M, #F(s,x,b,f)) ->
+    assert (s == false) (#F(true,x,b,f))
+  case (#F _, #P) -> assert false (([])[0])
+  case (#P, #F _) -> assert false (([])[0])
+  case (#F _, #F _) -> assert false (([])[0])


### PR DESCRIPTION
Fixes #2483.

## Problem

When a match column contains both wildcard patterns and explicit constructors, `incompleteCase` computed `sigma` (the set of explicit constructors) but discarded the default-matrix witnesses without checking sub-patterns of sigma constructors. If sigma happened to cover all constructors, the function returned `[]` — no warning — even when combinations were genuinely unmatched.

## Fix

Add `recurseOnConstrHeads`: when wildcards are present alongside structural constructors (sum, tuple, record), specialise on each unique constructor head and recurse to find unmatched sub-patterns. Wildcard rows are automatically included via `specialise`, so the check is correct. For Sum types with incomplete sigma, missing constructors are still reported via the default matrix as before.

Literal patterns (`ConstrLit`) are excluded from this path since their domain is infinite and enumeration is not possible.