### PR TITLE
Add OpenBSD support for C targets

### DIFF
--- a/rts/c/scheduler.h
+++ b/rts/c/scheduler.h
@@ -101,6 +101,10 @@ static inline int scheduler_execute_task(struct scheduler *scheduler,
 #include <sys/sysinfo.h>
 #include <sys/resource.h>
 #include <signal.h>
+#elif defined(__OpenBSD__)
+#include <sys/resource.h>
+#include <sys/sysctl.h>
+#include <signal.h>
 #elif defined(__EMSCRIPTEN__)
 #include <emscripten/threading.h>
 #include <sys/sysinfo.h>
@@ -157,6 +161,15 @@ static int num_processors(void) {
   return ncores;
 #elif defined(__linux__)
   return get_nprocs();
+#elif defined(__OpenBSD__)
+  int mib[2], ncores;
+  size_t len;
+
+  mib[0] = CTL_HW;
+  mib[1] = HW_NCPUONLINE;
+  len = sizeof(ncores);
+  CHECK_ERRNO(sysctl(mib, 2, &ncores, &len, NULL, 0), "sysctl");
+  return ncores;
 #elif __EMSCRIPTEN__
   return emscripten_num_logical_cores();
 #else


### PR DESCRIPTION
The full test suite passes except `soacs/scan9`, but that seems unrelated to OpenBSD itself:

```
Compiling with --backend=multicore:
Running compiled program:
Running ./tests/soacs/scan9:
Entry point: scan_arr; dataset: 1000000i64 100i64 [100000000]i32:
Cannot load value from generated byte stream:
not enough bytes
```