### PR TITLE
Redundant checks and invalid passing of input and output arrays in `fusible`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * An issue where `#[scratch]` would apply to subexpressions in undesirable ways,
   changing the type of the expression at the IR level.
 
+* Simplified fusibility check by removing redundant accumulator overlap check
+  and fixed fusibility check by giving the correct number of elements.
+
 ## [0.26.4]
 
 ### Added

--- a/src/Futhark/Optimise/Fusion/Screma.hs
+++ b/src/Futhark/Optimise/Fusion/Screma.hs
@@ -102,9 +102,6 @@ splitLambdaByPar names inp lam out = do
   when
     (parAccsOverlap new_lam new_lam')
     (fail "Can not fuse due to overlap in parameter accumalators.")
-  when
-    (resAccsOverlap new_lam new_lam')
-    (fail "Can not fuse due to overlap in result accumalators.")
   pure
     ( (new_inp, new_lam, new_out),
       (new_inp', new_lam', new_out')
@@ -134,16 +131,14 @@ splitLambdaByPar names inp lam out = do
 -- consumers scans or reduces.
 fusible ::
   (MonadFail m) =>
-  [SOAC.Input] ->
   ScremaForm SOACS ->
   [VName] ->
   [SOAC.Input] ->
   ScremaForm SOACS ->
-  [VName] ->
   m ()
-fusible inp_p form_p out_p inp_c form_c out_c = do
+fusible form_p out_p inp_c form_c = do
   ((_, post_scan_p, _), _) <-
-    splitLambdaByPar post_scan_pars_p inp_p post_p out_c
+    splitLambdaByPar post_scan_pars_p (lambdaParams post_p) post_p (lambdaReturnType post_p)
   let post_scan_res_p = bodyResult $ lambdaBody post_scan_p
       forbidden_p = namesFromList $ resToOut out_p post_p <$> post_scan_res_p
       is_fusible =
@@ -381,21 +376,11 @@ moveLastSuperScrema _ =
 parAccs :: Lambda SOACS -> [Type]
 parAccs = filter isAcc . map typeOf . lambdaParams
 
--- | Find all Accumulator results.
-resAccs :: Lambda SOACS -> [Type]
-resAccs = filter isAcc . lambdaReturnType
-
 -- | Check if the lambda parameters have overlapping accumulators.
 parAccsOverlap :: Lambda SOACS -> Lambda SOACS -> Bool
 parAccsOverlap lam = any (`elem` accs) . parAccs
   where
     accs = parAccs lam
-
--- | Check if the lambdas result have overlapping accumulators.
-resAccsOverlap :: Lambda SOACS -> Lambda SOACS -> Bool
-resAccsOverlap lam = any (`elem` accs) . resAccs
-  where
-    accs = resAccs lam
 
 -- | Check if the lambdas have parameters that overlap due to
 -- consumption.
@@ -496,7 +481,7 @@ fuseScrema ::
   [VName] ->
   m ([SOAC.Input], ScremaForm SOACS, [VName])
 fuseScrema w inp_p form_p out_p inp_c form_c out_c = do
-  fusible inp_p form_p out_p inp_c form_c out_c
+  fusible form_p out_p inp_c form_c
   (super_screma, new_out) <- fuseSuperScrema w inp_p form_p out_p inp_c form_c out_c
   (new_inp, form') <-
     fmap (second prunePreLambdaResults . toScrema) $


### PR DESCRIPTION
The splitting of lambdas was incorrect in `fusible` I am sure, and it seems like may be possible to get it to throw an error but I have not created program that would cause an error. The inputs should have the same size as the number of lambda parameters and the outputs should have the same size as the lambda return type. These values are extra and used in certain cases but not for fusible error which is likely why there have been no problems.

I am pretty sure I found another mistake, check for overlapping accumulators in result is redundant because there is performed a partition on the results so they would never overlap.