### PR TITLE
Fix development shell on macOS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -281,7 +281,6 @@
                   haskell.haskell-language-server
                   haskellPackages.graphmod
                   #      haskellPackages.apply-refact
-                  xdot
                   pkg-config
                   zlib
                   zlib.out
@@ -305,6 +304,7 @@
                   imagemagick # needed for literate tests
                 ]
                 ++ lib.optionals (stdenv.isLinux) [
+                  xdot
                   opencl-headers
                   ocl-icd
                   (callPackage ./nix/oclgrind.nix { })


### PR DESCRIPTION
`nix develop` failed because `xdot` depends on a package that is not supported on macOS. `xdot` doesn't seem essential, so this just makes it Linux-only.