### PR TITLE
Use device-wide atomic scope on OpenCL 2.0 or later

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Simplified fusibility check by removing redundant accumulator overlap check
   and fixed fusibility check by giving the correct number of elements.
 
+
 * A compiler crash due to missing double buffering inside sequential code
   migrated to GPU. (#2513)
+
+* Atomics now use device-wide memory scope when compiling for OpenCL C 2.0, or
+  OpenCL C 3.0 with the required atomic features. OpenCL C 2.0 is selected
+  automatically for Rusticl on Asahi; elsewhere it must be selected explicitly.
+  This fixes incorrect results from cross-workgroup operations
+  ([#734](https://github.com/diku-dk/futhark/issues/734)).
 
 ## [0.26.4]
 

--- a/rts/c/atomics32.h
+++ b/rts/c/atomics32.h
@@ -28,6 +28,10 @@ SCALAR_FUN_ATTR int32_t atomic_xor_i32_shared(volatile __local int32_t *p, int32
 SCALAR_FUN_ATTR int32_t atomic_xchg_i32_global(volatile __global int32_t *p, int32_t x) {
 #if defined(FUTHARK_CUDA) || defined(FUTHARK_HIP)
   return atomicExch((int32_t*)p, x);
+#elif defined(FUTHARK_OPENCL_DEVICE_ATOMICS)
+  return atomic_exchange_explicit((volatile atomic_int*)p, x,
+                                  memory_order_acq_rel,
+                                  memory_scope_device);
 #else
   return atomic_xor(p, x);
 #endif
@@ -45,6 +49,11 @@ SCALAR_FUN_ATTR int32_t atomic_cmpxchg_i32_global(volatile __global int32_t *p,
                                                   int32_t cmp, int32_t val) {
 #if defined(FUTHARK_CUDA) || defined(FUTHARK_HIP)
   return atomicCAS((int32_t*)p, cmp, val);
+#elif defined(FUTHARK_OPENCL_DEVICE_ATOMICS)
+  atomic_compare_exchange_strong_explicit(
+    (volatile atomic_int*)p, &cmp, val,
+    memory_order_acq_rel, memory_order_acquire, memory_scope_device);
+  return cmp;
 #else
   return atomic_cmpxchg(p, cmp, val);
 #endif
@@ -62,6 +71,10 @@ SCALAR_FUN_ATTR int32_t atomic_cmpxchg_i32_shared(volatile __local int32_t *p,
 SCALAR_FUN_ATTR int32_t atomic_add_i32_global(volatile __global int32_t *p, int32_t x) {
 #if defined(FUTHARK_CUDA) || defined(FUTHARK_HIP)
   return atomicAdd((int32_t*)p, x);
+#elif defined(FUTHARK_OPENCL_DEVICE_ATOMICS)
+  return atomic_fetch_add_explicit((volatile atomic_int*)p, x,
+                                   memory_order_acq_rel,
+                                   memory_scope_device);
 #else
   return atomic_add(p, x);
 #endif
@@ -123,6 +136,10 @@ SCALAR_FUN_ATTR float atomic_fadd_f32_shared(volatile __local float *p, float x)
 SCALAR_FUN_ATTR int32_t atomic_smax_i32_global(volatile __global int32_t *p, int32_t x) {
 #if defined(FUTHARK_CUDA) || defined(FUTHARK_HIP)
   return atomicMax((int32_t*)p, x);
+#elif defined(FUTHARK_OPENCL_DEVICE_ATOMICS)
+  return atomic_fetch_max_explicit((volatile atomic_int*)p, x,
+                                  memory_order_acq_rel,
+                                  memory_scope_device);
 #else
   return atomic_max(p, x);
 #endif
@@ -139,6 +156,10 @@ SCALAR_FUN_ATTR int32_t atomic_smax_i32_shared(volatile __local int32_t *p, int3
 SCALAR_FUN_ATTR int32_t atomic_smin_i32_global(volatile __global int32_t *p, int32_t x) {
 #if defined(FUTHARK_CUDA) || defined(FUTHARK_HIP)
   return atomicMin((int32_t*)p, x);
+#elif defined(FUTHARK_OPENCL_DEVICE_ATOMICS)
+  return atomic_fetch_min_explicit((volatile atomic_int*)p, x,
+                                  memory_order_acq_rel,
+                                  memory_scope_device);
 #else
   return atomic_min(p, x);
 #endif
@@ -155,6 +176,10 @@ SCALAR_FUN_ATTR int32_t atomic_smin_i32_shared(volatile __local int32_t *p, int3
 SCALAR_FUN_ATTR uint32_t atomic_umax_i32_global(volatile __global uint32_t *p, uint32_t x) {
 #if defined(FUTHARK_CUDA) || defined(FUTHARK_HIP)
   return atomicMax((uint32_t*)p, x);
+#elif defined(FUTHARK_OPENCL_DEVICE_ATOMICS)
+  return atomic_fetch_max_explicit((volatile atomic_uint*)p, x,
+                                  memory_order_acq_rel,
+                                  memory_scope_device);
 #else
   return atomic_max(p, x);
 #endif
@@ -171,6 +196,10 @@ SCALAR_FUN_ATTR uint32_t atomic_umax_i32_shared(volatile __local uint32_t *p, ui
 SCALAR_FUN_ATTR uint32_t atomic_umin_i32_global(volatile __global uint32_t *p, uint32_t x) {
 #if defined(FUTHARK_CUDA) || defined(FUTHARK_HIP)
   return atomicMin((uint32_t*)p, x);
+#elif defined(FUTHARK_OPENCL_DEVICE_ATOMICS)
+  return atomic_fetch_min_explicit((volatile atomic_uint*)p, x,
+                                  memory_order_acq_rel,
+                                  memory_scope_device);
 #else
   return atomic_min(p, x);
 #endif
@@ -187,6 +216,10 @@ SCALAR_FUN_ATTR uint32_t atomic_umin_i32_shared(volatile __local uint32_t *p, ui
 SCALAR_FUN_ATTR int32_t atomic_and_i32_global(volatile __global int32_t *p, int32_t x) {
 #if defined(FUTHARK_CUDA) || defined(FUTHARK_HIP)
   return atomicAnd((int32_t*)p, x);
+#elif defined(FUTHARK_OPENCL_DEVICE_ATOMICS)
+  return atomic_fetch_and_explicit((volatile atomic_int*)p, x,
+                                  memory_order_acq_rel,
+                                  memory_scope_device);
 #else
   return atomic_and(p, x);
 #endif
@@ -203,6 +236,10 @@ SCALAR_FUN_ATTR int32_t atomic_and_i32_shared(volatile __local int32_t *p, int32
 SCALAR_FUN_ATTR int32_t atomic_or_i32_global(volatile __global int32_t *p, int32_t x) {
 #if defined(FUTHARK_CUDA) || defined(FUTHARK_HIP)
   return atomicOr((int32_t*)p, x);
+#elif defined(FUTHARK_OPENCL_DEVICE_ATOMICS)
+  return atomic_fetch_or_explicit((volatile atomic_int*)p, x,
+                                 memory_order_acq_rel,
+                                 memory_scope_device);
 #else
   return atomic_or(p, x);
 #endif
@@ -219,6 +256,10 @@ SCALAR_FUN_ATTR int32_t atomic_or_i32_shared(volatile __local int32_t *p, int32_
 SCALAR_FUN_ATTR int32_t atomic_xor_i32_global(volatile __global int32_t *p, int32_t x) {
 #if defined(FUTHARK_CUDA) || defined(FUTHARK_HIP)
   return atomicXor((int32_t*)p, x);
+#elif defined(FUTHARK_OPENCL_DEVICE_ATOMICS)
+  return atomic_fetch_xor_explicit((volatile atomic_int*)p, x,
+                                  memory_order_acq_rel,
+                                  memory_scope_device);
 #else
   return atomic_xor(p, x);
 #endif

--- a/rts/c/atomics64.h
+++ b/rts/c/atomics64.h
@@ -33,6 +33,10 @@ SCALAR_FUN_ATTR double atomic_fadd_f64_shared(volatile __local double *p, double
 SCALAR_FUN_ATTR int64_t atomic_xchg_i64_global(volatile __global int64_t *p, int64_t x) {
 #if defined(FUTHARK_CUDA) || defined(FUTHARK_HIP)
   return atomicExch((unsigned long long*)p, x);
+#elif defined(FUTHARK_OPENCL_DEVICE_ATOMICS)
+  return atomic_exchange_explicit((volatile atomic_long*)p, x,
+                                  memory_order_acq_rel,
+                                  memory_scope_device);
 #else
   return atom_xchg(p, x);
 #endif
@@ -50,6 +54,11 @@ SCALAR_FUN_ATTR int64_t atomic_cmpxchg_i64_global(volatile __global int64_t *p,
                                                          int64_t cmp, int64_t val) {
 #if defined(FUTHARK_CUDA) || defined(FUTHARK_HIP)
   return atomicCAS((unsigned long long*)p, cmp, val);
+#elif defined(FUTHARK_OPENCL_DEVICE_ATOMICS)
+  atomic_compare_exchange_strong_explicit(
+    (volatile atomic_long*)p, &cmp, val,
+    memory_order_acq_rel, memory_order_acquire, memory_scope_device);
+  return cmp;
 #else
   return atom_cmpxchg(p, cmp, val);
 #endif
@@ -67,6 +76,10 @@ SCALAR_FUN_ATTR int64_t atomic_cmpxchg_i64_shared(volatile __local int64_t *p,
 SCALAR_FUN_ATTR int64_t atomic_add_i64_global(volatile __global int64_t *p, int64_t x) {
 #if defined(FUTHARK_CUDA) || defined(FUTHARK_HIP)
   return atomicAdd((unsigned long long*)p, x);
+#elif defined(FUTHARK_OPENCL_DEVICE_ATOMICS)
+  return atomic_fetch_add_explicit((volatile atomic_long*)p, x,
+                                   memory_order_acq_rel,
+                                   memory_scope_device);
 #else
   return atom_add(p, x);
 #endif
@@ -144,6 +157,10 @@ SCALAR_FUN_ATTR int64_t atomic_smax_i64_global(volatile __global int64_t *p, int
     old = atomic_cmpxchg_i64_global((volatile __global int64_t*)p, assumed, old);
   } while (assumed != old);
   return old;
+#elif defined(FUTHARK_OPENCL_DEVICE_ATOMICS)
+  return atomic_fetch_max_explicit((volatile atomic_long*)p, x,
+                                   memory_order_acq_rel,
+                                   memory_scope_device);
 #else
   return atom_max(p, x);
 #endif
@@ -178,6 +195,10 @@ SCALAR_FUN_ATTR int64_t atomic_smin_i64_global(volatile __global int64_t *p, int
     old = atomic_cmpxchg_i64_global((volatile __global int64_t*)p, assumed, old);
   } while (assumed != old);
   return old;
+#elif defined(FUTHARK_OPENCL_DEVICE_ATOMICS)
+  return atomic_fetch_min_explicit((volatile atomic_long*)p, x,
+                                   memory_order_acq_rel,
+                                   memory_scope_device);
 #else
   return atom_min(p, x);
 #endif
@@ -203,6 +224,10 @@ SCALAR_FUN_ATTR int64_t atomic_smin_i64_shared(volatile __local int64_t *p, int6
 SCALAR_FUN_ATTR uint64_t atomic_umax_i64_global(volatile __global uint64_t *p, uint64_t x) {
 #if defined(FUTHARK_CUDA) || defined(FUTHARK_HIP)
   return atomicMax((unsigned long long*)p, x);
+#elif defined(FUTHARK_OPENCL_DEVICE_ATOMICS)
+  return atomic_fetch_max_explicit((volatile atomic_ulong*)p, x,
+                                   memory_order_acq_rel,
+                                   memory_scope_device);
 #else
   return atom_max(p, x);
 #endif
@@ -219,6 +244,10 @@ SCALAR_FUN_ATTR uint64_t atomic_umax_i64_shared(volatile __local uint64_t *p, ui
 SCALAR_FUN_ATTR uint64_t atomic_umin_i64_global(volatile __global uint64_t *p, uint64_t x) {
 #if defined(FUTHARK_CUDA) || defined(FUTHARK_HIP)
   return atomicMin((unsigned long long*)p, x);
+#elif defined(FUTHARK_OPENCL_DEVICE_ATOMICS)
+  return atomic_fetch_min_explicit((volatile atomic_ulong*)p, x,
+                                   memory_order_acq_rel,
+                                   memory_scope_device);
 #else
   return atom_min(p, x);
 #endif
@@ -235,6 +264,10 @@ SCALAR_FUN_ATTR uint64_t atomic_umin_i64_shared(volatile __local uint64_t *p, ui
 SCALAR_FUN_ATTR int64_t atomic_and_i64_global(volatile __global int64_t *p, int64_t x) {
 #if defined(FUTHARK_CUDA) || defined(FUTHARK_HIP)
   return atomicAnd((unsigned long long*)p, x);
+#elif defined(FUTHARK_OPENCL_DEVICE_ATOMICS)
+  return atomic_fetch_and_explicit((volatile atomic_long*)p, x,
+                                   memory_order_acq_rel,
+                                   memory_scope_device);
 #else
   return atom_and(p, x);
 #endif
@@ -251,6 +284,10 @@ SCALAR_FUN_ATTR int64_t atomic_and_i64_shared(volatile __local int64_t *p, int64
 SCALAR_FUN_ATTR int64_t atomic_or_i64_global(volatile __global int64_t *p, int64_t x) {
 #if defined(FUTHARK_CUDA) || defined(FUTHARK_HIP)
   return atomicOr((unsigned long long*)p, x);
+#elif defined(FUTHARK_OPENCL_DEVICE_ATOMICS)
+  return atomic_fetch_or_explicit((volatile atomic_long*)p, x,
+                                  memory_order_acq_rel,
+                                  memory_scope_device);
 #else
   return atom_or(p, x);
 #endif
@@ -267,6 +304,10 @@ SCALAR_FUN_ATTR int64_t atomic_or_i64_shared(volatile __local int64_t *p, int64_
 SCALAR_FUN_ATTR int64_t atomic_xor_i64_global(volatile __global int64_t *p, int64_t x) {
 #if defined(FUTHARK_CUDA) || defined(FUTHARK_HIP)
   return atomicXor((unsigned long long*)p, x);
+#elif defined(FUTHARK_OPENCL_DEVICE_ATOMICS)
+  return atomic_fetch_xor_explicit((volatile atomic_long*)p, x,
+                                   memory_order_acq_rel,
+                                   memory_scope_device);
 #else
   return atom_xor(p, x);
 #endif

--- a/rts/c/backends/opencl.h
+++ b/rts/c/backends/opencl.h
@@ -508,6 +508,7 @@ static char* mk_compile_opts(struct futhark_context *ctx,
                              const char *extra_build_opts[],
                              struct opencl_device_option device_option) {
   int compile_opts_size = 1024;
+  bool cl_std_was_set = false;
 
   for (int i = 0; i < NUM_TUNING_PARAMS; i++) {
     compile_opts_size += 2*(strlen(ctx->cfg->tuning_params[i].name) + 20);
@@ -519,6 +520,7 @@ static char* mk_compile_opts(struct futhark_context *ctx,
 
   for (int i = 0; extra_build_opts[i] != NULL; i++) {
     compile_opts_size += strlen(extra_build_opts[i] + 1);
+    cl_std_was_set |= strncmp(extra_build_opts[i], "-cl-std=", 8) == 0;
   }
 
   for (int i = 0; i < num_macros; i++) {
@@ -530,6 +532,14 @@ static char* mk_compile_opts(struct futhark_context *ctx,
   int w = snprintf(compile_opts, compile_opts_size,
                    "-DLOCKSTEP_WIDTH=%d ",
                    (int)ctx->lockstep_width);
+
+  bool is_rusticl_asahi =
+    strcmp(device_option.platform_name, "rusticl") == 0 &&
+    strncmp(device_option.device_name, "Apple M", 7) == 0;
+  if (is_rusticl_asahi && !cl_std_was_set) {
+    w += snprintf(compile_opts+w, compile_opts_size-w,
+                  "-cl-std=CL2.0 ");
+  }
 
   w += snprintf(compile_opts+w, compile_opts_size-w,
                 "-D%s=%d ",

--- a/rts/opencl/prelude.cl
+++ b/rts/opencl/prelude.cl
@@ -29,9 +29,21 @@ typedef ulong uint64_t;
 #pragma OPENCL EXTENSION cl_khr_int64_base_atomics : enable
 #pragma OPENCL EXTENSION cl_khr_int64_extended_atomics : enable
 
+#if (__OPENCL_C_VERSION__ >= 200 && __OPENCL_C_VERSION__ < 300) || \
+  (defined(__opencl_c_atomic_order_acq_rel) && \
+   defined(__opencl_c_atomic_scope_device))
+#define FUTHARK_OPENCL_DEVICE_ATOMICS
+#endif
+
 // NVIDIAs OpenCL does not create device-wide memory fences (see #734), so we
-// use inline assembly if we detect we are on an NVIDIA GPU.
-#ifdef cl_nv_pragma_unroll
+// use inline assembly if we detect we are on an NVIDIA GPU.  OpenCL 2.0
+// provides a portable device-wide fence.
+#ifdef FUTHARK_OPENCL_DEVICE_ATOMICS
+static inline void mem_fence_global() {
+  atomic_work_item_fence(CLK_LOCAL_MEM_FENCE | CLK_GLOBAL_MEM_FENCE,
+                         memory_order_acq_rel, memory_scope_device);
+}
+#elif defined(cl_nv_pragma_unroll)
 static inline void mem_fence_global() {
   asm("membar.gl;");
 }

--- a/rts/python/opencl.py
+++ b/rts/python/opencl.py
@@ -288,6 +288,15 @@ def initialise_opencl_object(
     # compiler should provide us with the variables to which
     # parameters are mapped.
     if len(program_src) >= 0:
+        is_rusticl_asahi = (
+            self.platform.name == "rusticl"
+            and self.device.name.startswith("Apple M")
+        )
+        if is_rusticl_asahi and not any(
+            opt.startswith("-cl-std=") for opt in build_options
+        ):
+            build_options += ["-cl-std=CL2.0"]
+
         build_options += ["-DLOCKSTEP_WIDTH={}".format(lockstep_width)]
 
         build_options += [

--- a/tests/issue734.fut
+++ b/tests/issue734.fut
@@ -1,0 +1,21 @@
+-- ==
+-- compiled input { 6400000i64 } output { 30483u16 38172u16 }
+
+let min_max_nonzero (a: (u16, u16)) (b: (u16, u16)): (u16, u16) =
+  let (amin, amax) = a
+  let (bmin, bmax) = b
+  let min =
+    if amin == 0 then bmin
+    else if bmin == 0 then amin
+    else u16.min amin bmin
+  in (min, u16.max amax bmax)
+
+entry main (n: i64): (u16, u16) =
+  let values =
+    map
+      (\i ->
+        if i == 0 then 30483u16
+        else if i == n - 1 then 38172u16
+        else 32000u16)
+      (iota n)
+  in reduce_comm min_max_nonzero (0u16, 0u16) (map (\x -> (x, x)) values)


### PR DESCRIPTION
Atomics now use device-wide memory scope when OpenCL 2.0 or later is available, fixing cross-workgroup synchronization in both the C and Python OpenCL runtimes.

(re-)Fixes https://github.com/diku-dk/futhark/issues/734

I'm definitely not a opencl expert, this is basically the second time I ever had to move down to this level. so please review it carefully.



