### PR TITLE
Fix uniqueness violation in diffUpdateAcc for Safe scatter over 2D arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Fixed
 
+* A compiler crash (internal type error after the `ad` pass) when applying
+  reverse-mode AD to a `scatter` over a 2D array with a concatenated index
+  array.  The reverse pass generated an `if`-expression that consumed the
+  accumulator adjoint in the true branch via `Update` while the false branch
+  also referenced it, violating uniqueness.
+
 * A case where complex sizes referring to explicit parameters was mishandled by
   monomorphisation (#2230).
 

--- a/src/Futhark/AD/Rev/Acc.hs
+++ b/src/Futhark/AD/Rev/Acc.hs
@@ -392,22 +392,25 @@ diffUpdateAcc pat aux safety acc is vs m = do
         -- zero sensitivity. XXX: this is only true for scatter-like
         -- accumulators, but these are probably the only ones that need this
         -- handling, as they are all that appear in source programs.
-        zeroed = do
+        zeroed a = do
           z <- letSubExp "acc_adj_zero" $ zeroExp elem_t
-          pure $ BasicOp $ Update Unsafe adj slice z
+          pure $ BasicOp $ Update Unsafe a slice z
     (adj_i, acc_adj) <- case safety of
       Unsafe ->
         (,)
           <$> (letExp "updateacc_val_adj" =<< index_adj)
-          <*> (letExp "acc_adj" =<< zeroed)
+          <*> (letExp "acc_adj" =<< zeroed adj)
       Safe -> do
         -- The primal UpdateAcc may be out-of-bounds, in which case indexing the
         -- adjoint is dangerous and the input accumulator adjoint is unchanged.
+        -- We copy adj so the true branch can consume the copy via Update
+        -- while the false branch returns the original unchanged.
+        adj_copy <- letExp (baseName adj <> "_copy") . BasicOp $ Replicate mempty (Var adj)
         ~[adj_i, acc_adj] <-
           letTupExp "updateacc_adj"
             =<< eIf
               (eShapeInBounds (arrayShape adj_t) (map eSubExp is))
-              (eBody [index_adj, zeroed])
+              (eBody [index_adj, zeroed adj_copy])
               (eBody [pure $ zeroExp elem_t, pure $ BasicOp $ SubExp $ Var adj])
         pure (adj_i, acc_adj)
     -- XXX: this is only OK because we assume accumulators are currently

--- a/tests/ad/scatter4.fut
+++ b/tests/ad/scatter4.fut
@@ -1,0 +1,16 @@
+-- Reverse-mode AD of a scatter over a 2D array where the index array is formed
+-- by concatenation.  This used to crash the compiler with an internal type
+-- error ("Variable X referenced after being consumed") after the 'ad' pass,
+-- because diffUpdateAcc generated an if-expression whose true branch consumed
+-- the accumulator adjoint via Update while the false branch also referenced it.
+-- ==
+-- tags { autodiff }
+-- entry: main
+-- input { [[1.0], [2.0], [3.0]] }
+-- output { [[1.0], [1.0], [1.0]] }
+
+def f [n] (xs: [n][1]f64) : [n][1]f64 =
+  scatter (#[scratch] replicate n (replicate 1 0.0)) ((0..<n) ++ (0..<n)) (xs ++ xs)
+
+entry main [n] (xs: [n][1]f64) =
+  vjp f xs (replicate n (replicate 1 1.0))


### PR DESCRIPTION
## Summary

When applying \`vjp\` to a \`scatter\` over a \`[n][k]f64\` array with a concatenated index array (e.g. \`(0..<n) ++ (0..<n)\`), the compiler crashed with an internal type error after the \`ad\` pass: \`Variable X referenced after being consumed\`.

**Root cause:** In \`diffUpdateAcc\`, the \`Safe\` branch built an \`if\`-expression whose **true branch body** referenced \`adj\` twice in a sequential scope: first observing it via \`Index adj slice\` (to read out \`adj_i\`), then consuming it via \`Update Unsafe adj slice zero\` (to produce \`acc_adj\`). Even though cross-branch consumption is legal in Futhark (it is fine for one branch to consume a variable that the other only observes), within a single branch body the two uses are sequenced, and the type checker fires when a variable is consumed after being observed in the same scope. The bug only triggers for 2D (or higher) element types because those yield \`Safe\` \`UpdateAcc\` statements; 1D scatters use \`Unsafe\` and are unaffected.

**Fix:** Made \`zeroed\` take the array name as a parameter. In the \`Safe\` branch, a copy of \`adj\` (\`adj_copy\`) is made before the \`if\` so the true branch consumes the copy via \`Update Unsafe adj_copy slice zero\` while still observing the original \`adj\` via \`Index adj slice\`. The false branch returns the original \`adj\` unchanged. This eliminates the within-branch conflict entirely.

**Concern:** The copy added in the \`Safe\` branch should be eliminated by simplification in normal cases, but could leave a constant memory overhead if simplification doesn't fire. Also, the \`copyConsumedArrsInStm\` mechanism handles this class of problem for the forward pass generically — generated return-sweep code is not covered by it, so similar issues in other \`diff*\` functions would need their own fixes.