### PR TITLE
Add a semipartition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Added
 
+* Added semipartition, faster than partition but it is not stable for
+  false elements.
+
 * Rewrote partition to be a single kernel.
 
 * The type checker has been rewritten, with contributions from Jacob Aleksandar

--- a/prelude/soacs.fut
+++ b/prelude/soacs.fut
@@ -255,6 +255,9 @@ def filter [n] 'a (p: a -> bool) (as: [n]a) : *[]a =
 -- | Split an array into those elements that satisfy the given
 -- predicate, and those that do not.
 --
+-- Both result arrays preserve the relative order of elements from the
+-- input array. In other words, `partition`@term is stable.
+--
 -- **Work:** *O(n ✕ W(p))*
 --
 -- **Span:** *O(log(n) ✕ W(p))*
@@ -279,6 +282,45 @@ def partition [n] 'a
   let idxs1 = map2 to_index1 f_flags offsets
   let is = intrinsics.concat idxs0 idxs1
   let res = scatter (#[scratch] [as][0]) is (intrinsics.concat as rev_as)
+  let count =
+    scatter [0]
+            (map (\j -> if j == n - 1 then 0 else -1) (0..1..<n))
+            (map (.0) offsets)
+  in (res[0:count[0]], res[count[0]:n])
+
+-- | Split an array into those elements that satisfy the given
+-- predicate, and those that do not. Elements satisfying the predicate
+-- preserve their relative order from
+--
+-- Elements satisfying the predicate preserve their relative order
+-- from the input array. Elements not satisfying the predicate are
+-- returned in reverse relative order.
+--
+-- Compared to `partition`@term, this operation performs fewer memory
+-- accesses (approximately 2n reads/writes instead of 3n), and can
+-- therefore be faster when the relaxed ordering guarantee is
+-- acceptable.
+--
+-- **Work:** *O(n ✕ W(p))*
+--
+-- **Span:** *O(log(n) ✕ W(p))*
+def semipartition [n] 'a
+                  (p: a -> bool)
+                  (as: [n]a) : ?[k].([k]a, [n - k]a) =
+  let to_index0 f (o0, o1) = if f then o0 - 1 else n - o1
+  let add2 (a0, b0) (a1, b1) = (a0 + a1, b0 + b1)
+  let t_flags = map p as
+  let f_flags = map (\x -> !x) t_flags
+  let flags =
+    map2 (\x y ->
+            ( intrinsics.btoi_bool_i64 x
+            , intrinsics.btoi_bool_i64 y
+            ))
+         t_flags
+         f_flags
+  let offsets = scan add2 (0, 0) flags
+  let is = map2 to_index0 t_flags offsets
+  let res = scatter (#[scratch] [as][0]) is as
   let count =
     scatter [0]
             (map (\j -> if j == n - 1 then 0 else -1) (0..1..<n))

--- a/tests/soacs/partition3.fut
+++ b/tests/soacs/partition3.fut
@@ -1,0 +1,34 @@
+def is_sorted [n] (xs: [n]i64) : bool =
+  all (\i -> i == 0 || xs[i - 1] < xs[i]) (indices xs)
+
+def is_partition [n] [m] (p: i32 -> bool) (ts: [n]i32) (fs: [m]i32) : bool =
+  all p ts && all (not <-< p) fs
+
+-- ==
+-- property: test_partition_stable test_semipartition_semistable test_partition test_semipartition
+
+#[prop]
+entry test_partition [n] (xs: [n]i32) =
+  let p = (== 0) <-< (% 2)
+  let (ts, fs) = partition p xs
+  in is_partition p ts fs
+
+#[prop]
+entry test_semipartition [n] (xs: [n]i32) =
+  let p = (== 0) <-< (% 2)
+  let (ts, fs) = semipartition p xs
+  in is_partition p ts fs
+
+#[prop]
+entry test_partition_stable [n] (xs: [n]bool) =
+  let zs = zip xs (indices xs)
+  let (ts, fs) = partition (.0) zs
+  in is_sorted (map (.1) ts)
+     && is_sorted (map (.1) fs)
+
+#[prop]
+entry test_semipartition_semistable [n] (xs: [n]bool) =
+  let zs = zip xs (indices xs)
+  let (ts, fs) = semipartition (.0) zs
+  in is_sorted (map (.1) ts)
+     && is_sorted (map (.1) (reverse fs))

--- a/tests/soacs/partition3.fut
+++ b/tests/soacs/partition3.fut
@@ -5,28 +5,31 @@ def is_partition [n] [m] (p: i32 -> bool) (ts: [n]i32) (fs: [m]i32) : bool =
   all p ts && all (not <-< p) fs
 
 -- ==
--- property: test_partition_stable test_semipartition_semistable test_partition test_semipartition
+-- entry: test_partition_stable test_semipartition_semistable
+-- random input { [1000]bool }
+-- output { true }
 
-#[prop]
+-- ==
+-- entry: test_partition test_semipartition
+-- random input { [1000]i32 }
+-- output { true }
+
 entry test_partition [n] (xs: [n]i32) =
   let p = (== 0) <-< (% 2)
   let (ts, fs) = partition p xs
   in is_partition p ts fs
 
-#[prop]
 entry test_semipartition [n] (xs: [n]i32) =
   let p = (== 0) <-< (% 2)
   let (ts, fs) = semipartition p xs
   in is_partition p ts fs
 
-#[prop]
 entry test_partition_stable [n] (xs: [n]bool) =
   let zs = zip xs (indices xs)
   let (ts, fs) = partition (.0) zs
   in is_sorted (map (.1) ts)
      && is_sorted (map (.1) fs)
 
-#[prop]
 entry test_semipartition_semistable [n] (xs: [n]bool) =
   let zs = zip xs (indices xs)
   let (ts, fs) = semipartition (.0) zs


### PR DESCRIPTION
This pull request adds a semipartition and tests, it matches the partition implementation found in CUB.
True elements are ordered relative to their indices but false elements are in reverse order relative to their indices.
