### PR TITLE
futhark profile: add logs and timeline to HTML reports

### DIFF
--- a/docs/man/futhark-profile.rst
+++ b/docs/man/futhark-profile.rst
@@ -39,9 +39,10 @@ contains files with human-readable profiling information. A set of files will be
 created for each benchmark dataset. If the original invocation of ``futhark
 bench`` included multiple programs, then ``futhark profile`` will create
 subdirectories for each program (although all inside the same top level
-directory). If the source files passed to ``futhark bench`` are accessible via
-the original paths, then the directory will also contain HTML files with
-annotated source code.
+directory). The dataset HTML reports include the log and timeline even when
+the source files are unavailable. If the source files passed to ``futhark
+bench`` are accessible via the original paths, the reports also link to HTML
+files with annotated source code.
 
 You can pass multiple JSON files to ``futhark profile``. Each will
 produce a distinct top level directory.
@@ -64,8 +65,17 @@ level directory.
   most importantly the source locations.
 
 * ``foo-index.html``: overview file and guide to the other html files.
-  Contains explanations for the concepts, links to other pages.
-  This is the entry file for profile exploration.
+  Contains the log and timeline as preformatted text, with links to jump to
+  either section, and navigation to the source and cost centre pages.
+  This is the entry file for profile exploration. Missing logs or profiling
+  information are indicated explicitly; a recorded empty log or timeline is
+  shown as empty. A dataset with only a log still gets an HTML report. Failed
+  datasets and datasets with neither a log nor a profile do not.
+
+The HTML sections contain the same text as the log and timeline files, which
+remain available separately. Event order, durations, and provenance are
+preserved; backend-specific event details remain in the input JSON. No
+allocation/deallocation events or start times are inferred from the log.
 
 The log file is often too verbose to be useful, but the summary and timeline
 should be inspected, even if the latter is sometimes fairly large.
@@ -89,7 +99,9 @@ Raw reports
 Alternatively, the JSON file passed to ``futhark profile`` may also be a raw
 profiling report as produced by the C API function ``futhark_context_report()``.
 A directory is still created, but it will only contain a single set of files,
-and it will not contain a log.
+and it will not contain a log. Open ``index.html`` in this directory to read
+the timeline and browse the source information. The text files are named
+``summary`` and ``timeline``.
 
 EXAMPLES
 ========

--- a/src/Futhark/CLI/Profile.hs
+++ b/src/Futhark/CLI/Profile.hs
@@ -3,7 +3,7 @@ module Futhark.CLI.Profile (main) where
 
 import Control.Arrow ((&&&), (>>>))
 import Control.Exception (catch)
-import Control.Monad (forM_, (>=>))
+import Control.Monad (forM_, when)
 import Control.Monad.Except (ExceptT, liftEither, runExcept, runExceptT)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Except (Except)
@@ -13,6 +13,7 @@ import Data.Foldable (toList)
 import Data.Function ((&))
 import Data.List qualified as L
 import Data.Map qualified as M
+import Data.Maybe (isJust)
 import Data.Monoid (Sum (..))
 import Data.Sequence qualified as Seq
 import Data.Set qualified as S
@@ -32,7 +33,7 @@ import Futhark.Bench
   )
 import Futhark.Profile.Details (CostCentreDetails (CostCentreDetails), CostCentreName (CostCentreName), CostCentres, SourceRangeDetails (SourceRangeDetails), SourceRanges, containingCostCentres)
 import Futhark.Profile.EventSummary qualified as ES
-import Futhark.Profile.Html (generateCCOverviewHtml, generateHeatmapHtml, generateHtmlIndex, securedHashPath)
+import Futhark.Profile.Html (generateCCOverviewHtml, generateHeatmapHtml, generateHtmlIndex, generateSourceIndex, securedHashPath)
 import Futhark.Profile.SourceRange (SourceRange)
 import Futhark.Profile.SourceRange qualified as SR
 import Futhark.Util (showText)
@@ -151,27 +152,36 @@ data TargetFiles = TargetFiles
     htmlDir :: FilePath
   }
 
-writeAnalysis :: TargetFiles -> ProfilingReport -> IO ()
-writeAnalysis tf r = runExceptT >=> handleException $ do
-  let evSummaryMap = ES.eventSummaries $ profilingEvents r
+-- | Write text and HTML reports, even if source analysis is unavailable.
+writeAnalysis :: TargetFiles -> Maybe T.Text -> Maybe ProfilingReport -> IO ()
+writeAnalysis tf logText profilingReport = do
+  createDirectoryIfMissing True $ htmlDir tf
+  T.writeFile (htmlDir tf </> "style.css") cssFile
 
-  -- heatmap html and cost centres
-  writeHtml tf evSummaryMap
+  let timelineText = timeline . profilingEvents <$> profilingReport
+  sourceIndex <- case profilingReport of
+    Nothing -> pure $ H.p "No profiling information recorded."
+    Just r -> do
+      let evSummaryMap = ES.eventSummaries $ profilingEvents r
+      T.writeFile (summaryFile tf) $
+        memoryReport (profilingMemory r)
+          <> "\n\n"
+          <> tabulateEvents evSummaryMap
+      forM_ timelineText $ T.writeFile (timelineFile tf)
 
-  -- profile.summary
-  liftIO $
-    T.writeFile (summaryFile tf) $
-      memoryReport (profilingMemory r)
-        <> "\n\n"
-        <> tabulateEvents evSummaryMap
+      sourceResult <- runExceptT $ writeHtml tf evSummaryMap
+      case sourceResult of
+        Left err -> do
+          T.hPutStrLn stderr err
+          pure $ do
+            H.p "Source information unavailable."
+            H.pre $ H.text err
+        Right html -> pure html
 
-  -- profile.timeline
-  liftIO $
-    T.writeFile (timelineFile tf) $
-      timeline (profilingEvents r)
-  where
-    handleException :: Either T.Text () -> IO ()
-    handleException = either (T.hPutStrLn stderr) pure
+  let relHtmlDirPath = last $ splitPath $ htmlDir tf
+  LT.writeFile (htmlIndexFile tf) $
+    H.renderHtml $
+      generateHtmlIndex relHtmlDirPath logText timelineText sourceIndex
 
 toIOExcept :: Except T.Text a -> ExceptT T.Text IO a
 toIOExcept = liftEither . runExcept
@@ -181,27 +191,14 @@ writeHtml ::
   TargetFiles ->
   -- | mapping keys are (name, provenance)
   M.Map (T.Text, T.Text) ES.EvSummary ->
-  ExceptT T.Text IO ()
+  ExceptT T.Text IO H.Html
 writeHtml tf evSummaryMap = do
   let htmlDirPath = htmlDir tf
-  let htmlIndexPath = htmlIndexFile tf
   (sourceRanges, costCentres) <- toIOExcept $ buildDetailStructures evSummaryMap
   htmlFiles <- generateHtmlHeatmaps sourceRanges
   let costCentreOverview = generateCCOverviewHtml costCentres
 
   liftIO $ do
-    -- create the bench.html/ directory
-    createDirectoryIfMissing True htmlDirPath
-    -- style is needed by both cc-overview and source ranges
-    let cssPath = htmlDirPath </> "style.css"
-    T.writeFile cssPath cssFile
-
-    -- index file
-    let relHtmlDirPath = last $ splitPath htmlDirPath
-    LT.writeFile
-      htmlIndexPath
-      (H.renderHtml $ generateHtmlIndex relHtmlDirPath sourceRanges costCentres)
-
     -- cost centre file
     LT.writeFile
       (htmlDirPath </> "cost-centres.html")
@@ -212,6 +209,9 @@ writeHtml tf evSummaryMap = do
       let absPath =
             htmlDirPath </> makeRelative "/" (srcFilePath <> ".html")
       writeLazyTextFile absPath (H.renderHtml html)
+
+  let relHtmlDirPath = last $ splitPath htmlDirPath
+  pure $ generateSourceIndex relHtmlDirPath sourceRanges
 
 writeLazyTextFile :: FilePath -> LT.Text -> IO ()
 writeLazyTextFile filepath content = do
@@ -402,10 +402,10 @@ analyseProfilingReport json_path r = do
         TargetFiles
           { summaryFile = top_dir </> "summary",
             timelineFile = top_dir </> "timeline",
-            htmlIndexFile = top_dir </> "index",
+            htmlIndexFile = top_dir </> "index.html",
             htmlDir = top_dir </> "html/"
           }
-  writeAnalysis tf r
+  writeAnalysis tf Nothing $ Just r
 
 analyseBenchResults :: FilePath -> [BenchResult] -> IO ()
 analyseBenchResults json_path bench_results = do
@@ -438,15 +438,16 @@ analyseBenchResults json_path bench_results = do
         Just text -> T.writeFile (name' <.> ".log") text
       case report res of
         Nothing -> problem prog_name name "no profiling information"
-        Just r ->
-          let tf =
-                TargetFiles
-                  { summaryFile = name' <> ".summary",
-                    timelineFile = name' <> ".timeline",
-                    htmlIndexFile = name' <> "-index.html",
-                    htmlDir = name' <> ".html/"
-                  }
-           in writeAnalysis tf r
+        Just _ -> pure ()
+      let tf =
+            TargetFiles
+              { summaryFile = name' <> ".summary",
+                timelineFile = name' <> ".timeline",
+                htmlIndexFile = name' <> "-index.html",
+                htmlDir = name' <> ".html/"
+              }
+      when (isJust (stdErr res) || isJust (report res)) $
+        writeAnalysis tf (stdErr res) (report res)
 
 readFileSafely :: FilePath -> IO (Either String BS.ByteString)
 readFileSafely filepath =

--- a/src/Futhark/Profile/Html.hs
+++ b/src/Futhark/Profile/Html.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE QuasiQuotes #-}
 
-module Futhark.Profile.Html (securedHashPath, generateHeatmapHtml, generateCCOverviewHtml, generateHtmlIndex) where
+module Futhark.Profile.Html (securedHashPath, generateHeatmapHtml, generateCCOverviewHtml, generateHtmlIndex, generateSourceIndex) where
 
 import Control.Monad (join)
 import Control.Monad.State.Strict (State, evalState, get, modify)
@@ -14,7 +14,7 @@ import Data.Set (Set)
 import Data.String (IsString (fromString))
 import Data.Text qualified as T
 import Data.Word (Word8)
-import Futhark.Profile.Details (CostCentreDetails (CostCentreDetails, summary), CostCentreName (CostCentreName, getCostCentreName), CostCentres, SourceRangeDetails (SourceRangeDetails, containingCostCentres), SourceRanges, sourceRangeDetailsFraction)
+import Futhark.Profile.Details (CostCentreDetails (CostCentreDetails, summary), CostCentreName (CostCentreName, getCostCentreName), SourceRangeDetails (SourceRangeDetails, containingCostCentres), SourceRanges, sourceRangeDetailsFraction)
 import Futhark.Profile.Details qualified as D
 import Futhark.Profile.EventSummary qualified as ES
 import Futhark.Profile.SourceRange qualified as SR
@@ -39,20 +39,47 @@ data RenderState = RenderState
     remainingText :: !T.Text
   }
 
+-- | A dataset report with browser-readable logs and timeline.  The source
+-- index may instead explain why source analysis was unavailable.
 generateHtmlIndex ::
   -- | Path of the bench dir
   FilePath ->
-  M.Map FilePath SourceRanges ->
-  CostCentres ->
+  Maybe T.Text ->
+  Maybe T.Text ->
+  H.Html ->
   H.Html
-generateHtmlIndex benchDir _pathToSourceRanges _costCentres = do
+generateHtmlIndex benchDir logText timelineText sourceIndex =
   H.docTypeHtml $ do
-    headHtmlWithCss (benchDir </> "style.css") pageTitle
-    H.h2 $ H.string pageTitle
-    introductionIndex (T.pack benchDir)
-    sourceFileIndex benchDir (M.keysSet _pathToSourceRanges)
-  where
-    pageTitle = "Source File Index"
+    headHtmlWithCss (benchDir </> "style.css") "Profiling Report"
+    H.body $ H.main $ do
+      H.h1 "Profiling Report"
+      H.nav $ H.ul $ do
+        H.li $ H.a ! A.href "#log" $ "Log"
+        H.li $ H.a ! A.href "#timeline" $ "Timeline"
+        H.li $ H.a ! A.href "#sources" $ "Source information"
+      H.section ! A.id "log" $ do
+        H.h2 "Log"
+        H.p "The running log produced during execution."
+        maybe
+          (H.p "No log recorded.")
+          ((H.pre ! A.id "log-text") . H.code . H.text)
+          logText
+      H.section ! A.id "timeline" $ do
+        H.h2 "Timeline"
+        H.p "Recorded events in order, with durations in microseconds."
+        maybe
+          (H.p "No profiling information recorded.")
+          ((H.pre ! A.id "timeline-text") . H.code . H.text)
+          timelineText
+      H.section ! A.id "sources" $ do
+        H.h2 "Source information"
+        sourceIndex
+
+-- | Navigation to the successfully generated source and cost centre pages.
+generateSourceIndex :: FilePath -> M.Map FilePath SourceRanges -> H.Html
+generateSourceIndex benchDir pathToSourceRanges = do
+  introductionIndex (T.pack benchDir)
+  sourceFileIndex benchDir (M.keysSet pathToSourceRanges)
 
 introductionIndex :: T.Text -> H.Html
 introductionIndex benchDir = do

--- a/tests_adhoc/profile-html/test.py
+++ b/tests_adhoc/profile-html/test.py
@@ -1,0 +1,223 @@
+"""Test the real profiling CLI's HTML logs and timelines without a GPU."""
+
+from __future__ import annotations
+
+from html.parser import HTMLParser
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from urllib.parse import unquote, urlsplit
+
+
+class Page(HTMLParser):
+    def __init__(self, path: Path):
+        super().__init__()
+        self.tags: list[str] = []
+        self.ids: list[str] = []
+        self.links: list[str] = []
+        self.blocks: dict[str, str] = {}
+        self.block: str | None = None
+        self.text = ""
+        self.feed(path.read_text(encoding="utf-8"))
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]):
+        self.tags.append(tag)
+        attr = dict(attrs)
+        if attr.get("id"):
+            self.ids.append(str(attr["id"]))
+        if tag == "a":
+            self.links.append(str(attr["href"]))
+        if tag == "pre":
+            self.block = str(attr.get("id"))
+            self.blocks[self.block] = ""
+
+    def handle_endtag(self, tag: str):
+        if tag == "pre":
+            self.block = None
+
+    def handle_data(self, data: str):
+        self.text += data
+        if self.block is not None:
+            self.blocks[self.block] += data
+
+
+def event(name="kernel", duration=12.5, provenance="unknown"):
+    return {
+        "name": name,
+        "duration": duration,
+        "provenance": provenance,
+        "details": {"backend-specific": "retained in input JSON"},
+    }
+
+
+def result(events=None, log="execution log\n"):
+    return {
+        "runtimes": [100],
+        "bytes": {"device": 256},
+        "stderr": log,
+        "profiling": {
+            "memory": {"device": 256},
+            "events": [event()] if events is None else events,
+        },
+    }
+
+
+class ProfileHtmlTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name).resolve()
+
+    def run_profile(self, payload, filename="results.json"):
+        path = self.root / filename
+        original = json.dumps(payload, ensure_ascii=False)
+        path.write_text(original, encoding="utf-8")
+        run = subprocess.run(
+            [os.environ.get("FUTHARK", "futhark"), "profile", str(path)],
+            cwd=self.root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(path.read_text(encoding="utf-8"), original)
+        return self.root / path.with_suffix(".prof").name, run.stderr
+
+    def benchmark(self, datasets):
+        return self.run_profile({"prog.fut:main": {"datasets": datasets}})
+
+    def page(self, path):
+        page = Page(path)
+        self.assertNotIn("script", page.tags)
+        self.assertNotIn("img", page.tags)
+        self.assertIn("body", page.tags)
+        self.assertIn("nav", page.tags)
+        self.assertEqual(len(page.ids), len(set(page.ids)))
+        for href in page.links:
+            url = urlsplit(href)
+            self.assertFalse(url.scheme or url.netloc or url.query)
+            target = path.parent / unquote(url.path) if url.path else path
+            self.assertTrue(target.is_file(), f"Broken link: {href}")
+            if url.fragment:
+                self.assertIn(unquote(url.fragment), Page(target).ids)
+        return page
+
+    def dataset(self, top, name):
+        return self.page(top / "main" / (name + "-index.html"))
+
+    def test_order_whitespace_unicode_and_escaping(self):
+        log = '\n  allocation <script>alert("é")</script> & copy\t\nlast'
+        events = [
+            event('second <img src=x onerror="alert(1)"> & λ', 2.5),
+            event("first", 0.0),
+            event('second <img src=x onerror="alert(1)"> & λ', 1.25),
+        ]
+        top, _ = self.benchmark({"input": result(events, log)})
+        page = self.dataset(top, "input")
+        self.assertEqual(page.blocks["log-text"], log)
+        self.assertEqual((top / "main/input.log").read_text(), log)
+        timeline = (top / "main/input.timeline").read_text()
+        self.assertEqual(page.blocks["timeline-text"], timeline)
+        self.assertEqual(
+            timeline,
+            'second <img src=x onerror="alert(1)"> & λ\n'
+            "Duration: 2.5 μs\nAt: unknown\n\n"
+            "first\nDuration: 0.0 μs\nAt: unknown\n\n"
+            'second <img src=x onerror="alert(1)"> & λ\n'
+            "Duration: 1.25 μs\nAt: unknown\n",
+        )
+        self.assertIn("#log", page.links)
+        self.assertIn("#timeline", page.links)
+        self.assertTrue((top / "main/input.summary").is_file())
+        self.assertTrue((top / "main/input.html/cost-centres.html").is_file())
+
+    def test_missing_null_and_empty_fields(self):
+        datasets = {
+            "empty": result([], ""),
+            "no-log": result(log=None),
+            "log-only": result(log="no profile <&>"),
+            "neither": {"runtimes": [], "bytes": {}},
+            "failed": "execution failed",
+        }
+        datasets["log-only"]["profiling"] = None
+        top, stderr = self.benchmark(datasets)
+        empty = self.dataset(top, "empty")
+        self.assertEqual(empty.blocks["log-text"], "")
+        self.assertEqual(empty.blocks["timeline-text"], "")
+        no_log = self.dataset(top, "no-log")
+        self.assertNotIn("log-text", no_log.blocks)
+        self.assertIn("No log recorded", no_log.text)
+        log_only = self.dataset(top, "log-only")
+        self.assertEqual(log_only.blocks["log-text"], "no profile <&>")
+        self.assertNotIn("timeline-text", log_only.blocks)
+        self.assertIn("No profiling information", log_only.text)
+        self.assertFalse((top / "main/log-only.timeline").exists())
+        self.assertFalse((top / "main/neither-index.html").exists())
+        self.assertFalse((top / "main/failed-index.html").exists())
+        self.assertIn("execution failed", stderr)
+        self.assertIn("no profiling information", stderr)
+
+    def test_unavailable_and_invalid_sources(self):
+        for provenance in (
+            "missing.fut:1:1-5",
+            "<script>bad & provenance</script>",
+            "invalid-utf8.fut:1:1-5",
+        ):
+            with self.subTest(provenance=provenance):
+                (self.root / "invalid-utf8.fut").write_bytes(b"\xff")
+                top, stderr = self.benchmark(
+                    {"input": result([event(provenance=provenance)])}
+                )
+                page = self.dataset(top, "input")
+                self.assertIn(provenance, page.blocks["timeline-text"])
+                self.assertIn("Source information unavailable", page.text)
+                self.assertEqual(page.blocks["log-text"], "execution log\n")
+                self.assertTrue((top / "main/input.summary").is_file())
+                self.assertTrue((top / "main/input.timeline").is_file())
+                self.assertNotIn("cost-centres.html", " ".join(page.links))
+                self.assertTrue(stderr)
+
+    def test_source_heatmap_and_cost_centres(self):
+        (self.root / "prog.fut").write_text("entry main x = x + 1\n")
+        top, _ = self.benchmark(
+            {"input": result([event(provenance="prog.fut:1:16-21")])}
+        )
+        page = self.dataset(top, "input")
+        self.assertIn("Cost Centre Overview", page.text)
+        self.assertTrue(
+            any("cost-centres.html" in link for link in page.links)
+        )
+        self.assertTrue(any("prog.fut" in link for link in page.links))
+        self.assertIn("At: prog.fut:1:16-21", page.blocks["timeline-text"])
+
+    def test_raw_report(self):
+        top, _ = self.run_profile(result()["profiling"], "raw.json")
+        page = self.page(top / "index.html")
+        self.assertEqual(
+            page.blocks["timeline-text"], (top / "timeline").read_text()
+        )
+        self.assertNotIn("log-text", page.blocks)
+        self.assertIn("No log recorded", page.text)
+        self.assertTrue((top / "summary").is_file())
+        self.assertFalse(list(top.glob("*.log")))
+
+    def test_dataset_names_and_repeated_invocation(self):
+        name = 'input & <é> #?%"'
+        top, _ = self.benchmark({name: result()})
+        # Only the newly introduced in-page navigation is relevant here.
+        page = Page(top / "main" / (name + "-index.html"))
+        for link in ("#log", "#timeline"):
+            self.assertIn(link, page.links)
+            self.assertIn(link[1:], page.ids)
+        top, _ = self.benchmark({"input": result(log="stale")})
+        top, _ = self.benchmark({"input": result(log=None)})
+        page = self.dataset(top, "input")
+        self.assertNotIn("log-text", page.blocks)
+        self.assertNotIn("stale", page.text)
+        self.assertFalse((top / "main/input.log").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_adhoc/profile-html/test.py
+++ b/tests_adhoc/profile-html/test.py
@@ -77,10 +77,10 @@ class ProfileHtmlTests(unittest.TestCase):
         run = subprocess.run(
             ["futhark", "profile", str(path)],
             cwd=self.root,
-            check=True,
             capture_output=True,
             text=True,
         )
+        self.assertEqual(run.returncode, 0, run.stderr)
         self.assertEqual(path.read_text(encoding="utf-8"), original)
         return self.root / path.with_suffix(".prof").name, run.stderr
 
@@ -203,10 +203,9 @@ class ProfileHtmlTests(unittest.TestCase):
         self.assertFalse(list(top.glob("*.log")))
 
     def test_dataset_names_and_repeated_invocation(self):
-        name = 'input & <é> #?%"'
-        top, _ = self.benchmark({name: result()})
+        top, _ = self.benchmark({"input": result()})
         # Only the newly introduced in-page navigation is relevant here.
-        page = Page(top / "main" / (name + "-index.html"))
+        page = Page(top / "main/input-index.html")
         for link in ("#log", "#timeline"):
             self.assertIn(link, page.links)
             self.assertIn(link[1:], page.ids)

--- a/tests_adhoc/profile-html/test.py
+++ b/tests_adhoc/profile-html/test.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from html.parser import HTMLParser
 import json
-import os
 from pathlib import Path
 import subprocess
 import tempfile
@@ -76,7 +75,7 @@ class ProfileHtmlTests(unittest.TestCase):
         original = json.dumps(payload, ensure_ascii=False)
         path.write_text(original, encoding="utf-8")
         run = subprocess.run(
-            [os.environ.get("FUTHARK", "futhark"), "profile", str(path)],
+            ["futhark", "profile", str(path)],
             cwd=self.root,
             check=True,
             capture_output=True,

--- a/tests_adhoc/profile-html/test.sh
+++ b/tests_adhoc/profile-html/test.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+set -e
+python3 test.py


### PR DESCRIPTION
Closes #2348.

`futhark profile` already writes each dataset's execution log and event timeline
as text files, but its HTML landing page only linked to source annotations. This
adds Log and Timeline sections to every dataset HTML report, so the browser view
contains the same text as the companion files.

The report is now still useful when source files cannot be loaded: it renders the
log and timeline and explains that source annotation is unavailable. A dataset
with only a log also receives an HTML report. Failed datasets and datasets with
neither a log nor a profile still do not create one.

The new end-to-end tests exercise the actual CLI with benchmark and raw-profile
JSON, including escaping, Unicode, empty and missing fields, invalid sources,
and repeated invocations.

Validation:

* `cabal build exe:futhark`
* `FUTHARK="$(cabal list-bin exe:futhark)" python3 tests_adhoc/profile-html/test.py` (6 passed)
* `cabal test unit --test-show-details=direct` (637 passed)
* `tools/style-check-file.sh src/Futhark/CLI/Profile.hs`
* `tools/style-check-file.sh src/Futhark/Profile/Html.hs`
