### PR TITLE
futhark bench: record result metadata

### DIFF
--- a/docs/man/futhark-bench.rst
+++ b/docs/man/futhark-bench.rst
@@ -99,7 +99,11 @@ OPTIONS
 
 --json=file
 
-  Write raw results in JSON format to the specified file.
+  Write raw results in JSON format to the specified file.  Each benchmark
+  includes metadata describing when and where it ran, the compiler version and
+  backend, and options explicitly forwarded to the compiler or runtime.  This
+  makes it possible to identify the environment and invocation that produced a
+  result file.
 
 --no-tuning
 

--- a/src-testing/Futhark/BenchTests.hs
+++ b/src-testing/Futhark/BenchTests.hs
@@ -44,5 +44,23 @@ encodeDecodeJSON = testProperty "encoding and decoding are inverse" prop
     prop :: BenchResult -> Bool
     prop brs = decodeBenchResults (encodeBenchResults [brs]) == Right [brs]
 
+metadataJSON :: TestTree
+metadataJSON = testProperty "metadata preserves benchmark decoding" prop
+  where
+    prop :: BenchResult -> Bool
+    prop brs =
+      decodeBenchResults (encodeBenchResultsWithMetadata metadata [brs])
+        == Right [brs]
+    metadata =
+      BenchMetadata
+        { benchStartTime = read "2026-09-09 01:02:03 UTC",
+          benchEndTime = read "2026-09-09 01:02:04 UTC",
+          benchHostname = Just "benchmark-host",
+          benchCompilerVersion = Just "Futhark test compiler",
+          benchBackend = "c",
+          benchCompilerOptions = ["--safe"],
+          benchRuntimeOptions = ["--debugging"]
+        }
+
 tests :: TestTree
-tests = testGroup "Futhark.BenchTests" [encodeDecodeJSON]
+tests = testGroup "Futhark.BenchTests" [encodeDecodeJSON, metadataJSON]

--- a/src/Futhark/Bench.hs
+++ b/src/Futhark/Bench.hs
@@ -4,8 +4,10 @@ module Futhark.Bench
   ( RunResult (..),
     DataResult (..),
     BenchResult (..),
+    BenchMetadata (..),
     Result (..),
     encodeBenchResults,
+    encodeBenchResultsWithMetadata,
     decodeBenchResults,
     binaryName,
     benchmarkDataset,
@@ -75,9 +77,22 @@ data BenchResult = BenchResult
   }
   deriving (Eq, Show)
 
+-- | Information about the environment and invocation that produced a
+-- benchmark result file.
+data BenchMetadata = BenchMetadata
+  { benchStartTime :: UTCTime,
+    benchEndTime :: UTCTime,
+    benchHostname :: Maybe T.Text,
+    benchCompilerVersion :: Maybe T.Text,
+    benchBackend :: T.Text,
+    benchCompilerOptions :: [T.Text],
+    benchRuntimeOptions :: [T.Text]
+  }
+  deriving (Eq, Show)
+
 newtype DataResults = DataResults {unDataResults :: [DataResult]}
 
-newtype BenchResults = BenchResults {unBenchResults :: [BenchResult]}
+data BenchResults = BenchResults (Maybe BenchMetadata) [BenchResult]
 
 instance JSON.ToJSON Result where
   toJSON (Result runres memmap err profiling) =
@@ -131,19 +146,33 @@ dataResultJSON (DataResult desc (Right (Result runtimes bytes progerr_opt profil
           Just profiling -> [("profiling", JSON.toJSON profiling)]
   )
 
-benchResultJSON :: BenchResult -> (JSON.Key, JSON.Value)
-benchResultJSON (BenchResult prog r) =
+benchMetadataJSON :: BenchMetadata -> JSON.Value
+benchMetadataJSON metadata =
+  JSON.object
+    [ ("start_time", JSON.toJSON $ benchStartTime metadata),
+      ("end_time", JSON.toJSON $ benchEndTime metadata),
+      ("hostname", JSON.toJSON $ benchHostname metadata),
+      ("compiler_version", JSON.toJSON $ benchCompilerVersion metadata),
+      ("backend", JSON.toJSON $ benchBackend metadata),
+      ("compiler_options", JSON.toJSON $ benchCompilerOptions metadata),
+      ("runtime_options", JSON.toJSON $ benchRuntimeOptions metadata)
+    ]
+
+benchResultJSON :: Maybe BenchMetadata -> BenchResult -> (JSON.Key, JSON.Value)
+benchResultJSON metadata (BenchResult prog r) =
   ( JSON.fromString prog,
-    JSON.object [("datasets", JSON.toJSON $ DataResults r)]
+    JSON.object $
+      [("datasets", JSON.toJSON $ DataResults r)]
+        <> maybe [] (pure . ("metadata",) . benchMetadataJSON) metadata
   )
 
 instance JSON.ToJSON BenchResults where
-  toJSON (BenchResults rs) =
-    JSON.object $ map benchResultJSON rs
+  toJSON (BenchResults metadata rs) =
+    JSON.object $ map (benchResultJSON metadata) rs
 
 instance JSON.FromJSON BenchResults where
   parseJSON = JSON.withObject "benchmarks" $ \o ->
-    BenchResults <$> mapM onBenchmark (JSON.toList o)
+    BenchResults Nothing <$> mapM onBenchmark (JSON.toList o)
     where
       onBenchmark (k, v) =
         BenchResult (JSON.toString k)
@@ -153,11 +182,22 @@ instance JSON.FromJSON BenchResults where
 
 -- | Transform benchmark results to a JSON bytestring.
 encodeBenchResults :: [BenchResult] -> LBS.ByteString
-encodeBenchResults = JSON.encode . BenchResults
+encodeBenchResults = JSON.encode . BenchResults Nothing
+
+-- | Transform benchmark results and their provenance metadata to a JSON
+-- bytestring.  Metadata is stored inside each benchmark object so existing
+-- consumers that iterate the top-level program keys remain compatible.
+encodeBenchResultsWithMetadata ::
+  BenchMetadata ->
+  [BenchResult] ->
+  LBS.ByteString
+encodeBenchResultsWithMetadata = (JSON.encode .) . BenchResults . Just
 
 -- | Decode benchmark results from a JSON bytestring.
 decodeBenchResults :: LBS.ByteString -> Either String [BenchResult]
 decodeBenchResults = fmap unBenchResults . JSON.eitherDecode'
+  where
+    unBenchResults (BenchResults _ results) = results
 
 --- Running benchmarks
 

--- a/src/Futhark/CLI/Bench.hs
+++ b/src/Futhark/CLI/Bench.hs
@@ -105,10 +105,10 @@ combineDuplicates =
   where
     f [] = Nothing
     f (x : xs) =
-      Just
-        $ BenchResult (benchResultProg x)
-        $ concatMap benchResultResults
-        $ x : xs
+      Just $
+        BenchResult (benchResultProg x) $
+          concatMap benchResultResults $
+            x : xs
 
 runBenchmarks :: BenchOptions -> [FilePath] -> IO ()
 runBenchmarks opts paths = do
@@ -164,9 +164,9 @@ runBenchmarks opts paths = do
                 benchCompilerOptions = map T.pack $ optCompilerOptions opts,
                 benchRuntimeOptions = map T.pack $ optExtraOptions opts
               }
-      LBS.writeFile file
-        $ encodeBenchResultsWithMetadata metadata
-        $ combineDuplicates results
+      LBS.writeFile file $
+        encodeBenchResultsWithMetadata metadata $
+          combineDuplicates results
   when (any isNothing maybe_results || anyFailed results) exitFailure
   where
     ignored f = any (`match` f) $ optIgnoreFiles opts

--- a/src/Futhark/CLI/Bench.hs
+++ b/src/Futhark/CLI/Bench.hs
@@ -34,6 +34,7 @@ import System.Environment
 import System.Exit
 import System.FilePath
 import System.IO
+import System.Process.ByteString (readProcessWithExitCode)
 import System.Random.MWC (create)
 import Text.Printf
 import Text.Regex.TDFA
@@ -104,10 +105,10 @@ combineDuplicates =
   where
     f [] = Nothing
     f (x : xs) =
-      Just $
-        BenchResult (benchResultProg x) $
-          concatMap benchResultResults $
-            x : xs
+      Just
+        $ BenchResult (benchResultProg x)
+        $ concatMap benchResultResults
+        $ x : xs
 
 runBenchmarks :: BenchOptions -> [FilePath] -> IO ()
 runBenchmarks opts paths = do
@@ -115,6 +116,7 @@ runBenchmarks opts paths = do
   -- Otherwise, CI tools and the like may believe we are hung and kill
   -- us.
   hSetBuffering stdout LineBuffering
+  start_time <- getCurrentTime
 
   benchmarks <- filter (not . ignored . fst) <$> testSpecsFromPathsOrDie paths
   -- Try to avoid concurrency at both program and data set level.
@@ -147,13 +149,37 @@ runBenchmarks opts paths = do
   let results = concat $ catMaybes maybe_results
   case optJSON opts of
     Nothing -> pure ()
-    Just file ->
-      LBS.writeFile file $
-        encodeBenchResults $
-          combineDuplicates results
+    Just file -> do
+      end_time <- getCurrentTime
+      hostname <- commandOutput "hostname" []
+      compile_opts <- compileOptions opts
+      compiler_version <- commandOutput (compFuthark compile_opts) ["--version"]
+      let metadata =
+            BenchMetadata
+              { benchStartTime = start_time,
+                benchEndTime = end_time,
+                benchHostname = hostname,
+                benchCompilerVersion = compiler_version,
+                benchBackend = T.pack $ optBackend opts,
+                benchCompilerOptions = map T.pack $ optCompilerOptions opts,
+                benchRuntimeOptions = map T.pack $ optExtraOptions opts
+              }
+      LBS.writeFile file
+        $ encodeBenchResultsWithMetadata metadata
+        $ combineDuplicates results
   when (any isNothing maybe_results || anyFailed results) exitFailure
   where
     ignored f = any (`match` f) $ optIgnoreFiles opts
+
+commandOutput :: FilePath -> [String] -> IO (Maybe T.Text)
+commandOutput command args = do
+  result <-
+    try (readProcessWithExitCode command args SBS.empty) ::
+      IO (Either SomeException (ExitCode, SBS.ByteString, SBS.ByteString))
+  pure $ case result of
+    Right (ExitSuccess, output, _) ->
+      Just $ T.strip $ T.pack $ SBS.unpack output
+    _ -> Nothing
 
 anyFailed :: [BenchResult] -> Bool
 anyFailed = any failedBenchResult

--- a/tests_adhoc/bench-metadata/test.py
+++ b/tests_adhoc/bench-metadata/test.py
@@ -1,0 +1,73 @@
+"""Exercise benchmark metadata through the real ``futhark bench`` CLI."""
+
+from __future__ import annotations
+
+from datetime import datetime
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+class BenchMetadataTests(unittest.TestCase):
+    def test_metadata_describes_invocation(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            program = root / "metadata.fut"
+            results = root / "results.json"
+            program.write_text(
+                "-- ==\n-- input { 1 } output { 2 }\n\n"
+                "entry main (x: i32) = x + 1\n",
+                encoding="utf-8",
+            )
+            futhark = os.environ.get("FUTHARK", "futhark")
+            run = subprocess.run(
+                [
+                    futhark,
+                    "bench",
+                    "--backend=c",
+                    "--runs=1",
+                    "--no-convergence-phase",
+                    "--no-tuning",
+                    "--pass-compiler-option=--safe",
+                    "--pass-option=--debugging",
+                    f"--json={results}",
+                    str(program),
+                ],
+                cwd=root,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(run.returncode, 0, run.stderr)
+
+            benchmarks = json.loads(results.read_text(encoding="utf-8"))
+            self.assertEqual(len(benchmarks), 1)
+            benchmark = next(iter(benchmarks.values()))
+            self.assertIn("datasets", benchmark)
+            metadata = benchmark["metadata"]
+            self.assertEqual(metadata["backend"], "c")
+            self.assertEqual(metadata["compiler_options"], ["--safe"])
+            self.assertEqual(metadata["runtime_options"], ["--debugging"])
+            self.assertTrue(metadata["hostname"])
+            self.assertIn("Futhark", metadata["compiler_version"])
+            start = datetime.fromisoformat(
+                metadata["start_time"].replace("Z", "+00:00")
+            )
+            end = datetime.fromisoformat(
+                metadata["end_time"].replace("Z", "+00:00")
+            )
+            self.assertLessEqual(start, end)
+
+            compare = subprocess.run(
+                [futhark, "benchcmp", str(results), str(results)],
+                cwd=root,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(compare.returncode, 0, compare.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_adhoc/bench-metadata/test.sh
+++ b/tests_adhoc/bench-metadata/test.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+set -e
+python3 test.py


### PR DESCRIPTION
Closes #2381.

Benchmark JSON files currently contain measurements without recording the environment or invocation that produced them. This adds a `metadata` object to each benchmark with UTC start/end times, hostname, the selected compiler's `--version` output, backend, and explicitly forwarded compiler and runtime options.

The top-level program-keyed JSON shape is unchanged. Existing decoders continue to read the enriched files because they already ignore extra fields inside each benchmark; the property tests cover round trips with and without metadata, and the end-to-end test also reads the result with `futhark benchcmp`. Metadata lookup failures do not prevent a completed benchmark file from being written.

Validation on macOS arm64 with GHC 9.10.3:

- `cabal test unit --test-show-details=direct` (638 passed)
- `cabal test unit --test-options="-p /Futhark.BenchTests/" --test-show-details=direct` (2 properties, 100 cases each)
- `FUTHARK="$(cabal list-bin exe:futhark)" tests_adhoc/bench-metadata/test.sh`
- `cabal build exe:futhark --ghc-options="-Wall -Werror"`
- repository style checks for all edited Haskell files
- Black and mypy checks for the Python integration test

The C backend integration test fails against the pre-change executable due to absent metadata and passes with this change. GPU backends and other operating systems were not tested.

AI assistance: OpenAI Codex (GPT-5) was used for implementation, review, and test execution.