### PR TITLE
Fix reverse AD for array-valued scans

### DIFF
--- a/src/Futhark/AD/Rev/Scan.hs
+++ b/src/Futhark/AD/Rev/Scan.hs
@@ -247,6 +247,10 @@ cases d t mat = case subMats d mat $ zeroExp t of
 -- Jacobian of the scan op. Figure out if the Jacobian has some
 -- special shape, discarding the temporary lambda.
 identifyCase :: VjpOps -> Lambda SOACS -> ADM ScanAlgo
+identifyCase _ lam
+  -- The IFL23 specialisation represents Jacobian entries as scalars.
+  -- Use PPAD for array results, before constructing the Jacobian.
+  | any ((> 0) . arrayRank) (lambdaReturnType lam) = pure GenericPPAD
 identifyCase ops lam = do
   let t = lambdaReturnType lam
   let d = length t

--- a/tests/ad/issue2208.fut
+++ b/tests/ad/issue2208.fut
@@ -1,0 +1,21 @@
+-- Array-valued scan from #2208. Each derivative is a suffix sum of adj.
+-- ==
+-- tags { autodiff }
+-- entry: scan_arr_add
+-- input { [[1f32, 2, 3], [4f32, 5, 6]]
+--         [[1f32, 2, 4], [3f32, 5, 7]] }
+-- output { [[7f32, 6, 4], [15f32, 12, 7]] }
+-- input { [[2f32], [3f32]] [[4f32], [5f32]] }
+-- output { [[4f32], [5f32]] }
+-- input { empty([2][0]f32) empty([2][0]f32) }
+-- output { empty([2][0]f32) }
+
+entry scan_arr_add [n]
+                   (inp: [2][n]f32)
+                   (adj: [2][n]f32) : [2][n]f32 =
+  let adj =
+    vjp (scan (\x y -> [x[0] + y[0], x[1] + y[1]])
+              (replicate 2 0))
+        (transpose inp)
+        (transpose adj)
+  in transpose adj

--- a/tests/ad/issue2208.fut
+++ b/tests/ad/issue2208.fut
@@ -10,12 +10,24 @@
 -- input { empty([2][0]f32) empty([2][0]f32) }
 -- output { empty([2][0]f32) }
 
+def scan_arr_add_primal [n] (inp: [2][n]f32) : [2][n]f32 =
+  scan (\x y -> [x[0] + y[0], x[1] + y[1]])
+       (replicate 2 0) (transpose inp)
+  |> transpose
+
 entry scan_arr_add [n]
                    (inp: [2][n]f32)
                    (adj: [2][n]f32) : [2][n]f32 =
-  let adj =
-    vjp (scan (\x y -> [x[0] + y[0], x[1] + y[1]])
-              (replicate 2 0))
-        (transpose inp)
-        (transpose adj)
-  in transpose adj
+  vjp scan_arr_add_primal inp adj
+
+-- ==
+-- entry: scan_arr_add_vec
+-- input { [[1f32, 2, 3], [4f32, 5, 6]]
+--         [[[1f32, 2, 4], [3f32, 5, 7]],
+--          [[2f32, -1, 3], [0f32, 4, -2]]] }
+-- output { [[[7f32, 6, 4], [15f32, 12, 7]],
+--           [[4f32, 2, 3], [2f32, 2, -2]]] }
+entry scan_arr_add_vec [n] [k]
+                       (inp: [2][n]f32)
+                       (adjs: [k][2][n]f32) : [k][2][n]f32 =
+  mjp scan_arr_add_primal inp adjs

--- a/tests/ad/scan-array-affine.fut
+++ b/tests/ad/scan-array-affine.fut
@@ -1,0 +1,23 @@
+-- Composition of affine functions: associative, noncommutative, and coupled.
+-- Prefixes satisfy A_i = a_i*A_(i-1), B_i = a_i*B_(i-1)+b_i.
+-- Expected derivatives are from these recurrences, not another AD mode.
+-- ==
+-- tags { autodiff }
+-- entry: main
+-- input { [[2f64, 3], [5f64, 7], [11f64, 13]]
+--         [[1f64, 1], [1f64, 1], [1f64, 1]] }
+-- output { [[61f64, 61], [60f64, 12], [32f64, 1]] }
+-- input { [[2f64, 3], [5f64, 7], [11f64, 13]]
+--         [[2f64, -1], [-3f64, 4], [5f64, -2]] }
+-- output { [[262f64, -91], [50f64, -18], [6f64, -2]] }
+-- input { [[2f64, 3], [0f64, 7], [11f64, 13]]
+--         [[2f64, -1], [-3f64, 4], [5f64, -2]] }
+-- output { [[2f64, -1], [50f64, -18], [-14f64, -2]] }
+-- input { [[2f64, 3]] [[4f64, 5]] }
+-- output { [[4f64, 5]] }
+-- input { empty([0][2]f64) empty([0][2]f64) }
+-- output { empty([0][2]f64) }
+
+entry main [n] (xs: [n][2]f64) (adj: [n][2]f64) =
+  vjp (scan (\x y -> [y[0] * x[0], y[0] * x[1] + y[1]]) [1, 0])
+      xs adj

--- a/tests/ad/scan-array-nested.fut
+++ b/tests/ad/scan-array-nested.fut
@@ -1,0 +1,19 @@
+-- Hessian-vector product of the sum of squared array-valued prefixes.
+-- H*v is twice the suffix sum of the prefix sums of v, componentwise.
+-- ==
+-- tags { autodiff }
+-- entry: main
+-- input { [[1f64, 2], [3f64, 4], [5f64, 6]]
+--         [[1f64, 2], [3f64, 4], [5f64, 6]] }
+-- output { [[28f64, 40], [26f64, 36], [18f64, 24]] }
+-- input { [[2f64, 3]] [[4f64, 5]] }
+-- output { [[8f64, 10]] }
+-- input { empty([0][2]f64) empty([0][2]f64) }
+-- output { empty([0][2]f64) }
+
+entry main [n] (xs: [n][2]f64) (direction: [n][2]f64) =
+  let objective ys =
+    scan (\x y -> [x[0] + y[0], x[1] + y[1]]) [0, 0] ys
+    |> map (\p -> p[0] * p[0] + p[1] * p[1])
+    |> reduce (+) 0
+  in jvp (\ys -> vjp objective ys 1) xs direction

--- a/tests/ad/scan-array-rank2.fut
+++ b/tests/ad/scan-array-rank2.fut
@@ -1,0 +1,20 @@
+-- Rank-two results. Expected derivatives are componentwise suffix sums.
+-- ==
+-- tags { autodiff }
+-- entry: main
+-- input { [[[1f64, 2], [3f64, 4]], [[5f64, 6], [7f64, 8]],
+--          [[9f64, 10], [11f64, 12]]]
+--         [[[1f64, 2], [3f64, 4]], [[5f64, 6], [7f64, 8]],
+--          [[9f64, 10], [11f64, 12]]] }
+-- output { [[[15f64, 18], [21f64, 24]], [[14f64, 16], [18f64, 20]],
+--           [[9f64, 10], [11f64, 12]]] }
+-- input { [[[1f64, 2], [3f64, 4]]] [[[5f64, 6], [7f64, 8]]] }
+-- output { [[[5f64, 6], [7f64, 8]]] }
+-- input { empty([0][2][2]f64) empty([0][2][2]f64) }
+-- output { empty([0][2][2]f64) }
+
+entry main [n] (xs: [n][2][2]f64) (adj: [n][2][2]f64) =
+  vjp (scan (\x y -> [[x[0, 0] + y[0, 0], x[0, 1] + y[0, 1]],
+                      [x[1, 0] + y[1, 0], x[1, 1] + y[1, 1]]])
+            (replicate 2 (replicate 2 0)))
+      xs adj

--- a/tests/ad/scan-array-tuple.fut
+++ b/tests/ad/scan-array-tuple.fut
@@ -1,0 +1,23 @@
+-- The scalar comes first; the array has a different element type.
+-- Scalar products have derivatives [1+5+5*11, 2+2*11, 2*5].
+-- The array components compose affine functions as in scan-array-affine.
+-- ==
+-- tags { autodiff }
+-- entry: main
+-- input { [2f32, 5, 11] [[2f64, 3], [5f64, 7], [11f64, 13]]
+--         [1f32, 1, 1] [[1f64, 1], [1f64, 1], [1f64, 1]] }
+-- output { [61f32, 24, 10] [[61f64, 61], [60f64, 12], [32f64, 1]] }
+-- input { [2f32] [[2f64, 3]] [4f32] [[4f64, 5]] }
+-- output { [4f32] [[4f64, 5]] }
+-- input { empty([0]f32) empty([0][2]f64)
+--         empty([0]f32) empty([0][2]f64) }
+-- output { empty([0]f32) empty([0][2]f64) }
+
+entry main [n] (as: [n]f32) (xs: [n][2]f64)
+               (da: [n]f32) (dx: [n][2]f64) =
+  let primal (bs, ys) =
+    scan (\(a, x) (b, y) ->
+            (a * b, [y[0] * x[0], y[0] * x[1] + y[1]]))
+         (1f32, [1f64, 0]) (zip bs ys)
+    |> unzip
+  in vjp primal (as, xs) (da, dx)


### PR DESCRIPTION
Fixes #2208.

Reverse AD can select the scalar Jacobian specialization for an array-valued scan operator, producing an internal type error. Check all scan result types before constructing that Jacobian and use the existing PPAD algorithm when any result has positive rank. Scalar selection is unchanged.

Adds 17 datasets covering the reported array addition, empty/singleton inputs, noncommutative affine composition with signed adjoints and a zero multiplier, mixed scalar/array types, rank-two results, and a nested Hessian-vector product. Expected derivatives are analytical and independently checked with finite differences. Four programs fail on the base revision; the mixed-type tuple is an existing-behavior check.

Validation on macOS arm64, GHC 9.10.3:

- All 184 AD programs and 56 additional scan programs pass on both C and multicore backends.
- All 637 unit tests pass.
- `cabal build all --ghc-options=-Werror` and `cabal check` pass.
- All 393 source/style checks pass with the repository-pinned Ormolu 0.8.0.2; new fixture style and whitespace checks pass.
- Three representative scalar scans produce byte-identical optimized SOACS before and after the fix.

GPU backends and performance were not measured. This restores the existing general algorithm for array results; it does not establish support for every possible array-valued operator.

Prepared and tested with assistance from OpenAI Codex.
